### PR TITLE
fix: 用户端「重新开始对话」重开回 AI 自助，而非直达人工排队

### DIFF
--- a/customer-work-app/src/main/java/com/richard/fyoung/customerworkapp/controller/UserTicketController.java
+++ b/customer-work-app/src/main/java/com/richard/fyoung/customerworkapp/controller/UserTicketController.java
@@ -173,8 +173,8 @@ public class UserTicketController {
     }
 
     @Operation(summary = "重新打开",
-        description = "RESOLVED|CLOSED → WAITING_AGENT；用户已存在另一张进行中会话时返回 409（体带该会话 sessionId/ticketId/status），"
-            + "其余非法状态流转 409")
+        description = "RESOLVED|CLOSED → AI_SERVING（重开回 AI 自助，需要人工时用户再显式转人工）；"
+            + "用户已存在另一张进行中会话时返回 409（体带该会话 sessionId/ticketId/status），其余非法状态流转 409")
     @PostMapping("/tickets/{id}/reopen")
     public Mono<ResponseEntity<Object>> reopen(@PathVariable String id, ServerWebExchange exchange,
                                @RequestBody(required = false) ReasonRequest request) {
@@ -188,7 +188,8 @@ public class UserTicketController {
                 return ResponseEntity.status(HttpStatus.CONFLICT)
                     .<Object>body(activeSessionBody(active.get(), REOPEN_ACTIVE_SESSION_EXISTS_MSG));
             }
-            Ticket reopened = ticketService.reopen(id, reasonOf(request), TicketActorType.USER, user.userId());
+            // 用户端"重新开始对话"回到 AI 自助而非人工排队（reopen 直达人工的语义保留给坐席/管理链路）
+            Ticket reopened = ticketService.reopenToAi(id, reasonOf(request), TicketActorType.USER, user.userId());
             return ResponseEntity.<Object>ok(reopened);
         });
     }

