### PR TITLE
feat(admin): 工作区主题色/新建会话工具栏上提到 Tab 上方并重做样式

### DIFF
--- a/customer-admin-web/src/components/ThemeToolbar.vue
+++ b/customer-admin-web/src/components/ThemeToolbar.vue
@@ -14,10 +14,11 @@ const showPicker = ref(false)
   <div class="theme-toolbar">
     <!-- 主题色选择 -->
     <div class="theme-picker" @mouseenter="showPicker = true" @mouseleave="showPicker = false">
-      <el-button text class="current-color" title="切换主题色">
+      <button type="button" class="theme-btn" title="切换主题色">
         <span class="color-dot" :style="{ backgroundColor: themeStore.primaryColor }" />
         <span class="color-label">主题色</span>
-      </el-button>
+        <el-icon class="arrow" :class="{ open: showPicker }"><ArrowDown /></el-icon>
+      </button>
       <transition name="fade">
         <div v-show="showPicker" class="color-popover">
           <div
@@ -34,10 +35,10 @@ const showPicker = ref(false)
     </div>
 
     <!-- 新建会话 -->
-    <el-button type="primary" size="small" class="new-session-btn" @click="props.onNewSession">
-      <el-icon style="margin-right: 4px"><Plus /></el-icon>
+    <button type="button" class="new-session-btn" @click="props.onNewSession">
+      <el-icon><Plus /></el-icon>
       新建会话
-    </el-button>
+    </button>
   </div>
 </template>
 
@@ -45,52 +46,76 @@ const showPicker = ref(false)
 .theme-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
 }
 
 .theme-picker {
   position: relative;
 }
 
