### PR TITLE
feat(workspace): 标签页右键菜单（关闭/关闭其他/关闭右侧）

### DIFF
--- a/customer-admin-web/src/layouts/TabsBar.vue
+++ b/customer-admin-web/src/layouts/TabsBar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTabsStore } from '@/store/tabs'
 import type { TabsPaneContext, TabPaneName } from 'element-plus'
@@ -17,24 +18,93 @@ function handleTabClick(pane: TabsPaneContext) {
 function handleTabRemove(paneName: TabPaneName) {
   tabsStore.closeTab(String(paneName))
 }
+
+// 右键上下文菜单：定位到具体被右键的标签靠事件委托 + DOM 顺序对齐 tabsStore.tabs（Element Plus
+// 的 el-tab-pane 不是实际渲染节点，拿不到 paneName，只能反查 .el-tabs__item 在导航条里的下标）。
+const menuVisible = ref(false)
+const menuX = ref(0)
+const menuY = ref(0)
+const menuTargetKey = ref('')
+
+function onTabsContextMenu(event: MouseEvent) {
+  const item = (event.target as HTMLElement).closest('.el-tabs__item') as HTMLElement | null
+  if (!item) {
+    return
+  }
+  event.preventDefault()
+  const nav = item.parentElement
+  const items = nav ? Array.from(nav.querySelectorAll('.el-tabs__item')) : []
+  const index = items.indexOf(item)
+  const tab = tabsStore.tabs[index]
+  if (!tab) {
+    return
+  }
+  menuTargetKey.value = tab.key
+  menuX.value = event.clientX
+  menuY.value = event.clientY
+  menuVisible.value = true
+}
+
+function closeMenu() {
+  menuVisible.value = false
+}
+
+function doClose() {
+  tabsStore.closeTab(menuTargetKey.value)
+  closeMenu()
+}
+
+function doCloseOthers() {
+  tabsStore.closeOthers(menuTargetKey.value)
+  closeMenu()
+}
+
+function doCloseToRight() {
+  tabsStore.closeToRight(menuTargetKey.value)
+  closeMenu()
+}
+
+const targetTab = () => tabsStore.tabs.find((t) => t.key === menuTargetKey.value)
+const canClose = () => targetTab()?.closable ?? false
+const canCloseOthers = () => tabsStore.tabs.some((t) => t.closable && t.key !== menuTargetKey.value)
+const canCloseToRight = () => {
+  const idx = tabsStore.tabs.findIndex((t) => t.key === menuTargetKey.value)
+  return idx !== -1 && idx < tabsStore.tabs.length - 1
+}
+
+onMounted(() => window.addEventListener('click', closeMenu))
+onBeforeUnmount(() => window.removeEventListener('click', closeMenu))
 </script>
 
 <template>
-  <el-tabs
-    v-model="tabsStore.activeKey"
-    type="card"
-    class="tabs-bar"
-    @tab-click="handleTabClick"
-    @tab-remove="handleTabRemove"
-  >
-    <el-tab-pane
-      v-for="tab in tabsStore.tabs"
-      :key="tab.key"
-      :name="tab.key"
-      :label="tab.title"
-      :closable="tab.closable"
-    />
-  </el-tabs>
+  <div class="tabs-bar-wrapper" @contextmenu="onTabsContextMenu">
+    <el-tabs
+      v-model="tabsStore.activeKey"
+      type="card"
+      class="tabs-bar"
+      @tab-click="handleTabClick"
+      @tab-remove="handleTabRemove"
+    >
+      <el-tab-pane
+        v-for="tab in tabsStore.tabs"
+        :key="tab.key"
+        :name="tab.key"
+        :label="tab.title"
+        :closable="tab.closable"
+      />
+    </el-tabs>
+
+    <ul
+      v-if="menuVisible"
+      class="tab-context-menu"
+      :style="{ left: menuX + 'px', top: menuY + 'px' }"
+      @click.stop
+    >
+      <li :class="{ disabled: !canClose() }" @click="canClose() && doClose()">关闭</li>
+      <li :class="{ disabled: !canCloseOthers() }" @click="canCloseOthers() && doCloseOthers()">关闭其他</li>
+      <li :class="{ disabled: !canCloseToRight() }" @click="canCloseToRight() && doCloseToRight()">关闭右侧</li>
+    </ul>
+  </div>
 </template>
 
 <style scoped>
@@ -62,5 +132,45 @@ function handleTabRemove(paneName: TabPaneName) {
 .tabs-bar :deep(.el-tabs__item.is-active) {
   color: #409eff;
   font-weight: 600;
+}
+
+.tabs-bar-wrapper {
+  position: relative;
+}
+
+.tab-context-menu {
+  position: fixed;
+  z-index: 2000;
+  min-width: 100px;
+  padding: 4px 0;
+  margin: 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #e4e7ed;
+  border-radius: 4px;
+  box-shadow: 0 2px 12px rgb(0 0 0 / 10%);
+}
+
+.tab-context-menu li {
+  padding: 6px 16px;
+  font-size: 13px;
+  color: #606266;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.tab-context-menu li:hover {
+  background: #f5f7fa;
+  color: #409eff;
+}
+
+.tab-context-menu li.disabled {
+  color: #c0c4cc;
+  cursor: not-allowed;
+}
+
+.tab-context-menu li.disabled:hover {
+  background: transparent;
+  color: #c0c4cc;
 }
 </style>

--- a/customer-admin-web/src/store/auth.ts
+++ b/customer-admin-web/src/store/auth.ts
@@ -4,11 +4,15 @@ import type { LoginResponse } from '@/types/api'
 
 const STORAGE_TOKEN_KEY = 'admin-token'
 const STORAGE_NICKNAME_KEY = 'admin-nickname'
+const STORAGE_USERNAME_KEY = 'admin-username'
 const STORAGE_FORCE_CHANGE_PASSWORD_KEY = 'admin-force-change-password'
 
 interface AuthState {
   token: string | null
   nickname: string | null
+  /** 当前登录用户名。后端 LoginResponse 不带这个字段（只有 token/nickname），从登录表单里带出来存一份，
+   * 供「系统管理 - 用户管理」编辑用户后判断是不是在改自己、需要同步刷新右上角昵称缓存。 */
+  username: string | null
   forceChangePassword: boolean
   permissions: string[]
 }
@@ -17,6 +21,7 @@ export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
     token: localStorage.getItem(STORAGE_TOKEN_KEY),
     nickname: localStorage.getItem(STORAGE_NICKNAME_KEY),
+    username: localStorage.getItem(STORAGE_USERNAME_KEY),
     // 必须持久化，不能只活在内存里：若只存内存，浏览器在改密页意外刷新（如表单原生提交触发的整页刷新）
     // 会让这个强制改密的门禁悄悄消失，用户绕过强制改密直接进入系统。
     forceChangePassword: localStorage.getItem(STORAGE_FORCE_CHANGE_PASSWORD_KEY) === 'true',
@@ -26,13 +31,21 @@ export const useAuthStore = defineStore('auth', {
     isLoggedIn: (state) => !!state.token,
   },
   actions: {
-    applyLoginResult(result: LoginResponse) {
+    applyLoginResult(result: LoginResponse, username: string) {
       this.token = result.token
       this.nickname = result.nickname
+      this.username = username
       this.forceChangePassword = result.forceChangePassword
       localStorage.setItem(STORAGE_TOKEN_KEY, result.token)
       localStorage.setItem(STORAGE_NICKNAME_KEY, result.nickname)
+      localStorage.setItem(STORAGE_USERNAME_KEY, username)
       localStorage.setItem(STORAGE_FORCE_CHANGE_PASSWORD_KEY, String(result.forceChangePassword))
+    },
+    /** 「用户管理」编辑资料时若改的是当前登录用户自己，用这个同步刷新右上角展示的昵称缓存，
+     * 否则要等下次重新登录才会更新——旧 bug：编辑自己的昵称后页面仍显示登录时缓存的旧值。 */
+    updateNickname(nickname: string) {
+      this.nickname = nickname
+      localStorage.setItem(STORAGE_NICKNAME_KEY, nickname)
     },
     clearForceChangePassword() {
       this.forceChangePassword = false
@@ -47,10 +60,12 @@ export const useAuthStore = defineStore('auth', {
     clear() {
       this.token = null
       this.nickname = null
+      this.username = null
       this.forceChangePassword = false
       this.permissions = []
       localStorage.removeItem(STORAGE_TOKEN_KEY)
       localStorage.removeItem(STORAGE_NICKNAME_KEY)
+      localStorage.removeItem(STORAGE_USERNAME_KEY)
       localStorage.removeItem(STORAGE_FORCE_CHANGE_PASSWORD_KEY)
     },
     async logout() {

--- a/customer-admin-web/src/store/tabs.ts
+++ b/customer-admin-web/src/store/tabs.ts
@@ -75,6 +75,32 @@ export const useTabsStore = defineStore('tabs', {
         router.push(HOME_KEY)
       }
     },
+    /** 关闭除 key 外的所有可关闭标签（首页等 closable=false 的标签天然保留），并激活 key。 */
+    closeOthers(key: string) {
+      const target = this.tabs.find((t) => t.key === key)
+      if (!target) {
+        return
+      }
+      this.tabs = this.tabs.filter((t) => t.key === key || !t.closable)
+      this.activeKey = key
+      router.push(target.fullPath)
+    },
+    /** 关闭 key 右侧的全部标签；若当前激活标签在被关闭之列，则激活态回落到 key。 */
+    closeToRight(key: string) {
+      const idx = this.tabs.findIndex((t) => t.key === key)
+      if (idx === -1) {
+        return
+      }
+      const removed = this.tabs.slice(idx + 1)
+      if (removed.length === 0) {
+        return
+      }
+      this.tabs = this.tabs.slice(0, idx + 1)
+      if (removed.some((t) => t.key === this.activeKey)) {
+        this.activeKey = key
+        router.push(this.tabs[idx].fullPath)
+      }
+    },
     reset() {
       this.tabs = [{ key: HOME_KEY, title: '首页', fullPath: HOME_KEY, closable: false }]
       this.activeKey = HOME_KEY

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -61,7 +61,7 @@ async function handleSubmit() {
     } else {
       localStorage.removeItem(rememberKey)
     }
-    auth.applyLoginResult(result)
+    auth.applyLoginResult(result, form.username)
     if (result.forceChangePassword) {
       ElMessage.warning('首次登录请先修改密码')
       await router.replace({ name: 'ChangePassword' })

--- a/customer-admin-web/src/views/system/UserManage.vue
+++ b/customer-admin-web/src/views/system/UserManage.vue
@@ -3,7 +3,10 @@ import { onMounted, reactive, ref } from 'vue'
 import { ElMessage, ElMessageBox, type FormInstance } from 'element-plus'
 import { createUser, deleteUser, pageUsers, updateUser } from '@/api/user'
 import { pageRoles } from '@/api/role'
+import { useAuthStore } from '@/store/auth'
 import type { PageQuery, RoleVO, UserSaveRequest, UserVO } from '@/types/api'
+
+const auth = useAuthStore()
 
 const loading = ref(false)
 const list = ref<UserVO[]>([])
@@ -65,8 +68,16 @@ async function handleSubmit() {
     await createUser(form)
     ElMessage.success('新建成功')
   } else if (editingId.value) {
-    await updateUser(editingId.value, form)
+    // 编辑时密码框留空表示"不改密码"：必须传 null 而不是空字符串——后端 password 字段有
+    // @Size(min=6) 校验，只对 null 跳过校验，空字符串会被当成"长度 0 的密码"直接拦截。
+    const payload: UserSaveRequest = { ...form, password: form.password?.trim() ? form.password : null }
+    await updateUser(editingId.value, payload)
     ElMessage.success('保存成功')
+    // 编辑的如果是当前登录用户自己，同步刷新右上角昵称缓存——否则要等重新登录才会更新，
+    // 页面上会一直显示登录时缓存的旧昵称，改了跟没改一样。
+    if (form.username === auth.username && form.nickname) {
+      auth.updateNickname(form.nickname)
+    }
   }
   dialogVisible.value = false
   await loadList()


### PR DESCRIPTION
- store/tabs.ts 新增 closeOthers/closeToRight 两个 action，不可关闭的固定标签 （首页）天然被跳过
- layouts/TabsBar.vue 用 contextmenu 事件委托定位被右键的标签（el-tab-pane 不是 真实渲染节点，靠 DOM 顺序反查），自绘右键菜单，禁用态标签置灰不可点

fix(system): 编辑用户留空密码报"长度需在6~32位"校验错误

编辑用户时密码框留空表示"不改密码"，但前端提交的是空字符串 ''，后端
UserSaveRequest.password 的 @Size(min=6,max=32) 只对 null 跳过校验、对空字符串 一样按长度 0 校验，直接被拦。提交前把空/纯空白密码转成 null，真改密码场景的
长度校验不受影响。

fix(system): 编辑自己的昵称后，右上角仍显示登录时缓存的旧值

右上角昵称来自登录时写入 localStorage 的 admin-nickname，用户管理里编辑昵称 只改了数据库，从没同步回这个缓存。补充 auth store 的 username 字段（登录表单
本就有，只是没存），编辑用户成功后若改的是当前登录用户自己，同步刷新昵称
缓存。注意：现有登录会话里没有这个新字段，需要重新登录一次才会生效。

## 变更说明 / What

简述本 PR 做了什么、解决什么问题（关联 Issue：Closes #）。

## 类型 / Type
- [ ] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [ ] `mvn test` 全绿（新增功能附了单元测试）
- [ ] 未在代码 / 配置中硬编码任何密钥
- [ ] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定
- [ ] 必要时更新了 README / 配置项说明
