### PR TITLE
feat(admin): 新增系统工具（HTTP 请求工具）与智能体多选挂载

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentSaveRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 /**
- * 智能体新建/编辑请求。{@code mcpIds}/{@code skillIds} 可选多选；{@code modelId} 必填。
+ * 智能体新建/编辑请求。{@code mcpIds}/{@code skillIds}/{@code systemToolIds} 可选多选；{@code modelId} 必填。
  * @author owlzhangfq@gmail.com
  */
 public record AgentSaveRequest(
@@ -15,6 +15,7 @@ public record AgentSaveRequest(
     @NotNull(message = "modelId 不能为空") Long modelId,
     List<Long> mcpIds,
     List<Long> skillIds,
+    List<Long> systemToolIds,
     String systemPrompt,
     List<String> capabilities,
     String icon,

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentVO.java
@@ -18,6 +18,7 @@ public class AgentVO {
     private String modelName;
     private List<Long> mcpIds;
     private List<Long> skillIds;
+    private List<Long> systemToolIds;
     private String systemPrompt;
     private List<String> capabilities;
     private String icon;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
@@ -15,6 +15,9 @@ import com.richard.fyoung.customeradmin.aiconfig.mcp.mapper.AiMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
 import com.richard.fyoung.customeradmin.aiconfig.model.mapper.AiModelConfigMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
@@ -50,19 +53,24 @@ public class AgentService {
     private final AiModelConfigMapper modelConfigMapper;
     private final AiMcpMapper mcpMapper;
     private final AiSkillMapper skillMapper;
+    private final AiAgentSystemToolMapper agentSystemToolMapper;
+    private final AiSystemToolMapper systemToolMapper;
     private final MenuVersionHolder menuVersionHolder;
     private final AgentInstanceCache agentInstanceCache;
 
     public AgentService(AiAgentMapper agentMapper, AiAgentMcpMapper agentMcpMapper,
                          AiAgentSkillMapper agentSkillMapper, AiModelConfigMapper modelConfigMapper,
-                         AiMcpMapper mcpMapper, AiSkillMapper skillMapper, MenuVersionHolder menuVersionHolder,
-                         AgentInstanceCache agentInstanceCache) {
+                         AiMcpMapper mcpMapper, AiSkillMapper skillMapper,
+                         AiAgentSystemToolMapper agentSystemToolMapper, AiSystemToolMapper systemToolMapper,
+                         MenuVersionHolder menuVersionHolder, AgentInstanceCache agentInstanceCache) {
         this.agentMapper = agentMapper;
         this.agentMcpMapper = agentMcpMapper;
         this.agentSkillMapper = agentSkillMapper;
         this.modelConfigMapper = modelConfigMapper;
         this.mcpMapper = mcpMapper;
         this.skillMapper = skillMapper;
+        this.agentSystemToolMapper = agentSystemToolMapper;
+        this.systemToolMapper = systemToolMapper;
         this.menuVersionHolder = menuVersionHolder;
         this.agentInstanceCache = agentInstanceCache;
     }
@@ -97,7 +105,7 @@ public class AgentService {
         AiAgent agent = new AiAgent();
         fillFromRequest(agent, request);
         agentMapper.insert(agent);
-        replaceRelations(agent.getId(), request.mcpIds(), request.skillIds());
+        replaceRelations(agent.getId(), request.mcpIds(), request.skillIds(), request.systemToolIds());
         menuVersionHolder.bump();
     }
 
@@ -108,7 +116,7 @@ public class AgentService {
         validate(request);
         fillFromRequest(agent, request);
         agentMapper.updateById(agent);
-        replaceRelations(id, request.mcpIds(), request.skillIds());
+        replaceRelations(id, request.mcpIds(), request.skillIds(), request.systemToolIds());
         menuVersionHolder.bump();
         // agentCode 理论上不应改变，但仍按新旧两个 code 双清，避免缓存键错位残留旧实例
         agentInstanceCache.evict(oldAgentCode);
@@ -121,6 +129,7 @@ public class AgentService {
         agentMapper.deleteById(id);
         agentMcpMapper.delete(new LambdaQueryWrapper<AiAgentMcp>().eq(AiAgentMcp::getAgentId, id));
         agentSkillMapper.delete(new LambdaQueryWrapper<AiAgentSkill>().eq(AiAgentSkill::getAgentId, id));
+        agentSystemToolMapper.delete(new LambdaQueryWrapper<AiAgentSystemTool>().eq(AiAgentSystemTool::getAgentId, id));
         menuVersionHolder.bump();
         agentInstanceCache.evict(agent.getAgentCode());
     }
@@ -152,6 +161,10 @@ public class AgentService {
             && skillMapper.selectBatchIds(request.skillIds()).size() != request.skillIds().size()) {
             throw new BizException(ResultCode.PARAM_INVALID, "存在无效的 skillIds");
         }
+        if (!CollectionUtils.isEmpty(request.systemToolIds())
+            && systemToolMapper.selectBatchIds(request.systemToolIds()).size() != request.systemToolIds().size()) {
+            throw new BizException(ResultCode.PARAM_INVALID, "存在无效的 systemToolIds");
+        }
         if (!CollectionUtils.isEmpty(request.capabilities())
             && !VALID_CAPABILITIES.containsAll(request.capabilities())) {
             throw new BizException(ResultCode.PARAM_INVALID, "capabilities 仅支持 chat/vibecoding");
@@ -159,7 +172,7 @@ public class AgentService {
     }
 
     /** 关联表整体替换：先清空该智能体现有关联行，再按本次提交的 ids 批量插入（比对差异做增量删改无必要，行数很少）。 */
-    private void replaceRelations(Long agentId, List<Long> mcpIds, List<Long> skillIds) {
+    private void replaceRelations(Long agentId, List<Long> mcpIds, List<Long> skillIds, List<Long> systemToolIds) {
         agentMcpMapper.delete(new LambdaQueryWrapper<AiAgentMcp>().eq(AiAgentMcp::getAgentId, agentId));
         if (!CollectionUtils.isEmpty(mcpIds)) {
             for (Long mcpId : mcpIds) {
@@ -176,6 +189,15 @@ public class AgentService {
                 relation.setAgentId(agentId);
                 relation.setSkillId(skillId);
                 agentSkillMapper.insert(relation);
+            }
+        }
+        agentSystemToolMapper.delete(new LambdaQueryWrapper<AiAgentSystemTool>().eq(AiAgentSystemTool::getAgentId, agentId));
+        if (!CollectionUtils.isEmpty(systemToolIds)) {
+            for (Long systemToolId : systemToolIds) {
+                AiAgentSystemTool relation = new AiAgentSystemTool();
+                relation.setAgentId(agentId);
+                relation.setSystemToolId(systemToolId);
+                agentSystemToolMapper.insert(relation);
             }
         }
     }
@@ -203,6 +225,8 @@ public class AgentService {
             .stream().map(AiAgentMcp::getMcpId).collect(Collectors.toList()));
         vo.setSkillIds(agentSkillMapper.selectList(new LambdaQueryWrapper<AiAgentSkill>().eq(AiAgentSkill::getAgentId, agent.getId()))
             .stream().map(AiAgentSkill::getSkillId).collect(Collectors.toList()));
+        vo.setSystemToolIds(agentSystemToolMapper.selectList(new LambdaQueryWrapper<AiAgentSystemTool>().eq(AiAgentSystemTool::getAgentId, agent.getId()))
+            .stream().map(AiAgentSystemTool::getSystemToolId).collect(Collectors.toList()));
         vo.setSystemPrompt(agent.getSystemPrompt());
         vo.setCapabilities(StringUtils.hasText(agent.getCapabilities())
             ? Arrays.asList(agent.getCapabilities().split(CAPABILITY_DELIMITER)) : List.of());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/controller/SystemToolController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/controller/SystemToolController.java
@@ -1,0 +1,52 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.dto.SystemToolSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.dto.SystemToolVO;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.service.SystemToolService;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 系统工具管理：分页查询 + 编辑（改名称/描述/启停/备注）。工具目录是代码定义的，不支持新建/删除。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/system-tool")
+public class SystemToolController {
+
+    private final SystemToolService systemToolService;
+
+    public SystemToolController(SystemToolService systemToolService) {
+        this.systemToolService = systemToolService;
+    }
+
+    @SaCheckPermission("system-tool:view")
+    @GetMapping
+    public Result<PageResult<SystemToolVO>> page(PageQuery query) {
+        return Result.success(systemToolService.page(query));
+    }
+
+    @SaCheckPermission("system-tool:view")
+    @GetMapping("/{id}")
+    public Result<SystemToolVO> get(@PathVariable Long id) {
+        return Result.success(systemToolService.get(id));
+    }
+
+    @SaCheckPermission("system-tool:edit")
+    @OperationLog(operation = "编辑系统工具", target = "ai_system_tool")
+    @PutMapping("/{id}")
+    public Result<Void> update(@PathVariable Long id, @Valid @RequestBody SystemToolSaveRequest request) {
+        systemToolService.update(id, request);
+        return Result.success();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/dto/SystemToolSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/dto/SystemToolSaveRequest.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 系统工具编辑请求。工具目录是代码定义的，{@code toolCode} 与其绑定的 Bean 不可修改，
+ * 故编辑请求体只含名称/描述/启停/备注，不含 {@code toolCode}。
+ * @author owlzhangfq@gmail.com
+ */
+public record SystemToolSaveRequest(
+    @NotBlank(message = "toolName 不能为空") String toolName,
+    String description,
+    Integer enabled,
+    String remark) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/dto/SystemToolVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/dto/SystemToolVO.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 系统工具视图对象。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SystemToolVO {
+    private Long id;
+    private String toolCode;
+    private String toolName;
+    private String description;
+    /** 0禁用 / 1启用。 */
+    private Integer enabled;
+    private String remark;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/entity/AiAgentSystemTool.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/entity/AiAgentSystemTool.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 智能体-系统工具 关联（纯关系表，无审计列，仿 {@code ai_agent_mcp}）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_agent_system_tool")
+public class AiAgentSystemTool {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private Long agentId;
+    private Long systemToolId;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/entity/AiSystemTool.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/entity/AiSystemTool.java
@@ -1,0 +1,43 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 系统工具目录。工具实现是代码定义的（{@code tool_code} 精确对应一个 Spring Bean 名），
+ * 库里只存"该工具是否启用 + 展示用的名称/描述/备注"，不存工具逻辑本身，因此不支持 UI 新建/删除。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_system_tool")
+public class AiSystemTool {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 工具编码（唯一），运行时按此值 {@code ApplicationContext.getBean(toolCode)} 取工具 Bean，不可修改。 */
+    private String toolCode;
+    private String toolName;
+    private String description;
+    /** 0禁用 / 1启用。 */
+    private Integer enabled;
+    private String remark;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private Long updateBy;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    @TableLogic
+    private Integer deleted;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/mapper/AiAgentSystemToolMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/mapper/AiAgentSystemToolMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
+
+/**
+ * 智能体-系统工具 关联 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiAgentSystemToolMapper extends BaseMapper<AiAgentSystemTool> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/mapper/AiSystemToolMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/mapper/AiSystemToolMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
+
+/**
+ * 系统工具 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiSystemToolMapper extends BaseMapper<AiSystemTool> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/service/SystemToolService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/service/SystemToolService.java
@@ -1,0 +1,108 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.dto.SystemToolSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.dto.SystemToolVO;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 系统工具管理：工具目录是代码定义的（{@code tool_code} 对应一个 Spring Bean），库里只维护启停状态与
+ * 展示信息，故只有分页查询 + 编辑（改名称/描述/启停/备注），没有新建/删除。
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class SystemToolService {
+
+    private final AiSystemToolMapper systemToolMapper;
+    private final AiAgentSystemToolMapper agentSystemToolMapper;
+    private final AiAgentMapper agentMapper;
+    private final AgentInstanceCache agentInstanceCache;
+
+    public SystemToolService(AiSystemToolMapper systemToolMapper, AiAgentSystemToolMapper agentSystemToolMapper,
+                             AiAgentMapper agentMapper, AgentInstanceCache agentInstanceCache) {
+        this.systemToolMapper = systemToolMapper;
+        this.agentSystemToolMapper = agentSystemToolMapper;
+        this.agentMapper = agentMapper;
+        this.agentInstanceCache = agentInstanceCache;
+    }
+
+    public PageResult<SystemToolVO> page(PageQuery query) {
+        LambdaQueryWrapper<AiSystemTool> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(query.getKeyword())) {
+            wrapper.like(AiSystemTool::getToolName, query.getKeyword());
+        }
+        if (query.getStatus() != null) {
+            wrapper.eq(AiSystemTool::getEnabled, query.getStatus());
+        }
+        wrapper.orderBy(true, "asc".equalsIgnoreCase(query.getSortOrder()), AiSystemTool::getCreateTime);
+
+        IPage<AiSystemTool> page = systemToolMapper.selectPage(new Page<>(query.getPageNum(), query.getPageSize()), wrapper);
+        return PageResult.of(page.convert(this::toVo));
+    }
+
+    public SystemToolVO get(Long id) {
+        return toVo(requireTool(id));
+    }
+
+    public void update(Long id, SystemToolSaveRequest request) {
+        AiSystemTool tool = requireTool(id);
+        tool.setToolName(request.toolName());
+        tool.setDescription(request.description());
+        tool.setEnabled(request.enabled() == null ? 1 : request.enabled());
+        tool.setRemark(request.remark());
+        systemToolMapper.updateById(tool);
+        evictAgentsReferencingTool(id);
+    }
+
+    /** 系统工具启停/信息变更会影响引用它的智能体运行时装配（启用与否决定是否注册进 Toolkit），需一并失效重建。 */
+    private void evictAgentsReferencingTool(Long systemToolId) {
+        List<Long> agentIds = agentSystemToolMapper.selectList(
+                new LambdaQueryWrapper<AiAgentSystemTool>().eq(AiAgentSystemTool::getSystemToolId, systemToolId))
+            .stream().map(AiAgentSystemTool::getAgentId).collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(agentIds)) {
+            return;
+        }
+        List<String> agentCodes = agentMapper.selectBatchIds(agentIds).stream()
+            .map(AiAgent::getAgentCode).collect(Collectors.toList());
+        agentInstanceCache.evictAll(agentCodes);
+    }
+
+    private SystemToolVO toVo(AiSystemTool tool) {
+        SystemToolVO vo = new SystemToolVO();
+        vo.setId(tool.getId());
+        vo.setToolCode(tool.getToolCode());
+        vo.setToolName(tool.getToolName());
+        vo.setDescription(tool.getDescription());
+        vo.setEnabled(tool.getEnabled());
+        vo.setRemark(tool.getRemark());
+        vo.setCreateTime(tool.getCreateTime());
+        vo.setUpdateTime(tool.getUpdateTime());
+        return vo;
+    }
+
+    private AiSystemTool requireTool(Long id) {
+        AiSystemTool tool = systemToolMapper.selectById(id);
+        if (tool == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "系统工具不存在: " + id);
+        }
+        return tool;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/HttpClientTools.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/HttpClientTools.java
@@ -1,0 +1,151 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.tool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.tool.dto.HttpResponse;
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.Map;
+
+/**
+ * HTTP 请求工具（系统工具 {@code httpclient}）。给挂载了本工具的智能体提供 GET/DELETE/POST/POST-Form/PUT
+ * 五种 HTTP 调用能力，供其在对话中访问外部/内网 HTTP 接口。
+ *
+ * <p>Bean 名精确等于 {@code tool_code}（"httpclient"），运行时
+ * {@code AdminAgentInstanceFactory#buildSystemTools} 按此名从容器取实例注册进 Toolkit。</p>
+ *
+ * <p>安全说明：TLS 走 JDK 默认信任链校验（不做 trust-all / 不关主机名校验）；但本工具允许智能体请求
+ * 任意可达 URL（含内网地址），是一个 SSRF 风险面，是否收紧到 URL 白名单后续按需迭代。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component("httpclient")
+public class HttpClientTools {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpClientTools.class);
+
+    private static final int CONNECT_TIMEOUT_MS = 2_000;
+    private static final int READ_TIMEOUT_MS = 30_000;
+    private static final String ERROR_CODE_HTTP_FAIL = "SYSTOOL-HTTP-FAIL";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public HttpClientTools() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        System.setProperty("http.keepAlive", "true");
+        System.setProperty("http.maxConnections", "50");
+        this.restTemplate = new RestTemplate(factory);
+    }
+
+    @Tool(name = "http_get", description = "get请求http地址")
+    public Mono<String> getRequest(
+            @ToolParam(name = "url", description = "http地址") String url,
+            @ToolParam(name = "header", required = false, description = "请求头") Map<String, String> headers) {
+        return async(() -> execute(url, HttpMethod.GET, buildHeaders(headers), null));
+    }
+
+    @Tool(name = "http_delete", description = "delete请求http地址")
+    public Mono<String> deleteRequest(
+            @ToolParam(name = "url", description = "http地址") String url,
+            @ToolParam(name = "header", required = false, description = "请求头") Map<String, String> headers) {
+        return async(() -> execute(url, HttpMethod.DELETE, buildHeaders(headers), null));
+    }
+
+    @Tool(name = "http_post_form", description = "post请求http地址(form表单)")
+    public Mono<String> postFormRequest(
+            @ToolParam(name = "url", description = "http地址") String url,
+            @ToolParam(name = "header", required = false, description = "请求头") Map<String, String> headers,
+            @ToolParam(name = "params", required = true, description = "form参数") Map<String, Object> forms) {
+        return async(() -> {
+            HttpHeaders h = buildHeaders(headers);
+            h.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            StringBuilder sb = new StringBuilder();
+            if (forms != null) {
+                for (Map.Entry<String, Object> e : forms.entrySet()) {
+                    if (sb.length() > 0) {
+                        sb.append("&");
+                    }
+                    sb.append(e.getKey()).append("=").append(e.getValue());
+                }
+            }
+            return execute(url, HttpMethod.POST, h, sb.toString());
+        });
+    }
+
+    @Tool(name = "http_post", description = "post请求http地址")
+    public Mono<String> postRequest(
+            @ToolParam(name = "url", description = "http地址") String url,
+            @ToolParam(name = "header", required = false, description = "请求头") Map<String, String> headers,
+            @ToolParam(name = "body", description = "请求body") String body) {
+        return async(() -> {
+            HttpHeaders h = buildHeaders(headers);
+            h.setContentType(MediaType.APPLICATION_JSON);
+            return execute(url, HttpMethod.POST, h, body);
+        });
+    }
+
+    @Tool(name = "http_put", description = "put请求http地址")
+    public Mono<String> putRequest(
+            @ToolParam(name = "url", description = "http地址") String url,
+            @ToolParam(name = "header", required = false, description = "请求头") Map<String, String> headers,
+            @ToolParam(name = "body", description = "请求body") String body) {
+        return async(() -> {
+            HttpHeaders h = buildHeaders(headers);
+            h.setContentType(MediaType.APPLICATION_JSON);
+            return execute(url, HttpMethod.PUT, h, body);
+        });
+    }
+
+    /** 阻塞的 RestTemplate 调用放到 boundedElastic 线程池执行，不占用 reactor 事件循环线程。 */
+    private Mono<String> async(java.util.concurrent.Callable<String> task) {
+        return Mono.fromCallable(task).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /** 发起一次请求并把结果序列化成 JSON 字符串回传给 LLM；任何异常都收敛成 error 字段而非抛出。 */
+    private String execute(String url, HttpMethod method, HttpHeaders headers, String body) {
+        HttpResponse response;
+        try {
+            HttpEntity<String> entity = body != null ? new HttpEntity<>(body, headers) : new HttpEntity<>(headers);
+            ResponseEntity<String> resp = restTemplate.exchange(url, method, entity, String.class);
+            response = HttpResponse.builder()
+                .url(url).method(method.name()).statusCode(resp.getStatusCode().value())
+                .body(resp.getBody()).build();
+        } catch (Exception e) {
+            log.error("http tool request failed, code={}, url={}, method={}", ERROR_CODE_HTTP_FAIL, url, method, e);
+            response = HttpResponse.builder()
+                .url(url).method(method.name()).error(e.getMessage()).build();
+        }
+        return toJson(response);
+    }
+
+    private String toJson(HttpResponse response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (Exception e) {
+            log.error("http tool serialize response failed, code={}, url={}", ERROR_CODE_HTTP_FAIL, response.getUrl(), e);
+            return "{\"url\":\"" + response.getUrl() + "\",\"error\":\"serialize response failed\"}";
+        }
+    }
+
+    private HttpHeaders buildHeaders(Map<String, String> headers) {
+        HttpHeaders h = new HttpHeaders();
+        if (headers != null) {
+            headers.forEach(h::add);
+        }
+        return h;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/dto/HttpResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/dto/HttpResponse.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.tool.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * HTTP 工具单次请求结果。序列化成 JSON 字符串回传给 LLM：正常时带 {@code statusCode}/{@code body}，
+ * 异常时（连不上/超时等）{@code error} 非空且 {@code statusCode} 为空——工具永远返回结果而非抛异常，
+ * 让 LLM 能读到失败原因继续决策。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@Builder
+public class HttpResponse {
+    private String url;
+    private String method;
+    private Integer statusCode;
+    private String body;
+    private String error;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -15,6 +15,10 @@ import com.richard.fyoung.customeradmin.aiconfig.model.mapper.AiModelConfigMappe
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.AdminModelFactory;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
 import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
@@ -39,7 +43,9 @@ import io.agentscope.harness.agent.filesystem.spec.SandboxFilesystemSpec;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerFilesystemSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.nio.file.Files;
@@ -86,6 +92,9 @@ public class AdminAgentInstanceFactory {
     private final AiModelConfigMapper modelConfigMapper;
     private final AiMcpMapper mcpMapper;
     private final AiSkillMapper skillMapper;
+    private final AiAgentSystemToolMapper agentSystemToolMapper;
+    private final AiSystemToolMapper systemToolMapper;
+    private final ApplicationContext applicationContext;
     private final AdminModelFactory modelFactory;
     private final AesGcmCryptoUtil cryptoUtil;
     private final AgentStateStore stateStore;
@@ -103,6 +112,8 @@ public class AdminAgentInstanceFactory {
     public AdminAgentInstanceFactory(AiAgentMapper agentMapper, AiAgentMcpMapper agentMcpMapper,
                                       AiAgentSkillMapper agentSkillMapper, AiModelConfigMapper modelConfigMapper,
                                       AiMcpMapper mcpMapper, AiSkillMapper skillMapper,
+                                      AiAgentSystemToolMapper agentSystemToolMapper, AiSystemToolMapper systemToolMapper,
+                                      ApplicationContext applicationContext,
                                       AdminModelFactory modelFactory, AesGcmCryptoUtil cryptoUtil,
                                       AgentStateStore stateStore, PermissionContextState permissionContext,
                                       AdminMcpFactory mcpFactory, AdminSandboxProperties sandboxProperties,
@@ -113,6 +124,9 @@ public class AdminAgentInstanceFactory {
         this.modelConfigMapper = modelConfigMapper;
         this.mcpMapper = mcpMapper;
         this.skillMapper = skillMapper;
+        this.agentSystemToolMapper = agentSystemToolMapper;
+        this.systemToolMapper = systemToolMapper;
+        this.applicationContext = applicationContext;
         this.modelFactory = modelFactory;
         this.cryptoUtil = cryptoUtil;
         this.stateStore = stateStore;
@@ -153,6 +167,7 @@ public class AdminAgentInstanceFactory {
         Model model = buildModel(agent.getModelId());
         Set<String> mcpToolNames = new HashSet<>();
         Toolkit toolkit = buildToolkit(agent.getId(), mcpToolNames);
+        buildSystemTools(agent.getId(), toolkit);
 
         ReActAgent.Builder builder = ReActAgent.builder()
             .name("AdminAgent-" + agentCode)
@@ -320,6 +335,32 @@ public class AdminAgentInstanceFactory {
         return mcpFactory.buildClientBuilder(mcp.getMcpName(), mcp.getMcpType(), mcp.getConfig())
             .timeout(java.time.Duration.ofSeconds(30))
             .buildAsync();
+    }
+
+    /**
+     * 读 {@code ai_agent_system_tool} 关联行，按 {@code tool_code}（= Spring Bean 名）取工具 Bean 注册进 Toolkit。
+     * 只注册 {@code enabled=1} 的工具；某个 tool_code 取不到 Bean（比如种子行存在但代码没实现对应类）不抛异常、
+     * {@code log.error} 记录后跳过，避免一个坏配置拖垮整个智能体装配。
+     */
+    private void buildSystemTools(Long agentId, Toolkit toolkit) {
+        List<Long> toolIds = agentSystemToolMapper.selectList(
+                new LambdaQueryWrapper<AiAgentSystemTool>().eq(AiAgentSystemTool::getAgentId, agentId))
+            .stream().map(AiAgentSystemTool::getSystemToolId).collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(toolIds)) {
+            return;
+        }
+        for (AiSystemTool tool : systemToolMapper.selectBatchIds(toolIds)) {
+            if (tool.getEnabled() == null || tool.getEnabled() != STATUS_ENABLED) {
+                continue;
+            }
+            try {
+                Object bean = applicationContext.getBean(tool.getToolCode());
+                toolkit.registerTool(bean);
+                log.info("[workspace] system tool registered: code={}", tool.getToolCode());
+            } catch (Exception e) {
+                log.error("system tool bean not found, code={}, toolCode={}", "SYSTOOL-BEAN-MISSING", tool.getToolCode(), e);
+            }
+        }
     }
 
     /**

--- a/customer-admin-server/src/main/resources/db/migration/V15__system_tool.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V15__system_tool.sql
@@ -1,0 +1,60 @@
+-- =============================================================================
+-- 系统工具（Flyway V15，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 维护一个"系统工具"目录：工具实现是代码定义的（一个 @Tool 注解的 Spring Bean，bean name 精确
+-- 等于 tool_code），库里只存"该工具是否启用 + 展示用名称/描述/备注"，不存工具逻辑本身。新增一个
+-- 工具 = 写一个新 @Tool 类 + 本迁移加一行种子；因此系统工具管理页没有新增/删除，只有启停 + 编辑。
+-- 智能体配置页可像挂 MCP/Skill 一样多选系统工具（ai_agent_system_tool 关联表），聊天运行时把勾选且
+-- enabled=1 的工具按 tool_code 从 Spring 容器取 Bean 注册进该智能体的 Toolkit。
+--
+-- 本轮只有一条种子：httpclient（HTTP 请求工具，提供 GET/DELETE/POST/POST-Form/PUT 五种调用）。
+-- 安全说明：该 HTTP 工具的 TLS 走 JDK 默认信任链校验（不做 trust-all / 不关主机名校验）；但它允许
+-- 挂载该工具的智能体请求任意可达 URL（含内网地址），是一个 SSRF 风险面，是否收紧到 URL 白名单本轮
+-- 先不做，后续按需迭代。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+--
+-- 菜单/权限种子：菜单 id=120（V13 用到 100、V14 用到 110-112，跳到 120 留安全间隔），parent_id=2
+-- 挂在"AI 配置"目录下，sort=6。按钮/接口权限点只有 view/edit（无 add/delete）。
+-- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接放行
+-- 全部权限点（沿用 V12/V13/V14 同款做法，普通角色需在角色管理页手工授权）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `ai_system_tool` (
+    `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `tool_code`   VARCHAR(64) NOT NULL COMMENT '工具编码（唯一，运行时按此值取同名 Spring Bean，不可修改）',
+    `tool_name`   VARCHAR(128) NOT NULL COMMENT '工具展示名称',
+    `description` VARCHAR(512) COMMENT '工具描述',
+    `enabled`     TINYINT NOT NULL DEFAULT 1 COMMENT '是否启用：0禁用 / 1启用',
+    `remark`      VARCHAR(255) COMMENT '备注',
+    `create_by`   BIGINT COMMENT '创建人ID',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`   BIGINT COMMENT '更新人ID',
+    `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`     TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    UNIQUE KEY `uk_ai_system_tool_code` (`tool_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='系统工具目录（代码定义，库存启停状态）';
+
+CREATE TABLE IF NOT EXISTS `ai_agent_system_tool` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `agent_id`       BIGINT NOT NULL COMMENT '智能体ID',
+    `system_tool_id` BIGINT NOT NULL COMMENT '系统工具ID',
+    INDEX `idx_ai_agent_system_tool_agent` (`agent_id`),
+    INDEX `idx_ai_agent_system_tool_tool` (`system_tool_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-系统工具关联（纯关系表）';
+
+-- 种子：HTTP 请求工具（tool_code 精确等于 @Component("httpclient") 的 Bean 名）。
+INSERT INTO `ai_system_tool` (`id`, `tool_code`, `tool_name`, `description`, `enabled`, `remark`)
+VALUES (1, 'httpclient', 'HTTP请求工具', 'http请求工具', 1, 'http请求工具');
+
+-- 菜单：系统工具（挂 AI 配置 id=2 下，sort=6）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (120, 2, '系统工具', 'system-tool', 1, '/aiconfig/system-tool', 'SetUp', 'library', 6);
+
+-- 按钮/接口权限点（type=2）：只有 view/edit（系统工具不支持新增/删除）。
+INSERT INTO `sys_permission` (`parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (120, '查看系统工具', 'system-tool:view', 2, 1),
+    (120, '编辑系统工具', 'system-tool:edit', 2, 2);

--- a/customer-admin-server/src/main/resources/db/migration/V15__system_tool.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V15__system_tool.sql
@@ -15,7 +15,7 @@
 -- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
 -- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
 --
--- 菜单/权限种子：菜单 id=120（V13 用到 100、V14 用到 110-112，跳到 120 留安全间隔），parent_id=2
+-- 菜单/权限种子：菜单 id=124（V13 用到 100、V14 用到 110-112，跳到 124 留安全间隔），parent_id=2
 -- 挂在"AI 配置"目录下，sort=6。按钮/接口权限点只有 view/edit（无 add/delete）。
 -- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接放行
 -- 全部权限点（沿用 V12/V13/V14 同款做法，普通角色需在角色管理页手工授权）。
@@ -52,9 +52,9 @@ VALUES (1, 'httpclient', 'HTTP请求工具', 'http请求工具', 1, 'http请求�
 
 -- 菜单：系统工具（挂 AI 配置 id=2 下，sort=6）。
 INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
-    (120, 2, '系统工具', 'system-tool', 1, '/aiconfig/system-tool', 'SetUp', 'library', 6);
+    (124, 2, '系统工具', 'system-tool', 1, '/aiconfig/system-tool', 'SetUp', 'library', 6);
 
 -- 按钮/接口权限点（type=2）：只有 view/edit（系统工具不支持新增/删除）。
 INSERT INTO `sys_permission` (`parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
-    (120, '查看系统工具', 'system-tool:view', 2, 1),
-    (120, '编辑系统工具', 'system-tool:edit', 2, 2);
+    (124, '查看系统工具', 'system-tool:view', 2, 1),
+    (124, '编辑系统工具', 'system-tool:edit', 2, 2);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentServiceTest.java
@@ -15,6 +15,10 @@ import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
 import com.richard.fyoung.customeradmin.aiconfig.model.mapper.AiModelConfigMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
 import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.menu.service.MenuVersionHolder;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
@@ -35,7 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link AgentService} 单测：字段校验、关联表整体替换事务、生命周期启停、菜单版本联动。
+ * {@link AgentService} 单测：字段校验、关联表整体替换事务、生命周期启停、菜单版本联动、系统工具关联。
  * @author owlzhangfq@gmail.com
  */
 class AgentServiceTest {
@@ -46,6 +50,8 @@ class AgentServiceTest {
     private AiModelConfigMapper modelConfigMapper;
     private AiMcpMapper mcpMapper;
     private AiSkillMapper skillMapper;
+    private AiAgentSystemToolMapper agentSystemToolMapper;
+    private AiSystemToolMapper systemToolMapper;
     private MenuVersionHolder menuVersionHolder;
     private AgentService service;
 
@@ -54,6 +60,7 @@ class AgentServiceTest {
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgent.class);
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentMcp.class);
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentSkill.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentSystemTool.class);
     }
 
     @BeforeEach
@@ -64,22 +71,24 @@ class AgentServiceTest {
         modelConfigMapper = mock(AiModelConfigMapper.class);
         mcpMapper = mock(AiMcpMapper.class);
         skillMapper = mock(AiSkillMapper.class);
+        agentSystemToolMapper = mock(AiAgentSystemToolMapper.class);
+        systemToolMapper = mock(AiSystemToolMapper.class);
         menuVersionHolder = new MenuVersionHolder();
         AgentInstanceCache agentInstanceCache = mock(AgentInstanceCache.class);
         service = new AgentService(agentMapper, agentMcpMapper, agentSkillMapper, modelConfigMapper,
-            mcpMapper, skillMapper, menuVersionHolder, agentInstanceCache);
+            mcpMapper, skillMapper, agentSystemToolMapper, systemToolMapper, menuVersionHolder, agentInstanceCache);
 
         when(modelConfigMapper.selectById(1L)).thenReturn(new AiModelConfig());
     }
 
     private AgentSaveRequest validRequest() {
-        return new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(10L), List.of(20L),
+        return new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(10L), List.of(20L), List.of(30L),
             "你是客服助手", List.of("chat", "vibecoding"), "robot", 1);
     }
 
     @Test
     void create_shouldRejectInvalidAgentCode() {
-        AgentSaveRequest request = new AgentSaveRequest("客服助手", "Customer_Helper", 1L, null, null,
+        AgentSaveRequest request = new AgentSaveRequest("客服助手", "Customer_Helper", 1L, null, null, null,
             null, null, null, 1);
 
         assertThrows(BizException.class, () -> service.create(request));
@@ -88,7 +97,7 @@ class AgentServiceTest {
     @Test
     void create_shouldRejectUnknownModelId() {
         when(modelConfigMapper.selectById(999L)).thenReturn(null);
-        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 999L, null, null,
+        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 999L, null, null, null,
             null, null, null, 1);
 
         assertThrows(BizException.class, () -> service.create(request));
@@ -97,7 +106,16 @@ class AgentServiceTest {
     @Test
     void create_shouldRejectInvalidMcpIds() {
         when(mcpMapper.selectBatchIds(List.of(10L))).thenReturn(List.of()); // 只有 0 条命中，说明 10L 不存在
-        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(10L), null,
+        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(10L), null, null,
+            null, null, null, 1);
+
+        assertThrows(BizException.class, () -> service.create(request));
+    }
+
+    @Test
+    void create_shouldRejectInvalidSystemToolIds() {
+        when(systemToolMapper.selectBatchIds(List.of(30L))).thenReturn(List.of()); // 0 条命中，说明 30L 不存在
+        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, List.of(30L),
             null, null, null, 1);
 
         assertThrows(BizException.class, () -> service.create(request));
@@ -105,7 +123,7 @@ class AgentServiceTest {
 
     @Test
     void create_shouldRejectInvalidCapability() {
-        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null,
+        AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null,
             null, List.of("not-a-real-capability"), null, 1);
 
         assertThrows(BizException.class, () -> service.create(request));
@@ -115,6 +133,7 @@ class AgentServiceTest {
     void create_shouldInsertRelationRows_andBumpMenuVersion() {
         when(mcpMapper.selectBatchIds(List.of(10L))).thenReturn(List.of(new AiMcp()));
         when(skillMapper.selectBatchIds(List.of(20L))).thenReturn(List.of(new AiSkill()));
+        when(systemToolMapper.selectBatchIds(List.of(30L))).thenReturn(List.of(new AiSystemTool()));
 
         long versionBefore = menuVersionHolder.current();
         service.create(validRequest());
@@ -122,6 +141,7 @@ class AgentServiceTest {
         verify(agentMapper).insert(any(AiAgent.class));
         verify(agentMcpMapper).insert(any(AiAgentMcp.class));
         verify(agentSkillMapper).insert(any(AiAgentSkill.class));
+        verify(agentSystemToolMapper).insert(any(AiAgentSystemTool.class));
         assertEquals(versionBefore + 1, menuVersionHolder.current());
     }
 
@@ -132,6 +152,7 @@ class AgentServiceTest {
         when(agentMapper.selectById(1L)).thenReturn(existing);
         when(mcpMapper.selectBatchIds(List.of(10L))).thenReturn(List.of(new AiMcp()));
         when(skillMapper.selectBatchIds(List.of(20L))).thenReturn(List.of(new AiSkill()));
+        when(systemToolMapper.selectBatchIds(List.of(30L))).thenReturn(List.of(new AiSystemTool()));
 
         service.update(1L, validRequest());
 
@@ -139,6 +160,8 @@ class AgentServiceTest {
         verify(agentMcpMapper).insert(any(AiAgentMcp.class));
         verify(agentSkillMapper).delete(any());
         verify(agentSkillMapper).insert(any(AiAgentSkill.class));
+        verify(agentSystemToolMapper).delete(any());
+        verify(agentSystemToolMapper).insert(any(AiAgentSystemTool.class));
     }
 
     @Test
@@ -153,6 +176,7 @@ class AgentServiceTest {
         verify(agentMapper).deleteById(1L);
         verify(agentMcpMapper).delete(any());
         verify(agentSkillMapper).delete(any());
+        verify(agentSystemToolMapper).delete(any());
         assertEquals(versionBefore + 1, menuVersionHolder.current());
     }
 
@@ -185,11 +209,15 @@ class AgentServiceTest {
         AiAgentMcp relation = new AiAgentMcp();
         relation.setMcpId(10L);
         when(agentMcpMapper.selectList(any())).thenReturn(List.of(relation));
+        AiAgentSystemTool toolRelation = new AiAgentSystemTool();
+        toolRelation.setSystemToolId(30L);
+        when(agentSystemToolMapper.selectList(any())).thenReturn(List.of(toolRelation));
 
         AgentVO vo = service.get(1L);
 
         assertEquals("gpt-4o", vo.getModelName());
         assertEquals(List.of(10L), vo.getMcpIds());
+        assertEquals(List.of(30L), vo.getSystemToolIds());
         assertEquals(List.of("chat", "vibecoding"), vo.getCapabilities());
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/service/SystemToolServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/service/SystemToolServiceTest.java
@@ -1,0 +1,120 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.dto.SystemToolSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.dto.SystemToolVO;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link SystemToolService} 单测：分页查询映射、编辑落库、编辑后失效引用该工具的智能体缓存。
+ * @author owlzhangfq@gmail.com
+ */
+class SystemToolServiceTest {
+
+    private AiSystemToolMapper systemToolMapper;
+    private AiAgentSystemToolMapper agentSystemToolMapper;
+    private AiAgentMapper agentMapper;
+    private AgentInstanceCache agentInstanceCache;
+    private SystemToolService service;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiSystemTool.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentSystemTool.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgent.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        systemToolMapper = mock(AiSystemToolMapper.class);
+        agentSystemToolMapper = mock(AiAgentSystemToolMapper.class);
+        agentMapper = mock(AiAgentMapper.class);
+        agentInstanceCache = mock(AgentInstanceCache.class);
+        service = new SystemToolService(systemToolMapper, agentSystemToolMapper, agentMapper, agentInstanceCache);
+    }
+
+    @Test
+    void page_shouldMapEntityToVo() {
+        AiSystemTool tool = new AiSystemTool();
+        tool.setId(1L);
+        tool.setToolCode("httpclient");
+        tool.setToolName("HTTP请求工具");
+        tool.setEnabled(1);
+        Page<AiSystemTool> page = new Page<>(1, 10);
+        page.setRecords(List.of(tool));
+        page.setTotal(1);
+        when(systemToolMapper.selectPage(any(), any())).thenReturn((IPage) page);
+
+        PageResult<SystemToolVO> result = service.page(new PageQuery());
+
+        assertEquals(1, result.getList().size());
+        assertEquals("httpclient", result.getList().get(0).getToolCode());
+    }
+
+    @Test
+    void update_shouldPersist_andEvictReferencingAgents() {
+        AiSystemTool tool = new AiSystemTool();
+        tool.setId(1L);
+        tool.setToolCode("httpclient");
+        when(systemToolMapper.selectById(1L)).thenReturn(tool);
+        AiAgentSystemTool relation = new AiAgentSystemTool();
+        relation.setAgentId(100L);
+        when(agentSystemToolMapper.selectList(any())).thenReturn(List.of(relation));
+        AiAgent agent = new AiAgent();
+        agent.setAgentCode("sales-assistant");
+        when(agentMapper.selectBatchIds(List.of(100L))).thenReturn(List.of(agent));
+
+        service.update(1L, new SystemToolSaveRequest("HTTP请求工具", "desc", 0, "remark"));
+
+        verify(systemToolMapper).updateById(any(AiSystemTool.class));
+        verify(agentInstanceCache).evictAll(List.of("sales-assistant"));
+    }
+
+    @Test
+    void update_shouldNotEvict_whenNoReferencingAgents() {
+        AiSystemTool tool = new AiSystemTool();
+        tool.setId(1L);
+        tool.setToolCode("httpclient");
+        when(systemToolMapper.selectById(1L)).thenReturn(tool);
+        when(agentSystemToolMapper.selectList(any())).thenReturn(List.of());
+
+        service.update(1L, new SystemToolSaveRequest("HTTP请求工具", "desc", 1, "remark"));
+
+        verify(systemToolMapper).updateById(any(AiSystemTool.class));
+        verify(agentInstanceCache, times(0)).evictAll(any());
+    }
+
+    @Test
+    void update_shouldRejectUnknownId() {
+        when(systemToolMapper.selectById(999L)).thenReturn(null);
+
+        assertThrows(BizException.class,
+            () -> service.update(999L, new SystemToolSaveRequest("x", null, 1, null)));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/HttpClientToolsTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/HttpClientToolsTest.java
@@ -1,0 +1,116 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link HttpClientTools} 单测：起一个本地临时 {@link HttpServer}（JDK 内置，不引入 WireMock）验证
+ * get/post/put/delete/postForm 的请求组装与响应解析，以及目标不可达时返回 error 字段而非抛异常。
+ * @author owlzhangfq@gmail.com
+ */
+class HttpClientToolsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClientTools tools = new HttpClientTools();
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        // 单一 handler：把"收到的方法 + 请求体"回显进响应体，供断言核对请求组装是否正确。
+        server.createContext("/echo", exchange -> {
+            String method = exchange.getRequestMethod();
+            byte[] reqBody = exchange.getRequestBody().readAllBytes();
+            String text = "method=" + method + ";body=" + new String(reqBody, StandardCharsets.UTF_8);
+            byte[] resp = text.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(resp);
+            }
+        });
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/echo";
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void getRequest_shouldReturn200AndEchoedMethod() throws Exception {
+        JsonNode node = objectMapper.readTree(tools.getRequest(baseUrl, null).block());
+
+        assertEquals(200, node.get("statusCode").asInt());
+        assertTrue(node.get("body").asText().contains("method=GET"));
+        assertTrue(node.get("error").isNull());
+    }
+
+    @Test
+    void deleteRequest_shouldEchoDeleteMethod() throws Exception {
+        JsonNode node = objectMapper.readTree(tools.deleteRequest(baseUrl, null).block());
+
+        assertEquals(200, node.get("statusCode").asInt());
+        assertTrue(node.get("body").asText().contains("method=DELETE"));
+    }
+
+    @Test
+    void postRequest_shouldCarryJsonBody() throws Exception {
+        JsonNode node = objectMapper.readTree(tools.postRequest(baseUrl, null, "hello-body").block());
+
+        assertEquals(200, node.get("statusCode").asInt());
+        assertTrue(node.get("body").asText().contains("method=POST"));
+        assertTrue(node.get("body").asText().contains("hello-body"));
+    }
+
+    @Test
+    void putRequest_shouldCarryJsonBody() throws Exception {
+        JsonNode node = objectMapper.readTree(tools.putRequest(baseUrl, null, "put-body").block());
+
+        assertEquals(200, node.get("statusCode").asInt());
+        assertTrue(node.get("body").asText().contains("method=PUT"));
+        assertTrue(node.get("body").asText().contains("put-body"));
+    }
+
+    @Test
+    void postFormRequest_shouldEncodeFormParams() throws Exception {
+        JsonNode node = objectMapper.readTree(
+            tools.postFormRequest(baseUrl, Map.of("X-Trace", "1"), Map.of("name", "tom")).block());
+
+        assertEquals(200, node.get("statusCode").asInt());
+        assertTrue(node.get("body").asText().contains("method=POST"));
+        assertTrue(node.get("body").asText().contains("name=tom"));
+    }
+
+    @Test
+    void getRequest_shouldReturnErrorField_whenTargetUnreachable() throws Exception {
+        int closedPort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            closedPort = socket.getLocalPort();
+        }
+        String unreachable = "http://127.0.0.1:" + closedPort + "/nope";
+
+        JsonNode node = objectMapper.readTree(tools.getRequest(unreachable, null).block());
+
+        assertNotNull(node.get("error"));
+        assertFalse(node.get("error").isNull());
+        assertTrue(node.get("statusCode").isNull());
+    }
+}

--- a/customer-admin-web/src/api/system-tool.ts
+++ b/customer-admin-web/src/api/system-tool.ts
@@ -1,0 +1,14 @@
+import { request } from './request'
+import type { PageQuery, PageResult, SystemToolSaveRequest, SystemToolVO } from '@/types/api'
+
+export function fetchSystemTools(query: PageQuery) {
+  return request<PageResult<SystemToolVO>>({ url: '/system-tool', method: 'get', params: query })
+}
+
+export function getSystemTool(id: number) {
+  return request<SystemToolVO>({ url: `/system-tool/${id}`, method: 'get' })
+}
+
+export function updateSystemTool(id: number, data: SystemToolSaveRequest) {
+  return request<void>({ url: `/system-tool/${id}`, method: 'put', data })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -15,6 +15,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),
   '/aiconfig/agent': () => import('@/views/aiconfig/AgentManage.vue'),
+  '/aiconfig/system-tool': () => import('@/views/aiconfig/SystemToolManage.vue'),
   '/aiconfig/scheduled-task': () => import('@/views/aiconfig/ScheduledTaskManage.vue'),
   '/project': () => import('@/views/project/ProjectManage.vue'),
   '/sql/datasource': () => import('@/views/sql/SqlDatasourceManage.vue'),

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -289,6 +289,26 @@ export interface SkillSaveRequest {
   status?: number | null
 }
 
+// ---------- aiconfig.system-tool ----------
+export interface SystemToolVO {
+  id: number
+  toolCode: string
+  toolName: string
+  description: string | null
+  /** 0禁用 / 1启用 */
+  enabled: number
+  remark: string | null
+  createTime: string
+  updateTime: string
+}
+
+export interface SystemToolSaveRequest {
+  toolName: string
+  description?: string | null
+  enabled?: number | null
+  remark?: string | null
+}
+
 // ---------- aiconfig.agent ----------
 export interface AgentVO {
   id: number
@@ -298,6 +318,7 @@ export interface AgentVO {
   modelName: string | null
   mcpIds: number[]
   skillIds: number[]
+  systemToolIds: number[]
   systemPrompt: string | null
   capabilities: string[]
   icon: string | null
@@ -311,6 +332,7 @@ export interface AgentSaveRequest {
   modelId: number
   mcpIds?: number[] | null
   skillIds?: number[] | null
+  systemToolIds?: number[] | null
   systemPrompt?: string | null
   capabilities?: string[] | null
   icon?: string | null

--- a/customer-admin-web/src/views/aiconfig/AgentManage.vue
+++ b/customer-admin-web/src/views/aiconfig/AgentManage.vue
@@ -5,9 +5,10 @@ import { createAgent, deleteAgent, disableAgent, enableAgent, pageAgents, update
 import { pageModels } from '@/api/model'
 import { pageMcps } from '@/api/mcp'
 import { pageSkills } from '@/api/skill'
+import { fetchSystemTools } from '@/api/system-tool'
 import { useMenuStore } from '@/store/menu'
 import IconPicker from '@/components/IconPicker.vue'
-import type { AgentSaveRequest, AgentVO, McpVO, ModelVO, PageQuery, SkillVO } from '@/types/api'
+import type { AgentSaveRequest, AgentVO, McpVO, ModelVO, PageQuery, SkillVO, SystemToolVO } from '@/types/api'
 
 const menuStore = useMenuStore()
 
@@ -19,13 +20,14 @@ const query = reactive<PageQuery>({ pageNum: 1, pageSize: 10, keyword: '' })
 const modelOptions = ref<ModelVO[]>([])
 const mcpOptions = ref<McpVO[]>([])
 const skillOptions = ref<SkillVO[]>([])
+const systemToolOptions = ref<SystemToolVO[]>([])
 
 const dialogVisible = ref(false)
 const dialogMode = ref<'create' | 'edit'>('create')
 const formRef = ref<FormInstance>()
 const editingId = ref<number | null>(null)
 const form = reactive<AgentSaveRequest>({
-  agentName: '', agentCode: '', modelId: undefined as unknown as number, mcpIds: [], skillIds: [],
+  agentName: '', agentCode: '', modelId: undefined as unknown as number, mcpIds: [], skillIds: [], systemToolIds: [],
   systemPrompt: '', capabilities: ['chat'], icon: '', status: 1,
 })
 
@@ -43,14 +45,17 @@ async function loadList() {
 }
 
 async function loadOptions() {
-  const [models, mcps, skills] = await Promise.all([
+  const [models, mcps, skills, systemTools] = await Promise.all([
     pageModels({ pageNum: 1, pageSize: 100 }),
     pageMcps({ pageNum: 1, pageSize: 100 }),
     pageSkills({ pageNum: 1, pageSize: 100 }),
+    fetchSystemTools({ pageNum: 1, pageSize: 100 }),
   ])
   modelOptions.value = models.list
   mcpOptions.value = mcps.list
   skillOptions.value = skills.list
+  // 只展示已启用的系统工具供挂载（停用的不出现在下拉里）。
+  systemToolOptions.value = systemTools.list.filter((t) => t.enabled === 1)
 }
 
 function handleSearch() {
@@ -62,7 +67,7 @@ function openCreate() {
   dialogMode.value = 'create'
   editingId.value = null
   Object.assign(form, {
-    agentName: '', agentCode: '', modelId: undefined, mcpIds: [], skillIds: [],
+    agentName: '', agentCode: '', modelId: undefined, mcpIds: [], skillIds: [], systemToolIds: [],
     systemPrompt: '', capabilities: ['chat'], icon: '', status: 1,
   })
   dialogVisible.value = true
@@ -73,7 +78,7 @@ function openEdit(row: AgentVO) {
   editingId.value = row.id
   Object.assign(form, {
     agentName: row.agentName, agentCode: row.agentCode, modelId: row.modelId,
-    mcpIds: row.mcpIds, skillIds: row.skillIds, systemPrompt: row.systemPrompt,
+    mcpIds: row.mcpIds, skillIds: row.skillIds, systemToolIds: row.systemToolIds, systemPrompt: row.systemPrompt,
     capabilities: row.capabilities, icon: row.icon, status: row.status,
   })
   dialogVisible.value = true
@@ -198,6 +203,11 @@ onMounted(() => {
         <el-form-item label="Skill">
           <el-select v-model="form.skillIds" multiple style="width: 100%" placeholder="可选">
             <el-option v-for="s in skillOptions" :key="s.id" :label="s.skillName" :value="s.id" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="系统工具">
+          <el-select v-model="form.systemToolIds" multiple style="width: 100%" placeholder="可选">
+            <el-option v-for="t in systemToolOptions" :key="t.id" :label="t.toolName" :value="t.id" />
           </el-select>
         </el-form-item>
         <el-form-item label="能力">

--- a/customer-admin-web/src/views/aiconfig/SystemToolManage.vue
+++ b/customer-admin-web/src/views/aiconfig/SystemToolManage.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage, type FormInstance } from 'element-plus'
+import { fetchSystemTools, updateSystemTool } from '@/api/system-tool'
+import type { PageQuery, SystemToolSaveRequest, SystemToolVO } from '@/types/api'
+
+const loading = ref(false)
+const list = ref<SystemToolVO[]>([])
+const total = ref(0)
+const query = reactive<PageQuery>({ pageNum: 1, pageSize: 10, keyword: '' })
+
+const dialogVisible = ref(false)
+const formRef = ref<FormInstance>()
+const editingId = ref<number | null>(null)
+const form = reactive<SystemToolSaveRequest>({
+  toolName: '', description: '', enabled: 1, remark: '',
+})
+
+async function loadList() {
+  loading.value = true
+  try {
+    const result = await fetchSystemTools(query)
+    list.value = result.list
+    total.value = result.total
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleSearch() {
+  query.pageNum = 1
+  loadList()
+}
+
+function openEdit(row: SystemToolVO) {
+  editingId.value = row.id
+  Object.assign(form, {
+    toolName: row.toolName, description: row.description ?? '', enabled: row.enabled, remark: row.remark ?? '',
+  })
+  dialogVisible.value = true
+}
+
+async function handleSubmit() {
+  const valid = await formRef.value?.validate().catch(() => false)
+  if (!valid || !editingId.value) {
+    return
+  }
+  await updateSystemTool(editingId.value, form)
+  ElMessage.success('保存成功')
+  dialogVisible.value = false
+  await loadList()
+}
+
+// 开关直接调 PUT 局部更新：把当前行其余字段一并回传，只改 enabled。
+async function handleToggleEnabled(row: SystemToolVO) {
+  try {
+    await updateSystemTool(row.id, {
+      toolName: row.toolName, description: row.description, enabled: row.enabled, remark: row.remark,
+    })
+    ElMessage.success(row.enabled === 1 ? '已启用' : '已停用')
+  } catch {
+    // 失败时回滚开关状态
+    row.enabled = row.enabled === 1 ? 0 : 1
+  }
+}
+
+onMounted(loadList)
+</script>
+
+<template>
+  <div class="page">
+    <el-card>
+      <div class="toolbar">
+        <el-input v-model="query.keyword" placeholder="按名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
+        <el-button type="primary" @click="handleSearch">搜索</el-button>
+      </div>
+
+      <el-table v-loading="loading" :data="list" style="width: 100%">
+        <el-table-column prop="toolCode" label="编码" width="160" />
+        <el-table-column prop="toolName" label="名称" width="180" />
+        <el-table-column prop="description" label="描述" show-overflow-tooltip />
+        <el-table-column label="状态" width="90">
+          <template #default="{ row }">
+            <el-switch
+              v-model="row.enabled"
+              v-permission="'system-tool:edit'"
+              :active-value="1"
+              :inactive-value="0"
+              @change="handleToggleEnabled(row)"
+            />
+          </template>
+        </el-table-column>
+        <el-table-column prop="updateTime" label="更新时间" width="180" />
+        <el-table-column label="操作" width="120" fixed="right">
+          <template #default="{ row }">
+            <el-button v-permission="'system-tool:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-model:current-page="query.pageNum"
+        v-model:page-size="query.pageSize"
+        :total="total"
+        layout="total, prev, pager, next"
+        style="margin-top: 16px; justify-content: flex-end"
+        @current-change="loadList"
+      />
+    </el-card>
+
+    <el-dialog v-model="dialogVisible" title="编辑系统工具" width="520px">
+      <el-form ref="formRef" :model="form" label-width="100px">
+        <el-form-item label="名称" prop="toolName" :rules="[{ required: true, message: '请输入名称' }]">
+          <el-input v-model="form.toolName" />
+        </el-form-item>
+        <el-form-item label="描述">
+          <el-input v-model="form.description!" type="textarea" :rows="3" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="form.remark!" />
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-switch v-model="form.enabled!" :active-value="1" :inactive-value="0" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="handleSubmit">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+</style>


### PR DESCRIPTION
## 概述

在 AI 配置菜单下新增"系统工具"能力：维护一个工具目录（本轮只有 `httpclient`），智能体配置页可像挂载 MCP/Skill 一样给智能体多选系统工具，聊天运行时把勾选且启用的工具注册进该智能体的 Toolkit。参照用户提供的 `HttpTool.java` 实现 HTTP 请求工具本身。

## 主要内容

**后端（新包 `aiconfig.systemtool`，admin-server 224 → 235 个测试全绿）**
- Flyway V15：`ai_system_tool`（工具目录，代码定义/库存启停状态）+ `ai_agent_system_tool` 关联表 + 菜单权限种子（AI 配置目录下，只有 view/edit 两个权限点，无 add/delete）
- `HttpClientTools`（`@Component("httpclient")`，bean name = tool_code）：GET/DELETE/POST/POST-Form/PUT 五种调用，`Mono` 异步 + `boundedElastic` 调度不阻塞 reactor 线程，异常收敛为 error 字段而非抛出
- `SystemToolController`/`Service`：分页 + 编辑（改名称/描述/启停/备注）；启停变更时反查引用该工具的智能体，`AgentInstanceCache.evictAll` 使缓存失效（同 `McpService` 已有模式）
- `AdminAgentInstanceFactory.build()` 新增 `buildSystemTools`：按 `tool_code` 从 Spring 容器取 Bean 注册进 Toolkit，取不到 Bean 时记日志跳过、不拖垮整个智能体装配
- `AgentSaveRequest`/`AgentVO`/`AgentService` 对称扩展 `systemToolIds`（validate/replaceRelations/toVo/delete 级联），与既有 `mcpIds`/`skillIds` 模式完全一致

**前端**
- `SystemToolManage.vue`：列表 + 启停开关 + 编辑弹窗（无新增/删除，工具由代码定义）
- `AgentManage.vue`：新增系统工具多选（挂载点、表单初始值、编辑回填与 mcpIds/skillIds 对称）

## 安全说明

用户提供的参照实现自定义了信任所有证书、关闭主机名校验的 SSLContext（trust-all）。**本 PR 未采用该写法**——已与用户确认，改为 RestTemplate 标准 JDK 默认信任链校验，不做 trust-all。工具本身仍允许智能体请求任意可达 URL（含内网地址），是一个 SSRF 风险面，Flyway 迁移注释里已显式记录，是否收紧到 URL 白名单留待后续按需迭代。

## 测试

- admin-server 全量测试 235 个全绿（新增 `HttpClientToolsTest` 用 JDK 内置 HttpServer 验证四个方法的请求组装/响应解析/异常收敛，`SystemToolServiceTest` 验证分页与 evict 触发）
- 前端 `npm run build`（含 vue-tsc 类型检查）通过
- 端到端人工验证：系统工具页启停 → 智能体挂载 → 对话触发 http_get 调用，均已确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)