-.current-color {
+/* 主题色胶囊按钮：白底细边框，悬浮时边框染上主题色并轻微上浮 */
+.theme-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
+  gap: 7px;
+  height: 34px;
+  padding: 0 14px;
+  border-radius: 17px;
+  border: 1px solid #dcdfe6;
+  background: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.theme-btn:hover {
+  border-color: var(--theme-primary, #409eff);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
 }
 
 .color-dot {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
   border-radius: 50%;
   border: 2px solid #fff;
-  box-shadow: 0 0 0 1px #dcdfe6;
+  box-shadow: 0 0 0 1px #dcdfe6, 0 1px 3px rgba(0, 0, 0, 0.15);
 }
 
 .color-label {
-  font-size: 13px;
   color: #606266;
+  font-weight: 500;
+}
+
+.arrow {
+  font-size: 12px;
+  color: #909399;
+  transition: transform 0.2s;
+}
+
+.arrow.open {
+  transform: rotate(180deg);
 }
 
 .color-popover {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + 8px);
   right: 0;
   z-index: 100;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 10px;
+  gap: 10px;
+  padding: 12px;
   background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
   border: 1px solid #ebeef5;
-  width: 160px;
+  width: 172px;
 }
 
 .color-option {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s;
@@ -98,7 +123,7 @@ const showPicker = ref(false)
 }
 
 .color-option:hover {
-  transform: scale(1.15);
+  transform: scale(1.18);
 }
 
 .color-option.active {
@@ -106,14 +131,37 @@ const showPicker = ref(false)
   box-shadow: 0 0 0 2px var(--theme-primary, #409eff);
 }
 
+/* 新建会话：主题色渐变胶囊按钮，悬浮提亮并上浮 */
 .new-session-btn {
-  background-color: var(--theme-primary, #409eff);
-  border-color: var(--theme-primary, #409eff);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 18px;
+  border: none;
+  border-radius: 17px;
+  background: linear-gradient(
+    135deg,
+    var(--theme-primary, #409eff),
+    var(--theme-primary-light, #79bbff)
+  );
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
 }
 
 .new-session-btn:hover {
-  background-color: var(--theme-primary-light, #79bbff);
-  border-color: var(--theme-primary-light, #79bbff);
+  filter: brightness(1.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  transform: translateY(-1px);
+}
+
+.new-session-btn:active {
+  transform: translateY(0);
+  filter: brightness(0.96);
 }
 
 .fade-enter-active,

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -5,7 +5,6 @@ import { getChatSessionMessages, interruptChat, parseChatAttachment, streamChat 
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import TraceTimeline, { type TraceNode } from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
-import ThemeToolbar from '@/components/ThemeToolbar.vue'
 import { useThemeStore } from '@/store/theme'
 import { generateUuid } from '@/utils/uuid'
 
@@ -202,15 +201,13 @@ onUnmounted(() => {
   abortStream?.()
 })
 
-defineExpose({ sessionId })
+// newSession 供 WorkspaceView 上提后的工具栏"新建会话"按钮按激活 Tab 分发调用
+defineExpose({ sessionId, newSession })
 </script>
 
 <template>
   <div class="chat-panel">
     <div class="chat-column">
-      <div class="panel-header">
-        <ThemeToolbar :on-new-session="newSession" />
-      </div>
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
         <div v-for="(msg, index) in messages" :key="index" class="message-row" :class="msg.role">
           <div class="bubble">
@@ -276,12 +273,6 @@ defineExpose({ sessionId })
   border-radius: 8px;
   padding: 12px;
   transition: background-color 0.3s ease;
-}
-
-.panel-header {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 8px;
 }
 
 .messages {

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -16,7 +16,6 @@ import { getChatSessionMessages, parseChatAttachment } from '@/api/chat'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import TraceTimeline, { type TraceNode } from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
-import ThemeToolbar from '@/components/ThemeToolbar.vue'
 import { useThemeStore } from '@/store/theme'
 import { generateUuid } from '@/utils/uuid'
 import type { FileChangeEvent, GitDiffSummary, WorkspaceFileContent, WorkspaceFileNode } from '@/types/api'
@@ -414,15 +413,15 @@ onMounted(() => {
 onUnmounted(() => {
   abortStream?.()
 })
+
+// newSession 供 WorkspaceView 上提后的工具栏"新建会话"按钮按激活 Tab 分发调用
+defineExpose({ newSession })
 </script>
 
 <template>
   <div class="vibecoding-panel">
     <!-- 左列：对话区 -->
     <div class="chat-column">
-      <div class="panel-header">
-        <ThemeToolbar :on-new-session="newSession" />
-      </div>
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
         <div v-for="(msg, index) in messages" :key="index" class="message-row" :class="msg.role">
           <div class="bubble">
@@ -657,12 +656,6 @@ onUnmounted(() => {
   border-radius: 8px;
   padding: 12px;
   transition: background-color 0.3s ease;
-}
-
-.panel-header {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 8px;
 }
 
 .messages {

--- a/customer-admin-web/src/views/workspace/WorkspaceView.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useMenuStore } from '@/store/menu'
 import type { MenuNode } from '@/types/api'
 import ChatPanel from './ChatPanel.vue'
 import VibeCodingPanel from './VibeCodingPanel.vue'
+import ThemeToolbar from '@/components/ThemeToolbar.vue'
 
 const props = defineProps<{ agentCode: string }>()
 const menuStore = useMenuStore()
@@ -28,21 +29,37 @@ function findNode(nodes: MenuNode[], agentCode: string): MenuNode | null {
 
 const agentNode = computed(() => findNode(menuStore.tree, props.agentCode))
 const supportsVibeCoding = computed(() => agentNode.value?.capabilities?.includes('vibecoding') ?? false)
+
+// 主题色/新建会话工具栏上提到 Tab 上方后，"新建会话"要按当前激活的 Tab 分发到对应面板
+const activeTab = ref<'chat' | 'vibecoding'>('chat')
+const chatPanelRef = ref<InstanceType<typeof ChatPanel>>()
+const vibeCodingPanelRef = ref<InstanceType<typeof VibeCodingPanel>>()
+
+function newSession() {
+  if (activeTab.value === 'vibecoding') {
+    vibeCodingPanelRef.value?.newSession()
+  } else {
+    chatPanelRef.value?.newSession()
+  }
+}
 </script>
 
 <template>
   <div class="workspace-view">
-    <h2 class="agent-title">{{ agentNode?.name ?? agentCode }}</h2>
-    <el-tabs type="border-card" class="workspace-tabs">
-      <el-tab-pane label="对话">
+    <div class="workspace-header">
+      <h2 class="agent-title">{{ agentNode?.name ?? agentCode }}</h2>
+      <ThemeToolbar :on-new-session="newSession" />
+    </div>
+    <el-tabs v-model="activeTab" type="border-card" class="workspace-tabs">
+      <el-tab-pane label="对话" name="chat">
         <!-- workspace/:agentCode 是同一条路由，只换参数，Vue Router 默认复用组件实例——
              不加 :key 的话切换智能体时 ChatPanel 内部的 messages/sessionId 状态会跟着串到下一个
              智能体身上。加 :key 强制按 agentCode 重建实例，天然顺带把上一个智能体未结束的 SSE
              流也一起 abort 掉（复用 ChatPanel 自己 onUnmounted 里已有的 abortStream 逻辑）。 -->
-        <ChatPanel :key="agentCode" :agent-code="agentCode" :initial-session-id="initialSessionId" />
+        <ChatPanel ref="chatPanelRef" :key="agentCode" :agent-code="agentCode" :initial-session-id="initialSessionId" />
       </el-tab-pane>
-      <el-tab-pane v-if="supportsVibeCoding" label="VibeCoding">
-        <VibeCodingPanel :key="agentCode" :agent-code="agentCode" />
+      <el-tab-pane v-if="supportsVibeCoding" label="VibeCoding" name="vibecoding">
+        <VibeCodingPanel ref="vibeCodingPanelRef" :key="agentCode" :agent-code="agentCode" />
       </el-tab-pane>
     </el-tabs>
   </div>
@@ -55,8 +72,15 @@ const supportsVibeCoding = computed(() => agentNode.value?.capabilities?.include
   flex-direction: column;
 }
 
+.workspace-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
 .agent-title {
-  margin: 0 0 12px;
+  margin: 0;
 }
 
 .workspace-tabs {


### PR DESCRIPTION
## 改动内容

**位置调整**：「主题色 / 新建会话」工具栏从对话框内部上提到「对话 / VibeCoding」Tab 上方，与智能体标题同一行、右侧对齐。

- `WorkspaceView.vue`：新增 `workspace-header` 标题行放置 `ThemeToolbar`；两个 `el-tab-pane` 加 `name` 并用 `v-model` 跟踪激活 Tab，「新建会话」按当前 Tab 分发到对应面板的 `newSession`
- `ChatPanel.vue` / `VibeCodingPanel.vue`：删除各自内部的工具栏，通过 `defineExpose` 暴露 `newSession` 供父组件调用（两个 Tab 从各渲染一份工具栏变为共用一份）

**样式重做**（`ThemeToolbar.vue`）：

- 「主题色」：白底细边框胶囊按钮（高 34px），色点指示 + 下拉箭头（展开旋转 180°），悬浮时边框染主题色并轻微上浮
- 「新建会话」：主题色渐变胶囊按钮带投影，悬浮提亮上浮、按下回弹，渐变跟随 `--theme-primary` / `--theme-primary-light` 主题变量
- 色板弹层加大色块间距与圆角阴影

## 为什么

原按钮嵌在对话面板内部右上角，与消息区视觉混在一起且两个 Tab 各一份；上提后布局更清晰，样式与后台整体风格更统一。

## 审阅提示

- 「新建会话」行为与原来一致（对话 Tab 新建对话会话，VibeCoding Tab 新建 VibeCoding 会话），仅调用路径改为父组件按激活 Tab 分发
- 已通过 `vue-tsc -b` 类型检查；纯前端改动，不涉及后端

🤖 Generated with [Claude Code](https://claude.com/claude-code)