### PR TITLE
feat(admin-server): AI 编码操作审计日志 + 需求文档 v2.0 重排

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/AiCodingOperation.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/AiCodingOperation.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customeradmin.workspace.audit;
+
+/**
+ * AI 编码操作类型（审计日志 {@code operation} 列取值，需求文档 §5.2/§5.3）。
+ *
+ * <p>只收录"AI 编码助手"域的操作：对话式编码、用户手工保存文件、Git 助手三件套。
+ * 后续新功能（回滚/Review 等）落地时在此追加，禁止在埋点处写裸字符串。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum AiCodingOperation {
+
+    /** VibeCoding 流式对话（Agent 读写 workspace，含模型多轮调用）。 */
+    CHAT_STREAM,
+
+    /** 用户在工作区文件查看器中手工保存文件。 */
+    FILE_SAVE,
+
+    /** Git 助手 · diff 摘要（只读，模型一次性调用）。 */
+    GIT_DIFF_SUMMARY,
+
+    /** Git 助手 · 生成 commit message（只读，模型一次性调用）。 */
+    COMMIT_MESSAGE,
+
+    /** Git 助手 · 生成 PR description（只读，模型一次性调用）。 */
+    PR_DESCRIPTION
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/controller/AiCodingAuditController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/controller/AiCodingAuditController.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customeradmin.workspace.audit.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.workspace.audit.dto.AiCodingAuditQuery;
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * AI 编码审计日志查询（只读——审计记录由各埋点写入，不提供增删改接口）。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/workspace/ai-coding-audit")
+public class AiCodingAuditController {
+
+    private final AiCodingAuditService auditService;
+
+    public AiCodingAuditController(AiCodingAuditService auditService) {
+        this.auditService = auditService;
+    }
+
+    @SaCheckPermission("ai-audit:view")
+    @GetMapping
+    public Result<PageResult<AiCodingAuditLog>> page(AiCodingAuditQuery query) {
+        return Result.success(auditService.page(query));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/dto/AiCodingAuditQuery.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/dto/AiCodingAuditQuery.java
@@ -1,0 +1,24 @@
+package com.richard.fyoung.customeradmin.workspace.audit.dto;
+
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * AI 编码审计日志查询条件：通用分页（keyword 匹配操作人、status 复用为结果过滤）之上，
+ * 追加 AI 编码域特有的三个精确过滤维度。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class AiCodingAuditQuery extends PageQuery {
+
+    /** 智能体编码（精确匹配）。 */
+    private String agentCode;
+
+    /** 会话ID（精确匹配，用于追溯单次会话的全部 AI 操作）。 */
+    private String sessionId;
+
+    /** 操作类型（{@code AiCodingOperation} 枚举名，精确匹配）。 */
+    private String operation;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/entity/AiCodingAuditLog.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/entity/AiCodingAuditLog.java
@@ -1,0 +1,62 @@
+package com.richard.fyoung.customeradmin.workspace.audit.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * AI 编码操作审计日志（需求文档 §5.2/§5.3：操作人、时间、变更文件、模型调用 token 数）。
+ *
+ * <p>与 {@code sys_operation_log}（系统通用操作账，面向全后台的增删改）职责不同：本表是
+ * AI 编码域的专项审计，独有"变更文件清单 / token 用量 / 会话维度"三类可查询字段，
+ * 支撑按会话追溯"这轮对话改了哪些文件、花了多少 token"。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_coding_audit_log")
+public class AiCodingAuditLog {
+
+    /** 结果：成功。 */
+    public static final int RESULT_SUCCESS = 1;
+    /** 结果：失败。 */
+    public static final int RESULT_FAILURE = 0;
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 操作人用户ID（未认证兜底场景可为空）。 */
+    private Long userId;
+    /** 操作人账号（冗余存储，用户改名/删除后历史记录仍可读）。 */
+    private String username;
+
+    private String agentCode;
+    private String sessionId;
+    /** 操作类型，取值见 {@link com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation}。 */
+    private String operation;
+
+    /** 本次操作产生变更的文件清单（JSON 数组），只读操作/无变更时为空。 */
+    private String changedFiles;
+
+    /** 模型输入 token 数；未发生模型调用或框架未返回用量时为空。 */
+    private Integer inputTokens;
+    private Integer outputTokens;
+    private Integer totalTokens;
+
+    /** 操作耗时（毫秒）。 */
+    private Long durationMs;
+
+    /** 结果：{@link #RESULT_SUCCESS} / {@link #RESULT_FAILURE}。 */
+    private Integer result;
+    /** 失败错误码（{@code ResultCode} 枚举名或流终止信号），成功时为空。 */
+    private String errorCode;
+
+    private LocalDateTime createTime;
+
+    /** 操作开始时间戳（毫秒），仅用于进程内计算耗时，不落库。 */
+    @TableField(exist = false)
+    private transient long startMillis;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/mapper/AiCodingAuditLogMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/mapper/AiCodingAuditLogMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.workspace.audit.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+
+/**
+ * AI 编码审计日志 Mapper（写入 + 分页查询，无自定义 SQL）。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiCodingAuditLogMapper extends BaseMapper<AiCodingAuditLog> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorder.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorder.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customeradmin.workspace.audit.service;
+
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 审计日志异步落库执行器。与 {@link AiCodingAuditService} 拆成两个类的原因：{@code @Async}
+ * 依赖 Spring 代理，同类内部 this 调用不会走代理导致注解静默失效，跨类调用才真正异步。
+ *
+ * <p>审计是旁路能力：落库失败只记 error 日志，绝不向业务主链路抛异常。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class AiCodingAuditRecorder {
+
+    private static final Logger log = LoggerFactory.getLogger(AiCodingAuditRecorder.class);
+
+    private final AiCodingAuditLogMapper auditLogMapper;
+
+    public AiCodingAuditRecorder(AiCodingAuditLogMapper auditLogMapper) {
+        this.auditLogMapper = auditLogMapper;
+    }
+
+    @Async
+    public void persist(AiCodingAuditLog entry) {
+        try {
+            if (entry.getCreateTime() == null) {
+                entry.setCreateTime(LocalDateTime.now());
+            }
+            auditLogMapper.insert(entry);
+        } catch (Exception e) {
+            log.error("persist ai coding audit log failed, code={}, operation={}, agentCode={}, sessionId={}",
+                "AI-CODING-AUDIT-PERSIST-FAIL", entry.getOperation(), entry.getAgentCode(), entry.getSessionId(), e);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditService.java
@@ -1,0 +1,150 @@
+package com.richard.fyoung.customeradmin.workspace.audit.service;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
+import com.richard.fyoung.customeradmin.workspace.audit.dto.AiCodingAuditQuery;
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import io.agentscope.core.model.ChatUsage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * AI 编码操作审计（需求文档 §5.2/§5.3）：构建审计条目、补全结果并异步落库、分页查询。
+ *
+ * <h3>埋点约定（调用方须知）</h3>
+ * <ul>
+ *   <li>{@link #begin} 必须在<b>请求线程的同步段</b>调用——操作人取自 Sa-Token 的 ThreadLocal
+ *       上下文，SSE 的 {@code doFinally} / {@code CompletableFuture} 回调线程里拿不到；</li>
+ *   <li>{@link #finish} 可在任意线程调用（耗时/结果补全 + 异步落库）；</li>
+ *   <li>业务动作必须自持控制流（try/catch 后调 finish），<b>不要</b>把业务 lambda 交给审计服务执行——
+ *       审计是旁路，它不可用/被替换时业务必须照常运转。</li>
+ * </ul>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class AiCodingAuditService {
+
+    private static final Logger log = LoggerFactory.getLogger(AiCodingAuditService.class);
+    /** 非业务异常统一归口的错误码（审计列宽 64，不存异常细节，细节看应用日志）。 */
+    private static final String ERROR_CODE_SYSTEM = "SYSTEM_ERROR";
+
+    private final AiCodingAuditRecorder recorder;
+    private final AiCodingAuditLogMapper auditLogMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AiCodingAuditService(AiCodingAuditRecorder recorder, AiCodingAuditLogMapper auditLogMapper) {
+        this.recorder = recorder;
+        this.auditLogMapper = auditLogMapper;
+    }
+
+    /**
+     * 开始一次审计：填充操作人（当前登录用户）、操作类型与计时起点。
+     * 未登录/无 Sa-Token 上下文（如单测）时操作人留空，不阻断业务。
+     */
+    public AiCodingAuditLog begin(AiCodingOperation operation, String agentCode, String sessionId) {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        entry.setOperation(operation.name());
+        entry.setAgentCode(agentCode);
+        entry.setSessionId(sessionId);
+        entry.setStartMillis(System.currentTimeMillis());
+        try {
+            if (StpUtil.isLogin()) {
+                entry.setUserId(StpUtil.getLoginIdAsLong());
+                entry.setUsername(StpUtil.getTokenSession().getString("username"));
+            }
+        } catch (Exception e) {
+            log.error("resolve audit operator failed, code={}, operation={}", "AI-CODING-AUDIT-OPERATOR-FAIL", operation, e);
+        }
+        return entry;
+    }
+
+    /** 结束一次审计（错误码形式）：补全耗时与结果并异步落库。{@code errorCode} 为空视为成功。 */
+    public void finish(AiCodingAuditLog entry, String errorCode) {
+        entry.setDurationMs(System.currentTimeMillis() - entry.getStartMillis());
+        entry.setResult(errorCode == null ? AiCodingAuditLog.RESULT_SUCCESS : AiCodingAuditLog.RESULT_FAILURE);
+        entry.setErrorCode(errorCode);
+        recorder.persist(entry);
+    }
+
+    /** 结束一次审计（异常形式）：{@code error} 为空视为成功，否则沿 cause 链解析错误码。 */
+    public void finish(AiCodingAuditLog entry, Throwable error) {
+        finish(entry, error == null ? null : errorCodeOf(error));
+    }
+
+    /** 把模型用量写入审计条目（{@code usage} 为空表示未发生模型调用/框架未返回，保持空值）。 */
+    public void applyUsage(AiCodingAuditLog entry, ChatUsage usage) {
+        if (usage == null) {
+            return;
+        }
+        entry.setInputTokens(usage.getInputTokens());
+        entry.setOutputTokens(usage.getOutputTokens());
+        entry.setTotalTokens(usage.getTotalTokens());
+    }
+
+    /** 把变更文件清单序列化进审计条目（空清单存空值，省存储且查询语义明确）。 */
+    public void applyChangedFiles(AiCodingAuditLog entry, List<String> changedFiles) {
+        if (CollectionUtils.isEmpty(changedFiles)) {
+            return;
+        }
+        try {
+            entry.setChangedFiles(objectMapper.writeValueAsString(changedFiles));
+        } catch (JsonProcessingException e) {
+            log.error("serialize audit changed files failed, code={}, operation={}",
+                "AI-CODING-AUDIT-FILES-JSON-FAIL", entry.getOperation(), e);
+        }
+    }
+
+    /** 分页查询：keyword 匹配操作人账号，status 复用为 result 过滤，其余为精确条件。 */
+    public PageResult<AiCodingAuditLog> page(AiCodingAuditQuery query) {
+        LambdaQueryWrapper<AiCodingAuditLog> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(query.getKeyword())) {
+            wrapper.like(AiCodingAuditLog::getUsername, query.getKeyword());
+        }
+        if (StringUtils.hasText(query.getAgentCode())) {
+            wrapper.eq(AiCodingAuditLog::getAgentCode, query.getAgentCode());
+        }
+        if (StringUtils.hasText(query.getSessionId())) {
+            wrapper.eq(AiCodingAuditLog::getSessionId, query.getSessionId());
+        }
+        if (StringUtils.hasText(query.getOperation())) {
+            wrapper.eq(AiCodingAuditLog::getOperation, query.getOperation());
+        }
+        if (query.getStatus() != null) {
+            wrapper.eq(AiCodingAuditLog::getResult, query.getStatus());
+        }
+        wrapper.orderBy(true, "asc".equalsIgnoreCase(query.getSortOrder()), AiCodingAuditLog::getCreateTime);
+
+        IPage<AiCodingAuditLog> page = auditLogMapper.selectPage(
+            new Page<>(query.getPageNum(), query.getPageSize()), wrapper);
+        return PageResult.of(page);
+    }
+
+    /**
+     * 从异常解析审计错误码：沿 cause 链找 {@link BizException} 取其 {@code ResultCode} 枚举名
+     * （{@code CompletableFuture}/{@code supplyAsync} 会包一层 {@code CompletionException}），
+     * 找不到业务异常统一归口 {@link #ERROR_CODE_SYSTEM}。
+     */
+    private String errorCodeOf(Throwable error) {
+        Throwable cause = error;
+        while (cause != null && !(cause instanceof BizException)) {
+            cause = cause.getCause();
+        }
+        if (cause instanceof BizException bizException) {
+            return bizException.getResultCode().name();
+        }
+        return ERROR_CODE_SYSTEM;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -17,6 +17,7 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatUsage;
 import io.agentscope.harness.agent.HarnessAgent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,8 +27,11 @@ import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -67,6 +71,19 @@ public class ChatService {
      * 任何 SSE 头下发之前就能拿到结构化错误响应，而不是半开的失败流）。
      */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText) {
+        return chatStream(agentCode, sessionId, userText, usage -> { });
+    }
+
+    /**
+     * 流式对话（带模型用量观察者）：流终止时（完成/错误/取消）把本轮全部模型调用的 token 用量
+     * 汇总后回调一次 {@code usageTotalObserver}——供 VibeCoding 审计记录 token 数（需求文档 §5.3）。
+     * 本轮无任何用量信息（框架/模型未返回 usage）时回调 {@code null}。
+     *
+     * <p>聚合方式：框架把 usage 挂在事件消息（{@link Msg#getUsage()}）上，同一条消息的增量事件
+     * 会重复携带（后到覆盖先到），不同消息各算一次——按 messageId 去重后求和，两种语义都兼容。</p>
+     */
+    public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
+                                             Consumer<ChatUsage> usageTotalObserver) {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
         RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
         ToolSourceInfo toolSource = agentInstanceFactory.toolSourceFor(agentCode);
@@ -100,7 +117,9 @@ public class ChatService {
         // 没机会接管。届时 Spring MVC 的 SSE 响应式适配器可能已经提交了响应头，连接就会挂起不报错
         // 也不关闭，前端永远卡在"生成中..."。defer 把方法调用推迟到订阅时执行，任何同步异常都会被
         // Reactor 自动转成 Flux.error(...)，从而能被 onErrorResume 正常捕获、优雅降级成兜底话术。
+        Map<String, ChatUsage> usageByMessage = new ConcurrentHashMap<>();
         Flux<ChatStreamChunk> body = Flux.defer(() -> streamEvents(agent, List.of(toUserMsg(userText)), options, ctx))
+            .doOnNext(event -> collectUsage(usageByMessage, event))
             .concatMap(event -> Flux.fromIterable(toChunks(event, toolSource, lastAnnouncedTool,
                 lastReasoningText, lastAnswerText, answerStreamed, modelCallAnnounced)));
 
@@ -112,7 +131,34 @@ public class ChatService {
                     new ChatStreamChunk(ChatNodeKind.THINKING_END, "结束思考"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, FALLBACK_REPLY));
             })
-            .doOnComplete(() -> historyCache.evict(agentCode, sessionId));
+            .doOnComplete(() -> historyCache.evict(agentCode, sessionId))
+            .doFinally(signal -> usageTotalObserver.accept(totalUsage(usageByMessage)));
+    }
+
+    /** 收集事件消息上的模型用量：同一 messageId 后到覆盖先到（增量事件重复携带累计值的场景）。 */
+    private void collectUsage(Map<String, ChatUsage> usageByMessage, Event event) {
+        Msg msg = event.getMessage();
+        if (msg != null && msg.getUsage() != null && msg.getId() != null) {
+            usageByMessage.put(msg.getId(), msg.getUsage());
+        }
+    }
+
+    /** 汇总本轮全部消息的用量；一条都没有时返回 null（区分"确实没有用量信息"与"用了 0 token"）。 */
+    private ChatUsage totalUsage(Map<String, ChatUsage> usageByMessage) {
+        if (usageByMessage.isEmpty()) {
+            return null;
+        }
+        int inputTokens = 0;
+        int outputTokens = 0;
+        int cachedTokens = 0;
+        double time = 0;
+        for (ChatUsage usage : usageByMessage.values()) {
+            inputTokens += usage.getInputTokens();
+            outputTokens += usage.getOutputTokens();
+            cachedTokens += usage.getCachedTokens();
+            time += usage.getTime();
+        }
+        return new ChatUsage(inputTokens, outputTokens, cachedTokens, time);
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -5,6 +5,9 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.CommitMessageResponse;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.GitDiffSummary;
@@ -13,6 +16,7 @@ import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import org.slf4j.Logger;
@@ -24,6 +28,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -60,18 +65,22 @@ public class GitAssistantService {
     private final AiAgentMapper agentMapper;
     private final AdminAgentInstanceFactory agentInstanceFactory;
     private final GitWorkspaceService gitWorkspaceService;
+    private final AiCodingAuditService auditService;
 
     public GitAssistantService(AiAgentMapper agentMapper, AdminAgentInstanceFactory agentInstanceFactory,
-                                GitWorkspaceService gitWorkspaceService) {
+                                GitWorkspaceService gitWorkspaceService, AiCodingAuditService auditService) {
         this.agentMapper = agentMapper;
         this.agentInstanceFactory = agentInstanceFactory;
         this.gitWorkspaceService = gitWorkspaceService;
+        this.auditService = auditService;
     }
 
     /** diff 摘要：无变更时直接返回空摘要，不额外调用模型。 */
     public CompletableFuture<GitDiffSummary> diffSummary(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
         Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        // 审计条目在请求线程同步段创建（操作人依赖 Sa-Token ThreadLocal），异步链路里只补结果
+        AiCodingAuditLog audit = auditService.begin(AiCodingOperation.GIT_DIFF_SUMMARY, agentCode, sessionId);
         return CompletableFuture.supplyAsync(() -> {
             String diff = gitWorkspaceService.diffAgainstBaseline(workspace);
             List<String> changedFiles = gitWorkspaceService.changedFilesAgainstBaseline(workspace);
@@ -79,18 +88,21 @@ public class GitAssistantService {
                 return new GitDiffSummary("本轮对话暂无文件变更", changedFiles);
             }
             Model model = agentInstanceFactory.buildModelForAgent(agentCode);
-            String summary = callModelOnce(model,
+            ModelCallOutcome outcome = callModelOnce(model,
                 "请用 1~3 句话总结以下 git diff 的变更内容，直接输出总结文字，不要输出多余的解释、前缀或代码块标记：\n\n"
                     + truncateDiff(diff));
-            return new GitDiffSummary(summary, changedFiles);
+            auditService.applyUsage(audit, outcome.usage());
+            return new GitDiffSummary(outcome.text(), changedFiles);
         }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .exceptionally(ex -> rethrow(ex, "GIT_DIFF_SUMMARY_FAIL", agentCode, sessionId));
+            .exceptionally(ex -> rethrow(ex, "GIT_DIFF_SUMMARY_FAIL", agentCode, sessionId))
+            .whenComplete((result, error) -> auditService.finish(audit, error));
     }
 
     /** 生成 commit message：无变更时直接报错，不调用模型（没有内容可总结）。 */
     public CompletableFuture<CommitMessageResponse> commitMessage(String agentCode, String sessionId, String style) {
         requireVibeCodingCapable(agentCode);
         Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        AiCodingAuditLog audit = auditService.begin(AiCodingOperation.COMMIT_MESSAGE, agentCode, sessionId);
         return CompletableFuture.supplyAsync(() -> {
             String diff = requireNonEmptyDiff(workspace);
             Model model = agentInstanceFactory.buildModelForAgent(agentCode);
@@ -100,15 +112,19 @@ public class GitAssistantService {
                     + "不要输出多余解释或代码块标记：\n\ndiff:\n" + truncateDiff(diff)
                 : "请根据以下 git diff 生成一条简洁的中文 commit message（一句话，不超过 50 字），"
                     + "直接输出文本，不要输出多余解释：\n\ndiff:\n" + truncateDiff(diff);
-            return new CommitMessageResponse(callModelOnce(model, prompt));
+            ModelCallOutcome outcome = callModelOnce(model, prompt);
+            auditService.applyUsage(audit, outcome.usage());
+            return new CommitMessageResponse(outcome.text());
         }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .exceptionally(ex -> rethrow(ex, "GIT_COMMIT_MESSAGE_FAIL", agentCode, sessionId));
+            .exceptionally(ex -> rethrow(ex, "GIT_COMMIT_MESSAGE_FAIL", agentCode, sessionId))
+            .whenComplete((result, error) -> auditService.finish(audit, error));
     }
 
     /** 生成 PR description：无变更时直接报错，不调用模型。 */
     public CompletableFuture<PrDescriptionResponse> prDescription(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
         Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        AiCodingAuditLog audit = auditService.begin(AiCodingOperation.PR_DESCRIPTION, agentCode, sessionId);
         return CompletableFuture.supplyAsync(() -> {
             String diff = requireNonEmptyDiff(workspace);
             List<String> changedFiles = gitWorkspaceService.changedFilesAgainstBaseline(workspace);
@@ -117,9 +133,12 @@ public class GitAssistantService {
                 + "## 变更摘要、## 改动文件清单、## 影响范围、## 自检清单。直接输出 Markdown 正文，"
                 + "不要输出多余解释或额外代码块包裹：\n\n变更文件：\n" + String.join("\n", changedFiles)
                 + "\n\ndiff:\n" + truncateDiff(diff);
-            return new PrDescriptionResponse(callModelOnce(model, prompt));
+            ModelCallOutcome outcome = callModelOnce(model, prompt);
+            auditService.applyUsage(audit, outcome.usage());
+            return new PrDescriptionResponse(outcome.text());
         }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .exceptionally(ex -> rethrow(ex, "GIT_PR_DESCRIPTION_FAIL", agentCode, sessionId));
+            .exceptionally(ex -> rethrow(ex, "GIT_PR_DESCRIPTION_FAIL", agentCode, sessionId))
+            .whenComplete((result, error) -> auditService.finish(audit, error));
     }
 
     // ---------------------- private helpers ----------------------
@@ -140,8 +159,12 @@ public class GitAssistantService {
             + MAX_DIFF_CHARS_FOR_MODEL + " 个字符]";
     }
 
-    /** 一次性模型调用：单条 user 消息，不带工具，取全部返回内容块中的文本拼接结果。 */
-    private String callModelOnce(Model model, String prompt) {
+    /** 一次性模型调用的结果：拼接文本 + token 用量（流式响应中最后一个非空 usage，可能为空）。 */
+    private record ModelCallOutcome(String text, ChatUsage usage) {
+    }
+
+    /** 一次性模型调用：单条 user 消息，不带工具，取全部返回内容块中的文本拼接结果与 token 用量。 */
+    private ModelCallOutcome callModelOnce(Model model, String prompt) {
         Msg userMsg = Msg.builder()
             .role(MsgRole.USER)
             .name("user")
@@ -163,7 +186,13 @@ public class GitAssistantService {
         if (!StringUtils.hasText(text)) {
             throw new BizException(ResultCode.GIT_ASSISTANT_AI_FAILED, "模型返回内容为空");
         }
-        return text.trim();
+        // 流式分片中 usage 通常只在最后一个分片携带（或逐片累计），取最后一个非空即最终值
+        ChatUsage usage = responses.stream()
+            .map(ChatResponse::getUsage)
+            .filter(Objects::nonNull)
+            .reduce((first, second) -> second)
+            .orElse(null);
+        return new ModelCallOutcome(text.trim(), usage);
     }
 
     private void requireVibeCodingCapable(String agentCode) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
@@ -8,6 +8,9 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminSandboxProperties;
+import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
@@ -15,11 +18,13 @@ import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFact
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.FileChangeEvent;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.WorkspaceFileContent;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.WorkspaceFileNode;
+import io.agentscope.core.model.ChatUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SignalType;
 
 import java.io.IOException;
 import java.nio.charset.MalformedInputException;
@@ -97,6 +102,7 @@ public class VibeCodingService {
     private final AiAgentMapper agentMapper;
     private final GitWorkspaceService gitWorkspaceService;
     private final AdminSandboxProperties sandboxProperties;
+    private final AiCodingAuditService auditService;
 
     /** {@code agentCode:sessionId -> 对话开始前的目录快照}，进程内、重启丢失（v1 降级方案的一部分）。 */
     private final Map<String, Map<String, FileFingerprint>> beforeSnapshots = new ConcurrentHashMap<>();
@@ -104,12 +110,13 @@ public class VibeCodingService {
 
     public VibeCodingService(ChatService chatService, AdminAgentInstanceFactory agentInstanceFactory,
                               AiAgentMapper agentMapper, GitWorkspaceService gitWorkspaceService,
-                              AdminSandboxProperties sandboxProperties) {
+                              AdminSandboxProperties sandboxProperties, AiCodingAuditService auditService) {
         this.chatService = chatService;
         this.agentInstanceFactory = agentInstanceFactory;
         this.agentMapper = agentMapper;
         this.gitWorkspaceService = gitWorkspaceService;
         this.sandboxProperties = sandboxProperties;
+        this.auditService = auditService;
     }
 
     /** 当前 VibeCoding 沙箱模式（{@code admin.sandbox.mode} 全局配置，不随会话变化）："docker"｜"local"。 */
@@ -159,8 +166,13 @@ public class VibeCodingService {
         String modeTag = sandboxMode();
         String enrichedText = String.format(FILE_DIRECTIVE_TEMPLATE, modeTag, safeSession, safeSession, safeSession, userText);
 
+        // 审计条目必须在请求线程的同步段创建（操作人取自 Sa-Token 的 ThreadLocal），
+        // doFinally 跑在 reactor 线程，届时已拿不到登录上下文。
+        AiCodingAuditLog audit = auditService.begin(AiCodingOperation.CHAT_STREAM, agentCode, safeSession);
+        AtomicReference<ChatUsage> usageTotal = new AtomicReference<>();
+
         AtomicReference<Map<String, FileFingerprint>> lastSnapshot = new AtomicReference<>(initialSnapshot);
-        Flux<ChatStreamChunk> chatFlux = chatService.chatStream(agentCode, sessionId, enrichedText)
+        Flux<ChatStreamChunk> chatFlux = chatService.chatStream(agentCode, sessionId, enrichedText, usageTotal::set)
             .concatMap(chunk -> chunk.kind() == ChatNodeKind.TOOL_RESULT
                 ? Flux.concat(Flux.just(chunk), Flux.fromIterable(detectFileChanges(sessionWorkspace, lastSnapshot)))
                 : Flux.just(chunk));
@@ -169,7 +181,14 @@ public class VibeCodingService {
         return chatFlux.concatWith(Flux.defer(() -> {
             syncDockerArtifactsIfNeeded(agentCode, safeSession, sessionWorkspace);
             return Flux.fromIterable(detectFileChanges(sessionWorkspace, lastSnapshot));
-        }));
+        })).doFinally(signal -> {
+            // 审计（需求 §5.2/§5.3）：变更文件 = 本轮初始快照 vs 最终快照（含删除），token 为本轮
+            // 全部模型调用的汇总；ChatService 内部已把流错误兜底成正常完成，这里的非 COMPLETE
+            // 信号主要是用户取消/连接断开，如实记录。
+            auditService.applyUsage(audit, usageTotal.get());
+            auditService.applyChangedFiles(audit, changedPaths(initialSnapshot, snapshot(sessionWorkspace)));
+            auditService.finish(audit, signal == SignalType.ON_COMPLETE ? null : "VIBECODING_STREAM_" + signal.name());
+        });
     }
 
     /**
@@ -266,22 +285,32 @@ public class VibeCodingService {
      */
     public void saveFileContent(String agentCode, String sessionId, String relativePath, String content) {
         requireVibeCodingCapable(agentCode);
-        Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
-        // 路径穿越防御
-        Path filePath = sessionWorkspace.resolve(relativePath).normalize();
-        if (!filePath.startsWith(sessionWorkspace.normalize())) {
-            throw new BizException(ResultCode.PARAM_INVALID, "非法文件路径：不允许写入 workspace 目录以外的文件");
-        }
-        if (Files.isDirectory(filePath)) {
-            throw new BizException(ResultCode.PARAM_INVALID, "指定路径是目录，无法写入: " + relativePath);
-        }
+        // 审计（需求 §5.2/§5.3）覆盖路径校验 + 写入全程：路径穿越等非法尝试同样留痕（result=0 +
+        // 错误码）。业务动作自持控制流，审计只在旁路记录——审计服务不可用/被替换都不影响保存本身。
+        AiCodingAuditLog audit = auditService.begin(AiCodingOperation.FILE_SAVE, agentCode, sessionId);
+        auditService.applyChangedFiles(audit, List.of(relativePath));
         try {
-            Files.createDirectories(filePath.getParent());
-            Files.writeString(filePath, content, StandardCharsets.UTF_8);
-            log.info("[workspace] file saved by user, agentCode={}, sessionId={}, path={}", agentCode, sessionId, relativePath);
-        } catch (IOException e) {
-            log.error("[workspace] save file content failed, agentCode={}, sessionId={}, path={}", agentCode, sessionId, relativePath, e);
-            throw new BizException(ResultCode.SYSTEM_ERROR, "文件保存失败: " + relativePath);
+            Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+            // 路径穿越防御
+            Path filePath = sessionWorkspace.resolve(relativePath).normalize();
+            if (!filePath.startsWith(sessionWorkspace.normalize())) {
+                throw new BizException(ResultCode.PARAM_INVALID, "非法文件路径：不允许写入 workspace 目录以外的文件");
+            }
+            if (Files.isDirectory(filePath)) {
+                throw new BizException(ResultCode.PARAM_INVALID, "指定路径是目录，无法写入: " + relativePath);
+            }
+            try {
+                Files.createDirectories(filePath.getParent());
+                Files.writeString(filePath, content, StandardCharsets.UTF_8);
+                log.info("[workspace] file saved by user, agentCode={}, sessionId={}, path={}", agentCode, sessionId, relativePath);
+            } catch (IOException e) {
+                log.error("[workspace] save file content failed, agentCode={}, sessionId={}, path={}", agentCode, sessionId, relativePath, e);
+                throw new BizException(ResultCode.SYSTEM_ERROR, "文件保存失败: " + relativePath);
+            }
+            auditService.finish(audit, (String) null);
+        } catch (RuntimeException e) {
+            auditService.finish(audit, e);
+            throw e;
         }
     }
 
@@ -426,6 +455,26 @@ public class VibeCodingService {
         }
         lastSnapshotRef.set(after);
         return chunks;
+    }
+
+    /**
+     * 两份快照间的全部变更文件路径（新增/修改/删除都算，与 file_change 事件口径一致），供审计
+     * 记录本轮对话的变更清单。与 {@link #listChangedArtifacts} 的差别：那边是"产物清单"语义
+     * （只含存在的文件，不含删除），两者语义不同不强行合并。
+     */
+    private List<String> changedPaths(Map<String, FileFingerprint> before, Map<String, FileFingerprint> after) {
+        List<String> changed = new ArrayList<>();
+        for (Map.Entry<String, FileFingerprint> entry : after.entrySet()) {
+            if (!entry.getValue().equals(before.get(entry.getKey()))) {
+                changed.add(entry.getKey());
+            }
+        }
+        for (String path : before.keySet()) {
+            if (!after.containsKey(path)) {
+                changed.add(path);
+            }
+        }
+        return changed;
     }
 
     private ChatStreamChunk fileChangeChunk(String operation, String path, String description) {

--- a/customer-admin-server/src/main/resources/db/migration/V13__ai_coding_audit.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V13__ai_coding_audit.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- AI 编码操作审计日志（Flyway V13，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 落地《AI编码助手需求文档》§5.2/§5.3：所有 AI 编码操作记录审计日志（操作人、时间、
+-- 变更文件、模型调用 token 数）。与 sys_operation_log（系统通用操作账）职责不同：
+-- 本表是 AI 编码域专项审计，独有变更文件清单 / token 用量 / 会话维度三类可查询字段。
+-- 菜单挂"系统管理"（id=1）下，只读页面仅建 view 权限点（参照操作日志 log:view 先例）；
+-- 超级管理员不需要 sys_role_permission 记录（AdminStpInterfaceImpl 对超管返回全部权限）。
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_coding_audit_log` (
+    `id`            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `user_id`       BIGINT COMMENT '操作人用户ID',
+    `username`      VARCHAR(64) COMMENT '操作人账号（冗余存储，用户改名/删除后历史仍可读）',
+    `agent_code`    VARCHAR(64) NOT NULL COMMENT '智能体编码',
+    `session_id`    VARCHAR(128) COMMENT '会话ID',
+    `operation`     VARCHAR(32) NOT NULL COMMENT '操作类型：CHAT_STREAM/FILE_SAVE/GIT_DIFF_SUMMARY/COMMIT_MESSAGE/PR_DESCRIPTION',
+    `changed_files` TEXT COMMENT '本次操作产生变更的文件清单（JSON数组），只读操作/无变更为空',
+    `input_tokens`  INT COMMENT '模型输入token数（未发生模型调用或框架未返回用量时为空）',
+    `output_tokens` INT COMMENT '模型输出token数',
+    `total_tokens`  INT COMMENT '模型总token数',
+    `duration_ms`   BIGINT COMMENT '操作耗时（毫秒）',
+    `result`        TINYINT NOT NULL COMMENT '结果：1成功 / 0失败',
+    `error_code`    VARCHAR(64) COMMENT '失败错误码（ResultCode枚举名或流终止信号），成功为空',
+    `create_time`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '操作时间',
+    INDEX `idx_ai_coding_audit_agent_session` (`agent_code`, `session_id`),
+    INDEX `idx_ai_coding_audit_user` (`user_id`),
+    INDEX `idx_ai_coding_audit_time` (`create_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI编码操作审计日志';
+
+-- 菜单：AI编码审计（挂系统管理下。id 跳跃分配到 100：V12 的按钮权限自增已把 id 用到 70，
+-- 60~70 全被占用，跳到 100 给后续迁移留出安全空间）
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (100, 1, 'AI编码审计', 'ai-audit', 1, '/system/ai-audit', 'DataAnalysis', 'library', 5);
+
+-- 按钮/接口权限点：只读页面仅 view（参照操作日志 log:view 先例，不建 add/edit/delete）
+INSERT INTO `sys_permission` (`parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (100, '查看AI编码审计', 'ai-audit:view', 2, 1);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorderTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorderTest.java
@@ -1,0 +1,48 @@
+package com.richard.fyoung.customeradmin.workspace.audit.service;
+
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AiCodingAuditRecorder} 单测：落库委托、createTime 兜底补全、
+ * 落库失败只记日志不向业务主链路抛异常（审计是旁路能力）。
+ * @author owlzhangfq@gmail.com
+ */
+class AiCodingAuditRecorderTest {
+
+    private AiCodingAuditLogMapper mapper;
+    private AiCodingAuditRecorder recorder;
+
+    @BeforeEach
+    void setUp() {
+        mapper = mock(AiCodingAuditLogMapper.class);
+        recorder = new AiCodingAuditRecorder(mapper);
+    }
+
+    @Test
+    void persist_shouldInsert_andBackfillCreateTime() {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        recorder.persist(entry);
+
+        ArgumentCaptor<AiCodingAuditLog> captor = ArgumentCaptor.forClass(AiCodingAuditLog.class);
+        verify(mapper).insert(captor.capture());
+        assertNotNull(captor.getValue().getCreateTime());
+    }
+
+    @Test
+    void persist_shouldSwallowPersistenceFailure() {
+        when(mapper.insert(any(AiCodingAuditLog.class))).thenThrow(new RuntimeException("db down"));
+
+        assertDoesNotThrow(() -> recorder.persist(new AiCodingAuditLog()));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditServiceTest.java
@@ -1,0 +1,162 @@
+package com.richard.fyoung.customeradmin.workspace.audit.service;
+
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
+import com.richard.fyoung.customeradmin.workspace.audit.dto.AiCodingAuditQuery;
+import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
+import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import io.agentscope.core.model.ChatUsage;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AiCodingAuditService} 单测：审计条目构建（无登录上下文防御）、结果补全与错误码解析
+ * （CompletionException 链 unwrap）、同步包装的异常透传、用量/变更文件写入、分页查询。
+ * @author owlzhangfq@gmail.com
+ */
+class AiCodingAuditServiceTest {
+
+    private AiCodingAuditRecorder recorder;
+    private AiCodingAuditLogMapper mapper;
+    private AiCodingAuditService service;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiCodingAuditLog.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        recorder = mock(AiCodingAuditRecorder.class);
+        mapper = mock(AiCodingAuditLogMapper.class);
+        service = new AiCodingAuditService(recorder, mapper);
+    }
+
+    // ===== begin：条目构建 =====
+
+    @Test
+    void begin_shouldFillOperationAndTimer_andLeaveOperatorEmptyWithoutLoginContext() {
+        // 单测没有 Sa-Token 上下文——操作人解析必须防御性兜底（留空），不能让审计炸掉业务
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.CHAT_STREAM, "coder", "s1");
+
+        assertEquals("CHAT_STREAM", entry.getOperation());
+        assertEquals("coder", entry.getAgentCode());
+        assertEquals("s1", entry.getSessionId());
+        assertTrue(entry.getStartMillis() > 0);
+        assertNull(entry.getUserId());
+        assertNull(entry.getUsername());
+    }
+
+    // ===== finish：结果补全与落库 =====
+
+    @Test
+    void finish_shouldMarkSuccess_whenErrorCodeIsNull() {
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.FILE_SAVE, "coder", "s1");
+        service.finish(entry, (String) null);
+
+        ArgumentCaptor<AiCodingAuditLog> captor = ArgumentCaptor.forClass(AiCodingAuditLog.class);
+        verify(recorder).persist(captor.capture());
+        assertEquals(AiCodingAuditLog.RESULT_SUCCESS, captor.getValue().getResult());
+        assertNull(captor.getValue().getErrorCode());
+        assertTrue(captor.getValue().getDurationMs() >= 0);
+    }
+
+    @Test
+    void finish_shouldMarkFailureWithErrorCode() {
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.CHAT_STREAM, "coder", "s1");
+        service.finish(entry, "VIBECODING_STREAM_CANCEL");
+
+        ArgumentCaptor<AiCodingAuditLog> captor = ArgumentCaptor.forClass(AiCodingAuditLog.class);
+        verify(recorder).persist(captor.capture());
+        assertEquals(AiCodingAuditLog.RESULT_FAILURE, captor.getValue().getResult());
+        assertEquals("VIBECODING_STREAM_CANCEL", captor.getValue().getErrorCode());
+    }
+
+    @Test
+    void finish_shouldUnwrapCompletionException_andUseBizResultCodeName() {
+        // CompletableFuture 链路（Git 助手）抛出的业务异常被 CompletionException 包装，
+        // 错误码必须沿 cause 链取到真实的 ResultCode 枚举名
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.COMMIT_MESSAGE, "coder", "s1");
+        service.finish(entry, new CompletionException(new BizException(ResultCode.NO_FILE_CHANGES)));
+
+        ArgumentCaptor<AiCodingAuditLog> captor = ArgumentCaptor.forClass(AiCodingAuditLog.class);
+        verify(recorder).persist(captor.capture());
+        assertEquals("NO_FILE_CHANGES", captor.getValue().getErrorCode());
+    }
+
+    @Test
+    void finish_shouldFallBackToSystemError_forNonBizException() {
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.GIT_DIFF_SUMMARY, "coder", "s1");
+        service.finish(entry, new RuntimeException("unexpected"));
+
+        ArgumentCaptor<AiCodingAuditLog> captor = ArgumentCaptor.forClass(AiCodingAuditLog.class);
+        verify(recorder).persist(captor.capture());
+        assertEquals("SYSTEM_ERROR", captor.getValue().getErrorCode());
+    }
+
+    // ===== 用量与变更文件写入 =====
+
+    @Test
+    void applyUsage_shouldFillTokenColumns_andKeepNullWhenUsageAbsent() {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        service.applyUsage(entry, null);
+        assertNull(entry.getTotalTokens());
+
+        service.applyUsage(entry, new ChatUsage(100, 50, 0.5));
+        assertEquals(100, entry.getInputTokens());
+        assertEquals(50, entry.getOutputTokens());
+        assertEquals(150, entry.getTotalTokens());
+    }
+
+    @Test
+    void applyChangedFiles_shouldSerializeToJson_andSkipEmptyList() {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        service.applyChangedFiles(entry, List.of());
+        assertNull(entry.getChangedFiles());
+
+        service.applyChangedFiles(entry, List.of("src/main/java/Foo.java", "pom.xml"));
+        assertEquals("[\"src/main/java/Foo.java\",\"pom.xml\"]", entry.getChangedFiles());
+    }
+
+    // ===== 分页查询 =====
+
+    @Test
+    void page_shouldQueryWithFilters_andConvertToPageResult() {
+        when(mapper.selectPage(any(), any())).thenAnswer(inv -> {
+            Page<AiCodingAuditLog> page = inv.getArgument(0);
+            page.setTotal(1);
+            page.setRecords(List.of(new AiCodingAuditLog()));
+            return page;
+        });
+
+        AiCodingAuditQuery query = new AiCodingAuditQuery();
+        query.setKeyword("admin");
+        query.setAgentCode("coder");
+        query.setSessionId("s1");
+        query.setOperation("CHAT_STREAM");
+        query.setStatus(1);
+        PageResult<AiCodingAuditLog> result = service.page(query);
+
+        assertEquals(1, result.getTotal());
+        assertEquals(1, result.getList().size());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
@@ -16,6 +16,7 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatUsage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -23,8 +24,10 @@ import reactor.core.publisher.Flux;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -311,5 +314,43 @@ class ChatServiceTest {
         List<ChatStreamChunk> chunks = stream("写一个 Fibonacci.java");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.THINKING_END, ChatNodeKind.ANSWER);
+    }
+
+    // ===== 模型用量聚合（审计需求 §5.3：token 数）=====
+
+    @Test
+    void chatStream_shouldAggregateUsageAcrossMessages_andDedupeByMessageId() {
+        // 同一 messageId 的增量事件重复携带 usage（后到为累计值，应覆盖而非累加），
+        // 不同 messageId 各算一次——总量 = msg-1 最终值(10+20) + msg-2(5+7)
+        Msg first = Msg.builder().id("msg-1").role(MsgRole.ASSISTANT).textContent("part")
+            .usage(new ChatUsage(3, 4, 0.1)).build();
+        Msg firstFinal = Msg.builder().id("msg-1").role(MsgRole.ASSISTANT).textContent("part2")
+            .usage(new ChatUsage(10, 20, 0.2)).build();
+        Msg second = Msg.builder().id("msg-2").role(MsgRole.ASSISTANT).textContent("done")
+            .usage(new ChatUsage(5, 7, 0.1)).build();
+        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(
+                new Event(EventType.REASONING, first, false),
+                new Event(EventType.REASONING, firstFinal, false),
+                new Event(EventType.AGENT_RESULT, second, true)));
+
+        AtomicReference<ChatUsage> observed = new AtomicReference<>();
+        chatService.chatStream("coder", "s1", "你好", observed::set).collectList().block();
+
+        assertEquals(15, observed.get().getInputTokens());
+        assertEquals(27, observed.get().getOutputTokens());
+        assertEquals(42, observed.get().getTotalTokens());
+    }
+
+    @Test
+    void chatStream_shouldObserveNullUsage_whenNoMessageCarriesUsage() {
+        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
+        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+
+        AtomicReference<ChatUsage> observed = new AtomicReference<>(new ChatUsage(1, 1, 0));
+        chatService.chatStream("coder", "s1", "你好", observed::set).collectList().block();
+
+        assertNull(observed.get(), "无任何用量信息时应回调 null，区分“没有用量”与“用了 0 token”");
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
@@ -5,6 +5,7 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.CommitMessageResponse;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.GitDiffSummary;
@@ -60,7 +61,9 @@ class GitAssistantServiceTest {
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
         gitWorkspaceService = mock(GitWorkspaceService.class);
         model = mock(Model.class);
-        service = new GitAssistantService(agentMapper, agentInstanceFactory, gitWorkspaceService);
+        // 审计服务用 mock（旁路能力，埋点行为由 AiCodingAuditServiceTest 单独覆盖）
+        service = new GitAssistantService(agentMapper, agentInstanceFactory, gitWorkspaceService,
+            mock(AiCodingAuditService.class));
 
         when(agentInstanceFactory.resolveSessionWorkspace(anyString(), anyString())).thenReturn(sessionWorkspace);
         when(agentInstanceFactory.buildModelForAgent(anyString())).thenReturn(model);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
@@ -7,6 +7,7 @@ import com.richard.fyoung.customeradmin.config.AdminSandboxProperties;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk;
+import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.WorkspaceFileContent;
@@ -60,9 +61,10 @@ class VibeCodingServiceTest {
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
         agentMapper = mock(AiAgentMapper.class);
         gitWorkspaceService = mock(GitWorkspaceService.class);
-        // 默认 local 模式（isDockerMode()=false），docker 产物同步逻辑在单测里天然跳过
+        // 默认 local 模式（isDockerMode()=false），docker 产物同步逻辑在单测里天然跳过；
+        // 审计服务用 mock（旁路能力，埋点行为由 AiCodingAuditServiceTest 单独覆盖）
         service = new VibeCodingService(chatService, agentInstanceFactory, agentMapper, gitWorkspaceService,
-            new AdminSandboxProperties());
+            new AdminSandboxProperties(), mock(AiCodingAuditService.class));
 
         // resolveWorkspace 返回 agentRoot（向后兼容，listChangedArtifacts 旧逻辑已不使用此方法）
         when(agentInstanceFactory.resolveWorkspace("coder")).thenReturn(agentRoot);
@@ -104,7 +106,7 @@ class VibeCodingServiceTest {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         // stream 会在用户消息头部注入路径指引，所以 chatService 收到的消息不是原始 "write 文件"
         // 而是含指引的 enrichedText，这里用 anyString() 匹配即可。
-        when(chatService.chatStream(anyString(), anyString(), anyString()))
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any()))
             .thenReturn(Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "好的")));
 
         List<ChatStreamChunk> emitted = service.stream("coder", "s1", "write 文件").collectList().block();
@@ -117,7 +119,7 @@ class VibeCodingServiceTest {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         // 捕获实际传给 chatService 的消息内容
         java.util.concurrent.atomic.AtomicReference<String> capturedText = new java.util.concurrent.atomic.AtomicReference<>();
-        when(chatService.chatStream(anyString(), anyString(), anyString())).thenAnswer(inv -> {
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenAnswer(inv -> {
             capturedText.set(inv.getArgument(2));
             return Flux.empty();
         });
@@ -135,7 +137,7 @@ class VibeCodingServiceTest {
     @Test
     void listChangedArtifacts_shouldDetectNewAndModifiedFiles_butNotUntouchedFiles() throws IOException {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(chatService.chatStream(anyString(), anyString(), anyString())).thenReturn(Flux.empty());
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenReturn(Flux.empty());
 
         // stream 开始前写两个文件（已存在于快照）
         Path sessionWs = agentRoot.resolve("sessions/s1");
@@ -159,7 +161,7 @@ class VibeCodingServiceTest {
     @Test
     void listChangedArtifacts_differentSessions_shouldBeIsolated() throws IOException {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(chatService.chatStream(anyString(), anyString(), anyString())).thenReturn(Flux.empty());
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenReturn(Flux.empty());
 
         // 会话 s1 产出文件
         service.stream("coder", "s1", "任务A").blockLast();
@@ -377,7 +379,7 @@ class VibeCodingServiceTest {
                 Mono.fromRunnable(() -> writeQuietly(sessionWs, "output.txt", "hello"))
                     .thenReturn(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok")),
                 Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
-            when(chatService.chatStream(anyString(), anyString(), anyString())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-1", "写个文件").collectList().block();
 
@@ -397,7 +399,7 @@ class VibeCodingServiceTest {
             // 没有任何 TOOL_RESULT 节点，文件是在流结束前"悄悄"写入的（异步落盘边界场景）
             Flux<ChatStreamChunk> simulated = Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成"))
                 .doOnComplete(() -> writeQuietly(sessionWs, "late-file.txt", "late"));
-            when(chatService.chatStream(anyString(), anyString(), anyString())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-2", "写个文件").collectList().block();
 
@@ -409,7 +411,7 @@ class VibeCodingServiceTest {
         @Test
         void shouldNotEmitFileChangeEvent_whenNoFileWritten() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-            when(chatService.chatStream(anyString(), anyString(), anyString())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「read_file」返回：内容"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
 
@@ -430,7 +432,7 @@ class VibeCodingServiceTest {
                 Mono.fromRunnable(() -> writeQuietly(sessionWs, ".git/hooks/pre-commit.sample", "#!/bin/sh"))
                     .thenReturn(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok")),
                 Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
-            when(chatService.chatStream(anyString(), anyString(), anyString())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-4", "写个文件").collectList().block();
 

--- a/customer-admin-web/src/api/aiCodingAudit.ts
+++ b/customer-admin-web/src/api/aiCodingAudit.ts
@@ -1,0 +1,7 @@
+import { request } from './request'
+import type { AiCodingAuditLog, AiCodingAuditQuery, PageResult } from '@/types/api'
+
+/** AI 编码审计日志分页查询（后端 /api/workspace/ai-coding-audit，只读）。 */
+export function pageAiCodingAudit(query: AiCodingAuditQuery) {
+  return request<PageResult<AiCodingAuditLog>>({ url: '/workspace/ai-coding-audit', method: 'get', params: query })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -9,6 +9,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/user': () => import('@/views/system/UserManage.vue'),
   '/system/role': () => import('@/views/system/RoleManage.vue'),
   '/system/log': () => import('@/views/system/OperationLog.vue'),
+  '/system/ai-audit': () => import('@/views/system/AiCodingAudit.vue'),
   '/system/menu': () => import('@/views/system/MenuManage.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -161,6 +161,32 @@ export interface SysOperationLog {
   createTime: string
 }
 
+// ---------- workspace.ai-coding-audit ----------
+/** AI 编码操作审计日志（操作人、时间、变更文件、token 用量，需求 §5.2/§5.3）。 */
+export interface AiCodingAuditLog {
+  id: number
+  userId: number | null
+  username: string | null
+  agentCode: string
+  sessionId: string | null
+  operation: 'CHAT_STREAM' | 'FILE_SAVE' | 'GIT_DIFF_SUMMARY' | 'COMMIT_MESSAGE' | 'PR_DESCRIPTION'
+  changedFiles: string | null
+  inputTokens: number | null
+  outputTokens: number | null
+  totalTokens: number | null
+  durationMs: number | null
+  result: number
+  errorCode: string | null
+  createTime: string
+}
+
+/** AI 编码审计查询条件：通用分页之上追加三个精确过滤维度。 */
+export interface AiCodingAuditQuery extends PageQuery {
+  agentCode?: string
+  sessionId?: string
+  operation?: string
+}
+
 // ---------- aiconfig.model ----------
 export interface ModelVO {
   id: number

--- a/customer-admin-web/src/views/system/AiCodingAudit.vue
+++ b/customer-admin-web/src/views/system/AiCodingAudit.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { pageAiCodingAudit } from '@/api/aiCodingAudit'
+import type { AiCodingAuditLog, AiCodingAuditQuery } from '@/types/api'
+
+/** 操作类型 -> 中文展示与标签色（与后端 AiCodingOperation 枚举一一对应）。 */
+const OPERATION_META: Record<string, { label: string; tag: 'primary' | 'success' | 'info' | 'warning' }> = {
+  CHAT_STREAM: { label: '对话编码', tag: 'primary' },
+  FILE_SAVE: { label: '保存文件', tag: 'success' },
+  GIT_DIFF_SUMMARY: { label: 'Diff 摘要', tag: 'info' },
+  COMMIT_MESSAGE: { label: 'Commit Message', tag: 'info' },
+  PR_DESCRIPTION: { label: 'PR 描述', tag: 'info' },
+}
+
+const loading = ref(false)
+const list = ref<AiCodingAuditLog[]>([])
+const total = ref(0)
+const query = reactive<AiCodingAuditQuery>({ pageNum: 1, pageSize: 10, keyword: '', operation: '', sessionId: '' })
+
+async function loadList() {
+  loading.value = true
+  try {
+    const result = await pageAiCodingAudit(query)
+    list.value = result.list
+    total.value = result.total
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleSearch() {
+  query.pageNum = 1
+  loadList()
+}
+
+/** changed_files 列是 JSON 数组字符串，解析失败时原样返回单元素兜底展示。 */
+function parseChangedFiles(raw: string | null): string[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : [raw]
+  } catch {
+    return [raw]
+  }
+}
+
+function operationLabel(op: string) {
+  return OPERATION_META[op]?.label ?? op
+}
+
+function operationTag(op: string) {
+  return OPERATION_META[op]?.tag ?? 'info'
+}
+
+onMounted(loadList)
+</script>
+
+<template>
+  <div class="page">
+    <el-card>
+      <div class="toolbar">
+        <el-input v-model="query.keyword" placeholder="按操作人搜索" style="width: 180px" clearable @keyup.enter="handleSearch" />
+        <el-select v-model="query.operation" placeholder="操作类型" style="width: 170px" clearable>
+          <el-option v-for="(meta, op) in OPERATION_META" :key="op" :label="meta.label" :value="op" />
+        </el-select>
+        <el-input v-model="query.sessionId" placeholder="会话ID" style="width: 200px" clearable @keyup.enter="handleSearch" />
+        <el-button type="primary" @click="handleSearch">搜索</el-button>
+      </div>
+
+      <el-table v-loading="loading" :data="list" style="width: 100%">
+        <el-table-column prop="createTime" label="时间" width="170" />
+        <el-table-column prop="username" label="操作人" width="100" />
+        <el-table-column label="操作类型" width="140">
+          <template #default="{ row }">
+            <el-tag :type="operationTag(row.operation)">{{ operationLabel(row.operation) }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="agentCode" label="智能体" width="110" />
+        <el-table-column prop="sessionId" label="会话ID" width="150" show-overflow-tooltip />
+        <el-table-column label="变更文件" min-width="160">
+          <template #default="{ row }">
+            <el-tooltip v-if="parseChangedFiles(row.changedFiles).length" placement="top">
+              <template #content>
+                <div v-for="file in parseChangedFiles(row.changedFiles)" :key="file">{{ file }}</div>
+              </template>
+              <span class="changed-files">{{ parseChangedFiles(row.changedFiles).length }} 个文件</span>
+            </el-tooltip>
+            <span v-else class="muted">—</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="Token" width="110" align="right">
+          <template #default="{ row }">
+            <el-tooltip v-if="row.totalTokens != null" placement="top"
+              :content="`输入 ${row.inputTokens ?? '-'} / 输出 ${row.outputTokens ?? '-'}`">
+              <span>{{ row.totalTokens }}</span>
+            </el-tooltip>
+            <span v-else class="muted">—</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="耗时" width="100" align="right">
+          <template #default="{ row }">
+            <span v-if="row.durationMs != null">{{ (row.durationMs / 1000).toFixed(1) }}s</span>
+            <span v-else class="muted">—</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="结果" width="90">
+          <template #default="{ row }">
+            <el-tag :type="row.result === 1 ? 'success' : 'danger'">{{ row.result === 1 ? '成功' : '失败' }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="errorCode" label="错误码" width="180" show-overflow-tooltip />
+      </el-table>
+
+      <el-pagination
+        v-model:current-page="query.pageNum"
+        v-model:page-size="query.pageSize"
+        :total="total"
+        layout="total, prev, pager, next"
+        style="margin-top: 16px; justify-content: flex-end"
+        @current-change="loadList"
+      />
+    </el-card>
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.changed-files {
+  color: var(--el-color-primary);
+  cursor: default;
+}
+.muted {
+  color: var(--el-text-color-placeholder);
+}
+</style>

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -139,9 +139,10 @@ function send() {
       }
       if (event.event.startsWith('node:')) {
         appendNode(assistantMessage, event.event.slice('node:'.length), event.data)
-      } else {
+      } else if (event.event === 'message') {
         assistantMessage.text += event.data
       }
+      // 其余未知事件静默忽略：后端新增 SSE 事件类型时旧前端不受影响（需求 §5.5 向后兼容）
       scrollToBottom()
     },
     onError: (error) => {

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -191,9 +191,11 @@ function send() {
       }
       if (event.event.startsWith('node:')) {
         appendNode(assistantMessage, event.event.slice('node:'.length), event.data)
-      } else {
+      } else if (event.event === 'message') {
         assistantMessage.text += event.data
       }
+      // 其余未知事件静默忽略：后端新增 SSE 事件类型（如 test_report/plan）时旧前端不受影响，
+      // 避免把结构化 JSON 拼进对话正文（需求 §5.5 向后兼容）
       scrollToBottom()
     },
     onError: (error) => {

--- a/docs/AI编码助手需求文档.md
+++ b/docs/AI编码助手需求文档.md
@@ -1,404 +1,515 @@
 # 智能体客服后台管理系统 —— AI 编码助手需求文档
 
-> 基于 AgentScope 2.0（2.0.0 GA，`ga2.0` 分支）与现有 `customer-work-spring-boot-starter` 能力进行二次开发。  
-> 版本：v1.0  
-> 目标读者：产品、后端/前端开发、测试  
-> 状态：待评审
+> 基于 AgentScope Java 2.0.0 GA（`main` 分支，官方文档 https://java.agentscope.io ）与现有
+> `customer-work-spring-boot-starter` 能力进行二次开发，载体为 `customer-admin-server`（后端）+ `customer-admin-web`（前端）。
+> 版本：v2.0（2026-07-13 修订）
+> 目标读者：产品、后端/前端开发、测试
+> 状态：v2.0 待评审
+>
+> **v2.0 修订说明**：v1.0 中的两个 P0（实时 file_change、Git 工作流集成）与 Sandbox 能力已全部交付并合入 main
+> （commit `1ed6d77`，admin-server 测试 127 → 175 全绿）。本版将已交付能力沉淀为"第 2 章 能力基线"，
+> 剩余需求按「对项目重要性 × 提升开发效率 × 已有基础成熟度」重排优先级，并修正 v1.0 与实际实现不符的
+> 接口、数据模型与配置项描述。
 
 ---
 
 ## 1. 背景与目标
 
 ### 1.1 背景
-当前系统已在 `customer-admin-server` 中实现基础的 **VibeCoding** 能力：用户可在智能体工作区通过自然语言让 Agent 读/写 `workspace` 目录下的代码文件，并在对话结束后通过"前后快照对比"返回变更文件清单。但该能力仍处于"一期降级方案"阶段，缺少实时反馈、与 Git 工作流打通、代码审查等关键能力。
+
+`customer-admin-server` 的 **VibeCoding** 能力已完成两轮迭代：
+
+- **一期（降级方案）**：Agent 读/写会话 workspace（`sessions/{sessionId}/`）下的代码文件，对话结束后快照对比返回变更清单。
+- **二期（已交付，详见第 2 章）**：文件变更实时流式推送（`file_change` 事件）、Git 助手（diff 摘要 / commit message / PR description）、
+  AgentScope 2.0 代码沙箱（local/docker 双模式）+ 危险命令拦截。
+
+当前阶段的主要矛盾已从"看不见 Agent 在做什么"转移到：**改错了不能一键恢复、代码质量靠人工逐行看、
+生成的代码对不对要自己跑**。这三点是日常使用 VibeCoding 时最直接的效率损耗，也是本版 P0 的来源。
 
 ### 1.2 目标
-在不改动 AgentScope 2.0 核心框架的前提下，基于已有能力（`ChatService`、`VibeCodingService`、`HarnessAgentFactory`、`MultiAgentOrchestrator`、`KnowledgeProvider`、`MCP`、`Sandbox`、`Plan Mode`、`Subagent`）构建一套面向开发团队的 **AI 编码助手**，覆盖：代码生成、代码审查、Bug 诊断、自动化重构、多 Agent 协作编程、Git 工作流集成、代码知识库问答。
+
+在不改动 AgentScope 2.0 核心框架的前提下，基于已交付基线（`VibeCodingService`、`GitWorkspaceService`、
+`GitAssistantService`、`AdminAgentInstanceFactory` 沙箱装配、`SandboxGuardMiddleware`）持续构建面向开发团队的
+**AI 编码助手**，本版覆盖：会话回滚、AI Code Review、生成代码自动验证闭环、Plan Mode 人工确认、
+交互式运行面板、Docker 沙箱补齐、Bug 诊断、自动化重构、多 Agent 协作编程、代码知识库问答。
 
 ### 1.3 成功指标
-- VibeCoding 流式输出中 **file_change 事件实时可见**，延迟 < 1s。
-- 代码审查 Agent 对典型 Java 代码 diff 给出可行动的评论（覆盖率 ≥ 80% 的常见规范项）。
-- Git 工作流集成后，单次代码变更可自动生成 commit message / PR description，人工修改率 < 30%。
-- 代码知识库问答：Top-3 检索命中率 ≥ 70%（以内部接口定位任务评估）。
+
+| 指标 | 状态 |
+|---|---|
+| file_change 事件实时可见，延迟 < 1s | ✅ 已达成（TOOL_RESULT 后增量快照推送） |
+| commit message 人工无需修改直接可用比例 ≥ 50% | ✅ 已交付，待线上度量 |
+| 误操作后一键回滚，恢复到对话前状态 ≤ 3s | 🎯 本版 P0-1 |
+| 典型问题 diff（NPE/SQL 注入/硬编码密码）CRITICAL 检出率 ≥ 90% | 🎯 本版 P0-2 |
+| 生成代码在沙箱内自动编译+测试，结构化报告返回率 100% | 🎯 本版 P0-3 |
+| 代码知识库问答 Top-3 检索命中率 ≥ 70% | 🎯 本版 P3-2 |
 
 ---
 
-## 2. 功能需求总览
+## 2. 已交付能力基线（v1.x，main@`1ed6d77`）
 
-| 优先级 | 功能模块 | 核心能力 | 依赖 | 验收标准 |
-|---|---|---|---|---|
-| P0 | 实时 file_change 事件 | VibeCoding 文件变更实时流式推送 | ChatService、SSE | 文件创建/修改/删除即时出现在对话流 |
-| P0 | Git 工作流集成 | git diff 摘要、自动生成 commit message / PR description | Git MCP / JGit | 可一键复制或自动填充 |
-| P1 | Sandbox + Plan Mode | 代码执行隔离、重大修改前计划确认 | HarnessAgentFactory | 危险操作需用户确认 |
-| P1 | AI Code Review | 对 diff 做自动 Review | RAG + Subagent | 输出结构化 Review 意见 |
-| P2 | 智能 Bug 修复 | 根据异常堆栈/日志定位并生成补丁 | DiagnosticService | 生成可应用的 patch |
-| P2 | 代码生成 + 单测生成 | 需求→代码→单测→运行反馈 | VibeCoding + Sandbox | 单测可运行并反馈结果 |
-| P2 | 自动化重构助手 | 批量替换、API 迁移、依赖升级 | Plan Mode + Skill | 按计划执行并产出 diff |
-| P3 | 多 Agent 协作编程 | 产品/架构/开发/测试/Review Agent 协同 | MultiAgentOrchestrator | 完成端到端需求实现 |
-| P3 | 代码知识库问答 | 基于 RAG 的代码语义检索 | KnowledgeProvider | 接口/逻辑定位准确 |
+新需求一律在此基线上叠加，不重复建设。实现细节与踩坑记录见
+`docs/VibeCoding-Git助手与代码沙箱-开发总结.md`，此处只列对后续需求有约束力的事实。
 
----
+| 能力 | 实现要点 | 与 v1.0 需求稿的差异 |
+|---|---|---|
+| 实时 file_change 事件 | `VibeCodingService.stream()` 在每个 `TOOL_RESULT` 后做增量快照 diff，以独立 SSE 事件 `file_change` 推送（`ChatNodeKind.FILE_CHANGE`），流结束兜底再检测一次 | 未采用 v1.0 的"500ms 后台轮询"或"框架 Hook"方案；`FileChangeEvent` 仅 `operation/path/description` 三字段，**无 RENAME/oldPath** |
+| Git 助手 | `GitWorkspaceService`：会话目录轻量 `git init` + 空提交 baseline（`stream()` 本轮写入前建立），本轮变更 = 相对 baseline 的 diff；`GitAssistantService`：一次性模型调用（不经 ReAct 工具循环）生成摘要/commit message/PR description，独立线程池 + 超时兜底 | 只做只读 diff 与文本生成，**不做真正的 git commit/push**（v1.0 的"自动执行 git add + commit"可选项未做，业务提交仍由开发者本地完成） |
+| 代码沙箱 | `admin.sandbox.*` 配置（mode=local/docker、超时、docker 镜像/内存/CPU/网络）；`AdminAgentInstanceFactory` 按 mode 挂 `LocalFilesystemSpec` / `DockerFilesystemSpec`（框架内置，零新增依赖）；Docker 模式端到端实测跑通 | 配置前缀是 **`admin.sandbox.*`** 而非 v1.0 写的 `customer-work.harness.*`（admin-server 排除了 starter 自动装配） |
+| 危险命令拦截 | `SandboxGuardMiddleware` 挂 `onActing`，破坏性命令正则命中改写为 `[BLOCKED_BY_SANDBOX_GUARD]`，不打断主链路，默认开启 | 走自研正则拦截，**未走框架 `PermissionMode.ASK`**（现状 BYPASS，确认闭环见 P1-1） |
+| 沙箱内自动验证引导 | VibeCoding prompt 追加"生成代码后在沙箱内 javac/mvn test 验证"引导 | 仅 prompt 引导，验证结果混在文本流中，无结构化 `test_report`（见 P0-3） |
+| 文件树/文件读写 | `GET /files`、`GET/PUT /file-content`、`GET /artifacts`、`GET /sandbox-mode` | — |
 
-## 3. 详细功能需求
+**已知架构约束（对后续需求有直接影响）**：
 
-### 3.1 实时 file_change 事件（P0）
-
-#### 3.1.1 现状
-`VibeCodingService#stream` 仅返回 `ChatStreamChunk`（reasoning/message），文件变更在对话结束后通过 `listChangedArtifacts` 用快照对比得出，用户无法在对话过程中看到 Agent 正在改哪些文件。
-
-#### 3.1.2 需求
-1. **事件类型扩展**：在 `ChatStreamChunk` 中新增 `file_change` 类型，字段包括：
-   - `type`: `file_change`
-   - `operation`: `CREATE | MODIFY | DELETE | RENAME`
-   - `path`: 相对 workspace 的路径
-   - `oldPath`: RENAME 时原路径（可选）
-   - `description`: 变更摘要（Agent 生成的一句话说明）
-2. **采集机制**：
-   - 方式 A（推荐）：Hook AgentScope 的 `FileChangeEvent`（若框架暴露）或在 Agent 调用文件工具时拦截。
-   - 方式 B（兜底）：在 `stream` 开始后启动一个后台线程，每 500ms 扫描一次 workspace 目录，与初始快照对比，发现变更即 emit `file_change` 事件。
-3. **前端渲染**：
-   - 在对话流右侧或折叠面板中显示"文件变更时间线"。
-   - 支持点击文件路径查看 diff（调用后端的 git diff 或文件对比接口）。
-
-#### 3.1.3 接口
-```
-POST /api/workspace/{agentCode}/vibecoding/stream
-响应 SSE event:
-  event: message          data: {text}
-  event: reasoning        data: {text}
-  event: file_change      data: {"operation":"MODIFY","path":"src/main/java/...","description":"修改了登录校验逻辑"}
-  event: done             data: [DONE]
-```
-
-#### 3.1.4 验收标准
-- 用户说"把 UserService 的密码校验改成 BCrypt"，Agent 修改文件后 1s 内前端显示该文件变更。
-- 变更时间线按时间顺序排列，不遗漏、不重复。
+1. **Docker 模式产物在容器内**：宿主机侧的产物文件树、file_change 事件、Git 助手读不到容器内文件——这是
+   Docker 隔离的固有特性。凡依赖宿主机文件系统的功能（回滚、Review、Git 助手），在 Docker 模式下都需要
+   P1-3 的容器↔宿主机同步先行。
+2. **`HarnessAgent.stream()` 同步异常**：沙箱资源获取失败时同步抛异常，已用 `Flux.defer` 包裹兜底（`ChatService`），
+   新增 SSE 接口须沿用该模式。
+3. **Docker 模式 sessionId 转义**：`SandboxSafeAgentStateStore` 装饰器负责 `/`→`_` 转义，新增涉及沙箱状态
+   持久化的功能须复用。
 
 ---
 
-### 3.2 Git 工作流集成（P0）
+## 3. 功能需求总览（v2.0 优先级）
 
-#### 3.2.1 目标
-让 AI 编码助手能感知当前代码变更，并辅助生成 Git 相关文本，减少开发者在提交环节的重复劳动。
+排序依据：**对当前项目重要性 × 对开发效率的直接提升 × 已有基础成熟度（越现成越先做）**。
+P0 三项共同特征：地基已在二期打好（git baseline / diff 能力 / 沙箱执行链路），属于"最后一公里"收口，
+投入小、每天都用。
 
-#### 3.2.2 需求
-1. **Git Diff 摘要**
-   - 后端提供接口 `GET /api/workspace/{agentCode}/vibecoding/git-diff?sessionId=xxx`。
-   - 对当前 workspace 执行 `git diff`，将 diff 文本传给 Agent，要求其用 1-3 句话总结变更内容。
-   - 返回结构化结果：`{ "summary": "...", "changedFiles": [...] }`。
-2. **自动生成 Commit Message**
-   - 接口：`POST /api/workspace/{agentCode}/vibecoding/commit-message`
-   - 请求体：`{ "sessionId": "...", "style": "conventional" | "simple" }`
-   - 返回：`{ "message": "feat(auth): 切换密码校验为 BCrypt" }`
-   - 默认采用 Conventional Commits 规范，可通过配置切换风格。
-3. **自动生成 PR Description**
-   - 接口：`POST /api/workspace/{agentCode}/vibecoding/pr-description`
-   - 返回 Markdown 格式 PR 描述，包含：变更摘要、改动文件清单、影响范围、自检清单。
-4. **前端集成**
-   - 在 VibeCoding 面板新增"Git 助手"抽屉：显示 diff 摘要、commit message、PR description，支持一键复制。
-   - （可选）提供"自动执行 git add + git commit"按钮，需二次确认。
+| 优先级 | 功能模块 | 核心能力 | 依托的已有基础 | 预估 | 验收标准 |
+|---|---|---|---|---|---|
+| **P0-1** | 会话一键回滚 | 撤销本次会话全部文件修改 | `GitWorkspaceService` baseline 机制已就位 | 0.5~1 天 | 点击后 ≤3s 恢复到对话前状态 |
+| **P0-2** | AI Code Review | 对本轮 diff 自动审查，输出结构化意见 | diff 能力 + `GitAssistantService` 一次性调用模式 | 2~3 天 | 典型问题 CRITICAL 检出率 ≥ 90% |
+| **P0-3** | 生成→验证→修复闭环 | 沙箱内编译/测试，结构化 `test_report`，失败自动修复 | 沙箱执行链路已通 + prompt 引导已有 | 3~5 天 | 测试结果 100% 结构化返回，失败自动修复 ≤3 轮 |
+| **P1-1** | Plan Mode 人工确认闭环 | 高风险操作先出计划、等确认再执行（HITL） | 框架 `PermissionMode`；starter 已有 Approval Store SPI 模式可参考 | 5~8 天 | 删除文件/批量修改前必须停下等确认 |
+| **P1-2** | 交互式运行面板 | 页面内直接对沙箱执行命令，输出流式回显 | 沙箱 execute 链路已通 | 3~5 天 | 常用命令（mvn test/java）免切终端 |
+| **P1-3** | Docker 沙箱补齐 | 容器↔宿主机产物同步 + `DockerSandboxIntegrationTest` | Docker 链路端到端已跑通 | 3~5 天 | Docker 模式下文件树/file_change/Git 助手可用 |
+| **P2-1** | 智能 Bug 修复 | 根据异常堆栈/日志定位并生成补丁 | workspace 文件检索 + 回滚保障 | 3~5 天 | 常见异常正确定位到源码行并给出合理修复 |
+| **P2-2** | 自动化重构助手 | 批量替换、API 迁移、依赖升级 | Plan Mode（P1-1）+ 回滚（P0-1） | 3~5 天 | 简单批量替换 100% 按预期完成 |
+| **P2-3** | 沙箱管理页面 | 会话沙箱状态查看、资源监控、手动清理 | `admin.sandbox.*` 配置体系 | 2~3 天 | 可查看并清理运行中的沙箱容器 |
+| **P3-1** | 多 Agent 协作编程 | 产品/架构/开发/测试/Review Agent 协同 | 需 starter 侧 SubAgent/Pipeline 编排能力先行 | 周级 | 简单需求走完全流程产出可编译代码 |
+| **P3-2** | 代码知识库问答 | 基于 RAG 的代码语义检索 | 需 starter 侧真实 Embedding RAG 先行（现为关键词版） | 周级 | Top-3 命中率 ≥ 70%，回答带出处 |
 
-#### 3.2.3 技术实现
-- 后端使用 **JGit** 或直接调用 `git` 命令读取 diff。
-- 接入 **Git MCP**（如果已有）或自定义 `GitTool`：
-  - `git_diff(workspace)`
-  - `git_status(workspace)`
-  - `git_commit(workspace, message)`
-  - `git_push(...)`
-- 将 diff 文本作为 user message 的一部分发送给 Agent，prompt 模板示例：
-  ```
-  请根据以下 git diff 生成一条符合 Conventional Commits 规范的 commit message，
-  要求：不超过 72 个字符的标题 + 详细描述。
-  diff:
-  {diff}
-  ```
-
-#### 3.2.4 验收标准
-- 对一次真实代码变更，生成的 commit message 人工无需修改即可直接使用的比例 ≥ 50%。
-- PR description 包含变更摘要、文件清单、影响范围三个部分。
+**P3 两项的前置依赖说明**：多 Agent 协作依赖 SubAgent/Pipeline 编排、知识库问答依赖真实 Embedding 向量检索，
+这两块是 `customer-work-spring-boot-starter` 的既定演进方向（见 `进度说明.txt` 缺口清单）。在 starter 能力
+就绪前，admin-server 侧不启动这两项，避免在业务模块里重复造框架轮子。
 
 ---
 
-### 3.3 Sandbox + Plan Mode（P1）
+## 4. 详细功能需求
 
-#### 3.3.1 目标
-让 Agent 的代码执行更安全，并在执行重大修改前给出可确认的计划。
+### 4.1 会话一键回滚（P0-1）
 
-#### 3.3.2 需求
-1. **Sandbox 配置开启**
-   - 默认使用 `local` 沙箱（限制在 workspace 目录内）。
-   - 生产环境可切换为 `docker` 沙箱，配置镜像、CPU/内存限制、网络策略。
-   - 沙箱内执行命令/代码时，禁止访问 `/etc`、`/root`、数据库连接等敏感资源。
-2. **Plan Mode 开启**
-   - 配置：`customer-work.harness.plan-mode.enabled=true`
-   - 当 Agent 计划执行以下高风险操作时，先输出计划并等待用户确认：
-     - 删除文件
-     - 批量修改多个文件（>3 个）
-     - 执行非只读命令（如 `mvn clean`、`rm -rf`）
-     - 修改依赖版本（pom.xml、package.json 等）
-   - 计划内容包含：操作类型、目标文件、预期效果、回滚方式。
-   - 前端在流中显示"计划确认卡片"，用户点击"确认"后 Agent 才继续执行。
-3. **回滚机制**
-   - 在执行高风险操作前，自动对目标文件做备份（拷贝到 `.ai-backup/{timestamp}/`）。
-   - 提供"撤销本次对话所有修改"按钮，恢复备份。
+#### 4.1.1 背景与依托
 
-#### 3.3.3 验收标准
-- 在 Plan Mode 下，Agent 删除文件前必须停下来等待用户确认。
-- 误操作后可一键撤销，文件恢复到对话前状态。
+`GitWorkspaceService` 已在每次 `stream()` 写入前对会话 workspace 建立 git baseline（空提交），
+"撤销本次会话全部修改"本质上就是 `git checkout baseline -- . && git clean -fd`，地基已完全就位。
+这是所有 AI 改代码场景的信任底座：**有回滚，才敢放手让 Agent 改**。
+
+#### 4.1.2 需求
+
+1. **会话级回滚（本期范围）**
+   - 接口：`POST /api/workspace/{agentCode}/vibecoding/rollback`，请求体 `{ "sessionId": "..." }`。
+   - 行为：将会话 workspace 恢复到 baseline 状态（已跟踪文件 checkout，新增未跟踪文件清理），
+     `.git` 目录本身保留。
+   - 返回：`{ "restoredFiles": [...], "deletedFiles": [...] }`，前端刷新文件树与"本轮变更"时间线。
+2. **前端交互**
+   - VibeCoding 面板"本轮变更"时间线顶部新增"撤销全部修改"按钮，二次确认后调用。
+   - 回滚成功后时间线清空、文件树刷新，并在对话流中插入一条系统提示。
+3. **轮次级回滚（增强项，可延后）**
+   - 每轮对话结束后自动 `git commit` 一次（message 带轮次号），支持"回滚到第 N 轮之后"。
+   - 本期只做会话级，轮次级待实际使用中确有需求再排。
+
+#### 4.1.3 约束
+
+- 复用 `GitWorkspaceService` 的 `ProcessBuilder` 调 git 方式与错误码体系（`GIT_COMMAND_FAILED`）。
+- 回滚是破坏性操作，接口幂等（重复调用恢复到同一 baseline），日志记录操作人、sessionId、恢复文件数。
+- Docker 模式下产物在容器内，本接口暂只支持 local 模式，Docker 支持随 P1-3 落地。
+
+#### 4.1.4 验收标准
+
+- Agent 修改/新增/删除多个文件后，点击撤销，≤3s 全部恢复到对话前状态，文件树与磁盘一致。
+- 回滚后再次对话可正常建立新变更（baseline 不被破坏）。
 
 ---
 
-### 3.4 AI Code Review（P1）
+### 4.2 AI Code Review（P0-2）
 
-#### 3.4.1 目标
-利用子智能体对代码 diff 进行自动化审查，输出结构化、可行动的 Review 意见。
+#### 4.2.1 背景与依托
 
-#### 3.4.2 需求
+`GitWorkspaceService.diffAgainstBaseline()` 已能拿到本轮完整 diff；`GitAssistantService` 已验证
+"一次性模型调用（不经 ReAct 工具循环）+ 独立线程池 + 超时兜底"的模式。Review 就是同一模式的第四个应用：
+输入 diff，输出结构化审查意见。
+
+#### 4.2.2 需求
+
 1. **入口**
-   - 工作区对话命令：`/review` 或 VibeCoding 面板"Review 本次变更"按钮。
-   - 接口：`POST /api/workspace/{agentCode}/vibecoding/review`
-2. **审查范围**
-   - 以当前 workspace 的 git diff 为输入。
-   - 可加载团队代码规范文档（通过 RAG 注入）。
-3. **Reviewer Agent（Subagent）**
-   - 角色：资深 Java 工程师 / 代码规范守门员。
-   - 系统提示词包含团队规范（如：禁止 SQL 注入、NPE 防护、异常处理、命名规范、单元测试要求等）。
-   - 输出结构化 JSON：
-     ```json
-     {
-       "issues": [
-         {
-           "severity": "CRITICAL|WARNING|SUGGESTION",
-           "file": "src/main/java/...",
-           "line": 42,
-           "category": "SECURITY|PERFORMANCE|READABILITY|BUG|STYLE",
-           "message": "...",
-           "suggestion": "..."
-         }
-       ],
-       "summary": "..."
-     }
-     ```
+   - 接口：`POST /api/workspace/{agentCode}/vibecoding/review`，请求体 `{ "sessionId": "..." }`。
+   - 前端：Git 助手抽屉内新增"Review 本次变更"标签页（与 diff 摘要/commit message/PR description 并列）。
+2. **审查范围与规则**
+   - 输入为本轮 diff（相对 baseline），diff 为空时返回 `NO_FILE_CHANGES` 错误码（复用现有）。
+   - 系统提示词内置团队规范：NPE 防护、SQL 注入、硬编码密钥、异常处理、命名规范、日志规范
+     （info/error、英文文案、错误码占位符）等。
+   - 规范后续可通过 RAG 注入团队文档（依赖 P3-2，本期先内置在 prompt）。
+3. **输出结构化 JSON**
+   ```json
+   {
+     "issues": [
+       {
+         "severity": "CRITICAL|WARNING|SUGGESTION",
+         "file": "src/main/java/...",
+         "line": 42,
+         "category": "SECURITY|PERFORMANCE|READABILITY|BUG|STYLE",
+         "message": "...",
+         "suggestion": "..."
+       }
+     ],
+     "summary": "..."
+   }
+   ```
 4. **前端展示**
-   - 以列表形式展示 Review 意见，按严重级别分组。
-   - 点击意见可定位到代码文件对应行（若信息足够）。
-   - 提供"一键生成修复"按钮，让 Agent 针对 CRITICAL/WARNING 项自动生成补丁。
+   - 按严重级别分组列表展示；点击 file 定位到工作区文件查看器（文件读取接口已有）。
+   - "一键生成修复"按钮：把选中的 CRITICAL/WARNING 意见拼成用户消息发回 `stream` 对话，
+     由 Agent 修复（修复本身走既有 VibeCoding 链路，天然带 file_change 与回滚保障）。
 
-#### 3.4.3 验收标准
-- 对包含 NPE、SQL 注入、硬编码密码等典型问题的代码 diff，CRITICAL 问题检出率 ≥ 90%。
-- Review 输出符合上述 JSON Schema，前端可正常解析展示。
+#### 4.2.3 约束
 
----
+- 模型输出 JSON 解析失败时降级：原文以 `summary` 返回、`issues` 为空，错误码 `GIT_ASSISTANT_AI_FAILED`（复用），
+  不让前端拿到裸异常。
+- 超大 diff（如 > 100KB）截断处理并在 summary 中声明"仅审查前 N 个文件"。
 
-### 3.5 智能 Bug 修复 / 日志诊断（P2）
+#### 4.2.4 验收标准
 
-#### 3.5.1 目标
-让 Agent 能根据异常堆栈、应用日志自动定位问题并生成修复补丁。
-
-#### 3.5.2 需求
-1. **输入方式**
-   - 用户粘贴异常堆栈到对话窗口。
-   - 用户选择时间范围，后端从日志文件/日志平台拉取相关日志。
-2. **诊断流程**
-   - Agent 解析堆栈，定位异常发生的类和方法。
-   - 在 workspace 中查找相关源码。
-   - 结合 RAG 中的历史修复记录/知识库，分析根因。
-   - 生成修复建议或补丁（patch 格式）。
-3. **输出**
-   - 根因分析说明。
-   - 修复后的代码片段或 patch 文件。
-   - （可选）自动生成单元测试覆盖该异常场景。
-4. **人工确认**
-   - 修复补丁需经用户确认后应用，应用前自动备份原文件。
-
-#### 3.5.3 验收标准
-- 对常见 NullPointerException、IndexOutOfBoundsException、SQL 语法错误等，能正确定位到源码行并给出合理修复。
+- 对包含 NPE、SQL 注入、硬编码密码等典型问题的 diff，CRITICAL 检出率 ≥ 90%。
+- Review 输出符合上述 Schema，前端可正常解析展示；"一键生成修复"能触发新一轮对话完成修复。
 
 ---
 
-### 3.6 代码生成 + 单元测试生成（P2）
+### 4.3 生成→沙箱验证→修复闭环（P0-3）
 
-#### 3.6.1 目标
-根据自然语言需求生成可运行的代码，并同步生成单元测试。
+#### 4.3.1 背景与依托
 
-#### 3.6.2 需求
-1. **需求→代码**
-   - 用户在 VibeCoding 面板输入需求文本，或者上传md文档、或者txt文件，如"实现一个基于 JWT 的登录接口"。
-   - Agent 自动分析需求，规划文件结构，生成代码，未明确的需求需要在页面提示人工确认后，明确需求后继续生成代码。
-   - 代码生成的文件采用 sessions/{sessionId}/ 方式存储，便于后续查询和管理。
-2. **同步生成单测**
-   - Agent 生成主代码后，自动识别需要测试的类/方法，保证编译通过。
-   - 生成 JUnit 5 / Mockito 测试用例，覆盖正常路径和异常路径。
-3. **运行反馈**
-   - 在 Sandbox 中执行 `mvn test`。
-   - 将测试结果（通过/失败、失败原因）流式返回给用户。
-   - 若测试失败，Agent 自动尝试修复（最多 3 轮）。
-4. **输出格式**
-   - `file_change` 事件实时展示生成的文件。
-   - 测试报告以 `test_report` 事件返回。
+沙箱执行链路已端到端跑通（实测 `write_file` → `javac Hello.java && java Hello` → `Exit code: 0`），
+且 prompt 已引导 Agent"生成代码后在沙箱内 javac/mvn test 验证"。当前缺口：**验证结果混在文本流里，
+前端无法结构化呈现，失败后是否修复完全靠 Agent 自觉**。本项是沙箱价值的最终变现，收口后
+"需求→代码→单测→验证→修复"全程免人工介入。
 
-#### 3.6.3 验收标准
-- 对简单 CRUD 接口，生成代码可编译通过。
-- 生成的单测全部覆盖主流程，运行成功率 ≥ 80%。
+#### 4.3.2 需求
+
+1. **结构化 `test_report` 事件**
+   - `VibeCodingService.stream()` 在检测到沙箱内执行编译/测试命令的 `TOOL_RESULT` 时
+     （识别 `javac`/`mvn test`/`mvn compile` 等命令特征 + Exit code），解析结果并以独立 SSE 事件推送：
+     ```
+     event: test_report
+     data: {"command":"mvn test","exitCode":0,"passed":12,"failed":0,"durationMs":8500,"failureDetails":[]}
+     ```
+   - 解析失败时降级为原始输出透传（`rawOutput` 字段），不阻断主流程。
+2. **失败自动修复循环**
+   - prompt 升级：明确要求"测试失败时分析失败原因并修复，最多重试 3 轮；3 轮后仍失败则停止并总结失败原因"。
+   - 每轮修复产生的文件变更照常走 `file_change` 事件。
+3. **单测生成约定**
+   - Agent 生成主代码后自动生成 JUnit 5 / Mockito 测试用例，覆盖正常路径与异常路径（prompt 约定，沿用现有引导）。
+   - 需求不明确时 Agent 在对话中先反问澄清（现有对话能力天然支持，不新增交互组件）。
+4. **前端渲染**
+   - 对话流中以"测试报告卡片"渲染 `test_report`：通过绿/失败红、展开可见失败明细。
+   - 多轮修复时按时间线依次展示各轮报告。
+
+#### 4.3.3 约束
+
+- 沙箱执行超时沿用 `admin.sandbox.execute-timeout-seconds`（默认 60s），`mvn test` 场景实测偏慢时
+  允许按 agent 粒度调大，但不全局放开。
+- Docker 模式（network=none）下 `mvn test` 需依赖预热镜像内的本地仓库缓存，首版验收只要求 local 模式，
+  Docker 模式随 P1-3 一并验证。
+
+#### 4.3.4 验收标准
+
+- 对简单 CRUD 需求，生成代码可编译通过，单测覆盖主流程，运行成功率 ≥ 80%。
+- 测试结果 100% 以 `test_report` 事件结构化返回；注入一个必然失败的用例，Agent 在 ≤3 轮内修复或明确报告失败原因。
 
 ---
 
-### 3.7 自动化重构助手（P2）
+### 4.4 Plan Mode 人工确认闭环（P1-1）
 
-#### 3.7.1 目标
-支持大规模、可审计、可回滚的代码重构任务。
+#### 4.4.1 背景与依托
 
-#### 3.7.2 需求
-1. **重构任务类型**
-   - 批量替换：如统一异常类、统一返回结果封装。
-   - API 迁移：如替换废弃的 API、升级 SDK。
-   - 依赖升级：如 Spring Boot 版本升级、依赖漏洞修复。
-   - 代码风格统一：如统一日志框架、统一常量命名。
-2. **执行流程**
+现状：`PermissionMode` 为 BYPASS，危险命令靠 `SandboxGuardMiddleware` 正则拦截兜底（简单可靠但一刀切，
+被拦截的命令 Agent 无法申请人工放行）。本项将其升级为框架级 HITL：高风险操作先出计划、等用户确认再执行。
+starter 侧已有 Approval Store SPI 模式（接口 + InMemory 默认 + Jdbc 实现）可参考，但 admin-server
+排除了 starter 自动装配，需在自己的 `@Configuration` 里显式装配。
+
+#### 4.4.2 需求
+
+1. **确认闭环（核心难点）**
+   - `ChatService`/`VibeCodingService` 实现"流中暂停等确认"：Agent 计划执行高风险操作时，
+     emit `plan` 事件后挂起等待，用户确认后恢复执行，拒绝则取消该操作并让 Agent 调整方案。
+   - 接口：`POST /api/workspace/{agentCode}/vibecoding/plan/confirm`，请求体
+     `{ "sessionId": "...", "planId": "...", "approved": true|false }`。
+   - 确认等待需有超时（默认 5 分钟），超时视为拒绝，流正常结束而非挂死。
+2. **高风险操作清单**
+   - 删除文件；单轮批量修改 > 3 个文件；执行非只读命令（`mvn clean`、`rm` 等）；修改依赖版本（pom.xml 等）。
+3. **`plan` SSE 事件**
+   ```
+   event: plan
+   data: {"planId":"...","actions":[{"type":"DELETE","target":"src/..."}],"reason":"...","requiresConfirmation":true}
+   ```
+4. **前端**：对话流中渲染"计划确认卡片"（操作类型、目标文件、预期效果），确认/拒绝按钮。
+5. **与现有拦截的关系**：`SandboxGuardMiddleware` 保留为最后防线（确认闭环故障时仍有兜底），
+   两者叠加而非替换。
+
+#### 4.4.3 技术风险提示
+
+- SSE 长连接挂起等确认涉及连接保活（心跳事件）与服务重启后的恢复策略，需在方案设计时明确
+  "挂起态不持久化、重启即取消"的简化边界，避免过度设计。
+- 沿用 `Flux.defer` 模式处理 `HarnessAgent.stream()` 的同步异常（见第 2 章约束 2）。
+
+#### 4.4.4 验收标准
+
+- Plan Mode 开启后，Agent 删除文件前必须停下等确认；拒绝后文件未被删除且对话正常继续。
+- 确认超时后流正常结束，不出现前端永久"生成中"。
+
+---
+
+### 4.5 交互式运行面板（P1-2）
+
+#### 4.5.1 目标
+
+让开发者在 VibeCoding 页面内直接对会话沙箱执行命令（编译、跑测试、运行程序），输出流式回显，
+免去"页面看代码、切终端跑命令"的割裂。
+
+#### 4.5.2 需求
+
+1. **命令执行接口**
+   - `POST /api/workspace/{agentCode}/vibecoding/execute`（SSE），请求体 `{ "sessionId": "...", "command": "mvn test" }`。
+   - 命令在会话对应的沙箱内执行（local/docker 跟随 `admin.sandbox.mode`），复用现有执行链路与超时配置。
+   - **必须过 `SandboxGuardMiddleware` 同一套危险命令校验**（用户手输的命令风险不低于 Agent 生成的）。
+2. **前端"运行"面板**
+   - VibeCoding 面板新增"运行"标签：命令输入框 + 常用命令快捷按钮（`javac`、`mvn compile`、`mvn test`）+
+     终端风格输出区（等宽字体、保留 ANSI 颜色可后置）。
+   - 执行历史保留本会话最近 20 条。
+3. **输出事件**：复用/对齐 `test_report` 的解析逻辑——命令属于编译/测试类时同步产出结构化报告。
+
+#### 4.5.3 验收标准
+
+- 页面输入 `mvn test` 可看到流式输出与最终 Exit code；危险命令被拦截并提示。
+
+---
+
+### 4.6 Docker 沙箱补齐（P1-3）
+
+#### 4.6.1 背景
+
+Docker 模式对话+执行链路已跑通，但产物文件在容器内，宿主机侧文件树 / file_change / Git 助手 / 回滚全部失效
+（隔离的固有特性，非 bug）。生产环境要用 Docker 模式，这条腿必须补齐。
+
+#### 4.6.2 需求
+
+1. **容器↔宿主机产物同步**
+   - 方案 A（优先评估）：容器启动时将会话 workspace 目录以 bind mount 挂载，产物直接落宿主机——
+     若框架 `DockerFilesystemSpec` 支持挂载配置则成本最低。
+   - 方案 B（兜底）：每轮 `TOOL_RESULT` 后通过 `docker cp` / tar 流增量同步容器内 workspace 到宿主机。
+   - 同步落地后，file_change / Git 助手 / 回滚（P0-1）/ Review（P0-2）在 Docker 模式下自动可用，无需改造。
+2. **`DockerSandboxIntegrationTest`（遗留待办）**
+   - 门控式集成测试（本机无 Docker 时自动跳过，对齐现有 MySQL/Redis/Nacos 门控测试约定）。
+   - 覆盖：容器内写文件→执行→读回、sessionId 转义（`SandboxSafeAgentStateStore`）、危险命令拦截、
+     沙箱资源获取失败时 SSE 正常报错不挂起（回归第 2 章约束 2 的坑）。
+3. **资源回收**：会话结束/超时后容器清理策略（对接 P2-3 沙箱管理页面的数据基础）。
+
+#### 4.6.3 验收标准
+
+- Docker 模式下：Agent 写文件后宿主机文件树可见、file_change 正常推送、Git 助手可生成 diff 摘要。
+- 集成测试在有 Docker 的环境全绿，无 Docker 环境自动跳过。
+
+---
+
+### 4.7 智能 Bug 修复 / 日志诊断（P2-1）
+
+#### 4.7.1 目标
+
+Agent 根据异常堆栈、应用日志自动定位问题并生成修复补丁。
+
+#### 4.7.2 需求
+
+1. **输入方式**：用户粘贴异常堆栈到对话窗口（首版）；后续可对接日志平台按时间范围拉取。
+2. **诊断流程**：解析堆栈定位类和方法 → workspace 中检索相关源码 → 分析根因 → 生成修复。
+3. **输出**：根因分析说明 + 修复代码（走既有 VibeCoding 文件写入，天然带 file_change / 回滚 / Review 保障）
+   +（可选）覆盖该异常场景的单元测试（联动 P0-3 验证闭环）。
+4. **入口**：对话命令 `/diagnose` 或独立接口 `POST /api/workspace/{agentCode}/vibecoding/diagnose`。
+
+#### 4.7.3 验收标准
+
+- 对常见 NullPointerException、IndexOutOfBoundsException、SQL 语法错误，能正确定位到源码行并给出合理修复；
+  修复后走 P0-3 闭环验证通过。
+
+---
+
+### 4.8 自动化重构助手（P2-2）
+
+#### 4.8.1 目标
+
+支持大规模、可审计、可回滚的代码重构任务。**强依赖 P1-1（Plan Mode）与 P0-1（回滚）先行**——
+没有确认与回滚保障的批量改动不允许上线。
+
+#### 4.8.2 需求
+
+1. **重构任务类型**：批量替换（统一异常类/返回封装）、API 迁移（替换废弃 API/升级 SDK）、
+   依赖升级（版本升级/漏洞修复）、代码风格统一（统一日志框架/常量命名）。
+2. **执行流程**：
    - Step 1：Plan Mode 输出重构计划（影响文件数、变更点、风险）。
-   - Step 2：用户确认后执行。
-   - Step 3：每完成一个文件 emit `file_change` 事件。
-   - Step 4：执行完成后运行编译/测试，反馈结果。
-3. **回滚与审计**
-   - 自动备份所有被修改文件。
-   - 记录重构日志（操作人、时间、变更文件、结果）。
+   - Step 2：用户确认后执行，每完成一个文件 emit `file_change`。
+   - Step 3：执行完成后走 P0-3 闭环编译/测试，反馈 `test_report`。
+3. **审计**：记录重构日志（操作人、时间、变更文件、结果）；回滚复用 P0-1。
 
-#### 3.7.3 验收标准
-- 对简单的批量替换任务（如替换某个工具类调用），100% 按预期完成。
-- 升级依赖后项目可编译通过。
+#### 4.8.3 验收标准
+
+- 简单批量替换任务 100% 按预期完成；升级依赖后项目在沙箱内编译通过。
 
 ---
 
-### 3.8 多 Agent 协作编程（P3）
+### 4.9 沙箱管理页面（P2-3）
 
-#### 3.8.1 目标
-模拟完整软件研发流程，让多个专家 Agent 协同完成需求。
+#### 4.9.1 目标
 
-#### 3.8.2 角色设计
+为运维/开发提供沙箱运行态的可见性与管理能力（Docker 模式为主）。
+
+#### 4.9.2 需求
+
+1. 会话沙箱列表：sessionId、模式、容器 ID、状态、创建时间、资源占用。
+2. 手动清理：停止并删除指定会话的沙箱容器（联动 P1-3 的资源回收策略）。
+3. 配置可视化：当前 `admin.sandbox.*` 生效配置只读展示（含 env 覆盖后的实际值）。
+
+#### 4.9.3 验收标准
+
+- 可查看运行中的沙箱并手动清理；清理后再次对话能正常重建沙箱。
+
+---
+
+### 4.10 多 Agent 协作编程（P3-1）
+
+> **前置依赖**：starter 侧 SubAgent / Pipeline 编排能力（`SubAgentProvider`、`SequentialPipeline` 等）
+> 在 admin-server 场景的显式装配验证。starter 能力就绪前本项不启动。
+
+#### 4.10.1 角色设计
+
 | 角色 | 职责 | 输出 |
 |---|---|---|
 | 产品经理 Agent | 理解用户需求，输出 PRD / 用户故事 | PRD 文档 |
 | 架构师 Agent | 设计接口、数据模型、模块划分 | 设计文档 / 接口契约 |
 | 开发 Agent | 根据设计写代码 | 代码文件 |
 | 测试 Agent | 写单测、集成测试 | 测试用例 |
-| Reviewer Agent | Code Review | Review 意见 |
+| Reviewer Agent | Code Review | Review 意见（复用 P0-2 结构） |
 
-#### 3.8.3 执行流程
-1. 用户输入原始需求。
-2. `MultiAgentOrchestrator` 按顺序调度各 Agent：
-   - 产品经理 → 架构师 → 开发 → 测试 → Reviewer。
-   - 每个 Agent 的输出作为下一个 Agent 的输入。
-3. 最终输出：PRD、设计文档、代码、测试、Review 意见汇总。
-4. 用户可中途介入，修改某一步的输出后继续。
+#### 4.10.2 执行流程
 
-#### 3.8.4 验收标准
-- 对简单需求（如"新增一个用户管理 CRUD 接口"），能走完完整流程并产出可编译代码。
+1. 用户输入原始需求，编排器按"产品经理 → 架构师 → 开发 → 测试 → Reviewer"顺序调度，
+   每个 Agent 的输出作为下一个的输入。
+2. 最终输出：PRD、设计文档、代码、测试、Review 意见汇总；代码/测试环节复用 P0-3 闭环验证。
+3. 用户可中途介入，修改某一步的输出后继续（依赖 P1-1 的暂停/恢复交互基础）。
 
----
+#### 4.10.3 验收标准
 
-### 3.9 代码知识库问答（P3）
-
-#### 3.9.1 目标
-让开发者通过自然语言查询私有代码库，快速定位业务逻辑和调用关系。
-
-#### 3.9.2 需求
-1. **代码库向量化**
-   - 扫描 workspace 或指定仓库的源码文件。
-   - 按类、方法、注释切块，使用 Embedding 模型生成向量。
-   - 存入向量数据库（RAG  Provider 已支持 bailian/dify/simple 等）。
-2. **问答能力**
-   - 接口： natural language → 相关代码片段 → 自然语言回答。
-   - 示例问题：
-     - "这段业务逻辑在哪实现的？"
-     - "这个接口有哪些调用方？"
-     - "UserService 的登录逻辑是怎么做的？"
-3. **与对话集成**
-   - 在 VibeCoding/Chat 面板中，用户可 @知识库 提问。
-   - Agent 在生成代码前可自动检索相关知识库做参考。
-
-#### 3.9.3 验收标准
-- 对常见接口定位问题，Top-3 检索命中率 ≥ 70%。
-- 回答中需标注引用来源（文件路径 + 行号范围）。
+- 对简单需求（如"新增一个用户管理 CRUD 接口"），走完完整流程并产出沙箱内可编译代码。
 
 ---
 
-## 4. 非功能需求
+### 4.11 代码知识库问答（P3-2）
 
-### 4.1 性能
+> **前置依赖**：starter 侧真实 Embedding RAG（`SimpleKnowledge` + `core.embedding` 向量语义检索）——
+> 当前项目 RAG 为自实现关键词版，语义检索命中率无法达标。starter 能力就绪前本项不启动。
+
+#### 4.11.1 需求
+
+1. **代码库向量化**：扫描 workspace 或指定仓库源码，按类/方法/注释切块，Embedding 后入向量库，
+   按用户/租户隔离，支持增量更新。
+2. **问答能力**：自然语言 → 相关代码片段 → 自然语言回答，回答标注引用来源（文件路径 + 行号范围）。
+   示例："这段业务逻辑在哪实现的？""这个接口有哪些调用方？"
+3. **与对话集成**：VibeCoding/Chat 面板 @知识库 提问；Agent 生成代码前自动检索知识库做参考；
+   Review（P0-2）的团队规范注入切换为 RAG 来源。
+
+#### 4.11.2 验收标准
+
+- 常见接口定位问题 Top-3 检索命中率 ≥ 70%；回答带出处。
+
+---
+
+## 5. 非功能需求
+
+### 5.1 性能
 - SSE 流首包响应时间 ≤ 2s（模型首 token 到达时间除外）。
-- file_change 事件从文件变更到前端展示 ≤ 1s。
-- 代码库向量化处理 1000 个文件 ≤ 10 分钟。
+- file_change 事件从文件变更到前端展示 ≤ 1s（✅ 已达成）。
+- 会话回滚 ≤ 3s；Review 单次 ≤ 30s（超时兜底沿用 `GitAssistantService` 模式）。
 
-### 4.2 安全
-- 所有代码执行必须在 Sandbox 内进行，禁止访问宿主机敏感路径。
-- Agent 调用 Git 写操作（commit/push）前必须人工确认。
-- 对代码库向量化的数据做访问控制，按用户/租户隔离。
+### 5.2 安全
+- 所有代码/命令执行必须经沙箱（local 受 workspace 路径约束，docker 受容器隔离 + network=none）。
+- `SandboxGuardMiddleware` 危险命令拦截默认开启，对 Agent 生成命令与用户手输命令（P1-2）一视同仁。
+- Agent 侧不做真正的 git commit/push；未来若放开，写操作必须人工确认 + 审计日志。
+- 回滚、计划确认等破坏性/敏感接口记录审计日志（操作人、时间、目标、结果）。
 
-### 4.3 可观测性
+### 5.3 可观测性
 - 所有 AI 编码操作记录审计日志（操作人、时间、变更文件、模型调用 token 数）。
-- 关键路径（代码生成、Review、重构）输出结构化日志，便于排查。
+- 关键路径（Review、验证闭环、回滚、重构）输出结构化日志；日志遵循项目规范
+  （info/error、英文文案、错误码占位符）。
 
-### 4.4 可回滚
-- 每次高风险操作前自动备份。
-- 提供"撤销本次对话所有修改"能力。
+### 5.4 可回滚
+- P0-1 落地后，"撤销本次会话所有修改"成为所有写操作类功能的统一兜底，不再各功能自建备份目录
+  （v1.0 的 `.ai-backup/{timestamp}/` 方案废弃，统一走 git baseline）。
 
-### 4.5 兼容性
-- 不影响现有 Chat / VibeCoding 核心流程。
-- 新功能通过配置开关控制，默认关闭，避免对未启用用户产生副作用。
-
----
-
-## 5. 接口设计（新增/调整）
-
-### 5.1 后端接口
-
-| 方法 | 路径 | 说明 |
-|---|---|---|
-| POST | `/api/workspace/{agentCode}/vibecoding/stream` | 已有，扩展 `file_change` 事件 |
-| GET | `/api/workspace/{agentCode}/vibecoding/git-diff` | 获取当前 workspace git diff |
-| POST | `/api/workspace/{agentCode}/vibecoding/commit-message` | 生成 commit message |
-| POST | `/api/workspace/{agentCode}/vibecoding/pr-description` | 生成 PR description |
-| POST | `/api/workspace/{agentCode}/vibecoding/review` | 对当前 diff 做 Code Review |
-| POST | `/api/workspace/{agentCode}/vibecoding/diagnose` | 根据堆栈/日志诊断 Bug |
-| POST | `/api/workspace/{agentCode}/vibecoding/generate-tests` | 为指定类生成单元测试 |
-| POST | `/api/workspace/{agentCode}/vibecoding/refactor` | 执行自动化重构任务 |
-| POST | `/api/workspace/{agentCode}/vibecoding/rollback` | 撤销本次对话所有修改 |
-| POST | `/api/workspace/{agentCode}/knowledge/ingest` | 代码库向量化入库 |
-| POST | `/api/workspace/{agentCode}/knowledge/query` | 代码知识库问答 |
-
-### 5.2 SSE 事件类型
-
-| event | data 示例 | 说明 |
-|---|---|---|
-| `reasoning` | `{text}` | 思考过程 |
-| `message` | `{text}` | 可见回答正文 |
-| `file_change` | `{operation, path, description}` | 文件变更事件 |
-| `test_report` | `{passed, failed, details}` | 测试报告 |
-| `plan` | `{actions, requiresConfirmation}` | Plan Mode 计划确认 |
-| `review_result` | `{issues, summary}` | Review 结果 |
-| `done` | `[DONE]` | 流结束 |
+### 5.5 兼容性
+- 不影响现有 Chat / VibeCoding 核心流程；新功能通过配置开关控制，默认关闭（沙箱 guard 除外，默认开启）。
+- 新增 SSE 事件类型对旧前端向后兼容（未知事件忽略不报错）。
 
 ---
 
-## 6. 数据模型
+## 6. 接口设计
 
-### 6.1 ChatStreamChunk（扩展）
+### 6.1 后端接口
+
+| 方法 | 路径（前缀 `/api/workspace/{agentCode}/vibecoding`） | 说明 | 状态 |
+|---|---|---|---|
+| POST | `/stream` | 流式对话（含 file_change 事件） | ✅ 已实现 |
+| GET | `/sandbox-mode` | 查询当前沙箱模式 | ✅ 已实现 |
+| GET | `/artifacts` | 会话产物清单 | ✅ 已实现 |
+| GET | `/files` | 会话文件树 | ✅ 已实现 |
+| GET | `/file-content` | 读文件内容 | ✅ 已实现 |
+| PUT | `/file-content` | 写文件内容 | ✅ 已实现 |
+| GET | `/git-diff` | 本轮 diff 摘要 | ✅ 已实现 |
+| POST | `/commit-message` | 生成 commit message | ✅ 已实现 |
+| POST | `/pr-description` | 生成 PR description | ✅ 已实现 |
+| POST | `/rollback` | 撤销本次会话全部修改 | 🎯 P0-1 |
+| POST | `/review` | 对本轮 diff 做 Code Review | 🎯 P0-2 |
+| POST | `/plan/confirm` | Plan Mode 计划确认/拒绝 | 🎯 P1-1 |
+| POST | `/execute` | 交互式沙箱命令执行（SSE） | 🎯 P1-2 |
+| POST | `/diagnose` | 根据堆栈/日志诊断 Bug | 🎯 P2-1 |
+| POST | `/refactor` | 执行自动化重构任务 | 🎯 P2-2 |
+| GET/DELETE | `/sandbox/**`（管理侧另定前缀） | 沙箱列表/清理 | 🎯 P2-3 |
+| POST | `/knowledge/ingest`、`/knowledge/query` | 代码库向量化/问答 | 🎯 P3-2 |
+
+### 6.2 SSE 事件类型
+
+| event | data 示例 | 说明 | 状态 |
+|---|---|---|---|
+| `message` | `{text}` | 可见回答正文 | ✅ 已实现 |
+| `node:*`（reasoning/tool_* 等） | `{text}` | 思考过程/工具执行节点（`ChatNodeKind` 派生） | ✅ 已实现 |
+| `file_change` | `{"operation":"MODIFY","path":"...","description":"..."}` | 文件变更事件（CREATE/MODIFY/DELETE） | ✅ 已实现 |
+| `done` | `[DONE]` | 流结束 | ✅ 已实现 |
+| `test_report` | `{"command":"mvn test","exitCode":0,"passed":12,"failed":0,...}` | 沙箱编译/测试结构化报告 | 🎯 P0-3 |
+| `plan` | `{"planId":"...","actions":[...],"requiresConfirmation":true}` | Plan Mode 计划确认 | 🎯 P1-1 |
+| `review_result` | `{issues, summary}` | Review 结果（若走 SSE 增量返回；同步接口则不需要） | 🎯 P0-2 可选 |
+
+---
+
+## 7. 数据模型
+
+### 7.1 FileChangeEvent（✅ 已实现，以实际代码为准）
 ```java
-public record ChatStreamChunk(
-    boolean reasoning,    // 是否思考过程
-    String text,          // 文本内容
-    FileChange fileChange // 新增：文件变更信息
-) {}
-
-public record FileChange(
-    String operation,
-    String path,
-    String oldPath,
-    String description
-) {}
+// file_change SSE 事件的 data 载荷；无 RENAME/oldPath
+public record FileChangeEvent(String operation, String path, String description) {
+    // operation: CREATE | MODIFY | DELETE
+}
 ```
 
-### 6.2 ReviewIssue
+### 7.2 ReviewIssue（🎯 P0-2）
 ```java
 public record ReviewIssue(
     String severity,    // CRITICAL|WARNING|SUGGESTION
@@ -410,7 +521,20 @@ public record ReviewIssue(
 ) {}
 ```
 
-### 6.3 RefactorTask
+### 7.3 TestReport（🎯 P0-3）
+```java
+public record TestReport(
+    String command,          // 触发的命令，如 mvn test
+    int exitCode,
+    Integer passed,          // 解析不出时为 null，rawOutput 兜底
+    Integer failed,
+    Long durationMs,
+    List<String> failureDetails,
+    String rawOutput         // 解析失败时的原始输出兜底
+) {}
+```
+
+### 7.4 RefactorTask（🎯 P2-2）
 ```java
 public record RefactorTask(
     String taskType,     // REPLACE|API_MIGRATION|DEPENDENCY_UPGRADE|STYLE
@@ -422,66 +546,85 @@ public record RefactorTask(
 
 ---
 
-## 7. 实施路线图
+## 8. 实施路线图
 
-### 阶段一：基础体验增强（2 周）
-- 实现实时 `file_change` 事件（方式 B 兜底）。
-- Git diff 摘要、commit message、PR description 生成。
-- 前端 VibeCoding 面板新增"Git 助手"抽屉。
+### 阶段一：P0 收口——信任与闭环（1~1.5 周）
+- 会话一键回滚（P0-1）：半天出接口，联调前端按钮。
+- AI Code Review（P0-2）：复用 GitAssistantService 模式 + 前端 Review 标签页。
+- 生成→验证→修复闭环（P0-3）：`test_report` 事件 + prompt 升级 + 测试报告卡片。
+- **出口标准**：日常 VibeCoding 使用中，"改错可撤销、质量有 Review、对错自动验"三件事全部页面内完成。
 
-### 阶段二：安全与审查（2 周）
-- 开启 Sandbox + Plan Mode。
-- 实现自动备份与撤销能力。
-- 搭建 Reviewer Subagent，实现 AI Code Review。
+### 阶段二：P1 升级——HITL 与生产化（2~3 周）
+- Plan Mode 人工确认闭环（P1-1）：先做方案设计评审（SSE 挂起边界），再实现。
+- 交互式运行面板（P1-2）。
+- Docker 沙箱补齐（P1-3）：优先验证 bind mount 方案；补 `DockerSandboxIntegrationTest`（遗留待办）。
 
-### 阶段三：智能诊断与生成（3 周）
-- 智能 Bug 修复 / 日志诊断。
-- 代码生成 + 单元测试生成 + 测试运行反馈。
-- 自动化重构助手。
+### 阶段三：P2 扩展——诊断与批量操作（2~3 周）
+- 智能 Bug 修复/日志诊断（P2-1）。
+- 自动化重构助手（P2-2，依赖阶段二的 Plan Mode）。
+- 沙箱管理页面（P2-3）。
 
-### 阶段四：高级协作（4 周）
-- 多 Agent 协作编程。
-- 代码知识库问答（向量化 + 检索）。
-- 效果评估与迭代优化。
+### 阶段四：P3 远期——协作与知识库（依赖 starter 演进，不设时限）
+- starter 侧先行：SubAgent/Pipeline 编排验证、真实 Embedding RAG。
+- 多 Agent 协作编程（P3-1）、代码知识库问答（P3-2）。
 
 ---
 
-## 8. 风险与应对
+## 9. 风险与应对
 
 | 风险 | 影响 | 应对措施 |
 |---|---|---|
-| Agent 生成代码质量不稳定 | 高 | 引入 Plan Mode、Review Agent、单测运行反馈三重校验 |
-| 自动化重构误改大量文件 | 高 | 强制 Plan Mode 确认、自动备份、分批执行 |
-| Sandbox 性能开销大 | 中 | 默认 local 沙箱，Docker 沙箱按环境开启 |
-| 代码库向量化成本高 | 中 | 增量更新、按租户/项目隔离、缓存 Embedding |
-| Git 写操作安全风险 | 高 | 所有写操作必须人工确认，记录审计日志 |
+| Agent 生成代码质量不稳定 | 高 | P0 三件套（回滚 + Review + 验证闭环）构成三重校验，均为本版最高优先级 |
+| SSE 挂起等确认导致连接泄漏/前端假死 | 高 | P1-1 明确"挂起不持久化、超时即拒绝、重启即取消"边界；沿用 `Flux.defer` 兜底同步异常（一期实测坑） |
+| Docker 模式产物不可见导致功能"看似失效" | 中 | 第 2 章已声明为架构约束；P1-3 同步机制落地前，依赖宿主机文件的功能明确标注"仅 local 模式" |
+| 自动化重构误改大量文件 | 高 | 强制 Plan Mode 确认（P1-1 先行）+ git baseline 回滚（P0-1 先行）+ 分批执行 |
+| 沙箱执行 `mvn test` 超时/离线仓库缺依赖 | 中 | local 模式先行验收；Docker 镜像预热本地仓库；超时按 agent 粒度可调 |
+| 代码库向量化成本高 | 中 | P3 延后启动；增量更新、按租户隔离、缓存 Embedding |
+| Git 写操作安全风险 | 高 | 维持现状：Agent 侧只读 diff，不做真实 commit/push；未来放开必须人工确认 + 审计 |
 
 ---
 
-## 9. 附录
+## 10. 附录
 
-### 9.1 相关代码入口
-- `VibeCodingService.java` —— VibeCoding 业务入口
-- `ChatService.java` —— 流式对话服务
-- `HarnessAgentFactory.java` —— Sandbox / Subagent / Plan Mode 配置
-- `MultiAgentOrchestrator.java` —— 多 Agent 编排
-- `KnowledgeProvider.java` —— RAG 知识检索
-- `SessionConfig.java` —— AgentStateStore 持久化配置
+### 10.1 相关代码入口（admin-server 实际类名）
 
-### 9.2 关键配置项
+- `VibeCodingService` —— VibeCoding 业务入口（流式对话 + file_change 增量快照）
+- `VibeCodingController` —— 接口层（`/api/workspace/{agentCode}/vibecoding/**`）
+- `GitWorkspaceService` —— 会话 git baseline / diff（P0-1 回滚在此扩展）
+- `GitAssistantService` —— 一次性模型调用生成 Git 文本（P0-2 Review 复用此模式）
+- `AdminAgentInstanceFactory` —— HarnessAgent 装配（沙箱模式挂载、P1-1 PermissionMode 切换点）
+- `AdminSandboxProperties` / `SandboxGuardMiddleware` / `SandboxSafeAgentStateStore` —— 沙箱配置/命令拦截/Docker sessionId 转义
+- `ChatService` —— 通用流式对话（`Flux.defer` 同步异常兜底模式）
+- `ChatNodeKind` —— SSE 事件类型枚举（新增事件类型在此扩展）
+
+> 注意：admin-server 排除了 starter 的自动装配（`spring.autoconfigure.exclude`），需要 starter 能力时在
+> 自己的 `@Configuration` 里显式 new——文档中凡引用 starter 类（如 Approval Store SPI）均指"参考其模式"，
+> 不是假设容器里有现成 Bean。
+
+### 10.2 关键配置项（实际生效前缀为 `admin.sandbox.*`）
+
 ```yaml
-customer-work:
-  harness:
-    plan-mode:
-      enabled: true
-    sandbox:
-      mode: local   # local | docker
-    subagent:
-      enabled: true
-  skill:
-    runtime-load-tool-enabled: true
-    code-execution-enabled: true
+admin:
+  sandbox:
+    mode: ${ADMIN_SANDBOX_MODE:local}            # local | docker
+    execute-timeout-seconds: ${ADMIN_SANDBOX_EXECUTE_TIMEOUT_SECONDS:60}
+    docker:
+      image: ${ADMIN_SANDBOX_DOCKER_IMAGE:maven:3.9-eclipse-temurin-17}
+      memory-mb: ${ADMIN_SANDBOX_DOCKER_MEMORY_MB:512}
+      cpu-count: ${ADMIN_SANDBOX_DOCKER_CPU_COUNT:1}
+      network: ${ADMIN_SANDBOX_DOCKER_NETWORK:none}
+    guard:
+      enabled: ${ADMIN_SANDBOX_GUARD_ENABLED:true}
 ```
+
+新功能的配置项按同一约定扩展（如 `admin.vibecoding.review.*`、`admin.vibecoding.plan-mode.*`），
+均支持 env 覆盖，默认值保守（新功能默认关闭）。
+
+### 10.3 参考文档
+
+- `docs/VibeCoding-Git助手与代码沙箱-开发总结.md` —— 一期/二期实现细节与踩坑记录
+- AgentScope Java 官方文档 https://java.agentscope.io （Harness / Sandbox / Plan Mode / Subagent）
+- `进度说明.txt` —— starter 侧框架能力缺口与演进优先级（P3 前置依赖的依据）
 
 ---
 


### PR DESCRIPTION
## Summary
- 落地 `docs/AI编码助手需求文档.md` §5.2/§5.3 非功能需求：AI 编码操作审计日志（操作人、时间、变更文件、模型 token 用量）。
- 需求文档同步升级到 v2.0：把已交付能力（实时 file_change、Git 助手、代码沙箱）沉淀为基线，剩余需求按「重要性 × 提效价值 × 已有基础成熟度」重排优先级。

## 变更内容
- 新表 `ai_coding_audit_log`（Flyway V13）+ 菜单/权限点（`ai-audit:view`）。
- 埋点覆盖 5 类 AI 编码操作：VibeCoding 流式对话（含 token 用量聚合）、文件保存、Git 助手三件套（diff 摘要/commit message/PR description）。
- `ChatService` 新增带 usage 观察者的 `chatStream` 重载，按 messageId 去重聚合 `ChatUsage`。
- 审计为纯旁路能力：业务自持控制流、落库走独立 `@Async` Recorder（规避同类自调用代理失效）、失败只记日志不抛异常。
- 查询接口 `/api/workspace/ai-coding-audit` + 前端审计列表页（系统管理菜单）。
- 顺带修复：前端 SSE 未知事件会被拼进对话正文，改为静默忽略（需求 §5.5 向后兼容），Chat/VibeCoding 双面板同步修正。

## Test plan
- [x] `mvn -gs/-s scripts/settings-central-direct.xml clean test -Djacoco.skip=true`：admin-server 175 → **187 全绿**
- [x] `customer-admin-web`：`vue-tsc -b && vite build` 通过
- [x] 本机 `customer_admin` 库手工执行 V13，菜单/权限验证生效
- [ ] 人工验收：VibeCoding 对话 + 保存文件 + 生成 commit message 各一次，"系统管理 → AI编码审计"页核对 token/变更文件/耗时展示

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>