### PR TITLE
docs: 新增 CLAUDE.md 项目工作手册，新会话免重新踩坑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data/
 # 本地手绘配图（仅用于文章配图，按需本地生成，不入库）
 handdrawn/
 .claude
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# customer-work 项目工作手册（AI 会话用）
+
+基于 AgentScope Java 2.0.0 GA 的生产级智能客服系统 + 后台管理系统。本文件只放**每次会话都需要的事实与坑**；
+细节现场读代码和 docs/ 下的文档，不要在这里复制它们。
+
+## 模块结构
+
+| 模块 | 说明 |
+|---|---|
+| `customer-work-spring-boot-starter` | 可复用智能体基础设施（模型/记忆/RAG/工具SPI/中间件/调度等），`@AutoConfiguration` 自动装配 |
+| `customer-work-app` | 可运行客服示例（端口 8080） |
+| `customer-work-downstream-app` | 下游接入示例 |
+| `customer-web` | 官方五套前端能力接入（admin/chat-completions/AG-UI/Studio/Channel，端口 8081） |
+| `customer-admin-server` | 后台管理系统后端（Spring MVC + MyBatis-Plus + Sa-Token，端口 8082，独立库 `customer_admin`） |
+| `customer-admin-web` | 后台管理前端（Vue3+TS+Vite+Element Plus，**非 Maven 模块**，端口 5174） |
+
+## 分支策略
+
+- `main` = AgentScope 2.0.0 GA（2026-07 起）。**有分支保护，禁止直接 push，必须走 PR**。
+- `legacy-main-1.0.12` 标签 = 升级前 1.0.12 最后状态；`rc2.0` 分支 = RC4 首轮迁移存档；`ga2.0` 分支 = 已并入 main 的历史开发分支（保留不删）。
+
+## 构建与测试（关键坑，全部实测踩过）
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)   # shell 默认 java 是 1.8，必须显式切 17
+mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.xml clean test -Djacoco.skip=true
+```
+
+- **`-gs` 与 `-s` 必须同传**同一 settings 文件：Maven 会合并全局+用户两处 `activeProfiles`，只传 `-s` 时
+  全局镜像 profile 仍生效，会挂死在内网 Nexus 上（无报错、0% CPU，极难判断）。
+- **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
+- **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
+- `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
+- 测试基线：全仓 **511 个**（starter 362 + app 13 + downstream 1 + customer-web 8 + admin-server 127）。
+  外部依赖门控测试：MySQL(root/root)、Redis(密码 123456)、Nacos(nacos/nacos:8848)，不可达自动跳过。
+- 模块 A 改完给模块 B 用时，先 `mvn install -Dmaven.test.skip=true -Djacoco.skip=true`（B 解析的是本地仓库的 jar，
+  不是 A 的工作树）；根 pom 变更后父 POM 也要 `mvn -N install`，否则 B 读到旧版本号。
+
+## 文档地图（哪个问题去读哪个文档）
+
+- 功能总表/配置项/接口速查 → `README.md`
+- 1.x→2.0 API 映射、RC4→GA 变更、issue 重新核对 → `docs/MIGRATION-2.0.md`
+- 框架 open issues 与本项目链路的交叉评估 → `docs/生产就绪评估.md`
+- 生产部署步骤/环境变量/灰度回滚 → `docs/部署手册.md`
+- 架构原理/时序图/UML → `docs/详细技术文档.md`
+- 后台管理系统需求 → `docs/AI编码助手需求文档.md`（admin-server 相关）
+
+## 项目编码规范（全局规范之外的项目特有约定）
+
+- 日志只用 info/error（不用 warn），日志文本英文，error 带错误码占位符：
+  `log.error("xxx failed, code={}, id={}", "MODULE-ACTION-FAIL", id, e)`
+- 持久化扩展走 Store SPI 模式（接口 + InMemory 默认 + Jdbc 实现 + `@ConditionalOnMissingBean`，
+  已套用 5 次：Approval/SlotFilling/DialogStage/Handoff/Feedback），别发明新模式。
+- 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
+- JDBC Store 的异常必须 `catch(Exception)` 而非 `SQLException`（HikariPool 初始化异常是 RuntimeException）。
+- 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。
+- admin-server 排除了 starter 的自动装配（`spring.autoconfigure.exclude`），需要 starter 能力时在自己的
+  `@Configuration` 里显式 new，不要假设容器里有现成 Bean。
+
+## 定时任务（XXL-JOB）约定
+
+- starter：`customer-work.scheduler.xxl-job.*` 配置化，官方 `XxlJobAgentScheduler`（cron 在调度中心配，代码侧只注册 JobHandler）。
+- admin-server：通用 JobHandler `agentScheduledTask`，调度中心任务参数填 `ai_scheduled_task.task_code`；
+  手动触发接口不依赖 XXL-JOB。执行器 appname：`customer-work-executor`(9999) / `customer-admin-executor`(9998)。
+
+## 本机环境
+
+本机专属信息（容器、凭据、IDE 坑）见 `CLAUDE.local.md`（gitignored，不进仓库）。


### PR DESCRIPTION
新建会话此前要靠对话历史/重新探索才能知道构建命令的 -gs/-s 同传坑、511 个测试基线、
Store SPI 模式约定、XXL-JOB 两处执行器 appname/port 等——每次都要重新消耗 token 探索 或凭记忆复述，还容易漏掉细节。

CLAUDE.md 只放"每次会话都需要的事实与坑"（模块结构、分支策略、构建踩坑、编码规范、
定时任务约定），具体细节保留在 README/docs/ 里现查，不在这里重复、不会跟代码脱节。
本机专属信息（容器凭据、IDE 坑、XXL-JOB 本机部署状态）拆到 CLAUDE.local.md， 已加入 .gitignore，不进仓库、不泄露到团队共享文档里。

全部条目逐条核对过当前代码/配置的真实值（executor appname/port、Store SPI 实现类、 各模块端口号），不是凭印象写的。

## 变更说明 / What

简述本 PR 做了什么、解决什么问题（关联 Issue：Closes #）。

## 类型 / Type
- [ ] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [ ] `mvn test` 全绿（新增功能附了单元测试）
- [ ] 未在代码 / 配置中硬编码任何密钥
- [ ] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定
- [ ] 必要时更新了 README / 配置项说明
