### PR TITLE
chore(release): 版本号提升至 2.0.0

### DIFF
--- a/customer-admin-server/pom.xml
+++ b/customer-admin-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-spring-boot-starter</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/customer-web/pom.xml
+++ b/customer-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-spring-boot-starter</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/customer-work-app/pom.xml
+++ b/customer-work-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-spring-boot-starter</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
         </dependency>
 
         <!-- 测试 -->

--- a/customer-work-downstream-app/pom.xml
+++ b/customer-work-downstream-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-spring-boot-starter</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
         </dependency>
 
         <dependency>

--- a/customer-work-spring-boot-starter/pom.xml
+++ b/customer-work-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.richardfyoung</groupId>
     <artifactId>customer-work-parent</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     <name>customer-work-parent</name>
     <description>基于 AgentScope Java 的生产级智能客服系统（多模块：可复用 starter + 可运行应用）</description>


### PR DESCRIPTION
## Summary
- 各模块 pom.xml 版本号从 1.0.0 提升至 2.0.0，对应 main 分支已完成的 AgentScope Java 1.0.12 → 2.0.0 GA 全量迁移
- 纯版本号变更，无功能代码改动，为发布 GitHub Release v2.0.0 做准备

## Test plan
- [x] `mvn validate`（多模块）通过
- [ ] 合并后打 tag `v2.0.0` 并创建 GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)