--- a/customer-work-app/src/test/java/com/richard/fyoung/customerworkapp/controller/UserTicketControllerTest.java
+++ b/customer-work-app/src/test/java/com/richard/fyoung/customerworkapp/controller/UserTicketControllerTest.java
@@ -115,7 +115,7 @@ class UserTicketControllerTest {
         Ticket owned = ownedTicket(); // TK-1，closed 状态由 service 内部校验，这里只关心 controller 层前置校验
         when(ticketService.find("TK-1")).thenReturn(Optional.of(owned));
         when(ticketService.findActiveByUser(USER_ID)).thenReturn(Optional.empty());
-        when(ticketService.reopen(eq("TK-1"), any(), eq(TicketActorType.USER), eq(USER_ID))).thenReturn(owned);
+        when(ticketService.reopenToAi(eq("TK-1"), any(), eq(TicketActorType.USER), eq(USER_ID))).thenReturn(owned);
 
         webTestClient.post().uri("/api/customer/user/tickets/TK-1/reopen")
             .header(HttpHeaders.AUTHORIZATION, bearer())
@@ -149,7 +149,7 @@ class UserTicketControllerTest {
         Ticket owned = ownedTicket();
         when(ticketService.find("TK-1")).thenReturn(Optional.of(owned));
         when(ticketService.findActiveByUser(USER_ID)).thenReturn(Optional.of(owned));
-        when(ticketService.reopen(eq("TK-1"), any(), eq(TicketActorType.USER), eq(USER_ID))).thenReturn(owned);
+        when(ticketService.reopenToAi(eq("TK-1"), any(), eq(TicketActorType.USER), eq(USER_ID))).thenReturn(owned);
 
         webTestClient.post().uri("/api/customer/user/tickets/TK-1/reopen")
             .header(HttpHeaders.AUTHORIZATION, bearer())

--- a/customer-work-spring-boot-starter/src/main/java/com/richard/fyoung/customerwork/ticket/Ticket.java
+++ b/customer-work-spring-boot-starter/src/main/java/com/richard/fyoung/customerwork/ticket/Ticket.java
@@ -204,6 +204,24 @@ public class Ticket {
     }
 
     /**
+     * 重新打开回 AI 自助：RESOLVED | CLOSED → AI_SERVING（reopen 计数 +1，清坐席）。
+     *
+     * <p>用户端"重新开始对话"专用：重开后由 AI 继续服务，需要人工时用户再显式转人工；
+     * 区别于 {@link #reopen}（重开直达人工排队，供"问题未解决重新找人工"场景）。</p>
+     */
+    public void reopenToAi(String reason) {
+        if (status != TicketStatus.RESOLVED && status != TicketStatus.CLOSED) {
+            throw new IllegalStateException(illegal("reopenToAi"));
+        }
+        this.status = TicketStatus.AI_SERVING;
+        this.assignee = null;
+        this.handoffReason = reason;
+        this.reopenCount++;
+        markUserActive();
+        touch();
+    }
+
+    /**
      * 刷新用户最后活跃时间：用户发消息 / 主动操作（转人工/确认/驳回/重开）时调用。
      *
      * <p>非状态流转（不改 {@code status}），仅重置空闲计时基准，避免活跃会话被空闲巡检误关。

--- a/customer-work-spring-boot-starter/src/main/java/com/richard/fyoung/customerwork/ticket/TicketService.java
+++ b/customer-work-spring-boot-starter/src/main/java/com/richard/fyoung/customerwork/ticket/TicketService.java
@@ -156,6 +156,12 @@ public class TicketService {
             actorType, actorId, reason);
     }
 
+    /** 重新打开回 AI 自助：RESOLVED|CLOSED → AI_SERVING（用户端"重新开始对话"专用）。 */
+    public Ticket reopenToAi(String ticketId, String reason, TicketActorType actorType, String actorId) {
+        return applyTransition(ticketId, t -> t.reopenToAi(reason), TicketEventType.REOPEN,
+            actorType, actorId, reason);
+    }
+
     /** 变更优先级（任意非 CLOSED 态）。 */
     public Ticket changePriority(String ticketId, TicketPriority priority, TicketActorType actorType, String actorId) {
         return applyTransition(ticketId, t -> t.changePriority(priority), TicketEventType.PRIORITY_CHANGE,

--- a/customer-work-spring-boot-starter/src/test/java/com/richard/fyoung/customerwork/ticket/TicketServiceTest.java
+++ b/customer-work-spring-boot-starter/src/test/java/com/richard/fyoung/customerwork/ticket/TicketServiceTest.java
@@ -224,4 +224,17 @@ class TicketServiceTest {
         assertEquals(TicketStatus.WAITING_AGENT, reopened.getStatus());
         assertEquals(1, reopened.getReopenCount());
     }
+
+    @Test
+    void reopenToAi_shouldReturnToAiServing() {
+        // 用户端"重新开始对话"：重开回 AI 自助，不进人工排队，重开后该会话重新成为用户的活跃会话
+        TicketService svc = service();
+        Ticket t = svc.createForSession("s1", "u1", "标题", TicketCategory.ORDER);
+        svc.close(t.getId(), "done", TicketActorType.USER, "u1");
+
+        Ticket reopened = svc.reopenToAi(t.getId(), "重新开始对话", TicketActorType.USER, "u1");
+        assertEquals(TicketStatus.AI_SERVING, reopened.getStatus());
+        assertEquals(1, reopened.getReopenCount());
+        assertEquals(t.getId(), svc.findActiveByUser("u1").orElseThrow().getId());
+    }
 }

--- a/customer-work-spring-boot-starter/src/test/java/com/richard/fyoung/customerwork/ticket/TicketTest.java
+++ b/customer-work-spring-boot-starter/src/test/java/com/richard/fyoung/customerwork/ticket/TicketTest.java
@@ -256,6 +256,27 @@ class TicketTest {
     }
 
     @Test
+    void reopenToAi_shouldReturnToAiServingAndCountUp() {
+        // RESOLVED → AI_SERVING：回 AI 自助而非人工排队，reopen 计数 +1、清坐席、刷新用户活跃基准
+        Ticket r = resolved();
+        long before = r.getLastUserActiveAtMs();
+        r.reopenToAi("重新开始对话");
+        assertEquals(TicketStatus.AI_SERVING, r.getStatus());
+        assertEquals(1, r.getReopenCount());
+        assertNull(r.getAssignee());
+        assertTrue(r.getLastUserActiveAtMs() >= before);
+
+        // CLOSED → AI_SERVING 同样允许
+        Ticket closed = aiServing();
+        closed.close("done");
+        closed.reopenToAi("重开");
+        assertEquals(TicketStatus.AI_SERVING, closed.getStatus());
+
+        // 非 RESOLVED|CLOSED 态 fast-fail
+        assertThrows(IllegalStateException.class, () -> processing().reopenToAi("x"));
+    }
+
+    @Test
     void fillTitleIfBlank_shouldFillOnlyWhenBlank() {
         // 已有标题：不覆盖
         Ticket withTitle = Ticket.create("TK-a", "s", "u", "原标题", TicketCategory.CONSULT);


### PR DESCRIPTION
## 变更说明 / What

修复 PR #25 遗留问题：用户在消息列表点已结束会话的「重新开始对话」后，工单直接进入「转人工排队」（WAITING_AGENT），而非回到 AI 自助。

根因：用户端 reopen 接口复用了既有 `Ticket.reopen()`，其语义是"问题未解决重新找人工"（`RESOLVED|CLOSED → WAITING_AGENT`）。

修复：新增独立流转 `Ticket.reopenToAi()`（`RESOLVED|CLOSED → AI_SERVING`，reopen 计数 +1、清坐席、刷新用户活跃基准），用户端 `POST /tickets/{id}/reopen` 改走该分支——重开后由 AI 继续服务，需要人工时用户再显式点「转人工」。原 `reopen()`（直达人工）语义原样保留给坐席/管理链路，坐席端零影响。用户级唯一活跃会话的 409 前置校验不变。

## 类型 / Type
- [ ] feat 新功能
- [x] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（TicketTest 21 / TicketServiceTest 14 / TicketSlaSchedulerTest 8 / UserTicketControllerTest 11，新增 reopenToAi 状态机与服务层用例）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 无新增外部后端（纯状态机分支扩展）
- [x] 接口无破坏性变更（仅 reopen 后的目标状态变化），前端无需改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)