### PR TITLE
feat: 智能路由中控中心——敏感词拦截 + 会话总结建议 + 工单智能分配

### DIFF
--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/AgentAssistController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/AgentAssistController.java
@@ -2,17 +2,21 @@ package com.richard.fyoung.customerworkapp.controller;
 
 import com.richard.fyoung.customerwork.assist.AgentAssistService;
 import com.richard.fyoung.customerwork.assist.AssistSuggestion;
+import com.richard.fyoung.customerwork.assist.ConversationSummary;
+import com.richard.fyoung.customerwork.assist.ConversationSummaryService;
 import com.richard.fyoung.customerwork.quality.QualityFeedbackRecorder;
 import com.richard.fyoung.customerwork.quality.QualityReport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 
@@ -31,11 +35,14 @@ public class AgentAssistController {
     private static final String DEFAULT_SESSION_ID = "unknown";
 
     private final AgentAssistService assistService;
+    private final ConversationSummaryService conversationSummaryService;
     private final QualityFeedbackRecorder qualityFeedbackRecorder;
 
     public AgentAssistController(AgentAssistService assistService,
+                                ConversationSummaryService conversationSummaryService,
                                 QualityFeedbackRecorder qualityFeedbackRecorder) {
         this.assistService = assistService;
+        this.conversationSummaryService = conversationSummaryService;
         this.qualityFeedbackRecorder = qualityFeedbackRecorder;
     }
 
@@ -43,6 +50,15 @@ public class AgentAssistController {
     @PostMapping("/assist")
     public Mono<AssistSuggestion> assist(@RequestParam String message) {
         return Mono.just(assistService.suggest(message));
+    }
+
+    @Operation(summary = "会话总结建议", description = "对整段会话历史做一次性 LLM 结构化总结（意图/情绪/已尝试/待解决/建议）；"
+        + "模型不可用时自动降级到规则版建议（fail-open，永不失败）。供坐席接手前快速了解上下文。")
+    @GetMapping("/assist/summary")
+    public Mono<ConversationSummary> summary(@RequestParam String sessionId) {
+        // summarize 内部会阻塞式调用模型（model.stream().block()），派发到弹性线程池，不占用事件循环线程
+        return Mono.fromCallable(() -> conversationSummaryService.summarize(sessionId))
+            .subscribeOn(Schedulers.boundedElastic());
     }
 
     @Operation(summary = "会话质检", description = "对一组坐席/Agent 回复做合规与服务规范打分；"

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/HandoffController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/HandoffController.java
@@ -4,6 +4,7 @@ import com.richard.fyoung.customerwork.handoff.HandoffService;
 import com.richard.fyoung.customerwork.handoff.HandoffStatus;
 import com.richard.fyoung.customerwork.handoff.HandoffTicket;
 import com.richard.fyoung.customerwork.observability.AuditSink;
+import com.richard.fyoung.customerwork.routing.SeatRecommendation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -65,6 +66,15 @@ public class HandoffController {
         return Mono.justOrEmpty(handoffService.find(id))
             .switchIfEmpty(Mono.error(new ResponseStatusException(
                 HttpStatus.NOT_FOUND, "handoff not found: " + id)));
+    }
+
+    @Operation(summary = "工单智能分配推荐", description = "返回建单时预生成的 top-N 推荐坐席（含打分与可解释理由）供坐席工作台展示；"
+        + "坐席人工点选后仍走 claim 接单（HITL，不自动派单）。未开启智能分配 / 推荐尚未生成 / 无候选时返回空列表（fail-open）。")
+    @GetMapping("/{id}/routing-suggestions")
+    public Mono<List<SeatRecommendation>> routingSuggestions(@PathVariable String id) {
+        return Mono.justOrEmpty(handoffService.find(id))
+            .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "handoff not found: " + id)))
+            .map(ticket -> SeatRecommendation.parseList(ticket.getSuggestedAssignees()));
     }
 
     @Operation(summary = "坐席接单", description = "PENDING → CLAIMED，重复接单返回 409")

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/assist/ConversationSummary.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/assist/ConversationSummary.java
@@ -1,0 +1,24 @@
+package com.richard.fyoung.customerwork.assist;
+
+import java.util.List;
+
+/**
+ * 会话总结建议（转人工时给接手坐席的结构化上下文摘要）。
+ *
+ * <p>由 {@link ConversationSummaryService} 对整段会话历史做一次性 LLM 总结得到；模型不守 JSON 格式时降级为
+ * 规则版建议（{@code fromModel=false}），保证坐席始终能拿到一份可用摘要（fail-open）。</p>
+ *
+ * @param oneLineSummary   一句话摘要
+ * @param userIntent       用户核心意图
+ * @param emotion          用户情绪（如 平静/不满/愤怒）
+ * @param triedSolutions   已尝试过的方案（可空列表）
+ * @param pendingIssues    仍待解决的问题（可空列表）
+ * @param suggestedNextStep 建议下一步动作
+ * @param suggestedReply   建议话术
+ * @param fromModel        true=LLM 生成；false=模型不可用/不守格式时的规则降级结果
+ * @author owlzhangfq@gmail.com
+ */
+public record ConversationSummary(String oneLineSummary, String userIntent, String emotion,
+                                  List<String> triedSolutions, List<String> pendingIssues,
+                                  String suggestedNextStep, String suggestedReply, boolean fromModel) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/assist/ConversationSummaryService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/assist/ConversationSummaryService.java
@@ -1,0 +1,280 @@
+package com.richard.fyoung.customerwork.assist;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.chatlog.ChatMessage;
+import com.richard.fyoung.customerwork.chatlog.ChatMessageStore;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.ticket.TicketActorType;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 会话总结建议服务（智能路由中控·会话总结）：对整段会话历史做一次性 LLM 总结，产出结构化
+ * {@link ConversationSummary} 供接手坐席快速了解上下文。
+ *
+ * <p><b>fail-open（与敏感词的 fail-closed 相反）：</b>总结是"增强"能力——模型不可达 / 空响应 / 不守 JSON
+ * 格式时，一律降级到规则版 {@link AgentAssistService} 的建议 + 历史原文进摘要（{@code fromModel=false}），
+ * <b>绝不抛异常打断转人工与对话主链路</b>。这与"总结/推荐挂了不能影响转人工本身"的定位一致。</p>
+ *
+ * <p>一次性调用手法与 {@code ModelVisionOcrService} / admin 侧 {@code GitAssistantService.callModelOnce}
+ * 一致（单条 user 消息、不带工具、收集全部文本块拼接）。结果按 sessionId 进有界缓存，供转人工时预生成、
+ * 坐席工作台随后免二次 LLM 调用拉取。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class ConversationSummaryService {
+
+    private static final Logger log = LoggerFactory.getLogger(ConversationSummaryService.class);
+
+    /** 送入模型的历史文本上限，超过截断，避免撑爆上下文。 */
+    private static final int MAX_TRANSCRIPT_CHARS = 12_000;
+    /** 一句话摘要降级时的原文截断长度。 */
+    private static final int FALLBACK_SUMMARY_MAX_CHARS = 120;
+
+    private static final String SUMMARY_PROMPT =
+        "你是资深客服主管。请阅读下面这段客服会话记录，为即将接手的人工坐席做一份结构化摘要。\n"
+        + "只输出一个 JSON 对象，不要输出任何解释文字或 Markdown 代码块标记，结构严格为：\n"
+        + "{\"oneLineSummary\":\"一句话概括\",\"userIntent\":\"用户核心诉求\",\"emotion\":\"用户情绪(平静/不满/愤怒/焦虑等)\","
+        + "\"triedSolutions\":[\"已尝试的方案1\"],\"pendingIssues\":[\"仍待解决的问题1\"],"
+        + "\"suggestedNextStep\":\"给坐席的下一步建议\",\"suggestedReply\":\"建议的开场话术\"}\n"
+        + "列表字段没有内容时返回空数组。会话记录如下：\n\n";
+
+    private final Model model;
+    private final ChatMessageStore chatMessageStore;
+    private final AgentAssistService assistService;
+    private final CustomerWorkProperties properties;
+
+    /** 宽松 JSON 解析（忽略模型多吐的未知字段），窄用途、不依赖容器注入。 */
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    /** sessionId → 最近一次摘要缓存（有界，供坐席工作台免二次 LLM 拉取转人工时预生成的结果）。 */
+    private final Map<String, ConversationSummary> latestBySession;
+
+    public ConversationSummaryService(Model model, ChatMessageStore chatMessageStore,
+                                      AgentAssistService assistService, CustomerWorkProperties properties) {
+        this.model = model;
+        this.chatMessageStore = chatMessageStore;
+        this.assistService = assistService;
+        this.properties = properties;
+        int cap = Math.max(1, properties.getAssist().getSummaryCacheMaxSessions());
+        // 按插入序淘汰最旧：accessOrder=false 的 LinkedHashMap + removeEldestEntry，外层 synchronized 保证线程安全
+        this.latestBySession = Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, false) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, ConversationSummary> eldest) {
+                return size() > cap;
+            }
+        });
+    }
+
+    /**
+     * 对指定会话做整段总结。<b>永不抛异常</b>：任何失败都降级为规则版摘要返回。结果同时进缓存供
+     * {@link #findLatest} 免二次调用拉取。
+     */
+    public ConversationSummary summarize(String sessionId) {
+        List<ChatMessage> history = loadHistory(sessionId);
+        String transcript = toTranscript(history);
+        String lastUserMessage = lastUserMessage(history);
+        ConversationSummary summary;
+        try {
+            summary = summarizeByModel(transcript, lastUserMessage);
+        } catch (Exception e) {
+            // fail-open：模型调用失败不阻断转人工/对话主链路，降级到规则版建议
+            log.error("[ConversationSummaryService] summarize failed, code={}, session={}",
+                "SUMMARY-GENERATE-FAIL", sessionId, e);
+            summary = fallbackSummary(transcript, lastUserMessage);
+        }
+        cache(sessionId, summary);
+        return summary;
+    }
+
+    /** 拉取转人工时预生成并缓存的最近一次摘要（无则空，坐席工作台可据此决定是否触发按需生成）。 */
+    public Optional<ConversationSummary> findLatest(String sessionId) {
+        return Optional.ofNullable(latestBySession.get(sessionId));
+    }
+
+    // ---------------------- private helpers ----------------------
+
+    private List<ChatMessage> loadHistory(String sessionId) {
+        int limit = Math.max(1, properties.getAssist().getSummaryHistoryLimit());
+        try {
+            return chatMessageStore.findBySession(sessionId, null, limit);
+        } catch (Exception e) {
+            log.error("[ConversationSummaryService] load history failed, code={}, session={}",
+                "SUMMARY-HISTORY-LOAD-FAIL", sessionId, e);
+            return List.of();
+        }
+    }
+
+    /** 一次性 LLM 总结：拼接历史 → 单条 user 消息 → 收集文本 → 解析 JSON；空历史/空响应/解析失败一律走降级。 */
+    private ConversationSummary summarizeByModel(String transcript, String lastUserMessage) {
+        if (!StringUtils.hasText(transcript)) {
+            // 无历史：不调用模型，直接给规则降级摘要
+            return fallbackSummary(transcript, lastUserMessage);
+        }
+        String text = callModelOnce(SUMMARY_PROMPT + truncate(transcript, MAX_TRANSCRIPT_CHARS));
+        Optional<ConversationSummary> parsed = parse(text);
+        if (parsed.isPresent()) {
+            return parsed.get();
+        }
+        // 模型没吐合法 JSON：降级但保留原文进摘要，便于坐席仍能看到模型的自由文本输出
+        log.error("[ConversationSummaryService] summary json parse degraded, code={}", "SUMMARY-LLM-DEGRADE");
+        ConversationSummary fallback = fallbackSummary(transcript, lastUserMessage);
+        String rawOneLine = StringUtils.hasText(text) ? truncate(text.trim(), FALLBACK_SUMMARY_MAX_CHARS)
+            : fallback.oneLineSummary();
+        return new ConversationSummary(rawOneLine, fallback.userIntent(), fallback.emotion(),
+            fallback.triedSolutions(), fallback.pendingIssues(), fallback.suggestedNextStep(),
+            fallback.suggestedReply(), false);
+    }
+
+    /** 解析模型返回的摘要 JSON（容忍前后夹带说明/代码块标记）；结构不完整或异常返回 empty 交由上层降级。 */
+    private Optional<ConversationSummary> parse(String modelText) {
+        String json = extractJsonObject(modelText);
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            SummaryPayload p = objectMapper.readValue(json, SummaryPayload.class);
+            if (!StringUtils.hasText(p.oneLineSummary)) {
+                return Optional.empty();
+            }
+            return Optional.of(new ConversationSummary(
+                p.oneLineSummary, p.userIntent, p.emotion,
+                nullSafe(p.triedSolutions), nullSafe(p.pendingIssues),
+                p.suggestedNextStep, p.suggestedReply, true));
+        } catch (Exception e) {
+            log.error("[ConversationSummaryService] summary json deserialize failed, code={}", "SUMMARY-LLM-DEGRADE", e);
+            return Optional.empty();
+        }
+    }
+
+    /** 规则降级摘要：复用规则版 {@link AgentAssistService} 的建议，历史/末条用户消息进 oneLineSummary。 */
+    private ConversationSummary fallbackSummary(String transcript, String lastUserMessage) {
+        AssistSuggestion suggestion = assistService.suggest(lastUserMessage);
+        String oneLine = StringUtils.hasText(lastUserMessage)
+            ? "用户最新诉求：" + truncate(lastUserMessage, FALLBACK_SUMMARY_MAX_CHARS)
+            : (StringUtils.hasText(transcript) ? truncate(transcript, FALLBACK_SUMMARY_MAX_CHARS) : "暂无会话历史");
+        return new ConversationSummary(oneLine, lastUserMessage, null,
+            List.of(), List.of(), suggestion.knowledgeHint(), suggestion.suggestedReply(), false);
+    }
+
+    /** 一次性模型调用：单条 user 消息、不带工具，取全部返回文本块拼接结果。空响应抛异常交由上层降级。 */
+    private String callModelOnce(String prompt) {
+        Msg userMsg = Msg.builder()
+            .role(MsgRole.USER)
+            .name("user")
+            .content(TextBlock.builder().text(prompt).build())
+            .build();
+        long timeout = Math.max(1, properties.getAssist().getSummaryTimeoutSeconds());
+        List<ChatResponse> responses = model.stream(List.of(userMsg), List.of(), GenerateOptions.builder().build())
+            .collectList()
+            .block(Duration.ofSeconds(timeout));
+        if (responses == null || responses.isEmpty()) {
+            throw new IllegalStateException("summary model returned empty response");
+        }
+        String text = responses.stream()
+            .flatMap(response -> response.getContent().stream())
+            .filter(TextBlock.class::isInstance)
+            .map(TextBlock.class::cast)
+            .map(TextBlock::getText)
+            .filter(StringUtils::hasText)
+            .collect(Collectors.joining());
+        if (!StringUtils.hasText(text)) {
+            throw new IllegalStateException("summary model returned no text content");
+        }
+        return text.trim();
+    }
+
+    private String toTranscript(List<ChatMessage> history) {
+        if (history == null || history.isEmpty()) {
+            return "";
+        }
+        return history.stream()
+            .map(m -> roleLabel(m.senderType()) + "：" + (m.content() == null ? "" : m.content()))
+            .collect(Collectors.joining("\n"));
+    }
+
+    private String lastUserMessage(List<ChatMessage> history) {
+        if (history == null) {
+            return "";
+        }
+        for (int i = history.size() - 1; i >= 0; i--) {
+            ChatMessage m = history.get(i);
+            if (m.senderType() == TicketActorType.USER && StringUtils.hasText(m.content())) {
+                return m.content();
+            }
+        }
+        return "";
+    }
+
+    private String roleLabel(TicketActorType type) {
+        if (type == null) {
+            return "未知";
+        }
+        switch (type) {
+            case USER:
+                return "用户";
+            case BOT:
+                return "机器人";
+            case AGENT:
+                return "坐席";
+            default:
+                return "系统";
+        }
+    }
+
+    private String extractJsonObject(String text) {
+        if (!StringUtils.hasText(text)) {
+            return null;
+        }
+        int start = text.indexOf('{');
+        int end = text.lastIndexOf('}');
+        return (start >= 0 && end > start) ? text.substring(start, end + 1) : null;
+    }
+
+    private List<String> nullSafe(List<String> list) {
+        return list == null ? List.of() : new ArrayList<>(list);
+    }
+
+    private String truncate(String text, int max) {
+        if (text == null) {
+            return "";
+        }
+        return text.length() <= max ? text : text.substring(0, max) + "…";
+    }
+
+    private void cache(String sessionId, ConversationSummary summary) {
+        if (StringUtils.hasText(sessionId) && summary != null) {
+            latestBySession.put(sessionId, summary);
+        }
+    }
+
+    /** 模型 JSON 反序列化载体（贫血，仅解析用）：字段名与提示词约定的 JSON key 一一对应。 */
+    private static final class SummaryPayload {
+        public String oneLineSummary;
+        public String userIntent;
+        public String emotion;
+        public List<String> triedSolutions;
+        public List<String> pendingIssues;
+        public String suggestedNextStep;
+        public String suggestedReply;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -95,6 +95,50 @@ public class CustomerWorkProperties {
     /** 敏感词"一次拦截"过滤（入站/出站高性能词表拦截，智能路由中控第一块）。 */
     private final SensitiveWord sensitiveWord = new SensitiveWord();
 
+    /** 会话总结建议（转人工时给接手坐席的结构化摘要，智能路由中控第二块之一）。 */
+    private final Assist assist = new Assist();
+
+    /** 工单智能分配（LLM 分类 + 打分器 + HITL 推荐，智能路由中控第二块之二）。 */
+    private final Routing routing = new Routing();
+
+    /**
+     * 会话总结建议配置。默认关闭。
+     *
+     * <p>转人工时对整段历史做一次性 LLM 总结，产出结构化 {@code ConversationSummary} 供接手坐席快速了解上下文。
+     * 失败 fail-open（降级到规则版 {@code AgentAssistService} 建议，绝不阻断转人工主链路）。按需触发的
+     * {@code GET /api/customer/assist/summary} 端点不受本开关约束（显式人工请求），本开关仅控制转人工时的自动预生成。</p>
+     */
+    @Data
+    public static class Assist {
+        /** 转人工时自动预生成会话摘要（默认关，开启会产生真实模型调用费用）。 */
+        private boolean summaryEnabled = false;
+        /** 摘要拉取会话历史的最大条数。 */
+        private int summaryHistoryLimit = 30;
+        /** 单次摘要 LLM 调用超时（秒）。 */
+        private long summaryTimeoutSeconds = 30;
+        /** 摘要缓存的最大会话数（供坐席工作台按 sessionId 拉取预生成结果，超出按插入序淘汰最旧）。 */
+        private int summaryCacheMaxSessions = 512;
+    }
+
+    /**
+     * 工单智能分配配置。默认关闭。
+     *
+     * <p>转人工时对工单做一次性 LLM 分类（类目/技能/优先级/情绪）+ 确定性打分器给候选坐席打分，把 top-N
+     * 推荐写入工单供坐席工作台展示——<b>仅推荐、不自动派单</b>，人工点选后仍复用现有 claim 流程。任一步失败
+     * fail-open（退回现有拉取模型：无推荐、坐席照常手动接单），不阻断转人工。</p>
+     */
+    @Data
+    public static class Routing {
+        /** 转人工时自动做工单分类 + 坐席打分推荐（默认关；不自动派单，仅写入推荐供坐席点选）。 */
+        private boolean assignEnabled = false;
+        /** 坐席库存储模式：memory（进程内带演示种子，默认）| jdbc（跨实例共享）。 */
+        private String seatStoreMode = "memory";
+        /** 推荐坐席 top-N（默认 3）。 */
+        private int topN = 3;
+        /** 单次工单分类 LLM 调用超时（秒）。 */
+        private long classifyTimeoutSeconds = 30;
+    }
+
     /**
      * 多轮槽位收集存储配置。
      *

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -92,6 +92,9 @@ public class CustomerWorkProperties {
     /** 基于 AgentScope 的定时任务调度配置（XXL-JOB 接入）。 */
     private final Scheduler scheduler = new Scheduler();
 
+    /** 敏感词"一次拦截"过滤（入站/出站高性能词表拦截，智能路由中控第一块）。 */
+    private final SensitiveWord sensitiveWord = new SensitiveWord();
+
     /**
      * 多轮槽位收集存储配置。
      *
@@ -542,6 +545,56 @@ public class CustomerWorkProperties {
         private long idleCloseSeconds = 300;
         /** SLA 巡检总开关（关闭则告警与自动流转全部停用）。 */
         private boolean slaEnabled = true;
+    }
+
+    /**
+     * 敏感词"一次拦截"过滤配置。默认关闭。
+     *
+     * <p>入站（用户输入）与出站（AI 输出）各过一遍高性能敏感词自动机，命中即处置（BLOCK/MASK/REVIEW）。
+     * 零 LLM、微秒级、可解释。词表由 {@code store-mode} 决定持久化方式（memory 带演示种子 / jdbc 跨实例共享）。</p>
+     */
+    @Data
+    public static class SensitiveWord {
+        /** 命中 BLOCK 时的掩码字符默认值。 */
+        public static final String DEFAULT_MASK_CHAR = "*";
+        /** 入站命中 BLOCK 的统一安全话术。 */
+        public static final String DEFAULT_INBOUND_SAFE_REPLY = "您的消息包含不当内容，请调整后重试。";
+        /** 出站命中 BLOCK 的安全兜底话术（替换 AI 原始回复）。 */
+        public static final String DEFAULT_OUTBOUND_SAFE_REPLY = "抱歉，这个问题我暂时无法回答，请换个方式提问或联系人工客服。";
+
+        /** 总开关。默认关闭。 */
+        private boolean enabled = false;
+        /** 生效方向：inbound（仅入站）| outbound（仅出站）| both（默认）。 */
+        private Direction direction = Direction.BOTH;
+        /** 存储模式：memory（进程内，带演示种子，默认）| jdbc（跨实例共享）。 */
+        private String storeMode = "memory";
+        /** 词条动作缺省时的兜底动作（防御式：正常词条均带动作，仅脏数据/异常兜底用），默认 BLOCK。 */
+        private com.richard.fyoung.customerwork.sensitiveword.SensitiveWordAction defaultAction =
+            com.richard.fyoung.customerwork.sensitiveword.SensitiveWordAction.BLOCK;
+        /** 打码字符（取首字符）。 */
+        private String maskChar = DEFAULT_MASK_CHAR;
+        /** 入站 BLOCK 安全话术。 */
+        private String inboundSafeReply = DEFAULT_INBOUND_SAFE_REPLY;
+        /** 出站 BLOCK 安全兜底话术。 */
+        private String outboundSafeReply = DEFAULT_OUTBOUND_SAFE_REPLY;
+
+        /** 取打码字符（配置为空则回退默认 '*'）。 */
+        public char resolveMaskChar() {
+            return (maskChar == null || maskChar.isEmpty()) ? DEFAULT_MASK_CHAR.charAt(0) : maskChar.charAt(0);
+        }
+
+        public boolean inboundEnabled() {
+            return enabled && direction != Direction.OUTBOUND;
+        }
+
+        public boolean outboundEnabled() {
+            return enabled && direction != Direction.INBOUND;
+        }
+    }
+
+    /** 敏感词过滤生效方向。 */
+    public enum Direction {
+        INBOUND, OUTBOUND, BOTH
     }
 
     /**

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/PersistenceJdbcCondition.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/PersistenceJdbcCondition.java
@@ -29,6 +29,7 @@ public class PersistenceJdbcCondition implements Condition {
         "customer-work.user-auth.store-mode",
         "customer-work.chat-log.store-mode",
         "customer-work.attachment.store-mode",
+        "customer-work.sensitive-word.store-mode",
         "customer-work.tool-backend.mode"
     };
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/HandoffService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/HandoffService.java
@@ -1,7 +1,9 @@
 package com.richard.fyoung.customerwork.handoff;
 
+import com.richard.fyoung.customerwork.routing.HandoffCreatedEnricher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -30,9 +32,24 @@ public class HandoffService {
 
     private final HandoffStore store;
 
+    /**
+     * 转人工增强器（智能路由中控·会话总结 + 工单智能分配）：<b>可选</b>，setter 注入。
+     *
+     * <p>用 setter 而非构造注入：一是保留既有无参/单参构造不破坏旧测试；二是打破
+     * {@code HandoffService ⇆ HandoffCreatedEnricher}（增强器构造依赖本服务做推荐回写）的循环依赖。
+     * 未装配（未开启增强 / 纯工具场景）时建单行为与此前完全一致。</p>
+     */
+    private HandoffCreatedEnricher enricher;
+
     /** Spring 注入构造：使用自动装配的 HandoffStore Bean。 */
     public HandoffService(HandoffStore store) {
         this.store = store;
+    }
+
+    /** 可选注入转人工增强器（不存在则不增强，建单行为不变）。 */
+    @Autowired(required = false)
+    public void setEnricher(HandoffCreatedEnricher enricher) {
+        this.enricher = enricher;
     }
 
     /** 无参构造（兼容旧测试与无 Spring 场景）：使用默认内存存储。 */
@@ -46,7 +63,44 @@ public class HandoffService {
         HandoffTicket ticket = new HandoffTicket(id, sessionId, reason, System.currentTimeMillis());
         store.save(ticket);
         log.info("handoff created: id={}, session={}, reason={}", id, sessionId, reason);
+        fireEnrichment(ticket);
         return ticket;
+    }
+
+    /**
+     * 触发转人工增强（会话摘要预生成 + 工单分类打分推荐），<b>异步、fail-open</b>：增强器内部把耗时工作派发到
+     * 独立线程池，此处仅同步派发。摘要/推荐是增强，挂了不能影响转人工——故即便派发本身异常也只 error 不抛。
+     */
+    private void fireEnrichment(HandoffTicket ticket) {
+        if (enricher == null) {
+            return;
+        }
+        try {
+            enricher.onHandoffCreated(ticket);
+        } catch (Exception e) {
+            log.error("[HandoffService] enrichment trigger failed, code={}, id={}",
+                "HANDOFF-ENRICH-TRIGGER-FAIL", ticket.getId(), e);
+        }
+    }
+
+    /**
+     * 回写工单智能分配的分类与推荐结果（由 {@code HandoffCreatedEnricher} 异步调用）。
+     *
+     * <p>走本服务自身的 {@link HandoffStore}，保证与坐席工作台经本服务读到的是同一份工单。工单不存在时只
+     * error 记录、不抛（fail-open：增强回写迟到于工单已被清理等边界情况不应产生异常）。</p>
+     */
+    public void applyRoutingSuggestion(String id, String category, String requiredSkill,
+                                       String priority, String emotion, String suggestedAssignees) {
+        Optional<HandoffTicket> found = store.find(id);
+        if (found.isEmpty()) {
+            log.error("[HandoffService] apply routing suggestion skipped (ticket not found), code={}, id={}",
+                "HANDOFF-ROUTING-APPLY-MISS", id);
+            return;
+        }
+        HandoffTicket ticket = found.get();
+        ticket.applyRoutingSuggestion(category, requiredSkill, priority, emotion, suggestedAssignees);
+        store.update(ticket);
+        log.info("handoff routing suggestion applied: id={}, category={}, priority={}", id, category, priority);
     }
 
     /** 全部工单（含已结案）。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/HandoffTicket.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/HandoffTicket.java
@@ -24,6 +24,18 @@ public class HandoffTicket {
     private volatile String resolutionNote;
     private volatile long resolvedAtMs;
 
+    // ---- 智能路由中控·工单智能分配增强字段（全部可空、建单后异步回写，向后兼容旧数据不迁移）----
+    /** 工单分类（LLM 分类，如 退款/物流/投诉）。 */
+    private volatile String category;
+    /** 所需坐席技能标签（LLM 分类，可空表示无硬性要求）。 */
+    private volatile String requiredSkill;
+    /** 优先级枚举名（LOW/MEDIUM/HIGH/URGENT）。 */
+    private volatile String priority;
+    /** 用户情绪（LLM 分类）。 */
+    private volatile String emotion;
+    /** 推荐坐席列表（JSON，{@code SeatRecommendation} 序列化；HITL 供坐席点选，非自动派单）。 */
+    private volatile String suggestedAssignees;
+
     public HandoffTicket(String id, String sessionId, String reason, long createdAtMs) {
         this.id = id;
         this.sessionId = sessionId;
@@ -52,19 +64,51 @@ public class HandoffTicket {
     }
 
     /**
+     * 智能路由中控·工单智能分配：建单后由 {@code HandoffCreatedEnricher} 异步回写分类与推荐结果。
+     *
+     * <p>纯字段赋值、不触碰状态机（分类/推荐是旁挂增强，与 PENDING→CLAIMED→RESOLVED 主流转无关），全部可空。</p>
+     */
+    public void applyRoutingSuggestion(String category, String requiredSkill, String priority,
+                                       String emotion, String suggestedAssignees) {
+        this.category = category;
+        this.requiredSkill = requiredSkill;
+        this.priority = priority;
+        this.emotion = emotion;
+        this.suggestedAssignees = suggestedAssignees;
+    }
+
+    /**
+     * 向后兼容重载（无智能分配增强字段）：路由相关列一律置空。保留给未涉及增强字段的既有调用方/测试，
+     * 避免签名变更的连锁改动。
+     */
+    static HandoffTicket reconstruct(String id, String sessionId, String reason, long createdAtMs,
+                                     HandoffStatus status, String claimedBy, long claimedAtMs,
+                                     String resolutionNote, long resolvedAtMs) {
+        return reconstruct(id, sessionId, reason, createdAtMs, status, claimedBy, claimedAtMs,
+            resolutionNote, resolvedAtMs, null, null, null, null, null);
+    }
+
+    /**
      * 供持久化存储层（如 {@link MybatisHandoffStore}）从数据源重建已有工单——跳过
      * {@link #claim}/{@link #resolve} 的业务状态机校验（这不是一次新的坐席动作，只是把已发生过的
      * 流转结果读回内存）。包级可见，仅供本包内的 {@link HandoffStore} 实现使用。
      */
     static HandoffTicket reconstruct(String id, String sessionId, String reason, long createdAtMs,
                                      HandoffStatus status, String claimedBy, long claimedAtMs,
-                                     String resolutionNote, long resolvedAtMs) {
+                                     String resolutionNote, long resolvedAtMs,
+                                     String category, String requiredSkill, String priority,
+                                     String emotion, String suggestedAssignees) {
         HandoffTicket ticket = new HandoffTicket(id, sessionId, reason, createdAtMs);
         ticket.status = status;
         ticket.claimedBy = claimedBy;
         ticket.claimedAtMs = claimedAtMs;
         ticket.resolutionNote = resolutionNote;
         ticket.resolvedAtMs = resolvedAtMs;
+        ticket.category = category;
+        ticket.requiredSkill = requiredSkill;
+        ticket.priority = priority;
+        ticket.emotion = emotion;
+        ticket.suggestedAssignees = suggestedAssignees;
         return ticket;
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/MybatisHandoffStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/MybatisHandoffStore.java
@@ -102,7 +102,12 @@ public class MybatisHandoffStore implements HandoffStore {
             row.getClaimedBy(),
             row.getClaimedAtMs(),
             row.getResolutionNote(),
-            row.getResolvedAtMs());
+            row.getResolvedAtMs(),
+            row.getCategory(),
+            row.getRequiredSkill(),
+            row.getPriority(),
+            row.getEmotion(),
+            row.getSuggestedAssignees());
     }
 
     private HandoffTicketDO toDO(HandoffTicket ticket) {
@@ -116,6 +121,11 @@ public class MybatisHandoffStore implements HandoffStore {
         row.setClaimedAtMs(ticket.getClaimedAtMs());
         row.setResolutionNote(ticket.getResolutionNote());
         row.setResolvedAtMs(ticket.getResolvedAtMs());
+        row.setCategory(ticket.getCategory());
+        row.setRequiredSkill(ticket.getRequiredSkill());
+        row.setPriority(ticket.getPriority());
+        row.setEmotion(ticket.getEmotion());
+        row.setSuggestedAssignees(ticket.getSuggestedAssignees());
         return row;
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/entity/HandoffTicketDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/entity/HandoffTicketDO.java
@@ -29,4 +29,11 @@ public class HandoffTicketDO {
     private Long claimedAtMs;
     private String resolutionNote;
     private Long resolvedAtMs;
+
+    // ---- 工单智能分配增强列（可空，建单后异步回写；旧数据为 NULL，向后兼容）----
+    private String category;
+    private String requiredSkill;
+    private String priority;
+    private String emotion;
+    private String suggestedAssignees;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/middleware/SensitiveWordMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/middleware/SensitiveWordMiddleware.java
@@ -1,0 +1,346 @@
+package com.richard.fyoung.customerwork.middleware;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.observability.AuditSink;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWord;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordAction;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordFilter;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordFilterResult;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordHit;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+
+/**
+ * 敏感词"一次拦截"中间件（2.0 Middleware，「安全合规 · 内容风控」，智能路由中控第一块）。
+ *
+ * <p>用户输入与 AI 输出各过一遍高性能敏感词自动机（{@link SensitiveWordFilter}），命中即处置——零 LLM、
+ * 微秒级、可解释。命中动作分三档：{@code BLOCK}（硬拦截）/ {@code MASK}（打码放行）/ {@code REVIEW}（放行标记）。</p>
+ *
+ * <ul>
+ *   <li><b>入站</b>（{@link #onAgent} 拦 {@link AgentInput#msgs()}，照 {@link PromptInjectionGuardMiddleware}）：
+ *       命中 BLOCK 则<b>不调 next</b>、直接返回安全话术（不产生模型调用）；命中 MASK 则打码后放行；
+ *       命中 REVIEW 放行但审计标记。</li>
+ *   <li><b>出站</b>（改写 {@link AgentResultEvent}，照 {@link MaskingMiddleware}）：AI 回复同样过一遍，
+ *       命中 BLOCK 替换为安全兜底话术，命中 MASK 打码。</li>
+ *   <li><b>fail-closed</b>：过滤器自身抛异常时，入站按<b>拦截</b>处理、出站替换为<b>安全兜底</b>——安全优先。
+ *       这与 {@link MaskingMiddleware} 的 fail-open（原样放行）刻意<b>相反</b>：脱敏漏一次只是隐私风险，
+ *       敏感词漏一次是合规事故，故内容风控必须 fail-closed。</li>
+ * </ul>
+ *
+ * <p>默认关闭（{@code customer-work.sensitive-word.enabled=false}）：与 {@link SensitiveWordFilter} 同用
+ * {@code @ConditionalOnProperty} 门控，关闭时整套 Bean（含本中间件与其依赖的过滤器）全不装配，启动零开销；
+ * 保留的运行时 {@code enabled} 判断仅服务于直接构造（单测）与防御式收口。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+@ConditionalOnProperty(prefix = "customer-work.sensitive-word", name = "enabled", havingValue = "true")
+public class SensitiveWordMiddleware implements MiddlewareBase {
+
+    private static final Logger log = LoggerFactory.getLogger(SensitiveWordMiddleware.class);
+
+    private static final String CODE_FILTER_FAIL = "SENSITIVE-FILTER-FAIL";
+    private static final String M_INBOUND_BLOCKED = "customerwork.sensitive.inbound.blocked";
+    private static final String M_INBOUND_MASKED = "customerwork.sensitive.inbound.masked";
+    private static final String M_OUTBOUND_BLOCKED = "customerwork.sensitive.outbound.blocked";
+    private static final String M_OUTBOUND_MASKED = "customerwork.sensitive.outbound.masked";
+    private static final String ASSISTANT = "assistant";
+
+    private final boolean enabled;
+    private final boolean inboundEnabled;
+    private final boolean outboundEnabled;
+    private final String inboundSafeReply;
+    private final String outboundSafeReply;
+
+    private final SensitiveWordFilter filter;
+    private final AuditSink auditSink;
+    private final MeterRegistry meterRegistry;
+
+    /** 入站命中 BLOCK 的累计次数（供单测断言 / 监控采样）。 */
+    private final LongAdder inboundBlockedHits = new LongAdder();
+
+    public SensitiveWordMiddleware(CustomerWorkProperties properties,
+                                   SensitiveWordFilter filter,
+                                   AuditSink auditSink,
+                                   ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        CustomerWorkProperties.SensitiveWord cfg = properties.getSensitiveWord();
+        this.enabled = cfg.isEnabled();
+        this.inboundEnabled = cfg.inboundEnabled();
+        this.outboundEnabled = cfg.outboundEnabled();
+        this.inboundSafeReply = cfg.getInboundSafeReply();
+        this.outboundSafeReply = cfg.getOutboundSafeReply();
+        this.filter = filter;
+        this.auditSink = auditSink;
+        this.meterRegistry = meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable();
+    }
+
+    /** 入站命中 BLOCK 的累计次数（供单测断言）。 */
+    long inboundBlockedCount() {
+        return inboundBlockedHits.sum();
+    }
+
+    @Override
+    public Flux<AgentEvent> onAgent(Agent agent, RuntimeContext ctx, AgentInput input,
+                                    Function<AgentInput, Flux<AgentEvent>> next) {
+        if (!enabled) {
+            return next.apply(input);
+        }
+
+        AgentInput effectiveInput = input;
+        if (inboundEnabled) {
+            try {
+                InboundOutcome outcome = filterInbound(agent, input);
+                if (outcome.blocked) {
+                    return Flux.just(new AgentResultEvent(safeMsg(inboundSafeReply)));
+                }
+                effectiveInput = outcome.input;
+            } catch (Exception e) {
+                // fail-closed：过滤器故障，入站按拦截处理（安全优先），与 MaskingMiddleware 的 fail-open 相反
+                inboundBlockedHits.increment();
+                metric(M_INBOUND_BLOCKED);
+                log.error("[SENSITIVE] inbound filter failed (fail-closed, blocking), code={}, agent={}",
+                    CODE_FILTER_FAIL, agentName(agent), e);
+                audit("sensitive-inbound-fail-closed", agent, null);
+                return Flux.just(new AgentResultEvent(safeMsg(inboundSafeReply)));
+            }
+        }
+
+        Flux<AgentEvent> downstream = next.apply(effectiveInput);
+        if (outboundEnabled) {
+            downstream = downstream.map(event -> filterOutbound(agent, event));
+        }
+        return downstream;
+    }
+
+    // ---------------- 入站 ----------------
+
+    private InboundOutcome filterInbound(Agent agent, AgentInput input) {
+        if (input == null || CollectionUtils.isEmpty(input.msgs())) {
+            return InboundOutcome.pass(input);
+        }
+        List<Msg> msgs = input.msgs();
+        List<Msg> rebuilt = new ArrayList<>(msgs.size());
+        boolean changed = false;
+        for (Msg msg : msgs) {
+            MsgScan scan = scanMsg(msg);
+            if (scan.decision == SensitiveWordAction.BLOCK) {
+                inboundBlockedHits.increment();
+                metric(M_INBOUND_BLOCKED);
+                log.info("[SENSITIVE] inbound blocked, category={}, word={}, agent={}",
+                    categoryOf(scan.topWord), wordOf(scan.topWord), agentName(agent));
+                audit("sensitive-inbound-block", agent, scan.topWord);
+                return InboundOutcome.blocked();
+            }
+            if (scan.decision == SensitiveWordAction.MASK && scan.maskedMsg != null) {
+                metric(M_INBOUND_MASKED);
+                audit("sensitive-inbound-mask", agent, scan.topWord);
+                rebuilt.add(scan.maskedMsg);
+                changed = true;
+            } else {
+                if (scan.decision == SensitiveWordAction.REVIEW) {
+                    audit("sensitive-inbound-review", agent, scan.topWord);
+                }
+                rebuilt.add(msg);
+            }
+        }
+        return changed ? InboundOutcome.masked(new AgentInput(rebuilt)) : InboundOutcome.pass(input);
+    }
+
+    // ---------------- 出站 ----------------
+
+    private AgentEvent filterOutbound(Agent agent, AgentEvent event) {
+        if (!(event instanceof AgentResultEvent result)) {
+            return event;
+        }
+        try {
+            MsgScan scan = scanMsg(result.getResult());
+            if (scan.decision == SensitiveWordAction.BLOCK) {
+                metric(M_OUTBOUND_BLOCKED);
+                log.info("[SENSITIVE] outbound blocked, category={}, word={}, agent={}",
+                    categoryOf(scan.topWord), wordOf(scan.topWord), agentName(agent));
+                audit("sensitive-outbound-block", agent, scan.topWord);
+                return new AgentResultEvent(safeMsg(outboundSafeReply));
+            }
+            if (scan.decision == SensitiveWordAction.MASK && scan.maskedMsg != null) {
+                metric(M_OUTBOUND_MASKED);
+                audit("sensitive-outbound-mask", agent, scan.topWord);
+                return new AgentResultEvent(scan.maskedMsg);
+            }
+            if (scan.decision == SensitiveWordAction.REVIEW) {
+                audit("sensitive-outbound-review", agent, scan.topWord);
+            }
+            return event;
+        } catch (Exception e) {
+            // fail-closed：出站过滤故障不放行未过滤内容，替换为安全兜底
+            log.error("[SENSITIVE] outbound filter failed (fail-closed), code={}, agent={}",
+                CODE_FILTER_FAIL, agentName(agent), e);
+            return new AgentResultEvent(safeMsg(outboundSafeReply));
+        }
+    }
+
+    // ---------------- 单条消息扫描 ----------------
+
+    /**
+     * 扫描一条消息的全部文本块，聚合整体决策。命中 MASK 时逐块替换为打码文本（保留角色/名称/元数据），
+     * 只改文本内容块（照 {@link MaskingMiddleware}）。
+     */
+    private MsgScan scanMsg(Msg msg) {
+        if (msg == null) {
+            return MsgScan.pass();
+        }
+        List<ContentBlock> blocks = msg.getContent();
+        if (CollectionUtils.isEmpty(blocks)) {
+            return MsgScan.pass();
+        }
+        SensitiveWordAction topDecision = null;
+        SensitiveWord topWord = null;
+        List<ContentBlock> rebuilt = new ArrayList<>(blocks.size());
+        boolean maskedAny = false;
+        for (ContentBlock block : blocks) {
+            if (block instanceof TextBlock tb) {
+                SensitiveWordFilterResult res = filter.check(tb.getText());
+                if (res.hasHit()) {
+                    if (topDecision == null || res.decision().severity() > topDecision.severity()) {
+                        topDecision = res.decision();
+                        topWord = strongestWord(res);
+                    }
+                    if (res.masked()) {
+                        rebuilt.add(TextBlock.builder().text(res.maskedText()).build());
+                        maskedAny = true;
+                        continue;
+                    }
+                }
+            }
+            rebuilt.add(block);
+        }
+        if (topDecision == null) {
+            return MsgScan.pass();
+        }
+        Msg maskedMsg = maskedAny ? rebuildMsg(msg, rebuilt) : null;
+        return new MsgScan(topDecision, maskedMsg, topWord);
+    }
+
+    /** 取与整体决策同档的首个命中词（用于审计/日志展示）。 */
+    private SensitiveWord strongestWord(SensitiveWordFilterResult res) {
+        for (SensitiveWordHit hit : res.hits()) {
+            if (hit.word().getAction() == res.decision()) {
+                return hit.word();
+            }
+        }
+        return res.hits().isEmpty() ? null : res.hits().get(0).word();
+    }
+
+    private Msg rebuildMsg(Msg original, List<ContentBlock> rebuilt) {
+        return Msg.builder()
+            .id(original.getId())
+            .name(original.getName())
+            .role(original.getRole())
+            .content(rebuilt)
+            .metadata(original.getMetadata())
+            .build();
+    }
+
+    // ---------------- 辅助 ----------------
+
+    private void audit(String type, Agent agent, SensitiveWord word) {
+        if (auditSink == null) {
+            return;
+        }
+        try {
+            Map<String, Object> fields = new LinkedHashMap<>();
+            fields.put("agent", agentName(agent));
+            fields.put("category", categoryOf(word));
+            fields.put("word", wordOf(word));
+            fields.put("action", word == null || word.getAction() == null ? "?" : word.getAction().name());
+            fields.put("ts", System.currentTimeMillis());
+            auditSink.record(type, fields);
+        } catch (Exception e) {
+            log.error("[SENSITIVE] audit record failed, code={}", CODE_FILTER_FAIL, e);
+        }
+    }
+
+    private void metric(String name) {
+        if (meterRegistry != null) {
+            Counter.builder(name).register(meterRegistry).increment();
+        }
+    }
+
+    private Msg safeMsg(String text) {
+        return Msg.builder().role(MsgRole.ASSISTANT).name(ASSISTANT).textContent(text).build();
+    }
+
+    private static String agentName(Agent agent) {
+        return agent == null ? "?" : agent.getName();
+    }
+
+    private static String categoryOf(SensitiveWord word) {
+        return word == null || word.getCategory() == null ? "?" : word.getCategory().name();
+    }
+
+    private static String wordOf(SensitiveWord word) {
+        return word == null ? "?" : word.getWord();
+    }
+
+    /** 入站处置结果：命中 BLOCK（短路）/ 打码后重建的 input / 原样放行。 */
+    private static final class InboundOutcome {
+        private final boolean blocked;
+        private final AgentInput input;
+
+        private InboundOutcome(boolean blocked, AgentInput input) {
+            this.blocked = blocked;
+            this.input = input;
+        }
+
+        static InboundOutcome blocked() {
+            return new InboundOutcome(true, null);
+        }
+
+        static InboundOutcome masked(AgentInput input) {
+            return new InboundOutcome(false, input);
+        }
+
+        static InboundOutcome pass(AgentInput input) {
+            return new InboundOutcome(false, input);
+        }
+    }
+
+    /** 单条消息扫描结果：整体决策 + 打码后消息（仅 MASK）+ 最高档命中词。 */
+    private static final class MsgScan {
+        private final SensitiveWordAction decision;
+        private final Msg maskedMsg;
+        private final SensitiveWord topWord;
+
+        private MsgScan(SensitiveWordAction decision, Msg maskedMsg, SensitiveWord topWord) {
+            this.decision = decision;
+            this.maskedMsg = maskedMsg;
+            this.topWord = topWord;
+        }
+
+        static MsgScan pass() {
+            return new MsgScan(null, null, null);
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/HandoffCreatedEnricher.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/HandoffCreatedEnricher.java
@@ -1,0 +1,151 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.richard.fyoung.customerwork.assist.ConversationSummary;
+import com.richard.fyoung.customerwork.assist.ConversationSummaryService;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.handoff.HandoffService;
+import com.richard.fyoung.customerwork.handoff.HandoffTicket;
+import com.richard.fyoung.customerwork.observability.AuditSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 转人工增强器（智能路由中控·会话总结 + 工单智能分配的挂载点）：在建单后<b>异步</b>做会话摘要预生成 +
+ * 工单分类 + 坐席打分推荐，把 top-N 推荐回写工单供坐席工作台展示（HITL，人工点选才真正 claim）。
+ *
+ * <p><b>不阻塞转人工主链路：</b>建单动作在 {@link HandoffService#create} 同步完成后即返回；本增强器把耗时的
+ * LLM 摘要/分类派发到独立守护线程池执行，摘要生成慢/失败、分类/打分失败都<b>不影响转人工本身</b>。</p>
+ *
+ * <p><b>fail-open（与敏感词 fail-closed 相反，注释写明理由）：</b>摘要/推荐是"增强"——它们挂了不能影响
+ * 转人工与对话主链路。故整个增强链路任一步失败一律 {@code log.error} 后静默退回现有行为（无推荐，坐席照常手动
+ * claim），绝不把异常抛回建单调用方。开关默认关（{@code assist.summary-enabled} / {@code routing.assign-enabled}），
+ * 关闭时对应环节整段跳过、零模型调用。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class HandoffCreatedEnricher {
+
+    private static final Logger log = LoggerFactory.getLogger(HandoffCreatedEnricher.class);
+
+    private static final String AUDIT_TYPE_SUMMARY = "conversation-summary";
+    private static final String AUDIT_TYPE_ROUTING = "ticket-routing-suggestion";
+
+    /** 独立守护线程池：转人工增强不占用调用方/事件循环线程（与 GitAssistantService 同一手法）。 */
+    private final ExecutorService executor = Executors.newFixedThreadPool(4, r -> {
+        Thread thread = new Thread(r, "handoff-enricher-worker");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final HandoffService handoffService;
+    private final ConversationSummaryService summaryService;
+    private final TicketClassifier ticketClassifier;
+    private final SeatRoutingScorer seatRoutingScorer;
+    private final SeatAgentStore seatAgentStore;
+    private final CustomerWorkProperties properties;
+    private final AuditSink auditSink;
+
+    // handoffService 用 @Lazy 注入：本增强器与 HandoffService 互相依赖（HandoffService setter 注入本增强器做转人工触发，
+    // 本增强器回写推荐又需调 HandoffService）。Spring Boot 2.6+ 默认禁止循环引用，@Lazy 注入代理打破创建期环路，
+    // 且本增强器只在异步任务里真正用到 handoffService，惰性解析无副作用。
+    public HandoffCreatedEnricher(@Lazy HandoffService handoffService,
+                                  ConversationSummaryService summaryService,
+                                  TicketClassifier ticketClassifier,
+                                  SeatRoutingScorer seatRoutingScorer,
+                                  SeatAgentStore seatAgentStore,
+                                  CustomerWorkProperties properties,
+                                  AuditSink auditSink) {
+        this.handoffService = handoffService;
+        this.summaryService = summaryService;
+        this.ticketClassifier = ticketClassifier;
+        this.seatRoutingScorer = seatRoutingScorer;
+        this.seatAgentStore = seatAgentStore;
+        this.properties = properties;
+        this.auditSink = auditSink;
+    }
+
+    /**
+     * 转人工建单后触发：把增强派发到独立线程池，<b>立即返回不阻塞</b>建单主链路。两个开关全关时连线程都不派发。
+     */
+    public void onHandoffCreated(HandoffTicket ticket) {
+        if (ticket == null) {
+            return;
+        }
+        boolean summaryOn = properties.getAssist().isSummaryEnabled();
+        boolean assignOn = properties.getRouting().isAssignEnabled();
+        if (!summaryOn && !assignOn) {
+            return;
+        }
+        try {
+            executor.submit(() -> enrich(ticket));
+        } catch (Exception e) {
+            // 线程池拒绝等极端情况也不能影响转人工
+            log.error("[HandoffCreatedEnricher] dispatch failed, code={}, id={}",
+                "HANDOFF-ENRICH-DISPATCH-FAIL", ticket.getId(), e);
+        }
+    }
+
+    /**
+     * 增强主体（包级可见，供单测同步调用断言）：会话摘要 → 工单分类 → 坐席打分 → 回写工单推荐。
+     * 每步独立 try-catch，任一步失败不影响其余步骤，整体 fail-open。
+     */
+    void enrich(HandoffTicket ticket) {
+        try {
+            ConversationSummary summary = maybeSummarize(ticket);
+            maybeAssign(ticket, summary);
+        } catch (Exception e) {
+            // 兜底：增强链路任何未预期异常都不能逃逸（fail-open，转人工已在主链路完成）
+            log.error("[HandoffCreatedEnricher] enrich failed, code={}, id={}",
+                "HANDOFF-ENRICH-FAIL", ticket.getId(), e);
+        }
+    }
+
+    /** 会话摘要预生成（开关关则跳过、返回 null）。摘要服务自身 fail-open，此处只做审计埋点。 */
+    private ConversationSummary maybeSummarize(HandoffTicket ticket) {
+        if (!properties.getAssist().isSummaryEnabled()) {
+            return null;
+        }
+        ConversationSummary summary = summaryService.summarize(ticket.getSessionId());
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put("handoffId", ticket.getId());
+        fields.put("sessionId", ticket.getSessionId());
+        fields.put("fromModel", summary.fromModel());
+        fields.put("emotion", summary.emotion());
+        auditSink.record(AUDIT_TYPE_SUMMARY, fields);
+        return summary;
+    }
+
+    /** 工单分类 + 坐席打分 + 回写推荐（开关关则跳过）。分类器/打分器自身 fail-open。 */
+    private void maybeAssign(HandoffTicket ticket, ConversationSummary summary) {
+        if (!properties.getRouting().isAssignEnabled()) {
+            return;
+        }
+        TicketClassification classification = ticketClassifier.classify(ticket.getReason(), summary);
+        List<SeatAgent> seats = seatAgentStore.findAll();
+        List<SeatRecommendation> recommendations = seatRoutingScorer.score(
+            classification, seats, properties.getRouting().getTopN());
+        String suggestedAssignees = SeatRecommendation.toJson(recommendations);
+
+        // 回写走 HandoffService（用其自身的 store，保证与坐席工作台读到的是同一份工单）
+        handoffService.applyRoutingSuggestion(ticket.getId(), classification.category(),
+            classification.requiredSkill(), classification.priority().name(), classification.emotion(),
+            suggestedAssignees);
+
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put("handoffId", ticket.getId());
+        fields.put("sessionId", ticket.getSessionId());
+        fields.put("category", classification.category());
+        fields.put("requiredSkill", classification.requiredSkill());
+        fields.put("priority", classification.priority().name());
+        fields.put("recommendCount", recommendations.size());
+        auditSink.record(AUDIT_TYPE_ROUTING, fields);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/InMemorySeatAgentStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/InMemorySeatAgentStore.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.routing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 进程内坐席库（默认实现）。
+ *
+ * <p>用 {@link ConcurrentHashMap} 保证线程安全；构造时加载与 {@code customer-work-schema.sql} 一致的演示坐席种子，
+ * 使 memory 模式下无需数据库即可演示分类打分推荐。以 {@code @ConditionalOnMissingBean} 注册，下游声明自己的
+ * {@link SeatAgentStore} 即可覆盖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemorySeatAgentStore implements SeatAgentStore {
+
+    private final ConcurrentHashMap<String, SeatAgent> store = new ConcurrentHashMap<>();
+
+    public InMemorySeatAgentStore() {
+        for (SeatAgent seed : SeatAgentSeeds.demoSeats()) {
+            save(seed);
+        }
+    }
+
+    @Override
+    public List<SeatAgent> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public void save(SeatAgent seat) {
+        if (seat == null || seat.getId() == null || seat.getId().isEmpty()) {
+            return;
+        }
+        store.put(seat.getId(), seat);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/MybatisSeatAgentStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/MybatisSeatAgentStore.java
@@ -1,0 +1,103 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.richard.fyoung.customerwork.routing.entity.SeatAgentDO;
+import com.richard.fyoung.customerwork.routing.mapper.SeatAgentMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * MyBatis-Plus 坐席库存储（生产实现：{@code customer-work.routing.seat-store-mode=jdbc} 时装配）。
+ *
+ * <p>坐席落 {@code cw_seat_agent} 表，多实例共享、支持后台运营维护。建表与种子由统一 SchemaInitializer 负责，
+ * 本类只表达读写；DO ↔ 领域对象转换收敛在本层（{@code skills} 逗号串 ↔ Set）。异常一律 {@code catch(Exception)}
+ * （HikariPool 初始化异常是 RuntimeException，非 SQLException 子类）；{@link #findAll} 读失败降级空集合
+ * （fail-open：无候选 → 无推荐，坐席照常手动接单）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisSeatAgentStore implements SeatAgentStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MybatisSeatAgentStore.class);
+
+    private static final String SKILL_DELIMITER = ",";
+
+    private final SeatAgentMapper mapper;
+
+    public MybatisSeatAgentStore(SeatAgentMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<SeatAgent> findAll() {
+        try {
+            return toDomainList(mapper.selectList(null));
+        } catch (Exception e) {
+            log.error("[MybatisSeatAgentStore] findAll failed, code={}", "SEAT-STORE-FINDALL-FAIL", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public void save(SeatAgent seat) {
+        if (seat == null || seat.getId() == null || seat.getId().isEmpty()) {
+            return;
+        }
+        try {
+            mapper.upsert(toDO(seat));
+        } catch (Exception e) {
+            log.error("[MybatisSeatAgentStore] save failed, code={}, id={}", "SEAT-STORE-SAVE-FAIL", seat.getId(), e);
+            throw new IllegalStateException("failed to save seat agent: " + seat.getId(), e);
+        }
+    }
+
+    private List<SeatAgent> toDomainList(List<SeatAgentDO> rows) {
+        List<SeatAgent> result = new ArrayList<>(rows.size());
+        for (SeatAgentDO row : rows) {
+            result.add(toDomain(row));
+        }
+        return result;
+    }
+
+    private SeatAgent toDomain(SeatAgentDO row) {
+        return new SeatAgent(
+            row.getId(),
+            row.getName(),
+            parseSkills(row.getSkills()),
+            row.getMaxLoad() == null ? 0 : row.getMaxLoad(),
+            row.getCurrentLoad() == null ? 0 : row.getCurrentLoad(),
+            row.getOnline() != null && row.getOnline(),
+            row.getSeatGroup());
+    }
+
+    private SeatAgentDO toDO(SeatAgent seat) {
+        SeatAgentDO row = new SeatAgentDO();
+        row.setId(seat.getId());
+        row.setName(seat.getName());
+        row.setSkills(String.join(SKILL_DELIMITER, seat.getSkills()));
+        row.setMaxLoad(seat.getMaxLoad());
+        row.setCurrentLoad(seat.getCurrentLoad());
+        row.setOnline(seat.isOnline());
+        row.setSeatGroup(seat.getGroup());
+        long now = System.currentTimeMillis();
+        row.setCreatedAtMs(now);
+        row.setUpdatedAtMs(now);
+        return row;
+    }
+
+    private Set<String> parseSkills(String skills) {
+        Set<String> result = new LinkedHashSet<>();
+        if (StringUtils.hasText(skills)) {
+            for (String s : skills.split(SKILL_DELIMITER)) {
+                if (StringUtils.hasText(s)) {
+                    result.add(s.trim());
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgent.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgent.java
@@ -1,0 +1,84 @@
+package com.richard.fyoung.customerwork.routing;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * 坐席（人工客服）领域对象（不可变值对象）。
+ *
+ * <p>承载技能标签、负载与在线状态，供 {@link SeatRoutingScorer} 做确定性打分。{@code skills} 归一为小写，
+ * 使技能匹配大小写不敏感；{@code id} 仅 JDBC 实现回填，进程内实现可为 {@code null}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class SeatAgent {
+
+    private final String id;
+    private final String name;
+    private final Set<String> skills;
+    private final int maxLoad;
+    private final int currentLoad;
+    private final boolean online;
+    private final String group;
+
+    public SeatAgent(String id, String name, Set<String> skills, int maxLoad,
+                     int currentLoad, boolean online, String group) {
+        this.id = id;
+        this.name = name;
+        this.skills = normalizeSkills(skills);
+        this.maxLoad = maxLoad;
+        this.currentLoad = currentLoad;
+        this.online = online;
+        this.group = group;
+    }
+
+    /** 技能标签归一：去空、trim、小写，保持插入序去重（匹配大小写不敏感）。 */
+    private static Set<String> normalizeSkills(Set<String> raw) {
+        Set<String> result = new LinkedHashSet<>();
+        if (raw != null) {
+            for (String s : raw) {
+                if (s != null && !s.trim().isEmpty()) {
+                    result.add(s.trim().toLowerCase());
+                }
+            }
+        }
+        return result;
+    }
+
+    /** 是否具备某项技能（大小写不敏感）。 */
+    public boolean hasSkill(String skill) {
+        return skill != null && !skill.trim().isEmpty() && skills.contains(skill.trim().toLowerCase());
+    }
+
+    /** 是否已满负载（无空闲工位）。 */
+    public boolean isOverloaded() {
+        return maxLoad > 0 && currentLoad >= maxLoad;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<String> getSkills() {
+        return skills;
+    }
+
+    public int getMaxLoad() {
+        return maxLoad;
+    }
+
+    public int getCurrentLoad() {
+        return currentLoad;
+    }
+
+    public boolean isOnline() {
+        return online;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgentConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgentConfig.java
@@ -1,0 +1,44 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.routing.mapper.SeatAgentMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 坐席库存储配置。
+ *
+ * <p>按 {@code customer-work.routing.seat-store-mode} 选择实现：默认 {@code memory}（进程内带演示种子，离线可测）；
+ * {@code jdbc} 落地为 {@link MybatisSeatAgentStore}（复用 {@code CustomerWorkPersistenceConfig} 独立持久化环境）。
+ * {@link SeatAgentMapper} 用 {@link ObjectProvider} 惰性获取：memory 模式不装配 Mapper 也不报错。</p>
+ *
+ * <p><b>无条件装配</b>（不加 {@code @ConditionalOnProperty}）：坐席库是路由推荐的基础数据，即便
+ * {@code routing.assign-enabled=false} 也保留（InMemory 近乎零开销），便于后台随时维护/预置坐席；
+ * 真正是否触发分类打分由 {@code HandoffCreatedEnricher} 按开关运行时判断。下游声明自己的
+ * {@link SeatAgentStore} Bean 即可整体覆盖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class SeatAgentConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(SeatAgentConfig.class);
+
+    private static final String STORE_MODE_JDBC = "jdbc";
+
+    @Bean
+    @ConditionalOnMissingBean(SeatAgentStore.class)
+    public SeatAgentStore seatAgentStore(CustomerWorkProperties properties,
+                                         ObjectProvider<SeatAgentMapper> mapperProvider) {
+        String mode = properties.getRouting().getSeatStoreMode();
+        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+            log.info("seat-agent store: jdbc (MyBatis-Plus, table=cw_seat_agent)");
+            return new MybatisSeatAgentStore(mapperProvider.getObject());
+        }
+        log.info("seat-agent store: memory (in-process demo seeds, use seat-store-mode=jdbc in production)");
+        return new InMemorySeatAgentStore();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgentSeeds.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgentSeeds.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customerwork.routing;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 坐席演示种子，与 {@code customer-work-schema.sql} 的 {@code INSERT IGNORE} 保持一致：memory 模式由
+ * {@link InMemorySeatAgentStore} 装载，jdbc 模式由建表脚本装载。
+ *
+ * <p>覆盖退款/物流/投诉/发票多技能、不同负载与在离线状态，便于演示打分与 top-N 推荐。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class SeatAgentSeeds {
+
+    private SeatAgentSeeds() {
+    }
+
+    /** 演示坐席种子。 */
+    public static List<SeatAgent> demoSeats() {
+        return List.of(
+            new SeatAgent("SEAT-1001", "退款专员-小赵", Set.of("refund", "invoice"), 5, 1, true, "aftersales"),
+            new SeatAgent("SEAT-1002", "物流专员-小钱", Set.of("logistics"), 5, 3, true, "logistics"),
+            new SeatAgent("SEAT-1003", "投诉专员-小孙", Set.of("complaint", "refund"), 4, 0, true, "complaint"),
+            new SeatAgent("SEAT-1004", "综合坐席-小李", Set.of("refund", "logistics", "complaint", "invoice"), 6, 5, true, "general"),
+            new SeatAgent("SEAT-1005", "离线坐席-小周", Set.of("refund"), 5, 0, false, "aftersales"));
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgentStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatAgentStore.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.routing;
+
+import java.util.List;
+
+/**
+ * 坐席库存储 SPI（持久化扩展点）。
+ *
+ * <p>默认 {@link InMemorySeatAgentStore}（进程内、带演示坐席种子，离线可测）；生产可切
+ * {@link MybatisSeatAgentStore}（{@code customer-work.routing.seat-store-mode=jdbc}），或下游声明同类型 Bean 覆盖。
+ * {@link SeatRoutingScorer} 通过本 SPI 拉取候选坐席全集打分。</p>
+ *
+ * <p>语义约定：{@link #findAll} 读失败降级<b>空集合</b>（fail-open：无候选 → 无推荐，坐席照常手动接单，
+ * 与敏感词 fail-closed 相反）；{@link #save} 为 upsert（新建或更新坐席）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface SeatAgentStore {
+
+    /** 全部坐席（含离线；在线/负载过滤在打分器侧）。读失败降级空集合。 */
+    List<SeatAgent> findAll();
+
+    /** 保存（新建或更新）一个坐席。 */
+    void save(SeatAgent seat);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatRecommendation.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatRecommendation.java
@@ -1,0 +1,65 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * 坐席推荐项（HITL 推荐：给坐席工作台展示的候选坐席 + 打分 + 可解释理由）。
+ *
+ * <p>由 {@link SeatRoutingScorer} 产出并以 JSON 落到 {@code cw_handoff_ticket.suggested_assignees}；坐席
+ * <b>人工点选</b>后仍复用现有 claim 流程真正接单——<b>不自动派单</b>。JSON ↔ 对象转换收敛在本类静态方法，
+ * 解析失败降级空集合（fail-open：无推荐、坐席照常手动接单）。</p>
+ *
+ * @param seatId       坐席 ID
+ * @param seatName     坐席名
+ * @param seatGroup    坐席分组
+ * @param score        打分（越高越推荐，保留 4 位小数）
+ * @param matchedSkill 是否命中工单所需技能
+ * @param currentLoad  当前负载
+ * @param maxLoad      最大负载
+ * @param reason       可解释的打分理由
+ * @author owlzhangfq@gmail.com
+ */
+public record SeatRecommendation(String seatId, String seatName, String seatGroup, double score,
+                                 boolean matchedSkill, int currentLoad, int maxLoad, String reason) {
+
+    private static final Logger log = LoggerFactory.getLogger(SeatRecommendation.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private static final TypeReference<List<SeatRecommendation>> LIST_TYPE = new TypeReference<>() {
+    };
+
+    /** 序列化为 JSON 字符串（落库用）；失败返回 {@code null}（fail-open，不写推荐）。 */
+    public static String toJson(List<SeatRecommendation> recommendations) {
+        if (recommendations == null || recommendations.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(recommendations);
+        } catch (Exception e) {
+            log.error("[SeatRecommendation] serialize failed, code={}", "SEAT-RECOMMEND-SERIALIZE-FAIL", e);
+            return null;
+        }
+    }
+
+    /** 从 JSON 字符串反序列化（读库/端点展示用）；空/非法一律降级空集合。 */
+    public static List<SeatRecommendation> parseList(String json) {
+        if (json == null || json.trim().isEmpty()) {
+            return List.of();
+        }
+        try {
+            List<SeatRecommendation> list = MAPPER.readValue(json, LIST_TYPE);
+            return list == null ? List.of() : list;
+        } catch (Exception e) {
+            log.error("[SeatRecommendation] parse failed, code={}", "SEAT-RECOMMEND-PARSE-FAIL", e);
+            return List.of();
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatRoutingScorer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/SeatRoutingScorer.java
@@ -1,0 +1,120 @@
+package com.richard.fyoung.customerwork.routing;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 坐席路由打分器（确定性、纯函数、可测、可解释）。
+ *
+ * <p>对每个候选坐席打分：{@code score = 技能匹配 × 负载空闲度 × 优先级 × 在线状态}，返回 top-N 候选及每个的
+ * 打分理由。离线坐席直接排除（{@code 在线状态} 因子为 0）；满负载坐席降权保留（极端下全员满载仍能给出兜底推荐）。
+ * 打分不含任何 LLM/随机，同一输入恒定同一输出——供单测精确断言、供坐席工作台展示可信理由。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class SeatRoutingScorer {
+
+    /** 命中所需技能的因子。 */
+    private static final double SKILL_MATCH = 1.0;
+    /** 工单无硬性技能要求时的中性因子。 */
+    private static final double SKILL_NEUTRAL = 0.6;
+    /** 未命中所需技能的因子（不为 0：技能不匹配仍可兜底接单，只是排后）。 */
+    private static final double SKILL_MISS = 0.3;
+    /** 满负载坐席的负载因子（降权保留，避免全员满载时无任何推荐）。 */
+    private static final double LOAD_OVERLOADED = 0.1;
+    /** maxLoad 未配置（<=0）时的负载因子（信息缺失，取中性）。 */
+    private static final double LOAD_UNKNOWN = 0.5;
+    private static final int SCORE_SCALE = 10_000;
+
+    /**
+     * 对候选坐席打分并取 top-N。
+     *
+     * @param classification 工单分类（提供所需技能与优先级）
+     * @param candidates     候选坐席全集
+     * @param topN           返回的最大推荐数（&lt;=0 视为 1）
+     * @return 按分数降序、同分按 seatId 升序的推荐列表（离线坐席已排除）；无在线坐席时返回空列表
+     */
+    public List<SeatRecommendation> score(TicketClassification classification,
+                                          List<SeatAgent> candidates, int topN) {
+        if (candidates == null || candidates.isEmpty()) {
+            return List.of();
+        }
+        String requiredSkill = classification == null ? null : classification.requiredSkill();
+        double priorityFactor = priorityFactor(classification);
+        int limit = Math.max(1, topN);
+
+        List<SeatRecommendation> scored = new ArrayList<>();
+        for (SeatAgent seat : candidates) {
+            if (seat == null || !seat.isOnline()) {
+                // 在线状态因子为 0：离线坐席直接排除
+                continue;
+            }
+            boolean matched = seat.hasSkill(requiredSkill);
+            double skillFactor = skillFactor(requiredSkill, matched);
+            double loadFactor = loadFactor(seat);
+            double raw = skillFactor * loadFactor * priorityFactor;
+            double rounded = Math.round(raw * SCORE_SCALE) / (double) SCORE_SCALE;
+            scored.add(new SeatRecommendation(seat.getId(), seat.getName(), seat.getGroup(), rounded,
+                matched, seat.getCurrentLoad(), seat.getMaxLoad(),
+                explain(requiredSkill, matched, skillFactor, seat, loadFactor, classification, priorityFactor)));
+        }
+        return scored.stream()
+            .sorted(Comparator.comparingDouble(SeatRecommendation::score).reversed()
+                .thenComparing(r -> r.seatId() == null ? "" : r.seatId()))
+            .limit(limit)
+            .collect(Collectors.toList());
+    }
+
+    private double skillFactor(String requiredSkill, boolean matched) {
+        if (requiredSkill == null || requiredSkill.trim().isEmpty()) {
+            return SKILL_NEUTRAL;
+        }
+        return matched ? SKILL_MATCH : SKILL_MISS;
+    }
+
+    /** 负载空闲度：越空闲越高（空闲工位/最大工位）；满负载降权、未配置取中性。 */
+    private double loadFactor(SeatAgent seat) {
+        if (seat.getMaxLoad() <= 0) {
+            return LOAD_UNKNOWN;
+        }
+        if (seat.isOverloaded()) {
+            return LOAD_OVERLOADED;
+        }
+        int idle = seat.getMaxLoad() - seat.getCurrentLoad();
+        return (double) idle / seat.getMaxLoad();
+    }
+
+    private double priorityFactor(TicketClassification classification) {
+        TicketPriority priority = classification == null || classification.priority() == null
+            ? TicketPriority.MEDIUM : classification.priority();
+        return (double) priority.weight() / TicketPriority.MAX_WEIGHT;
+    }
+
+    /** 生成人读的打分理由（技能/负载/优先级/在线四因子逐项说明）。 */
+    private String explain(String requiredSkill, boolean matched, double skillFactor, SeatAgent seat,
+                           double loadFactor, TicketClassification classification, double priorityFactor) {
+        StringBuilder sb = new StringBuilder();
+        if (requiredSkill == null || requiredSkill.trim().isEmpty()) {
+            sb.append("无硬性技能要求(中性").append(fmt(skillFactor)).append(")");
+        } else if (matched) {
+            sb.append("技能匹配[").append(requiredSkill).append("](").append(fmt(skillFactor)).append(")");
+        } else {
+            sb.append("技能不匹配[需").append(requiredSkill).append("](").append(fmt(skillFactor)).append(")");
+        }
+        sb.append(" × 负载").append(seat.getCurrentLoad()).append("/").append(seat.getMaxLoad())
+            .append(seat.isOverloaded() ? "(满载" : "(空闲").append(fmt(loadFactor)).append(")");
+        TicketPriority priority = classification == null || classification.priority() == null
+            ? TicketPriority.MEDIUM : classification.priority();
+        sb.append(" × 优先级").append(priority.name()).append("(").append(fmt(priorityFactor)).append(")");
+        sb.append(" × 在线");
+        return sb.toString();
+    }
+
+    private String fmt(double v) {
+        return String.valueOf(Math.round(v * 100) / 100.0);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/TicketClassification.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/TicketClassification.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customerwork.routing;
+
+/**
+ * 工单分类结果（LLM 一次性分类的产物）。
+ *
+ * <p>由 {@link TicketClassifier} 从工单 reason + 会话摘要/历史推断得到；模型不守格式时降级为默认分类
+ * （{@code GENERAL / null 技能 / MEDIUM / UNKNOWN}），fail-open 不打断转人工。</p>
+ *
+ * @param category      工单分类（如 退款/物流/投诉/发票/GENERAL）
+ * @param requiredSkill 所需坐席技能标签（可空，null 表示无硬性技能要求）
+ * @param priority      优先级
+ * @param emotion       用户情绪
+ * @author owlzhangfq@gmail.com
+ */
+public record TicketClassification(String category, String requiredSkill,
+                                   TicketPriority priority, String emotion) {
+
+    /** 默认分类（分类失败/降级时使用）：无技能要求、中优先级、情绪未知。 */
+    public static final String DEFAULT_CATEGORY = "GENERAL";
+    public static final String DEFAULT_EMOTION = "UNKNOWN";
+
+    /** 降级默认分类：emotion 优先取会话摘要已识别的情绪，无则 UNKNOWN。 */
+    public static TicketClassification fallback(String emotionHint) {
+        String emotion = (emotionHint == null || emotionHint.isEmpty()) ? DEFAULT_EMOTION : emotionHint;
+        return new TicketClassification(DEFAULT_CATEGORY, null, TicketPriority.MEDIUM, emotion);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/TicketClassifier.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/TicketClassifier.java
@@ -1,0 +1,168 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.assist.ConversationSummary;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 工单分类器（智能路由中控·工单智能分配的分类环节）：一次性 LLM 调用，从工单 reason + 会话摘要推断
+ * 类目 / 所需技能 / 优先级 / 情绪，产出 {@link TicketClassification} 供打分器路由。
+ *
+ * <p><b>fail-open：</b>模型不可达 / 空响应 / 不守 JSON 格式时降级为默认分类
+ * （{@link TicketClassification#fallback}，情绪优先沿用会话摘要已识别的值），<b>绝不抛异常打断转人工</b>。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class TicketClassifier {
+
+    private static final Logger log = LoggerFactory.getLogger(TicketClassifier.class);
+
+    private static final int MAX_CONTEXT_CHARS = 4_000;
+
+    private static final String CLASSIFY_PROMPT =
+        "你是客服工单调度专家。请根据下面的转人工原因与会话摘要，判断该工单的分类信息。\n"
+        + "只输出一个 JSON 对象，不要输出任何解释文字或 Markdown 代码块标记，结构严格为：\n"
+        + "{\"category\":\"工单分类(如 退款/物流/投诉/发票/账户/其它)\",\"requiredSkill\":\"处理该工单所需的坐席技能标签"
+        + "(如 refund/logistics/complaint/invoice/account，无明确要求填 null)\",\"priority\":\"LOW|MEDIUM|HIGH|URGENT\","
+        + "\"emotion\":\"用户情绪(平静/不满/愤怒/焦虑等)\"}\n\n";
+
+    private final Model model;
+    private final CustomerWorkProperties properties;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    public TicketClassifier(Model model, CustomerWorkProperties properties) {
+        this.model = model;
+        this.properties = properties;
+    }
+
+    /**
+     * 对工单分类。<b>永不抛异常</b>：任何失败降级为默认分类返回。
+     *
+     * @param reason  转人工原因（工单 reason）
+     * @param summary 会话摘要（可空；提供意图/情绪等辅助上下文与降级时的情绪兜底）
+     */
+    public TicketClassification classify(String reason, ConversationSummary summary) {
+        String emotionHint = summary == null ? null : summary.emotion();
+        try {
+            String text = callModelOnce(buildPrompt(reason, summary));
+            return parse(text, emotionHint);
+        } catch (Exception e) {
+            // fail-open：分类失败不阻断转人工，退回默认分类（打分器据此仍能给出兜底推荐或空推荐）
+            log.error("[TicketClassifier] classify failed, code={}", "TICKET-CLASSIFY-FAIL", e);
+            return TicketClassification.fallback(emotionHint);
+        }
+    }
+
+    // ---------------------- private helpers ----------------------
+
+    private String buildPrompt(String reason, ConversationSummary summary) {
+        StringBuilder ctx = new StringBuilder();
+        ctx.append("转人工原因：").append(reason == null ? "(未提供)" : reason).append("\n");
+        if (summary != null) {
+            ctx.append("会话摘要：").append(nullToEmpty(summary.oneLineSummary())).append("\n");
+            ctx.append("用户意图：").append(nullToEmpty(summary.userIntent())).append("\n");
+            ctx.append("已识别情绪：").append(nullToEmpty(summary.emotion())).append("\n");
+        }
+        String context = ctx.toString();
+        if (context.length() > MAX_CONTEXT_CHARS) {
+            context = context.substring(0, MAX_CONTEXT_CHARS);
+        }
+        return CLASSIFY_PROMPT + context;
+    }
+
+    private TicketClassification parse(String modelText, String emotionHint) {
+        String json = extractJsonObject(modelText);
+        if (json == null) {
+            log.error("[TicketClassifier] classify json degraded (no json), code={}", "TICKET-CLASSIFY-DEGRADE");
+            return TicketClassification.fallback(emotionHint);
+        }
+        try {
+            ClassificationPayload p = objectMapper.readValue(json, ClassificationPayload.class);
+            String category = StringUtils.hasText(p.category) ? p.category.trim() : TicketClassification.DEFAULT_CATEGORY;
+            String requiredSkill = normalizeSkill(p.requiredSkill);
+            TicketPriority priority = TicketPriority.fromName(p.priority);
+            String emotion = StringUtils.hasText(p.emotion) ? p.emotion.trim()
+                : (StringUtils.hasText(emotionHint) ? emotionHint : TicketClassification.DEFAULT_EMOTION);
+            return new TicketClassification(category, requiredSkill, priority, emotion);
+        } catch (Exception e) {
+            log.error("[TicketClassifier] classify json deserialize failed, code={}", "TICKET-CLASSIFY-DEGRADE", e);
+            return TicketClassification.fallback(emotionHint);
+        }
+    }
+
+    /** 归一所需技能：空白 / 字面 "null" / "none" 一律视为无技能要求（null）。 */
+    private String normalizeSkill(String skill) {
+        if (!StringUtils.hasText(skill)) {
+            return null;
+        }
+        String trimmed = skill.trim();
+        if ("null".equalsIgnoreCase(trimmed) || "none".equalsIgnoreCase(trimmed) || "无".equals(trimmed)) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    private String callModelOnce(String prompt) {
+        Msg userMsg = Msg.builder()
+            .role(MsgRole.USER)
+            .name("user")
+            .content(TextBlock.builder().text(prompt).build())
+            .build();
+        long timeout = Math.max(1, properties.getRouting().getClassifyTimeoutSeconds());
+        List<ChatResponse> responses = model.stream(List.of(userMsg), List.of(), GenerateOptions.builder().build())
+            .collectList()
+            .block(Duration.ofSeconds(timeout));
+        if (responses == null || responses.isEmpty()) {
+            throw new IllegalStateException("classify model returned empty response");
+        }
+        String text = responses.stream()
+            .flatMap(response -> response.getContent().stream())
+            .filter(TextBlock.class::isInstance)
+            .map(TextBlock.class::cast)
+            .map(TextBlock::getText)
+            .filter(StringUtils::hasText)
+            .collect(Collectors.joining());
+        if (!StringUtils.hasText(text)) {
+            throw new IllegalStateException("classify model returned no text content");
+        }
+        return text.trim();
+    }
+
+    private String extractJsonObject(String text) {
+        if (!StringUtils.hasText(text)) {
+            return null;
+        }
+        int start = text.indexOf('{');
+        int end = text.lastIndexOf('}');
+        return (start >= 0 && end > start) ? text.substring(start, end + 1) : null;
+    }
+
+    private String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    /** 模型 JSON 反序列化载体（贫血，仅解析用）。 */
+    private static final class ClassificationPayload {
+        public String category;
+        public String requiredSkill;
+        public String priority;
+        public String emotion;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/TicketPriority.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/TicketPriority.java
@@ -1,0 +1,41 @@
+package com.richard.fyoung.customerwork.routing;
+
+/**
+ * 工单优先级（LLM 分类输出之一，以枚举名字符串落库）。
+ *
+ * <p>{@code weight} 供 {@link SeatRoutingScorer} 把优先级纳入打分（越紧急权重越大，score 量级随之放大，
+ * 可解释）。未知/空值一律安全归 {@link #MEDIUM}（fast fail 收口在此，避免脏数据打断打分）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum TicketPriority {
+
+    LOW(1),
+    MEDIUM(2),
+    HIGH(3),
+    URGENT(4);
+
+    /** 最高权重（用于把优先级归一到 (0,1] 因子）。 */
+    public static final int MAX_WEIGHT = 4;
+
+    private final int weight;
+
+    TicketPriority(int weight) {
+        this.weight = weight;
+    }
+
+    public int weight() {
+        return weight;
+    }
+
+    /** 安全解析：未知或空值一律归 {@link #MEDIUM}。 */
+    public static TicketPriority fromName(String name) {
+        if (name == null || name.isEmpty()) {
+            return MEDIUM;
+        }
+        try {
+            return TicketPriority.valueOf(name.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return MEDIUM;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/entity/SeatAgentDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/entity/SeatAgentDO.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customerwork.routing.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 坐席持久化对象（贫血数据袋）：与 {@code cw_seat_agent} 表一一映射。
+ *
+ * <p>{@code skills} 以逗号分隔的技能标签串落库（如 {@code refund,invoice}），拆解/拼接在
+ * {@link com.richard.fyoung.customerwork.routing.MybatisSeatAgentStore} 完成；{@code online} 以 0/1 落库；
+ * {@code seatGroup} 对应列 {@code seat_group}（避开 SQL 保留字 group）。驼峰字段由下划线映射自动对应下划线列。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_seat_agent")
+public class SeatAgentDO {
+
+    /** 坐席 ID（应用赋值，非自增）。 */
+    @TableId(value = "id", type = IdType.INPUT)
+    private String id;
+
+    private String name;
+    /** 逗号分隔技能标签串。 */
+    private String skills;
+    private Integer maxLoad;
+    private Integer currentLoad;
+    /** 是否在线（1 在线 / 0 离线）。 */
+    private Boolean online;
+    /** 坐席分组（列名 seat_group，避开保留字）。 */
+    private String seatGroup;
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/mapper/SeatAgentMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/routing/mapper/SeatAgentMapper.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customerwork.routing.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.routing.entity.SeatAgentDO;
+
+/**
+ * 坐席 Mapper（由 {@code CustomerWorkPersistenceConfig} 的 {@code @MapperScan} 扫描绑定，不加 {@code @Mapper}）：
+ * 继承 {@link BaseMapper} 复用单表 CRUD；{@link #upsert} 表达按主键的 {@code INSERT ... ON DUPLICATE KEY UPDATE}。
+ * @author owlzhangfq@gmail.com
+ */
+public interface SeatAgentMapper extends BaseMapper<SeatAgentDO> {
+
+    /** 按主键 upsert：存在则更新名称/技能/负载/在线/分组/更新时间，不存在则插入。 */
+    int upsert(SeatAgentDO record);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/AhoCorasickMatcher.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/AhoCorasickMatcher.java
@@ -1,0 +1,150 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aho-Corasick 多模式串匹配自动机（自研，零第三方依赖）。
+ *
+ * <p>由词表一次构建为 <b>不可变</b> DFA（goto 表 + 失败指针 + 输出链），单趟扫描 O(n + 命中数) 返回全部命中，
+ * 与词表规模无关。构建后所有字段只读，天然线程安全——热重建走"构建新实例 + 原子替换引用"，匹配热路径无锁
+ * （见 {@link SensitiveWordFilter}）。</p>
+ *
+ * <p>字符粒度基于 Java {@code char}（UTF-16），中文（BMP）为单 char，演示场景足够；扫描前文本与词面均已过
+ * {@link TextNormalizer} 归一化，命中下标为归一化文本内的偏移。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class AhoCorasickMatcher {
+
+    /** 空自动机单例（词表为空时复用，match 恒返回空）。 */
+    private static final AhoCorasickMatcher EMPTY = new AhoCorasickMatcher(Collections.emptyList());
+
+    /** goto 表：节点 -> (字符 -> 子节点)。 */
+    private final List<Map<Character, Integer>> gotoTable = new ArrayList<>();
+    /** 失败指针。 */
+    private final List<Integer> fail = new ArrayList<>();
+    /** 每个节点的输出（以该节点结尾的模式，含经失败链继承的），元素为词表下标。 */
+    private final List<List<Integer>> output = new ArrayList<>();
+    /** 词表（下标与 output 元素对应）。 */
+    private final List<SensitiveWord> patterns;
+
+    private AhoCorasickMatcher(List<SensitiveWord> words) {
+        this.patterns = new ArrayList<>(words);
+        newNode(); // root = 0
+        buildGoto();
+        buildFail();
+    }
+
+    /**
+     * 由词表构建自动机（跳过空词面）。
+     *
+     * @param words 已归一化词面的敏感词集合
+     * @return 不可变自动机；词表为空时返回共享空实例
+     */
+    public static AhoCorasickMatcher build(List<SensitiveWord> words) {
+        if (words == null || words.isEmpty()) {
+            return EMPTY;
+        }
+        List<SensitiveWord> valid = new ArrayList<>(words.size());
+        for (SensitiveWord w : words) {
+            if (w != null && w.getWord() != null && !w.getWord().isEmpty()) {
+                valid.add(w);
+            }
+        }
+        return valid.isEmpty() ? EMPTY : new AhoCorasickMatcher(valid);
+    }
+
+    /** 词表规模（供观测 / 单测）。 */
+    public int patternCount() {
+        return patterns.size();
+    }
+
+    /**
+     * 单趟扫描，返回全部命中（含重叠命中）。
+     *
+     * @param normalizedText 已归一化文本
+     * @return 命中列表（按结束位置自然有序）；无命中返回空列表
+     */
+    public List<SensitiveWordHit> match(String normalizedText) {
+        if (normalizedText == null || normalizedText.isEmpty() || patterns.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<SensitiveWordHit> hits = new ArrayList<>();
+        int node = 0;
+        for (int i = 0; i < normalizedText.length(); i++) {
+            char c = normalizedText.charAt(i);
+            node = step(node, c);
+            for (int patternIdx : output.get(node)) {
+                SensitiveWord word = patterns.get(patternIdx);
+                int end = i + 1;
+                int start = end - word.getWord().length();
+                hits.add(new SensitiveWordHit(word, start, end));
+            }
+        }
+        return hits;
+    }
+
+    /** 沿 goto/fail 转移一步（root 无匹配时停在 root）。 */
+    private int step(int node, char c) {
+        Integer next = gotoTable.get(node).get(c);
+        while (next == null && node != 0) {
+            node = fail.get(node);
+            next = gotoTable.get(node).get(c);
+        }
+        return next == null ? 0 : next;
+    }
+
+    private void buildGoto() {
+        for (int p = 0; p < patterns.size(); p++) {
+            String word = patterns.get(p).getWord();
+            int node = 0;
+            for (int i = 0; i < word.length(); i++) {
+                char c = word.charAt(i);
+                Integer child = gotoTable.get(node).get(c);
+                if (child == null) {
+                    child = newNode();
+                    gotoTable.get(node).put(c, child);
+                }
+                node = child;
+            }
+            output.get(node).add(p);
+        }
+    }
+
+    /** BFS 构建失败指针，并把失败节点的输出并入本节点（输出链展开）。 */
+    private void buildFail() {
+        Deque<Integer> queue = new ArrayDeque<>();
+        // root 的直接子节点失败指针指向 root
+        for (int child : gotoTable.get(0).values()) {
+            fail.set(child, 0);
+            queue.add(child);
+        }
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+            for (Map.Entry<Character, Integer> entry : gotoTable.get(cur).entrySet()) {
+                char c = entry.getKey();
+                int child = entry.getValue();
+                int f = fail.get(cur);
+                while (f != 0 && gotoTable.get(f).get(c) == null) {
+                    f = fail.get(f);
+                }
+                Integer target = gotoTable.get(f).get(c);
+                fail.set(child, (target == null || target == child) ? 0 : target);
+                output.get(child).addAll(output.get(fail.get(child)));
+                queue.add(child);
+            }
+        }
+    }
+
+    private int newNode() {
+        gotoTable.add(new HashMap<>());
+        fail.add(0);
+        output.add(new ArrayList<>());
+        return gotoTable.size() - 1;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/InMemorySensitiveWordStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/InMemorySensitiveWordStore.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * 进程内敏感词表（默认实现）。
+ *
+ * <p>用 {@link ConcurrentHashMap} 保证线程安全；构造时加载与 {@code customer-work-schema.sql} 一致的
+ * <b>脱敏演示种子</b>（占位词，非真实违禁词），使 memory 模式下无需数据库即可演示拦截/打码/复核三种动作。
+ * 以 {@code @ConditionalOnMissingBean} 注册，下游声明自己的 {@link SensitiveWordStore} 即可覆盖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemorySensitiveWordStore implements SensitiveWordStore {
+
+    private final ConcurrentHashMap<Long, SensitiveWord> store = new ConcurrentHashMap<>();
+    private final AtomicLong idGen = new AtomicLong(0);
+
+    public InMemorySensitiveWordStore() {
+        for (SensitiveWord seed : SensitiveWordSeeds.demoWords()) {
+            save(seed);
+        }
+    }
+
+    @Override
+    public List<SensitiveWord> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public Optional<List<SensitiveWord>> findEnabled() {
+        // 进程内实现读取不会失败，恒返回 Optional.of（哪怕空 list）
+        return Optional.of(store.values().stream()
+            .filter(SensitiveWord::isEnabled)
+            .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void save(SensitiveWord word) {
+        if (word == null || word.getWord() == null || word.getWord().isEmpty()) {
+            return;
+        }
+        Long id = word.getId() == null ? idGen.incrementAndGet() : word.getId();
+        store.put(id, new SensitiveWord(id, word.getWord(), word.getCategory(), word.getAction(), word.isEnabled()));
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/MybatisSensitiveWordStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/MybatisSensitiveWordStore.java
@@ -1,0 +1,100 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.richard.fyoung.customerwork.sensitiveword.entity.SensitiveWordEntity;
+import com.richard.fyoung.customerwork.sensitiveword.mapper.SensitiveWordMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MyBatis-Plus 敏感词表存储（生产实现：{@code sensitive-word.store-mode=jdbc} 时装配）。
+ *
+ * <p>词表落 {@code cw_sensitive_word} 表，多实例共享、支持后台运营维护。建表与种子由统一
+ * {@code SchemaInitializer} 负责，本类只表达读写；DO ↔ 领域对象转换收敛在本层。异常一律
+ * {@code catch(Exception)}（HikariPool 初始化异常是 RuntimeException，非 SQLException 子类）。</p>
+ *
+ * <p><b>读成败必须可区分</b>：{@link #findEnabled()} 读失败返回 {@code Optional.empty()}（而非空集合），
+ * 让上层 {@link SensitiveWordFilter} 能把"读失败"与"确实没词"分流处理——绝不把 DB 抖动误判成"放行"。
+ * {@link #findAll()} 仅供运营展示，读失败降级空集合无安全含义。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisSensitiveWordStore implements SensitiveWordStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MybatisSensitiveWordStore.class);
+
+    private final SensitiveWordMapper mapper;
+
+    public MybatisSensitiveWordStore(SensitiveWordMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<SensitiveWord> findAll() {
+        try {
+            return toDomainList(mapper.selectList(null));
+        } catch (Exception e) {
+            log.error("[MybatisSensitiveWordStore] findAll failed, code={}", "SENSITIVE-STORE-FINDALL-FAIL", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public Optional<List<SensitiveWord>> findEnabled() {
+        try {
+            QueryWrapper<SensitiveWordEntity> wrapper = new QueryWrapper<SensitiveWordEntity>().eq("enabled", true);
+            return Optional.of(toDomainList(mapper.selectList(wrapper)));
+        } catch (Exception e) {
+            // 读失败返回 empty（非空集合）：让 SensitiveWordFilter 走 fail-closed 分支，不静默放行
+            log.error("[MybatisSensitiveWordStore] findEnabled failed, code={}", "SENSITIVE-STORE-FINDENABLED-FAIL", e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void save(SensitiveWord word) {
+        if (word == null || word.getWord() == null || word.getWord().isEmpty()) {
+            return;
+        }
+        try {
+            mapper.upsert(toDO(word));
+        } catch (Exception e) {
+            log.error("[MybatisSensitiveWordStore] save failed, code={}, word={}",
+                "SENSITIVE-STORE-SAVE-FAIL", word.getWord(), e);
+            throw new IllegalStateException("failed to save sensitive word: " + word.getWord(), e);
+        }
+    }
+
+    private List<SensitiveWord> toDomainList(List<SensitiveWordEntity> rows) {
+        List<SensitiveWord> result = new ArrayList<>(rows.size());
+        for (SensitiveWordEntity row : rows) {
+            result.add(toDomain(row));
+        }
+        return result;
+    }
+
+    private SensitiveWord toDomain(SensitiveWordEntity row) {
+        return new SensitiveWord(
+            row.getId(),
+            row.getWord(),
+            SensitiveWordCategory.fromName(row.getCategory()),
+            SensitiveWordAction.valueOf(row.getAction()),
+            row.getEnabled() != null && row.getEnabled());
+    }
+
+    private SensitiveWordEntity toDO(SensitiveWord word) {
+        SensitiveWordEntity row = new SensitiveWordEntity();
+        row.setId(word.getId());
+        row.setWord(word.getWord());
+        row.setCategory(word.getCategory().name());
+        row.setAction(word.getAction().name());
+        row.setEnabled(word.isEnabled());
+        long now = System.currentTimeMillis();
+        row.setCreatedAtMs(now);
+        row.setUpdatedAtMs(now);
+        return row;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWord.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWord.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+/**
+ * 敏感词领域对象（不可变值对象）。
+ *
+ * <p>{@code word} 为词面：存储层保存人读原词，{@link SensitiveWordFilter} 构建自动机前统一经
+ * {@link TextNormalizer#normalize} 归一化（使 {@code 敏*感*词} / 全角 / 大小写变体也能命中），故喂给
+ * {@link AhoCorasickMatcher} 的实例其 {@code word} 已是归一化词面。{@code category} / {@code action} 决定
+ * 命中后的处置；{@code id} 仅 JDBC 实现回填，进程内实现可为 {@code null}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class SensitiveWord {
+
+    private final Long id;
+    private final String word;
+    private final SensitiveWordCategory category;
+    private final SensitiveWordAction action;
+    private final boolean enabled;
+
+    public SensitiveWord(Long id, String word, SensitiveWordCategory category,
+                         SensitiveWordAction action, boolean enabled) {
+        this.id = id;
+        this.word = word;
+        this.category = category;
+        this.action = action;
+        this.enabled = enabled;
+    }
+
+    /** 便捷构造：无 id、默认启用。 */
+    public static SensitiveWord of(String word, SensitiveWordCategory category, SensitiveWordAction action) {
+        return new SensitiveWord(null, word, category, action, true);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getWord() {
+        return word;
+    }
+
+    public SensitiveWordCategory getCategory() {
+        return category;
+    }
+
+    public SensitiveWordAction getAction() {
+        return action;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordAction.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordAction.java
@@ -1,0 +1,31 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+/**
+ * 敏感词处置动作（命中后如何处理）。
+ *
+ * <p>{@code severity} 表达优先级：同一段文本命中多个词、动作不一时取<b>最高优先级</b>的动作作为整体决策
+ * （{@code BLOCK} &gt; {@code MASK} &gt; {@code REVIEW}）——例如一句话里既有需打码词又有需拦截词，应整体拦截。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum SensitiveWordAction {
+
+    /** 放行但标记，供人工/异步复核（不改写、不拦截）。 */
+    REVIEW(1),
+
+    /** 命中片段打码后放行（入站进模型前 / 出站回吐前都可用）。 */
+    MASK(2),
+
+    /** 命中即硬拦截：入站不进模型、出站替换为安全兜底话术。 */
+    BLOCK(3);
+
+    private final int severity;
+
+    SensitiveWordAction(int severity) {
+        this.severity = severity;
+    }
+
+    /** 优先级（越大越严格），用于多命中时的整体决策仲裁。 */
+    public int severity() {
+        return severity;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordCategory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordCategory.java
@@ -1,0 +1,33 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+/**
+ * 敏感词分类（以枚举名字符串落库，便于按类目统计与差异化处置）。
+ *
+ * <p>演示用占位类目，生产可按合规要求扩展；未知/无法归类的一律 {@link #CUSTOM}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum SensitiveWordCategory {
+
+    /** 涉政。 */
+    POLITICS,
+    /** 涉黄。 */
+    PORN,
+    /** 辱骂 / 人身攻击。 */
+    ABUSE,
+    /** 竞品词（营销口径管控）。 */
+    COMPETITOR,
+    /** 自定义 / 其它。 */
+    CUSTOM;
+
+    /** 安全解析：未知或空值一律归 {@link #CUSTOM}，避免脏数据导致自动机构建失败（fast fail 收口在此）。 */
+    public static SensitiveWordCategory fromName(String name) {
+        if (name == null || name.isEmpty()) {
+            return CUSTOM;
+        }
+        try {
+            return SensitiveWordCategory.valueOf(name.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return CUSTOM;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordConfig.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.sensitiveword.mapper.SensitiveWordMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 敏感词过滤装配：按 {@code sensitive-word.store-mode} 选择词表存储实现，并构建可热重建的 {@link SensitiveWordFilter}。
+ *
+ * <p><b>默认关闭即零开销：</b>整个 {@code @Configuration} 用 {@code @ConditionalOnProperty} 只在
+ * {@code customer-work.sensitive-word.enabled=true} 时装配（照 XxlJobSchedulerConfig / SyntheticMonitor 先例）——
+ * enabled=false 时 Store / Filter / 中间件全不装配，启动期<b>零 IO（不查 DB）、零 AC 构建、零日志</b>。</p>
+ *
+ * <p>存储：默认 {@link InMemorySensitiveWordStore}（进程内带演示种子）；{@code jdbc} 落
+ * {@link MybatisSensitiveWordStore}（复用 {@code CustomerWorkPersistenceConfig} 独立持久化环境）。
+ * {@link SensitiveWordMapper} 用 {@link ObjectProvider} 惰性获取：memory 模式不装配 Mapper 也不报错。
+ * 下游声明自己的 {@link SensitiveWordStore} / {@link SensitiveWordFilter} Bean 即可覆盖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "customer-work.sensitive-word", name = "enabled", havingValue = "true")
+public class SensitiveWordConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(SensitiveWordConfig.class);
+
+    private static final String STORE_MODE_JDBC = "jdbc";
+
+    @Bean
+    @ConditionalOnMissingBean(SensitiveWordStore.class)
+    public SensitiveWordStore sensitiveWordStore(CustomerWorkProperties properties,
+                                                 ObjectProvider<SensitiveWordMapper> mapperProvider) {
+        String mode = properties.getSensitiveWord().getStoreMode();
+        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+            log.info("sensitive-word store: jdbc (MyBatis-Plus, table=cw_sensitive_word)");
+            return new MybatisSensitiveWordStore(mapperProvider.getObject());
+        }
+        log.info("sensitive-word store: memory (in-process demo seeds, use store-mode=jdbc in production)");
+        return new InMemorySensitiveWordStore();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SensitiveWordFilter.class)
+    public SensitiveWordFilter sensitiveWordFilter(CustomerWorkProperties properties, SensitiveWordStore store) {
+        CustomerWorkProperties.SensitiveWord cfg = properties.getSensitiveWord();
+        return new SensitiveWordFilter(store, cfg.resolveMaskChar(), cfg.getDefaultAction());
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordFilter.java
@@ -1,0 +1,172 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 敏感词过滤服务：{@code normalize → match}，返回命中与整体决策，支持词表热重建。
+ *
+ * <p><b>热重建：</b>{@link #reload()} 从 {@link SensitiveWordStore} 拉启用词、归一化后构建<b>不可变</b>
+ * {@link AhoCorasickMatcher} 新实例，经 {@code volatile} 引用原子替换——匹配热路径（{@link #check}）只读
+ * volatile 引用、<b>不加锁</b>，读到的永远是某个完整快照（旧的或新的），不会读到半构建态。</p>
+ *
+ * <p><b>fail-closed 词表加载（三分支，安全网关的核心契约）：</b>{@link SensitiveWordStore#findEnabled()}
+ * 用 {@code Optional} 区分读成败，{@link #reload()} 据此分流，<b>绝不把"读失败"当成"没词"而静默放行</b>：</p>
+ * <ol>
+ *   <li><b>读成功</b>（拿到 list，空 list 也算）→ 构建新 matcher 原子替换（"没配词"是合法状态，放行正确）；</li>
+ *   <li><b>读失败 + 已有好词表</b> → <b>保留旧 matcher 不替换</b>（一次 DB 抖动不能冲掉已加载的好状态），log.error；</li>
+ *   <li><b>读失败 + 从未成功加载过</b> → 装<b>"拦截一切"哨兵</b>（{@code failClosed=true}，非 EMPTY），log.error 告警。
+ *       理由：运营显式开了安全网关就是要保护，启动期 DB 挂了宁可"整条对话被拦、立刻暴露去修 DB"，
+ *       也绝不能"静默放行、以为在保护"。</li>
+ * </ol>
+ *
+ * <p><b>打码：</b>借 {@link TextNormalizer.Normalized} 的下标映射把命中片段还原到原文区间（含被剔除的插入符），
+ * 逐字符替换为掩码字符，保证 {@code 敏*感*词} 也能整段打码、且不改变原文长度（后续命中的下标映射不受影响）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class SensitiveWordFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(SensitiveWordFilter.class);
+
+    private static final String CODE_RELOAD_FAIL = "SENSITIVE-RELOAD-FAIL";
+
+    /** fail-closed 哨兵命中所用的合成词（拦截一切时对外呈现的处置元数据）。 */
+    private static final SensitiveWord SENTINEL_BLOCK_WORD =
+        new SensitiveWord(null, "*", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK, true);
+
+    private final SensitiveWordStore store;
+    private final char maskChar;
+    /** 词条动作缺省时的兜底动作（防御式：正常词条均带动作，仅脏数据兜底用）。 */
+    private final SensitiveWordAction defaultAction;
+
+    /** 当前生效的自动机快照（volatile：热重建时原子替换，匹配热路径无锁读取）。 */
+    private volatile AhoCorasickMatcher matcher;
+    /** fail-closed 哨兵态：首次加载即读失败时置 true，check() 对任何非空文本一律 BLOCK。 */
+    private volatile boolean failClosed;
+    /** 是否曾成功加载过词表（用于区分"读失败保留旧词表"与"首次加载失败 fail-closed"）。 */
+    private volatile boolean everLoadedGood;
+
+    public SensitiveWordFilter(SensitiveWordStore store, char maskChar, SensitiveWordAction defaultAction) {
+        this.store = store;
+        this.maskChar = maskChar;
+        this.defaultAction = defaultAction == null ? SensitiveWordAction.BLOCK : defaultAction;
+        this.matcher = AhoCorasickMatcher.build(List.of()); // 占位，保证 matcher 非空
+        reload();
+    }
+
+    /** 从存储重新拉取启用词表并重建自动机（词表变更后调用；线程安全，含 fail-closed 三分支）。 */
+    public void reload() {
+        Optional<List<SensitiveWord>> loaded = store.findEnabled();
+        if (loaded.isPresent()) {
+            // 分支①：读成功——构建新 matcher 原子替换，解除任何哨兵态
+            List<SensitiveWord> enabled = loaded.get();
+            List<SensitiveWord> normalized = new ArrayList<>(enabled.size());
+            for (SensitiveWord raw : enabled) {
+                String normWord = TextNormalizer.normalize(raw.getWord());
+                if (!normWord.isEmpty()) {
+                    normalized.add(new SensitiveWord(raw.getId(), normWord, raw.getCategory(), raw.getAction(), true));
+                }
+            }
+            this.matcher = AhoCorasickMatcher.build(normalized);
+            this.failClosed = false;
+            this.everLoadedGood = true;
+            log.info("[SENSITIVE] matcher rebuilt, patterns={}", matcher.patternCount());
+            return;
+        }
+        if (everLoadedGood) {
+            // 分支②：读失败但已有好词表——保留旧 matcher，绝不用空覆盖好状态
+            log.error("[SENSITIVE] word table reload failed, keep last good table (patterns={}), code={}",
+                matcher.patternCount(), CODE_RELOAD_FAIL);
+            return;
+        }
+        // 分支③：读失败且从未成功加载——fail-closed 拦截一切，告警促运营修 DB
+        this.failClosed = true;
+        log.error("[SENSITIVE] initial word table load failed, engage fail-closed block-all sentinel, code={}",
+            CODE_RELOAD_FAIL);
+    }
+
+    /** 当前词表规模（观测 / 单测）。 */
+    public int patternCount() {
+        return matcher.patternCount();
+    }
+
+    /** 是否处于 fail-closed 哨兵态（观测 / 单测）。 */
+    public boolean isFailClosed() {
+        return failClosed;
+    }
+
+    /**
+     * 过滤一段文本：归一化后单趟扫描，返回命中、整体决策与打码文本。
+     *
+     * @param rawText 原始文本（null / 空返回放行结果）
+     */
+    public SensitiveWordFilterResult check(String rawText) {
+        if (rawText == null || rawText.isEmpty()) {
+            return SensitiveWordFilterResult.pass(rawText);
+        }
+        if (failClosed) {
+            // fail-closed 哨兵：词表从未成功加载，任何非空文本一律拦截（合成一个 BLOCK 命中）
+            List<SensitiveWordHit> sentinelHits = List.of(new SensitiveWordHit(SENTINEL_BLOCK_WORD, 0, 0));
+            return new SensitiveWordFilterResult(rawText, rawText, sentinelHits, SensitiveWordAction.BLOCK);
+        }
+        TextNormalizer.Normalized norm = TextNormalizer.normalizeTracked(rawText);
+        List<SensitiveWordHit> hits = matcher.match(norm.text());
+        if (hits.isEmpty()) {
+            return SensitiveWordFilterResult.pass(rawText);
+        }
+        SensitiveWordAction decision = highestAction(hits);
+        String maskedText = decision == SensitiveWordAction.BLOCK
+            ? rawText  // BLOCK 决策整体替换为兜底话术，无需逐词打码
+            : maskHits(rawText, norm.originalIndex(), hits);
+        return new SensitiveWordFilterResult(rawText, maskedText, hits, decision);
+    }
+
+    /** 命中词的动作（防御式：动作缺省时回退 {@link #defaultAction}）。 */
+    private SensitiveWordAction actionOf(SensitiveWordHit hit) {
+        SensitiveWordAction a = hit.word().getAction();
+        return a == null ? defaultAction : a;
+    }
+
+    /** 取命中中优先级最高的动作（BLOCK &gt; MASK &gt; REVIEW）。 */
+    private SensitiveWordAction highestAction(List<SensitiveWordHit> hits) {
+        SensitiveWordAction top = null;
+        for (SensitiveWordHit hit : hits) {
+            SensitiveWordAction a = actionOf(hit);
+            if (top == null || a.severity() > top.severity()) {
+                top = a;
+            }
+        }
+        return top;
+    }
+
+    /** 把 MASK 动作命中片段在原文对应区间（含插入符）逐字符打码；非 MASK 命中不改写。 */
+    private String maskHits(String rawText, int[] originalIndex, List<SensitiveWordHit> hits) {
+        boolean[] maskFlags = new boolean[rawText.length()];
+        boolean any = false;
+        for (SensitiveWordHit hit : hits) {
+            if (actionOf(hit) != SensitiveWordAction.MASK) {
+                continue;
+            }
+            int origStart = originalIndex[hit.start()];
+            int origEnd = originalIndex[hit.end() - 1]; // 含
+            for (int i = origStart; i <= origEnd; i++) {
+                maskFlags[i] = true;
+            }
+            any = true;
+        }
+        if (!any) {
+            return rawText;
+        }
+        char[] chars = rawText.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            if (maskFlags[i]) {
+                chars[i] = maskChar;
+            }
+        }
+        return new String(chars);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordFilterResult.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordFilterResult.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 一次过滤的结果（不可变）。
+ *
+ * @param originalText 原始文本
+ * @param maskedText   已对 {@code MASK} 命中片段打码后的文本（无 MASK 命中时等于原文）
+ * @param hits         全部命中（归一化文本内偏移）
+ * @param decision     整体决策：多命中时取最高优先级动作；无命中为 {@code null}（放行）
+ * @author owlzhangfq@gmail.com
+ */
+public record SensitiveWordFilterResult(String originalText, String maskedText,
+                                        List<SensitiveWordHit> hits, SensitiveWordAction decision) {
+
+    /** 无命中的放行结果。 */
+    public static SensitiveWordFilterResult pass(String text) {
+        return new SensitiveWordFilterResult(text, text, Collections.emptyList(), null);
+    }
+
+    public boolean hasHit() {
+        return decision != null;
+    }
+
+    public boolean blocked() {
+        return decision == SensitiveWordAction.BLOCK;
+    }
+
+    public boolean masked() {
+        return decision == SensitiveWordAction.MASK;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordHit.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordHit.java
@@ -1,0 +1,12 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+/**
+ * 一次命中结果（自动机在归一化文本上的一次匹配）。
+ *
+ * @param word  命中的敏感词（含 category / action）
+ * @param start 命中片段在<b>归一化文本</b>中的起始下标（含）
+ * @param end   命中片段在<b>归一化文本</b>中的结束下标（不含）
+ * @author owlzhangfq@gmail.com
+ */
+public record SensitiveWordHit(SensitiveWord word, int start, int end) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordSeeds.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordSeeds.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import java.util.List;
+
+/**
+ * 敏感词演示种子（<b>脱敏占位词，非真实违禁词</b>），与 {@code customer-work-schema.sql} 的
+ * {@code INSERT IGNORE} 保持一致：memory 模式由 {@link InMemorySensitiveWordStore} 装载，jdbc 模式由建表脚本装载。
+ *
+ * <p>覆盖三种处置动作与多类目，便于演示"拦截 / 打码 / 复核"分流。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class SensitiveWordSeeds {
+
+    private SensitiveWordSeeds() {
+    }
+
+    /** 演示种子词（占位）。 */
+    public static List<SensitiveWord> demoWords() {
+        return List.of(
+            SensitiveWord.of("测试敏感词A", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK),
+            SensitiveWord.of("涉政占位", SensitiveWordCategory.POLITICS, SensitiveWordAction.BLOCK),
+            SensitiveWord.of("辱骂占位", SensitiveWordCategory.ABUSE, SensitiveWordAction.BLOCK),
+            SensitiveWord.of("竞品XX", SensitiveWordCategory.COMPETITOR, SensitiveWordAction.MASK),
+            SensitiveWord.of("复核占位", SensitiveWordCategory.CUSTOM, SensitiveWordAction.REVIEW));
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordStore.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 敏感词表存储 SPI（持久化扩展点）。
+ *
+ * <p>默认 {@link InMemorySensitiveWordStore}（进程内、带演示种子，离线可测）；生产可切
+ * {@link MybatisSensitiveWordStore}（{@code sensitive-word.store-mode=jdbc}），或下游声明同类型 Bean 覆盖。
+ * {@link SensitiveWordFilter} 通过本 SPI 拉取启用词表构建自动机，词表变更后调用 {@code reload()} 热重建。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface SensitiveWordStore {
+
+    /** 全部词（含停用）。 */
+    List<SensitiveWord> findAll();
+
+    /**
+     * 仅启用的词（构建自动机用）。
+     *
+     * <p><b>成败必须可区分</b>（fail-closed 契约的关键）：{@code Optional.of(list)} 表示<b>读取成功</b>
+     * （空 list 也是合法的"没配词"）；{@code Optional.empty()} 表示<b>读取失败</b>（DB 不可达等）。
+     * {@link SensitiveWordFilter#reload()} 据此分流——绝不把"读失败"当成"没词"而静默放行。</p>
+     */
+    Optional<List<SensitiveWord>> findEnabled();
+
+    /** 保存（新建或更新）一个词。 */
+    void save(SensitiveWord word);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/TextNormalizer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/TextNormalizer.java
@@ -1,0 +1,107 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 文本归一化（纯函数，无状态、好单测）——敏感词"绕过对抗"的关键前处理。
+ *
+ * <p>三步归一，让 {@code 敏*感*词} / {@code 敏 感 词} / 全角 {@code ｍｉｎｇ} / 大小写变体都能落到同一词面：</p>
+ * <ol>
+ *   <li><b>全角转半角</b>：Unicode 全角区（U+FF01~U+FF5E）映回 ASCII，全角空格（U+3000）转普通空格；</li>
+ *   <li><b>大小写归一</b>：统一转小写；</li>
+ *   <li><b>去干扰字符</b>：剔除空白与常见插入符（{@code * . · • - _ ~ | / \} 及中文间隔号/顿号等），
+ *       使插入式绕过失效。</li>
+ * </ol>
+ *
+ * <p><b>繁转简：未做</b>——java8 标准库无内置繁简映射，引第三方库（如 opencc4j）会破坏"零新增依赖"约束，
+ * 故此处跳过；如需可在下游用同签名的自定义 normalizer 叠加。</p>
+ *
+ * <p>{@link #normalizeTracked} 额外产出"归一化下标 → 原文下标"的映射，供打码时把命中片段还原到原文
+ * （含被剔除的插入符）区间上，保证 {@code 敏*感*词} 也能整段打码。全角/小写均为 1:1 变换，剔除只减不增，
+ * 故映射恒为单射、无需展开。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class TextNormalizer {
+
+    /** 全角可视字符区间（对应 ASCII 0x21~0x7E）。 */
+    private static final char FULLWIDTH_START = '！';
+    private static final char FULLWIDTH_END = '～';
+    private static final char FULLWIDTH_SPACE = '　';
+    private static final int FULLWIDTH_TO_ASCII_OFFSET = 0xFEE0;
+
+    /** 需剔除的常见插入干扰符（空白另行用 {@link Character#isWhitespace} 判定）。 */
+    private static final Set<Character> NOISE_CHARS = buildNoiseChars();
+
+    private TextNormalizer() {
+    }
+
+    /** 归一化并返回纯文本（构建词表 / 断言用；等价于 {@code normalizeTracked(raw).text()}）。 */
+    public static String normalize(String raw) {
+        return normalizeTracked(raw).text();
+    }
+
+    /**
+     * 归一化并保留原文下标映射。
+     *
+     * @param raw 原始文本（null 视为空串）
+     * @return 归一化文本 + {@code originalIndex[i]}=归一化第 i 个字符在原文中的下标
+     */
+    public static Normalized normalizeTracked(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return new Normalized("", new int[0]);
+        }
+        int len = raw.length();
+        StringBuilder sb = new StringBuilder(len);
+        int[] idx = new int[len];
+        int kept = 0;
+        for (int i = 0; i < len; i++) {
+            char c = toHalfWidth(raw.charAt(i));
+            if (isNoise(c)) {
+                continue;
+            }
+            sb.append(Character.toLowerCase(c));
+            idx[kept++] = i;
+        }
+        int[] originalIndex = new int[kept];
+        System.arraycopy(idx, 0, originalIndex, 0, kept);
+        return new Normalized(sb.toString(), originalIndex);
+    }
+
+    /** 全角字符转半角（非全角原样返回）。 */
+    private static char toHalfWidth(char c) {
+        if (c == FULLWIDTH_SPACE) {
+            return ' ';
+        }
+        if (c >= FULLWIDTH_START && c <= FULLWIDTH_END) {
+            return (char) (c - FULLWIDTH_TO_ASCII_OFFSET);
+        }
+        return c;
+    }
+
+    private static boolean isNoise(char c) {
+        return Character.isWhitespace(c) || NOISE_CHARS.contains(c);
+    }
+
+    private static Set<Character> buildNoiseChars() {
+        Set<Character> set = new HashSet<>();
+        // ASCII 插入符
+        for (char c : new char[]{'*', '.', '-', '_', '~', '|', '/', '\\', '^', '+', '='}) {
+            set.add(c);
+        }
+        // 中文常见间隔/顿点符（全角转半角覆盖不到的 BMP 标点）
+        for (char c : new char[]{'·', '•', '・', '。', '、', '‧', '･'}) {
+            set.add(c);
+        }
+        return set;
+    }
+
+    /**
+     * 归一化结果。
+     *
+     * @param text          归一化后的文本
+     * @param originalIndex 归一化下标 → 原文下标的映射（长度与 {@code text} 一致）
+     */
+    public record Normalized(String text, int[] originalIndex) {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/entity/SensitiveWordEntity.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/entity/SensitiveWordEntity.java
@@ -1,0 +1,38 @@
+package com.richard.fyoung.customerwork.sensitiveword.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 敏感词持久化对象（贫血数据袋）：与 {@code cw_sensitive_word} 表一一映射。
+ *
+ * <p>{@code category} / {@code action} 以枚举名字符串落库，转换在
+ * {@link com.richard.fyoung.customerwork.sensitiveword.MybatisSensitiveWordStore} 完成。
+ * 驼峰字段由 MyBatis-Plus 下划线映射自动对应下划线列。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_sensitive_word")
+public class SensitiveWordEntity {
+
+    /** 自增主键。 */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    /** 敏感词原词面。 */
+    private String word;
+
+    /** 类目枚举名（POLITICS/PORN/ABUSE/COMPETITOR/CUSTOM）。 */
+    private String category;
+
+    /** 处置动作枚举名（BLOCK/MASK/REVIEW）。 */
+    private String action;
+
+    /** 是否启用（1 启用 / 0 停用）。 */
+    private Boolean enabled;
+
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/mapper/SensitiveWordMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/mapper/SensitiveWordMapper.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customerwork.sensitiveword.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.sensitiveword.entity.SensitiveWordEntity;
+
+/**
+ * 敏感词 Mapper：继承 {@link BaseMapper} 复用单表 CRUD；
+ * {@link #upsert} 表达按 {@code word} 唯一键的 {@code INSERT ... ON DUPLICATE KEY UPDATE}。
+ * @author owlzhangfq@gmail.com
+ */
+public interface SensitiveWordMapper extends BaseMapper<SensitiveWordEntity> {
+
+    /** 按唯一键 word upsert：存在则更新类目/动作/启用/更新时间，不存在则插入。 */
+    int upsert(SensitiveWordEntity record);
+}

--- a/customer-work-starter/src/main/resources/customerwork/mapper/HandoffMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/HandoffMapper.xml
@@ -6,11 +6,15 @@
     <!-- 按主键 upsert：对应旧 JdbcHandoffStore 的 ON DUPLICATE KEY UPDATE 语义 -->
     <insert id="upsert" parameterType="com.richard.fyoung.customerwork.handoff.entity.HandoffTicketDO">
         INSERT INTO cw_handoff_ticket (id, session_id, reason, created_at_ms,
-            status, claimed_by, claimed_at_ms, resolution_note, resolved_at_ms)
+            status, claimed_by, claimed_at_ms, resolution_note, resolved_at_ms,
+            category, required_skill, priority, emotion, suggested_assignees)
         VALUES (#{id}, #{sessionId}, #{reason}, #{createdAtMs},
-            #{status}, #{claimedBy}, #{claimedAtMs}, #{resolutionNote}, #{resolvedAtMs})
+            #{status}, #{claimedBy}, #{claimedAtMs}, #{resolutionNote}, #{resolvedAtMs},
+            #{category}, #{requiredSkill}, #{priority}, #{emotion}, #{suggestedAssignees})
         ON DUPLICATE KEY UPDATE status = VALUES(status), claimed_by = VALUES(claimed_by),
             claimed_at_ms = VALUES(claimed_at_ms), resolution_note = VALUES(resolution_note),
-            resolved_at_ms = VALUES(resolved_at_ms)
+            resolved_at_ms = VALUES(resolved_at_ms), category = VALUES(category),
+            required_skill = VALUES(required_skill), priority = VALUES(priority),
+            emotion = VALUES(emotion), suggested_assignees = VALUES(suggested_assignees)
     </insert>
 </mapper>

--- a/customer-work-starter/src/main/resources/customerwork/mapper/SeatAgentMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/SeatAgentMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customerwork.routing.mapper.SeatAgentMapper">
+
+    <!-- 按主键 upsert：存在则更新名称/技能/负载/在线/分组/更新时间，不存在则插入（created_at_ms 仅首次生效） -->
+    <insert id="upsert" parameterType="com.richard.fyoung.customerwork.routing.entity.SeatAgentDO">
+        INSERT INTO cw_seat_agent (id, name, skills, max_load, current_load, online, seat_group,
+            created_at_ms, updated_at_ms)
+        VALUES (#{id}, #{name}, #{skills}, #{maxLoad}, #{currentLoad}, #{online}, #{seatGroup},
+            #{createdAtMs}, #{updatedAtMs})
+        ON DUPLICATE KEY UPDATE name = VALUES(name), skills = VALUES(skills), max_load = VALUES(max_load),
+            current_load = VALUES(current_load), online = VALUES(online), seat_group = VALUES(seat_group),
+            updated_at_ms = VALUES(updated_at_ms)
+    </insert>
+</mapper>

--- a/customer-work-starter/src/main/resources/customerwork/mapper/SensitiveWordMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/SensitiveWordMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customerwork.sensitiveword.mapper.SensitiveWordMapper">
+
+    <!-- 按唯一键 word upsert：存在则更新类目/动作/启用/更新时间，不存在则插入（created_at_ms 仅首次生效） -->
+    <insert id="upsert" parameterType="com.richard.fyoung.customerwork.sensitiveword.entity.SensitiveWordEntity">
+        INSERT INTO cw_sensitive_word (word, category, action, enabled, created_at_ms, updated_at_ms)
+        VALUES (#{word}, #{category}, #{action}, #{enabled}, #{createdAtMs}, #{updatedAtMs})
+        ON DUPLICATE KEY UPDATE category = VALUES(category), action = VALUES(action),
+            enabled = VALUES(enabled), updated_at_ms = VALUES(updated_at_ms)
+    </insert>
+</mapper>

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -65,9 +65,23 @@ CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
     `claimed_at_ms`     BIGINT DEFAULT 0 COMMENT '接单时间戳（毫秒）',
     `resolution_note`   TEXT COMMENT '处理结果备注',
     `resolved_at_ms`    BIGINT DEFAULT 0 COMMENT '结案时间戳（毫秒）',
+    `category`          VARCHAR(64) COMMENT '工单分类（LLM 分类，可空）',
+    `required_skill`    VARCHAR(64) COMMENT '所需坐席技能标签（LLM 分类，可空）',
+    `priority`          VARCHAR(16) COMMENT '优先级 LOW/MEDIUM/HIGH/URGENT（LLM 分类，可空）',
+    `emotion`           VARCHAR(32) COMMENT '用户情绪（LLM 分类，可空）',
+    `suggested_assignees` TEXT COMMENT '推荐坐席列表 JSON（HITL 推荐，人工点选非自动派单，可空）',
     INDEX `idx_handoff_status` (`status`),
     INDEX `idx_handoff_created` (`created_at_ms`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='人机切换工单（AI 转人工闭环）';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='人机切换工单（AI 转人工闭环 + 智能分配增强）';
+
+-- 人机切换工单智能分配增强列（cw_handoff_ticket 已在上文建表时含 category/required_skill/priority/emotion/suggested_assignees；
+-- 旧库存量表可手工执行下列 ALTER 补列，MySQL 无 ADD COLUMN IF NOT EXISTS，重复执行报 Duplicate column 可忽略）：
+-- ALTER TABLE `cw_handoff_ticket`
+--   ADD COLUMN `category` VARCHAR(64) NULL COMMENT '工单分类（LLM 分类，可空）',
+--   ADD COLUMN `required_skill` VARCHAR(64) NULL COMMENT '所需坐席技能标签（LLM 分类，可空）',
+--   ADD COLUMN `priority` VARCHAR(16) NULL COMMENT '优先级 LOW/MEDIUM/HIGH/URGENT（LLM 分类，可空）',
+--   ADD COLUMN `emotion` VARCHAR(32) NULL COMMENT '用户情绪（LLM 分类，可空）',
+--   ADD COLUMN `suggested_assignees` TEXT NULL COMMENT '推荐坐席列表 JSON（HITL 推荐，可空）';
 
 -- 消息级用户反馈表（MybatisFeedbackStore）。
 CREATE TABLE IF NOT EXISTS `cw_message_feedback` (
@@ -304,3 +318,25 @@ INSERT IGNORE INTO `cw_sensitive_word` (`word`, `category`, `action`, `enabled`,
 ('辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
 ('竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
 ('复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);
+
+-- 坐席库表（MybatisSeatAgentStore / cw_seat_agent）：智能路由中控"工单智能分配"的候选坐席池。
+-- skills 为逗号分隔技能标签串；seat_group 避开 SQL 保留字 group；种子为演示坐席（多技能/负载/在离线）。
+CREATE TABLE IF NOT EXISTS `cw_seat_agent` (
+    `id`             VARCHAR(64) PRIMARY KEY COMMENT '坐席ID',
+    `name`           VARCHAR(64) NOT NULL COMMENT '坐席名',
+    `skills`         VARCHAR(512) COMMENT '技能标签（逗号分隔，如 refund,invoice）',
+    `max_load`       INT NOT NULL DEFAULT 0 COMMENT '最大并发工单数',
+    `current_load`   INT NOT NULL DEFAULT 0 COMMENT '当前在处理工单数',
+    `online`         TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否在线: 1在线/0离线',
+    `seat_group`     VARCHAR(64) COMMENT '坐席分组',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    INDEX `idx_seat_online` (`online`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='坐席库（智能分配候选坐席池）';
+
+INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current_load`, `online`, `seat_group`, `created_at_ms`, `updated_at_ms`) VALUES
+('SEAT-1001', '退款专员-小赵', 'refund,invoice', 5, 1, 1, 'aftersales', 1779235200000, 1779235200000),
+('SEAT-1002', '物流专员-小钱', 'logistics', 5, 3, 1, 'logistics', 1779235200000, 1779235200000),
+('SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
+('SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
+('SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -284,3 +284,23 @@ INSERT IGNORE INTO `cw_knowledge` (`keyword`, `title`, `content`, `source`) VALU
 ('退货,退款,七天,无理由', '七天无理由退货政策', '支持七天无理由退货，商品需保持完好、不影响二次销售；定制类、生鲜类除外。', '《售后服务政策》第 3 条'),
 ('发票,开票,报销', '发票开具规则', '支持开具电子普通发票与增值税专用发票，可在订单详情页自助申请，1-3 个工作日开具。', '《发票管理规则》第 1 条'),
 ('运费,包邮,邮费', '运费说明', '单笔订单满 99 元包邮，偏远地区除外；退货运费由责任方承担。', '《运费说明》第 2 条');
+
+-- 敏感词表（SensitiveWordFilter / cw_sensitive_word）：智能路由中控"一次拦截"词库。
+-- 种子为脱敏占位词（非真实违禁词），覆盖 BLOCK/MASK/REVIEW 三种动作与多类目。
+CREATE TABLE IF NOT EXISTS `cw_sensitive_word` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `word`           VARCHAR(128) NOT NULL COMMENT '敏感词原词面',
+    `category`       VARCHAR(32) NOT NULL COMMENT '类目: POLITICS/PORN/ABUSE/COMPETITOR/CUSTOM',
+    `action`         VARCHAR(16) NOT NULL COMMENT '处置动作: BLOCK/MASK/REVIEW',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_sensitive_word` (`word`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词表（一次拦截词库）';
+
+INSERT IGNORE INTO `cw_sensitive_word` (`word`, `category`, `action`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('测试敏感词A', 'CUSTOM', 'BLOCK', 1, 1779235200000, 1779235200000),
+('涉政占位', 'POLITICS', 'BLOCK', 1, 1779235200000, 1779235200000),
+('辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
+('竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
+('复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/assist/ConversationSummaryServiceTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/assist/ConversationSummaryServiceTest.java
@@ -1,0 +1,112 @@
+package com.richard.fyoung.customerwork.assist;
+
+import com.richard.fyoung.customerwork.chatlog.ChatMessage;
+import com.richard.fyoung.customerwork.chatlog.ChatMessageStore;
+import com.richard.fyoung.customerwork.chatlog.InMemoryChatMessageStore;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.ticket.TicketActorType;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 会话总结服务单测：LLM 用 mock Model 隔离（真实 key 不需要）。覆盖 LLM 成功解析、模型不守格式降级、
+ * 模型调用异常降级、空历史降级四条路径——全部 fail-open，永不抛异常。
+ * @author owlzhangfq@gmail.com
+ */
+class ConversationSummaryServiceTest {
+
+    private static final String SESSION = "conv-summary-1";
+
+    private final AgentAssistService assistService = new AgentAssistService();
+    private final CustomerWorkProperties properties = new CustomerWorkProperties();
+
+    /** mock Model：一次性调用返回给定文本（模拟 LLM 输出）。 */
+    private Model modelReturning(String text) {
+        Model model = mock(Model.class);
+        ChatResponse resp = mock(ChatResponse.class);
+        List<ContentBlock> blocks = List.of(TextBlock.builder().text(text).build());
+        when(resp.getContent()).thenReturn(blocks);
+        when(model.stream(any(), any(), any())).thenReturn(Flux.just(resp));
+        return model;
+    }
+
+    private ChatMessageStore storeWith(String... userTexts) {
+        InMemoryChatMessageStore store = new InMemoryChatMessageStore();
+        int i = 0;
+        for (String t : userTexts) {
+            store.append(ChatMessage.of("MSG-" + i++, SESSION, null, TicketActorType.USER, "u", t));
+        }
+        return store;
+    }
+
+    @Test
+    void summarize_shouldParseStructuredJson_whenModelReturnsValidJson() {
+        String json = "{\"oneLineSummary\":\"用户要退款\",\"userIntent\":\"退款\",\"emotion\":\"不满\","
+            + "\"triedSolutions\":[\"已引导自助退款\"],\"pendingIssues\":[\"退款未到账\"],"
+            + "\"suggestedNextStep\":\"核实订单后手动退款\",\"suggestedReply\":\"您好，马上为您核实\"}";
+        ConversationSummaryService service = new ConversationSummaryService(
+            modelReturning(json), storeWith("我要退款", "怎么还没到账"), assistService, properties);
+
+        ConversationSummary summary = service.summarize(SESSION);
+
+        assertTrue(summary.fromModel());
+        assertEquals("用户要退款", summary.oneLineSummary());
+        assertEquals("不满", summary.emotion());
+        assertEquals(List.of("退款未到账"), summary.pendingIssues());
+        // 结果进缓存供坐席工作台拉取
+        assertTrue(service.findLatest(SESSION).isPresent());
+    }
+
+    @Test
+    void summarize_shouldDegrade_whenModelReturnsNonJson() {
+        ConversationSummaryService service = new ConversationSummaryService(
+            modelReturning("这是一段不守格式的自由文本"), storeWith("我要退款"), assistService, properties);
+
+        ConversationSummary summary = service.summarize(SESSION);
+
+        assertFalse(summary.fromModel());
+        // 降级仍给出可用的规则版建议话术（不为空）
+        assertTrue(summary.suggestedReply() != null && !summary.suggestedReply().isEmpty());
+    }
+
+    @Test
+    void summarize_shouldDegrade_whenModelThrows() {
+        Model model = mock(Model.class);
+        when(model.stream(any(), any(), any())).thenReturn(Flux.error(new RuntimeException("model down")));
+        ConversationSummaryService service = new ConversationSummaryService(
+            model, storeWith("我要退款"), assistService, properties);
+
+        ConversationSummary summary = service.summarize(SESSION);
+
+        assertFalse(summary.fromModel());
+        assertTrue(summary.suggestedReply() != null && !summary.suggestedReply().isEmpty());
+    }
+
+    @Test
+    void summarize_shouldDegradeWithoutCallingModel_whenNoHistory() {
+        // 空历史：不应调用模型，直接规则降级
+        Model model = mock(Model.class);
+        when(model.stream(any(), any(), any())).thenReturn(Flux.error(
+            new AssertionError("model should not be called when history is empty")));
+        ConversationSummaryService service = new ConversationSummaryService(
+            model, new InMemoryChatMessageStore(), assistService, properties);
+
+        ConversationSummary summary = service.summarize("empty-session");
+
+        assertFalse(summary.fromModel());
+        assertEquals("暂无会话历史", summary.oneLineSummary());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/handoff/HandoffRoutingTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/handoff/HandoffRoutingTest.java
@@ -1,0 +1,69 @@
+package com.richard.fyoung.customerwork.handoff;
+
+import com.richard.fyoung.customerwork.routing.HandoffCreatedEnricher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 人机切换工单·智能分配增强字段单测：回写、缺单 fail-open、建单触发增强器。
+ * @author owlzhangfq@gmail.com
+ */
+class HandoffRoutingTest {
+
+    @Test
+    void applyRoutingSuggestion_shouldUpdateFields() {
+        HandoffService service = new HandoffService();
+        HandoffTicket ticket = service.create("s1", "退款");
+
+        service.applyRoutingSuggestion(ticket.getId(), "退款", "refund", "HIGH", "不满", "[{\"seatId\":\"S1\"}]");
+
+        HandoffTicket updated = service.find(ticket.getId()).orElseThrow();
+        assertEquals("退款", updated.getCategory());
+        assertEquals("refund", updated.getRequiredSkill());
+        assertEquals("HIGH", updated.getPriority());
+        assertEquals("不满", updated.getEmotion());
+        assertEquals("[{\"seatId\":\"S1\"}]", updated.getSuggestedAssignees());
+    }
+
+    @Test
+    void applyRoutingSuggestion_shouldFailOpen_whenTicketMissing() {
+        HandoffService service = new HandoffService();
+        // 不存在的工单：只 error 不抛
+        service.applyRoutingSuggestion("HO-missing", "x", "y", "LOW", "z", "[]");
+    }
+
+    @Test
+    void create_shouldTriggerEnricher_whenWired() {
+        HandoffService service = new HandoffService();
+        HandoffCreatedEnricher enricher = mock(HandoffCreatedEnricher.class);
+        service.setEnricher(enricher);
+
+        HandoffTicket ticket = service.create("s2", "转人工");
+
+        verify(enricher).onHandoffCreated(ticket);
+    }
+
+    @Test
+    void newTicket_shouldHaveNullRoutingFields_byDefault() {
+        HandoffTicket ticket = new HandoffTicket("HO-1", "s", "r", System.currentTimeMillis());
+        assertNull(ticket.getCategory());
+        assertNull(ticket.getSuggestedAssignees());
+    }
+
+    @Test
+    void create_shouldNotFail_whenEnricherThrows() {
+        HandoffService service = new HandoffService();
+        HandoffCreatedEnricher enricher = mock(HandoffCreatedEnricher.class);
+        org.mockito.Mockito.doThrow(new RuntimeException("boom")).when(enricher).onHandoffCreated(any());
+        service.setEnricher(enricher);
+
+        // 建单主链路不受增强器异常影响
+        HandoffTicket ticket = service.create("s3", "转人工");
+        assertEquals("s3", ticket.getSessionId());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/handoff/MybatisHandoffRoutingStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/handoff/MybatisHandoffRoutingStoreTest.java
@@ -1,0 +1,68 @@
+package com.richard.fyoung.customerwork.handoff;
+
+import com.richard.fyoung.customerwork.handoff.mapper.HandoffMapper;
+import com.richard.fyoung.customerwork.support.MybatisTestSupport;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * MyBatis 人机切换工单·智能分配增强列 round-trip 测试（对接本机 MySQL，不可达自动跳过）。
+ * 验证 category/required_skill/priority/emotion/suggested_assignees 五个新列的读写与 upsert 更新。
+ * @author owlzhangfq@gmail.com
+ */
+class MybatisHandoffRoutingStoreTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 3306;
+
+    private HikariDataSource dataSource;
+    private MybatisHandoffStore store;
+
+    @BeforeEach
+    void setUp() {
+        assumeTrue(reachable(HOST, PORT), "MySQL 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+        dataSource = MybatisTestSupport.mysqlDataSource("test-handoff-routing-pool");
+        MybatisTestSupport.ensureSchema(dataSource);
+        store = new MybatisHandoffStore(MybatisTestSupport.mapper(dataSource, HandoffMapper.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    private static boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    void save_shouldPersistRoutingEnrichmentColumns() {
+        String id = "HO-IT-" + UUID.randomUUID();
+        HandoffTicket ticket = new HandoffTicket(id, "sess-it", "涉及大额退款", System.currentTimeMillis());
+        ticket.applyRoutingSuggestion("退款", "refund", "HIGH", "不满", "[{\"seatId\":\"SEAT-1001\"}]");
+        store.save(ticket);
+
+        HandoffTicket read = store.find(id).orElseThrow();
+        assertEquals("退款", read.getCategory());
+        assertEquals("refund", read.getRequiredSkill());
+        assertEquals("HIGH", read.getPriority());
+        assertEquals("不满", read.getEmotion());
+        assertEquals("[{\"seatId\":\"SEAT-1001\"}]", read.getSuggestedAssignees());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/middleware/SensitiveWordMiddlewareTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/middleware/SensitiveWordMiddlewareTest.java
@@ -1,0 +1,178 @@
+package com.richard.fyoung.customerwork.middleware;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.observability.AuditSink;
+import com.richard.fyoung.customerwork.observability.LoggingAuditSink;
+import com.richard.fyoung.customerwork.sensitiveword.InMemorySensitiveWordStore;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordAction;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordFilter;
+import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordFilterResult;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.middleware.AgentInput;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 敏感词中间件单测：入站拦截 / 入站打码 / 出站拦截 / fail-closed / disabled 放行 / direction。
+ * @author owlzhangfq@gmail.com
+ */
+class SensitiveWordMiddlewareTest {
+
+    private static final String INBOUND_SAFE =
+        CustomerWorkProperties.SensitiveWord.DEFAULT_INBOUND_SAFE_REPLY;
+    private static final String OUTBOUND_SAFE =
+        CustomerWorkProperties.SensitiveWord.DEFAULT_OUTBOUND_SAFE_REPLY;
+
+    private Msg userMsg(String text) {
+        return Msg.builder().role(MsgRole.USER).name("user").textContent(text).build();
+    }
+
+    private Msg assistantMsg(String text) {
+        return Msg.builder().role(MsgRole.ASSISTANT).name("assistant").textContent(text).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ObjectProvider<MeterRegistry> provider(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> p = mock(ObjectProvider.class);
+        when(p.getIfAvailable()).thenReturn(registry);
+        return p;
+    }
+
+    private SensitiveWordMiddleware middleware(CustomerWorkProperties props, SensitiveWordFilter filter) {
+        AuditSink sink = new LoggingAuditSink();
+        return new SensitiveWordMiddleware(props, filter, sink, provider(new SimpleMeterRegistry()));
+    }
+
+    private SensitiveWordFilter realFilter() {
+        return new SensitiveWordFilter(new InMemorySensitiveWordStore(), '*', SensitiveWordAction.BLOCK);
+    }
+
+    private CustomerWorkProperties enabledProps() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getSensitiveWord().setEnabled(true);
+        return props;
+    }
+
+    @Test
+    void disabledByDefault_shouldPassThrough() {
+        assertFalse(new CustomerWorkProperties().getSensitiveWord().isEnabled());
+    }
+
+    @Test
+    void inboundBlock_shouldNotInvokeNextAndReturnSafeReply() {
+        SensitiveWordMiddleware mw = middleware(enabledProps(), realFilter());
+        AtomicBoolean nextCalled = new AtomicBoolean(false);
+
+        AgentInput input = new AgentInput(List.of(userMsg("我想问测试敏感词A的事")));
+        List<AgentEvent> events = mw.onAgent(null, null, input, in -> {
+            nextCalled.set(true);
+            return Flux.just(new AgentResultEvent(assistantMsg("正常回复")));
+        }).collectList().block();
+
+        assertFalse(nextCalled.get(), "命中 BLOCK 不应调用 next");
+        assertNotNull(events);
+        assertEquals(INBOUND_SAFE, ((AgentResultEvent) events.get(0)).getResult().getTextContent());
+    }
+
+    @Test
+    void inboundMask_shouldPassMaskedInputToNext() {
+        SensitiveWordMiddleware mw = middleware(enabledProps(), realFilter());
+        AtomicReference<AgentInput> seen = new AtomicReference<>();
+
+        AgentInput input = new AgentInput(List.of(userMsg("帮我对比竞品XX的价格")));
+        mw.onAgent(null, null, input, in -> {
+            seen.set(in);
+            return Flux.just(new AgentResultEvent(assistantMsg("ok")));
+        }).blockLast();
+
+        assertNotNull(seen.get(), "MASK 应放行到 next");
+        String passed = seen.get().msgs().get(0).getTextContent();
+        assertFalse(passed.contains("竞品"), "竞品XX 应已被打码");
+        assertTrue(passed.contains("*"));
+    }
+
+    @Test
+    void outboundBlock_shouldReplaceAiReplyWithSafeFallback() {
+        SensitiveWordMiddleware mw = middleware(enabledProps(), realFilter());
+
+        AgentInput input = new AgentInput(List.of(userMsg("你好")));
+        List<AgentEvent> events = mw.onAgent(null, null, input,
+            in -> Flux.just(new AgentResultEvent(assistantMsg("这里混入了测试敏感词A的内容")))
+        ).collectList().block();
+
+        assertNotNull(events);
+        assertEquals(OUTBOUND_SAFE, ((AgentResultEvent) events.get(0)).getResult().getTextContent());
+    }
+
+    @Test
+    void inboundFailClosed_shouldBlockWhenFilterThrows() {
+        SensitiveWordFilter throwing = new SensitiveWordFilter(
+            new InMemorySensitiveWordStore(), '*', SensitiveWordAction.BLOCK) {
+            @Override
+            public SensitiveWordFilterResult check(String rawText) {
+                throw new RuntimeException("boom");
+            }
+        };
+        SensitiveWordMiddleware mw = middleware(enabledProps(), throwing);
+        AtomicBoolean nextCalled = new AtomicBoolean(false);
+
+        AgentInput input = new AgentInput(List.of(userMsg("任意输入")));
+        List<AgentEvent> events = mw.onAgent(null, null, input, in -> {
+            nextCalled.set(true);
+            return Flux.just(new AgentResultEvent(assistantMsg("正常回复")));
+        }).collectList().block();
+
+        assertFalse(nextCalled.get(), "fail-closed：过滤器异常时入站按拦截处理，不调用 next");
+        assertNotNull(events);
+        assertEquals(INBOUND_SAFE, ((AgentResultEvent) events.get(0)).getResult().getTextContent());
+        assertEquals(1, mw.inboundBlockedCount());
+    }
+
+    @Test
+    void disabled_shouldPassThroughEvenWithSensitiveText() {
+        CustomerWorkProperties props = new CustomerWorkProperties(); // enabled=false
+        SensitiveWordMiddleware mw = middleware(props, realFilter());
+        AtomicBoolean nextCalled = new AtomicBoolean(false);
+
+        AgentInput input = new AgentInput(List.of(userMsg("测试敏感词A")));
+        mw.onAgent(null, null, input, in -> {
+            nextCalled.set(true);
+            return Flux.just(new AgentResultEvent(assistantMsg("ok")));
+        }).blockLast();
+
+        assertTrue(nextCalled.get(), "禁用时即使命中也应直通");
+    }
+
+    @Test
+    void directionOutboundOnly_shouldNotFilterInbound() {
+        CustomerWorkProperties props = enabledProps();
+        props.getSensitiveWord().setDirection(CustomerWorkProperties.Direction.OUTBOUND);
+        SensitiveWordMiddleware mw = middleware(props, realFilter());
+        AtomicBoolean nextCalled = new AtomicBoolean(false);
+
+        AgentInput input = new AgentInput(List.of(userMsg("测试敏感词A")));
+        mw.onAgent(null, null, input, in -> {
+            nextCalled.set(true);
+            return Flux.just(new AgentResultEvent(assistantMsg("clean")));
+        }).blockLast();
+
+        assertTrue(nextCalled.get(), "direction=outbound 时入站不拦截");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/HandoffCreatedEnricherTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/HandoffCreatedEnricherTest.java
@@ -1,0 +1,89 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.richard.fyoung.customerwork.assist.ConversationSummaryService;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.handoff.HandoffService;
+import com.richard.fyoung.customerwork.handoff.HandoffTicket;
+import com.richard.fyoung.customerwork.observability.AuditSink;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 转人工增强器单测：分类打分结果回写工单（HITL 推荐），以及 fail-open（分类抛异常不影响转人工、不改工单）。
+ * LLM 相关依赖（摘要服务/分类器）用 mock 隔离；打分器与坐席库用真实实现（确定性）。
+ * @author owlzhangfq@gmail.com
+ */
+class HandoffCreatedEnricherTest {
+
+    private final ConversationSummaryService summaryService = mock(ConversationSummaryService.class);
+    private final TicketClassifier classifier = mock(TicketClassifier.class);
+    private final SeatRoutingScorer scorer = new SeatRoutingScorer();
+    private final SeatAgentStore seatStore = new InMemorySeatAgentStore();
+    private final AuditSink auditSink = mock(AuditSink.class);
+
+    private HandoffCreatedEnricher enricher(CustomerWorkProperties props, HandoffService handoffService) {
+        return new HandoffCreatedEnricher(handoffService, summaryService, classifier, scorer,
+            seatStore, props, auditSink);
+    }
+
+    @Test
+    void enrich_shouldWriteRoutingSuggestion_whenAssignEnabled() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getRouting().setAssignEnabled(true);
+        when(classifier.classify(anyString(), any()))
+            .thenReturn(new TicketClassification("退款", "refund", TicketPriority.HIGH, "不满"));
+
+        HandoffService handoffService = new HandoffService();
+        HandoffTicket ticket = handoffService.create("sess-1", "涉及大额退款");
+
+        enricher(props, handoffService).enrich(ticket);
+
+        HandoffTicket persisted = handoffService.find(ticket.getId()).orElseThrow();
+        assertEquals("退款", persisted.getCategory());
+        assertEquals("HIGH", persisted.getPriority());
+        assertEquals("refund", persisted.getRequiredSkill());
+        // 推荐坐席已写入（refund 技能坐席应命中）
+        assertTrue(persisted.getSuggestedAssignees() != null
+            && persisted.getSuggestedAssignees().contains("SEAT-"));
+        verify(auditSink).record(any(), any());
+    }
+
+    @Test
+    void enrich_shouldFailOpen_whenClassifierThrows() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getRouting().setAssignEnabled(true);
+        when(classifier.classify(anyString(), any())).thenThrow(new RuntimeException("boom"));
+
+        HandoffService handoffService = new HandoffService();
+        HandoffTicket ticket = handoffService.create("sess-2", "投诉");
+
+        // 不抛异常（fail-open）
+        enricher(props, handoffService).enrich(ticket);
+
+        HandoffTicket persisted = handoffService.find(ticket.getId()).orElseThrow();
+        assertTrue(persisted.getCategory() == null, "分类失败不应写入任何推荐");
+        assertTrue(persisted.getSuggestedAssignees() == null);
+    }
+
+    @Test
+    void onHandoffCreated_shouldDoNothing_whenBothFlagsOff() {
+        CustomerWorkProperties props = new CustomerWorkProperties(); // 默认全关
+        HandoffService handoffService = new HandoffService();
+        HandoffTicket ticket = handoffService.create("sess-3", "咨询");
+
+        enricher(props, handoffService).onHandoffCreated(ticket);
+
+        verify(classifier, never()).classify(anyString(), any());
+        verify(summaryService, never()).summarize(anyString());
+        assertFalse(handoffService.find(ticket.getId()).orElseThrow().getSuggestedAssignees() != null);
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/InMemorySeatAgentStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/InMemorySeatAgentStoreTest.java
@@ -1,0 +1,40 @@
+package com.richard.fyoung.customerwork.routing;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 进程内坐席库单测：演示种子装载 + save round-trip。
+ * @author owlzhangfq@gmail.com
+ */
+class InMemorySeatAgentStoreTest {
+
+    @Test
+    void constructor_shouldLoadDemoSeeds() {
+        InMemorySeatAgentStore store = new InMemorySeatAgentStore();
+        assertTrue(store.findAll().stream().anyMatch(s -> "SEAT-1001".equals(s.getId())));
+        // 含一个离线坐席用于打分排除演示
+        assertTrue(store.findAll().stream().anyMatch(s -> !s.isOnline()));
+    }
+
+    @Test
+    void save_shouldUpsertById() {
+        InMemorySeatAgentStore store = new InMemorySeatAgentStore();
+        int before = store.findAll().size();
+        store.save(new SeatAgent("SEAT-NEW", "新坐席", Set.of("refund"), 5, 0, true, "g"));
+        assertEquals(before + 1, store.findAll().size());
+        store.save(new SeatAgent("SEAT-NEW", "新坐席改名", Set.of("refund"), 5, 1, true, "g"));
+        assertEquals(before + 1, store.findAll().size(), "同 ID 应更新而非新增");
+    }
+
+    @Test
+    void seat_shouldNormalizeSkillsToLowerCase() {
+        SeatAgent seat = new SeatAgent("S", "n", Set.of("Refund", "LOGISTICS"), 5, 0, true, "g");
+        assertTrue(seat.hasSkill("refund"));
+        assertTrue(seat.hasSkill("Logistics"));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/MybatisSeatAgentStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/MybatisSeatAgentStoreTest.java
@@ -1,0 +1,105 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.routing.mapper.SeatAgentMapper;
+import com.richard.fyoung.customerwork.support.MybatisTestSupport;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * MyBatis-Plus 坐席库存储测试（对接本机 MySQL：localhost:3306，root/root，库 agent_scope_customer_work，
+ * 表 cw_seat_agent 由 {@link MybatisTestSupport#ensureSchema} 建好）。MySQL 不可达时自动跳过（assumeTrue）。
+ * @author owlzhangfq@gmail.com
+ */
+class MybatisSeatAgentStoreTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 3306;
+
+    private HikariDataSource dataSource;
+    private MybatisSeatAgentStore store;
+
+    @BeforeEach
+    void setUp() {
+        assumeTrue(reachable(HOST, PORT), "MySQL 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+        dataSource = MybatisTestSupport.mysqlDataSource("test-seat-pool");
+        MybatisTestSupport.ensureSchema(dataSource);
+        store = new MybatisSeatAgentStore(MybatisTestSupport.mapper(dataSource, SeatAgentMapper.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    private static boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    void saveAndFindAll_shouldRoundTripWithSkills() {
+        String id = "IT-SEAT-" + UUID.randomUUID();
+        store.save(new SeatAgent(id, "集成测试坐席", Set.of("refund", "invoice"), 5, 2, true, "aftersales"));
+
+        assertTrue(store.findAll().stream().anyMatch(s ->
+            id.equals(s.getId()) && s.hasSkill("refund") && s.hasSkill("invoice")
+                && s.getCurrentLoad() == 2 && s.isOnline()));
+    }
+
+    @Test
+    void seeds_shouldBePresentAfterSchemaInit() {
+        assertTrue(store.findAll().stream().anyMatch(s -> "SEAT-1001".equals(s.getId())), "建表脚本坐席种子应存在");
+    }
+
+    @Test
+    void seatAgentConfig_shouldSelectMybatisStore_whenStoreModeIsJdbc() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getRouting().setSeatStoreMode("jdbc");
+        SeatAgentStore selected = new SeatAgentConfig().seatAgentStore(props,
+            singletonProvider(MybatisTestSupport.mapper(dataSource, SeatAgentMapper.class)));
+        assertInstanceOf(MybatisSeatAgentStore.class, selected);
+    }
+
+    private static <T> ObjectProvider<T> singletonProvider(T bean) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject() {
+                return bean;
+            }
+
+            @Override
+            public T getObject(Object... args) {
+                return bean;
+            }
+
+            @Override
+            public T getIfAvailable() {
+                return bean;
+            }
+
+            @Override
+            public T getIfUnique() {
+                return bean;
+            }
+        };
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/SeatRecommendationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/SeatRecommendationTest.java
@@ -1,0 +1,43 @@
+package com.richard.fyoung.customerwork.routing;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 坐席推荐 JSON 序列化/解析单测：round-trip + 空/非法降级空集合（fail-open）。
+ * @author owlzhangfq@gmail.com
+ */
+class SeatRecommendationTest {
+
+    @Test
+    void toJsonAndParse_shouldRoundTrip() {
+        List<SeatRecommendation> recs = List.of(
+            new SeatRecommendation("S1", "小赵", "aftersales", 0.72, true, 1, 5, "技能匹配 × 负载1/5 × 在线"));
+        String json = SeatRecommendation.toJson(recs);
+        assertTrue(json != null && json.contains("S1"));
+
+        List<SeatRecommendation> parsed = SeatRecommendation.parseList(json);
+        assertEquals(1, parsed.size());
+        assertEquals("S1", parsed.get(0).seatId());
+        assertEquals(0.72, parsed.get(0).score());
+        assertTrue(parsed.get(0).matchedSkill());
+    }
+
+    @Test
+    void toJson_shouldReturnNull_forEmpty() {
+        assertNull(SeatRecommendation.toJson(List.of()));
+        assertNull(SeatRecommendation.toJson(null));
+    }
+
+    @Test
+    void parseList_shouldDegradeToEmpty_forBlankOrInvalid() {
+        assertTrue(SeatRecommendation.parseList(null).isEmpty());
+        assertTrue(SeatRecommendation.parseList("").isEmpty());
+        assertTrue(SeatRecommendation.parseList("not-json").isEmpty());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/SeatRoutingScorerTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/SeatRoutingScorerTest.java
@@ -1,0 +1,92 @@
+package com.richard.fyoung.customerwork.routing;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 坐席打分器单测：确定性纯函数，精确断言排序、离线排除、负载排序、topN、空输入与同分 tie-break。
+ * @author owlzhangfq@gmail.com
+ */
+class SeatRoutingScorerTest {
+
+    private final SeatRoutingScorer scorer = new SeatRoutingScorer();
+
+    private SeatAgent seat(String id, Set<String> skills, int max, int cur, boolean online) {
+        return new SeatAgent(id, "name-" + id, skills, max, cur, online, "g");
+    }
+
+    private TicketClassification cls(String skill, TicketPriority p) {
+        return new TicketClassification("退款", skill, p, "不满");
+    }
+
+    @Test
+    void score_shouldRankSkillMatchAboveMiss() {
+        SeatAgent match = seat("A", Set.of("refund"), 5, 2, true);
+        SeatAgent miss = seat("B", Set.of("logistics"), 5, 0, true);
+        List<SeatRecommendation> recs = scorer.score(cls("refund", TicketPriority.HIGH), List.of(miss, match), 3);
+
+        assertEquals("A", recs.get(0).seatId(), "技能匹配应排第一");
+        assertTrue(recs.get(0).matchedSkill());
+        assertTrue(recs.get(0).score() > recs.get(1).score());
+    }
+
+    @Test
+    void score_shouldExcludeOfflineSeats() {
+        SeatAgent offline = seat("OFF", Set.of("refund"), 5, 0, false);
+        SeatAgent online = seat("ON", Set.of("refund"), 5, 4, true);
+        List<SeatRecommendation> recs = scorer.score(cls("refund", TicketPriority.MEDIUM), List.of(offline, online), 3);
+
+        assertEquals(1, recs.size());
+        assertEquals("ON", recs.get(0).seatId());
+    }
+
+    @Test
+    void score_shouldPreferIdlerSeat_whenSkillEqual() {
+        SeatAgent busy = seat("BUSY", Set.of("refund"), 5, 4, true);
+        SeatAgent idle = seat("IDLE", Set.of("refund"), 5, 1, true);
+        List<SeatRecommendation> recs = scorer.score(cls("refund", TicketPriority.MEDIUM), List.of(busy, idle), 3);
+
+        assertEquals("IDLE", recs.get(0).seatId(), "同技能时更空闲的坐席应排前");
+    }
+
+    @Test
+    void score_shouldRespectTopN() {
+        List<SeatAgent> seats = List.of(
+            seat("A", Set.of("refund"), 5, 0, true),
+            seat("B", Set.of("refund"), 5, 1, true),
+            seat("C", Set.of("refund"), 5, 2, true));
+        assertEquals(2, scorer.score(cls("refund", TicketPriority.LOW), seats, 2).size());
+    }
+
+    @Test
+    void score_shouldReturnEmpty_whenNoCandidatesOrAllOffline() {
+        assertTrue(scorer.score(cls("refund", TicketPriority.HIGH), List.of(), 3).isEmpty());
+        assertTrue(scorer.score(cls("refund", TicketPriority.HIGH),
+            List.of(seat("X", Set.of("refund"), 5, 0, false)), 3).isEmpty());
+    }
+
+    @Test
+    void score_shouldBeDeterministic_withSeatIdTieBreak() {
+        // 完全同质坐席（同技能同负载）→ 同分，按 seatId 升序稳定排序
+        SeatAgent b = seat("B", Set.of("refund"), 5, 1, true);
+        SeatAgent a = seat("A", Set.of("refund"), 5, 1, true);
+        List<SeatRecommendation> recs = scorer.score(cls("refund", TicketPriority.MEDIUM), List.of(b, a), 3);
+        assertEquals("A", recs.get(0).seatId());
+        assertEquals("B", recs.get(1).seatId());
+    }
+
+    @Test
+    void score_shouldUseNeutralSkillFactor_whenNoRequiredSkill() {
+        SeatAgent s = seat("A", Set.of("logistics"), 5, 0, true);
+        List<SeatRecommendation> recs = scorer.score(cls(null, TicketPriority.MEDIUM), List.of(s), 3);
+        assertFalse(recs.get(0).matchedSkill());
+        assertTrue(recs.get(0).score() > 0);
+        assertTrue(recs.get(0).reason().contains("无硬性技能要求"));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/TicketClassifierTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/TicketClassifierTest.java
@@ -1,0 +1,79 @@
+package com.richard.fyoung.customerwork.routing;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 工单分类器单测：mock Model 隔离 LLM。覆盖成功解析、非法 JSON 降级、模型异常降级、requiredSkill=null 归一。
+ * @author owlzhangfq@gmail.com
+ */
+class TicketClassifierTest {
+
+    private final CustomerWorkProperties properties = new CustomerWorkProperties();
+
+    private Model modelReturning(String text) {
+        Model model = mock(Model.class);
+        ChatResponse resp = mock(ChatResponse.class);
+        List<ContentBlock> blocks = List.of(TextBlock.builder().text(text).build());
+        when(resp.getContent()).thenReturn(blocks);
+        when(model.stream(any(), any(), any())).thenReturn(Flux.just(resp));
+        return model;
+    }
+
+    @Test
+    void classify_shouldParseValidJson() {
+        String json = "{\"category\":\"退款\",\"requiredSkill\":\"refund\",\"priority\":\"HIGH\",\"emotion\":\"愤怒\"}";
+        TicketClassifier classifier = new TicketClassifier(modelReturning(json), properties);
+
+        TicketClassification c = classifier.classify("用户投诉退款未到账", null);
+
+        assertEquals("退款", c.category());
+        assertEquals("refund", c.requiredSkill());
+        assertEquals(TicketPriority.HIGH, c.priority());
+        assertEquals("愤怒", c.emotion());
+    }
+
+    @Test
+    void classify_shouldNormalizeNullSkill() {
+        String json = "{\"category\":\"咨询\",\"requiredSkill\":\"null\",\"priority\":\"LOW\",\"emotion\":\"平静\"}";
+        TicketClassifier classifier = new TicketClassifier(modelReturning(json), properties);
+
+        assertNull(classifier.classify("随便问问", null).requiredSkill());
+    }
+
+    @Test
+    void classify_shouldFallback_whenModelReturnsNonJson() {
+        TicketClassifier classifier = new TicketClassifier(modelReturning("我不会输出 JSON"), properties);
+
+        TicketClassification c = classifier.classify("投诉", null);
+
+        assertEquals(TicketClassification.DEFAULT_CATEGORY, c.category());
+        assertEquals(TicketPriority.MEDIUM, c.priority());
+        assertNull(c.requiredSkill());
+    }
+
+    @Test
+    void classify_shouldFallback_whenModelThrows() {
+        Model model = mock(Model.class);
+        when(model.stream(any(), any(), any())).thenReturn(Flux.error(new RuntimeException("down")));
+        TicketClassifier classifier = new TicketClassifier(model, properties);
+
+        TicketClassification c = classifier.classify("投诉", null);
+
+        assertEquals(TicketClassification.DEFAULT_CATEGORY, c.category());
+        assertEquals(TicketPriority.MEDIUM, c.priority());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/TicketPriorityTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/routing/TicketPriorityTest.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customerwork.routing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 工单优先级枚举单测：安全解析与权重。
+ * @author owlzhangfq@gmail.com
+ */
+class TicketPriorityTest {
+
+    @Test
+    void fromName_shouldParseKnownValuesCaseInsensitively() {
+        assertEquals(TicketPriority.URGENT, TicketPriority.fromName("urgent"));
+        assertEquals(TicketPriority.HIGH, TicketPriority.fromName(" HIGH "));
+    }
+
+    @Test
+    void fromName_shouldFallbackToMedium_forUnknownOrBlank() {
+        assertEquals(TicketPriority.MEDIUM, TicketPriority.fromName(null));
+        assertEquals(TicketPriority.MEDIUM, TicketPriority.fromName(""));
+        assertEquals(TicketPriority.MEDIUM, TicketPriority.fromName("P0"));
+    }
+
+    @Test
+    void weight_shouldBeMonotonic() {
+        assertEquals(TicketPriority.MAX_WEIGHT, TicketPriority.URGENT.weight());
+        org.junit.jupiter.api.Assertions.assertTrue(
+            TicketPriority.LOW.weight() < TicketPriority.MEDIUM.weight());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/AhoCorasickMatcherTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/AhoCorasickMatcherTest.java
@@ -1,0 +1,61 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Aho-Corasick 自动机单测：多词命中、重叠命中、位置、空表。
+ * @author owlzhangfq@gmail.com
+ */
+class AhoCorasickMatcherTest {
+
+    private SensitiveWord w(String word) {
+        return SensitiveWord.of(word, SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK);
+    }
+
+    @Test
+    void multiWord_shouldReturnAllHitsWithPositions() {
+        AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("abc"), w("cde")));
+        List<SensitiveWordHit> hits = m.match("xabcdey");
+        assertEquals(2, hits.size());
+        // abc 命中 [1,4)
+        assertTrue(hits.stream().anyMatch(h -> h.word().getWord().equals("abc") && h.start() == 1 && h.end() == 4));
+        // cde 命中 [3,6)
+        assertTrue(hits.stream().anyMatch(h -> h.word().getWord().equals("cde") && h.start() == 3 && h.end() == 6));
+    }
+
+    @Test
+    void overlappingPatterns_shouldAllMatch_classicUshers() {
+        // 经典重叠用例：she / he / hers 均在 "ushers" 中命中
+        AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("he"), w("she"), w("hers")));
+        List<SensitiveWordHit> hits = m.match("ushers");
+        assertTrue(hits.stream().anyMatch(h -> h.word().getWord().equals("she")));
+        assertTrue(hits.stream().anyMatch(h -> h.word().getWord().equals("he")));
+        assertTrue(hits.stream().anyMatch(h -> h.word().getWord().equals("hers")));
+    }
+
+    @Test
+    void chineseWords_shouldMatch() {
+        AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("测试敏感词a"), w("竞品xx")));
+        assertEquals(1, m.match("我想问测试敏感词a的事").size());
+        assertEquals(2, m.match("测试敏感词a和竞品xx").size());
+    }
+
+    @Test
+    void emptyOrNoDict_shouldReturnNoHit() {
+        assertTrue(AhoCorasickMatcher.build(List.of()).match("anything").isEmpty());
+        AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("abc")));
+        assertTrue(m.match("").isEmpty());
+        assertTrue(m.match("xyz").isEmpty());
+    }
+
+    @Test
+    void patternCount_shouldSkipBlankWords() {
+        AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("abc"), w(""), w("def")));
+        assertEquals(2, m.patternCount());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/InMemorySensitiveWordStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/InMemorySensitiveWordStoreTest.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 进程内敏感词存储单测：演示种子装载、启用过滤、upsert。
+ * @author owlzhangfq@gmail.com
+ */
+class InMemorySensitiveWordStoreTest {
+
+    @Test
+    void constructor_shouldLoadDemoSeeds() {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        assertEquals(SensitiveWordSeeds.demoWords().size(), store.findAll().size());
+        assertTrue(store.findEnabled().isPresent(), "进程内读取恒成功");
+        assertEquals(store.findAll().size(), store.findEnabled().get().size(), "种子默认全部启用");
+    }
+
+    @Test
+    void save_shouldAssignIdAndAppend() {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        int before = store.findAll().size();
+        store.save(SensitiveWord.of("追加词", SensitiveWordCategory.CUSTOM, SensitiveWordAction.MASK));
+        assertEquals(before + 1, store.findAll().size());
+        assertTrue(store.findAll().stream().anyMatch(w -> "追加词".equals(w.getWord())));
+    }
+
+    @Test
+    void disabledWord_shouldBeExcludedFromEnabled() {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        int enabledBefore = store.findEnabled().orElseThrow().size();
+        store.save(new SensitiveWord(null, "停用词", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK, false));
+        assertEquals(enabledBefore, store.findEnabled().orElseThrow().size(), "停用词不进 findEnabled");
+        assertTrue(store.findAll().stream().anyMatch(w -> "停用词".equals(w.getWord())));
+    }
+
+    @Test
+    void save_shouldIgnoreBlankWord() {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        int before = store.findAll().size();
+        store.save(SensitiveWord.of("", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK));
+        store.save(null);
+        assertEquals(before, store.findAll().size());
+        assertFalse(store.findAll().stream().anyMatch(w -> "".equals(w.getWord())));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/MybatisSensitiveWordStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/MybatisSensitiveWordStoreTest.java
@@ -1,0 +1,116 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.sensitiveword.mapper.SensitiveWordMapper;
+import com.richard.fyoung.customerwork.support.MybatisTestSupport;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * MyBatis-Plus 敏感词存储测试（对接本机 MySQL：localhost:3306，root/root，库 agent_scope_customer_work，
+ * 表 cw_sensitive_word 由 {@link MybatisTestSupport#ensureSchema} 建好）。
+ *
+ * <p>MySQL 不可达时自动跳过（assumeTrue），保证无 MySQL 环境仍通过。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class MybatisSensitiveWordStoreTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 3306;
+
+    private HikariDataSource dataSource;
+    private SensitiveWordMapper mapper;
+    private MybatisSensitiveWordStore store;
+
+    @BeforeEach
+    void setUp() {
+        assumeTrue(reachable(HOST, PORT), "MySQL 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+        dataSource = MybatisTestSupport.mysqlDataSource("test-sensitive-pool");
+        MybatisTestSupport.ensureSchema(dataSource);
+        mapper = MybatisTestSupport.mapper(dataSource, SensitiveWordMapper.class);
+        store = new MybatisSensitiveWordStore(mapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    private static boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    void saveAndFindEnabled_shouldRoundTrip() {
+        String word = "IT-敏感词-" + UUID.randomUUID();
+        store.save(SensitiveWord.of(word, SensitiveWordCategory.COMPETITOR, SensitiveWordAction.MASK));
+
+        assertTrue(store.findEnabled().orElseThrow().stream().anyMatch(w ->
+            word.equals(w.getWord())
+                && w.getCategory() == SensitiveWordCategory.COMPETITOR
+                && w.getAction() == SensitiveWordAction.MASK));
+    }
+
+    @Test
+    void seeds_shouldBePresentAfterSchemaInit() {
+        assertTrue(store.findAll().stream().anyMatch(w -> "测试敏感词A".equals(w.getWord())),
+            "建表脚本种子应存在");
+    }
+
+    @Test
+    void sensitiveWordConfig_shouldSelectMybatisStore_whenStoreModeIsJdbc() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getSensitiveWord().setStoreMode("jdbc");
+        SensitiveWordStore selected = new SensitiveWordConfig().sensitiveWordStore(props, singletonProvider(mapper));
+        assertInstanceOf(MybatisSensitiveWordStore.class, selected);
+    }
+
+    @Test
+    void filterOverMysql_shouldBlockSeedWord() {
+        SensitiveWordFilter filter = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);
+        assertEquals(SensitiveWordAction.BLOCK, filter.check("我想问测试敏感词A").decision());
+    }
+
+    private static <T> ObjectProvider<T> singletonProvider(T bean) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject() {
+                return bean;
+            }
+
+            @Override
+            public T getObject(Object... args) {
+                return bean;
+            }
+
+            @Override
+            public T getIfAvailable() {
+                return bean;
+            }
+
+            @Override
+            public T getIfUnique() {
+                return bean;
+            }
+        };
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordFilterTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordFilterTest.java
@@ -1,0 +1,150 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 敏感词过滤服务单测：三档动作决策、绕过变体命中、打码、放行、热重建、fail-closed 三分支。
+ * @author owlzhangfq@gmail.com
+ */
+class SensitiveWordFilterTest {
+
+    private SensitiveWordFilter filter() {
+        return new SensitiveWordFilter(new InMemorySensitiveWordStore(), '*', SensitiveWordAction.BLOCK);
+    }
+
+    /** 可切换读成败的存根 store：{@code readFail=true} 时 findEnabled 返回 Optional.empty()（模拟 DB 不可达）。 */
+    private static final class ToggleStore implements SensitiveWordStore {
+        volatile boolean readFail;
+        private final List<SensitiveWord> words;
+
+        ToggleStore(boolean readFail, List<SensitiveWord> words) {
+            this.readFail = readFail;
+            this.words = words;
+        }
+
+        @Override
+        public List<SensitiveWord> findAll() {
+            return words;
+        }
+
+        @Override
+        public Optional<List<SensitiveWord>> findEnabled() {
+            return readFail ? Optional.empty() : Optional.of(words);
+        }
+
+        @Override
+        public void save(SensitiveWord word) {
+            // no-op
+        }
+    }
+
+    @Test
+    void blockWord_shouldDecideBlock() {
+        SensitiveWordFilterResult r = filter().check("我想问测试敏感词A的问题");
+        assertTrue(r.blocked());
+        assertEquals(SensitiveWordAction.BLOCK, r.decision());
+    }
+
+    @Test
+    void bypassVariants_shouldStillHit() {
+        SensitiveWordFilter f = filter();
+        assertTrue(f.check("测*试*敏*感*词*A").blocked());
+        assertTrue(f.check("测 试 敏 感 词 Ａ").blocked());
+    }
+
+    @Test
+    void maskWord_shouldMaskSpanAndDecideMask() {
+        SensitiveWordFilterResult r = filter().check("请帮我对比竞品XX的价格");
+        assertEquals(SensitiveWordAction.MASK, r.decision());
+        assertFalse(r.maskedText().contains("竞品"), "MASK 片段应被打码");
+        assertTrue(r.maskedText().contains("*"));
+        // 打码不改变长度
+        assertEquals(r.originalText().length(), r.maskedText().length());
+    }
+
+    @Test
+    void reviewWord_shouldPassThroughWithoutMasking() {
+        SensitiveWordFilterResult r = filter().check("这里有复核占位内容");
+        assertEquals(SensitiveWordAction.REVIEW, r.decision());
+        assertEquals(r.originalText(), r.maskedText());
+    }
+
+    @Test
+    void blockDominatesMask_whenBothPresent() {
+        SensitiveWordFilterResult r = filter().check("竞品XX加上测试敏感词A");
+        assertEquals(SensitiveWordAction.BLOCK, r.decision(), "同句命中多档应取最高优先级 BLOCK");
+    }
+
+    @Test
+    void cleanText_shouldPass() {
+        SensitiveWordFilterResult r = filter().check("你好，帮我查一下订单物流");
+        assertFalse(r.hasHit());
+        assertNull(r.decision());
+    }
+
+    @Test
+    void reload_shouldPickUpNewWord() {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        SensitiveWordFilter f = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);
+        assertFalse(f.check("这里包含新增拦截词").blocked());
+
+        store.save(SensitiveWord.of("新增拦截词", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK));
+        f.reload();
+        assertTrue(f.check("这里包含新增拦截词").blocked(), "热重建后应命中新词");
+    }
+
+    // ---------------- fail-closed 三分支 ----------------
+
+    @Test
+    void firstLoadReadFailure_shouldFailClosedAndBlockEverything() {
+        // 分支③：首次加载即读失败 -> fail-closed 哨兵，任何非空文本一律拦截
+        ToggleStore store = new ToggleStore(true, List.of());
+        SensitiveWordFilter f = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);
+
+        assertTrue(f.isFailClosed(), "首次加载失败应进入 fail-closed 哨兵态");
+        assertTrue(f.check("完全干净的普通问题").blocked(), "fail-closed 下即使无敏感词也应拦截");
+        assertEquals(SensitiveWordAction.BLOCK, f.check("你好").decision());
+    }
+
+    @Test
+    void reloadReadFailure_shouldKeepLastGoodTable_notWipeToEmpty() {
+        // 分支②：已加载好词表后一次读失败 -> 保留旧词表，绝不被冲空
+        ToggleStore store = new ToggleStore(false,
+            List.of(SensitiveWord.of("测试敏感词A", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK)));
+        SensitiveWordFilter f = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);
+        assertTrue(f.check("我想问测试敏感词A").blocked());
+        assertFalse(f.isFailClosed());
+        int patternsBefore = f.patternCount();
+
+        store.readFail = true;   // 模拟 DB 抖动
+        f.reload();
+
+        assertFalse(f.isFailClosed(), "已有好词表时读失败不应进 fail-closed");
+        assertEquals(patternsBefore, f.patternCount(), "旧词表不应被清空");
+        assertTrue(f.check("我想问测试敏感词A").blocked(), "读失败后旧词表仍生效");
+    }
+
+    @Test
+    void recoverAfterFailClosed_shouldClearSentinelOnNextGoodReload() {
+        // 分支③ -> ①：首次失败进哨兵，DB 恢复后 reload 成功应解除哨兵
+        ToggleStore store = new ToggleStore(true,
+            List.of(SensitiveWord.of("测试敏感词A", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK)));
+        SensitiveWordFilter f = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);
+        assertTrue(f.isFailClosed());
+
+        store.readFail = false;  // DB 恢复
+        f.reload();
+
+        assertFalse(f.isFailClosed(), "恢复后应解除 fail-closed 哨兵");
+        assertFalse(f.check("完全干净的普通问题").blocked(), "解除哨兵后干净文本应放行");
+        assertTrue(f.check("我想问测试敏感词A").blocked(), "解除哨兵后正常词表生效");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/TextNormalizerTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/sensitiveword/TextNormalizerTest.java
@@ -1,0 +1,57 @@
+package com.richard.fyoung.customerwork.sensitiveword;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 文本归一化单测：全角转半角、大小写归一、去干扰符、下标映射。
+ * @author owlzhangfq@gmail.com
+ */
+class TextNormalizerTest {
+
+    @Test
+    void fullWidth_shouldBecomeHalfWidthAndLowercase() {
+        // 全角字母 ＡＢＣ -> abc
+        assertEquals("abc", TextNormalizer.normalize("ＡＢＣ"));
+        assertEquals("123", TextNormalizer.normalize("１２３"));
+    }
+
+    @Test
+    void caseAndWhitespace_shouldBeNormalized() {
+        assertEquals("abc", TextNormalizer.normalize("A b C"));
+        assertEquals("abc", TextNormalizer.normalize("Ab\tC\n"));
+        // 全角空格
+        assertEquals("abc", TextNormalizer.normalize("A　b　C"));
+    }
+
+    @Test
+    void noiseChars_shouldBeStripped() {
+        assertEquals("abc", TextNormalizer.normalize("a*b.c"));
+        assertEquals("abc", TextNormalizer.normalize("a_b-c"));
+        assertEquals("abc", TextNormalizer.normalize("a·b•c"));
+        assertEquals("mingan", TextNormalizer.normalize("m|i/n\\g^a+n"));
+    }
+
+    @Test
+    void chineseInsertion_shouldStillCollapse() {
+        assertEquals("测试敏感词a", TextNormalizer.normalize("测*试*敏*感*词*A"));
+        assertEquals("测试敏感词a", TextNormalizer.normalize("测 试 敏 感 词 A"));
+    }
+
+    @Test
+    void normalizeTracked_shouldMapBackToOriginalIndex() {
+        TextNormalizer.Normalized n = TextNormalizer.normalizeTracked("a*b");
+        assertEquals("ab", n.text());
+        // 归一化第 0 个字符 'a' 在原文下标 0；第 1 个 'b' 在原文下标 2（* 被剔除）
+        assertArrayEquals(new int[]{0, 2}, n.originalIndex());
+    }
+
+    @Test
+    void nullOrEmpty_shouldReturnEmpty() {
+        assertEquals("", TextNormalizer.normalize(null));
+        assertEquals("", TextNormalizer.normalize(""));
+        assertEquals(0, TextNormalizer.normalizeTracked(null).originalIndex().length);
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
@@ -13,6 +13,7 @@ import com.richard.fyoung.customerwork.dialog.mapper.DialogStageMapper;
 import com.richard.fyoung.customerwork.feedback.mapper.FeedbackMapper;
 import com.richard.fyoung.customerwork.handoff.mapper.HandoffMapper;
 import com.richard.fyoung.customerwork.observability.mapper.AuditLogMapper;
+import com.richard.fyoung.customerwork.sensitiveword.mapper.SensitiveWordMapper;
 import com.richard.fyoung.customerwork.slotfilling.mapper.SlotFillingMapper;
 import com.richard.fyoung.customerwork.ticket.mapper.TicketEventMapper;
 import com.richard.fyoung.customerwork.ticket.mapper.TicketMapper;
@@ -56,7 +57,8 @@ public final class MybatisTestSupport {
         FeedbackMapper.class, UserMapper.class, TicketMapper.class, TicketEventMapper.class,
         ChatMessageMapper.class, AuditLogMapper.class, OrderMapper.class, ProductMapper.class,
         RefundMapper.class, InvoiceRequestMapper.class, MemberMapper.class, MemberAccountLogMapper.class,
-        ComplaintMapper.class, KnowledgeMapper.class, ChatAttachmentMapper.class
+        ComplaintMapper.class, KnowledgeMapper.class, ChatAttachmentMapper.class,
+        SensitiveWordMapper.class
     };
 
     private MybatisTestSupport() {

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
@@ -13,6 +13,7 @@ import com.richard.fyoung.customerwork.dialog.mapper.DialogStageMapper;
 import com.richard.fyoung.customerwork.feedback.mapper.FeedbackMapper;
 import com.richard.fyoung.customerwork.handoff.mapper.HandoffMapper;
 import com.richard.fyoung.customerwork.observability.mapper.AuditLogMapper;
+import com.richard.fyoung.customerwork.routing.mapper.SeatAgentMapper;
 import com.richard.fyoung.customerwork.sensitiveword.mapper.SensitiveWordMapper;
 import com.richard.fyoung.customerwork.slotfilling.mapper.SlotFillingMapper;
 import com.richard.fyoung.customerwork.ticket.mapper.TicketEventMapper;
@@ -58,7 +59,7 @@ public final class MybatisTestSupport {
         ChatMessageMapper.class, AuditLogMapper.class, OrderMapper.class, ProductMapper.class,
         RefundMapper.class, InvoiceRequestMapper.class, MemberMapper.class, MemberAccountLogMapper.class,
         ComplaintMapper.class, KnowledgeMapper.class, ChatAttachmentMapper.class,
-        SensitiveWordMapper.class
+        SensitiveWordMapper.class, SeatAgentMapper.class
     };
 
     private MybatisTestSupport() {
@@ -116,6 +117,10 @@ public final class MybatisTestSupport {
     /**
      * 确保业务表结构与种子已就绪（幂等）：执行与生产 {@code SchemaInitializer} 相同的建表脚本。
      * 替代旧 {@code JdbcXxxStore} 构造里的 ensureTable/seed。
+     *
+     * <p>额外对存量表做<b>增量补列</b>（{@link #ensureColumns}）：{@code CREATE TABLE IF NOT EXISTS} 对已存在的表
+     * 不会追加新列，而 MySQL 无 {@code ADD COLUMN IF NOT EXISTS}，故对本地已存在的 {@code cw_handoff_ticket}
+     * 用 information_schema 探测后按需补齐智能分配增强列，保证已跑过旧 schema 的开发库仍能通过新字段的读写测试。</p>
      */
     public static void ensureSchema(DataSource dataSource) {
         ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
@@ -123,5 +128,38 @@ public final class MybatisTestSupport {
         populator.setSeparator(";");
         populator.setCommentPrefixes("--");
         populator.execute(dataSource);
+        ensureHandoffRoutingColumns(dataSource);
+    }
+
+    /** 智能路由中控·工单智能分配：为存量 cw_handoff_ticket 幂等补齐增强列（列已存在则跳过）。 */
+    private static void ensureHandoffRoutingColumns(DataSource dataSource) {
+        ensureColumn(dataSource, "cw_handoff_ticket", "category", "VARCHAR(64) NULL");
+        ensureColumn(dataSource, "cw_handoff_ticket", "required_skill", "VARCHAR(64) NULL");
+        ensureColumn(dataSource, "cw_handoff_ticket", "priority", "VARCHAR(16) NULL");
+        ensureColumn(dataSource, "cw_handoff_ticket", "emotion", "VARCHAR(32) NULL");
+        ensureColumn(dataSource, "cw_handoff_ticket", "suggested_assignees", "TEXT NULL");
+    }
+
+    /** 若指定列不存在则 ALTER 追加（information_schema 探测，避开 MySQL 无 ADD COLUMN IF NOT EXISTS 的限制）。 */
+    private static void ensureColumn(DataSource dataSource, String table, String column, String ddlType) {
+        try (java.sql.Connection conn = dataSource.getConnection()) {
+            boolean exists;
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                "SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() "
+                    + "AND table_name = ? AND column_name = ?")) {
+                ps.setString(1, table);
+                ps.setString(2, column);
+                try (java.sql.ResultSet rs = ps.executeQuery()) {
+                    exists = rs.next();
+                }
+            }
+            if (!exists) {
+                try (java.sql.Statement st = conn.createStatement()) {
+                    st.executeUpdate("ALTER TABLE `" + table + "` ADD COLUMN `" + column + "` " + ddlType);
+                }
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to ensure column " + table + "." + column, e);
+        }
     }
 }

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -356,3 +356,23 @@ INSERT IGNORE INTO `cw_knowledge` (`keyword`, `title`, `content`, `source`) VALU
 ('退货,退款,七天,无理由', '七天无理由退货政策', '支持七天无理由退货，商品需保持完好、不影响二次销售；定制类、生鲜类除外。', '《售后服务政策》第 3 条'),
 ('发票,开票,报销', '发票开具规则', '支持开具电子普通发票与增值税专用发票，可在订单详情页自助申请，1-3 个工作日开具。', '《发票管理规则》第 1 条'),
 ('运费,包邮,邮费', '运费说明', '单笔订单满 99 元包邮，偏远地区除外；退货运费由责任方承担。', '《运费说明》第 2 条');
+
+-- 敏感词表（SensitiveWordFilter / cw_sensitive_word）：智能路由中控"一次拦截"词库。
+-- 种子为脱敏占位词（非真实违禁词），覆盖 BLOCK/MASK/REVIEW 三种动作与多类目。
+CREATE TABLE IF NOT EXISTS `cw_sensitive_word` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `word`           VARCHAR(128) NOT NULL COMMENT '敏感词原词面',
+    `category`       VARCHAR(32) NOT NULL COMMENT '类目: POLITICS/PORN/ABUSE/COMPETITOR/CUSTOM',
+    `action`         VARCHAR(16) NOT NULL COMMENT '处置动作: BLOCK/MASK/REVIEW',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_sensitive_word` (`word`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词表（一次拦截词库）';
+
+INSERT IGNORE INTO `cw_sensitive_word` (`word`, `category`, `action`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('测试敏感词A', 'CUSTOM', 'BLOCK', 1, 1779235200000, 1779235200000),
+('涉政占位', 'POLITICS', 'BLOCK', 1, 1779235200000, 1779235200000),
+('辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
+('竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
+('复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -119,6 +119,11 @@ CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
     `claimed_at_ms`     BIGINT DEFAULT 0 COMMENT '接单时间戳（毫秒）',
     `resolution_note`   TEXT COMMENT '处理结果备注',
     `resolved_at_ms`    BIGINT DEFAULT 0 COMMENT '结案时间戳（毫秒）',
+    `category`          VARCHAR(64) COMMENT '工单分类（LLM 分类，可空）',
+    `required_skill`    VARCHAR(64) COMMENT '所需坐席技能标签（LLM 分类，可空）',
+    `priority`          VARCHAR(16) COMMENT '优先级 LOW/MEDIUM/HIGH/URGENT（LLM 分类，可空）',
+    `emotion`           VARCHAR(32) COMMENT '用户情绪（LLM 分类，可空）',
+    `suggested_assignees` TEXT COMMENT '推荐坐席列表 JSON（HITL 推荐，人工点选非自动派单，可空）',
     INDEX `idx_handoff_status` (`status`),
     INDEX `idx_handoff_created` (`created_at_ms`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -376,3 +381,34 @@ INSERT IGNORE INTO `cw_sensitive_word` (`word`, `category`, `action`, `enabled`,
 ('辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
 ('竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
 ('复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);
+
+-- 坐席库表（MybatisSeatAgentStore / cw_seat_agent）：智能路由中控"工单智能分配"的候选坐席池。
+-- skills 为逗号分隔技能标签串；seat_group 避开 SQL 保留字 group；种子为演示坐席（多技能/负载/在离线）。
+CREATE TABLE IF NOT EXISTS `cw_seat_agent` (
+    `id`             VARCHAR(64) PRIMARY KEY COMMENT '坐席ID',
+    `name`           VARCHAR(64) NOT NULL COMMENT '坐席名',
+    `skills`         VARCHAR(512) COMMENT '技能标签（逗号分隔，如 refund,invoice）',
+    `max_load`       INT NOT NULL DEFAULT 0 COMMENT '最大并发工单数',
+    `current_load`   INT NOT NULL DEFAULT 0 COMMENT '当前在处理工单数',
+    `online`         TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否在线: 1在线/0离线',
+    `seat_group`     VARCHAR(64) COMMENT '坐席分组',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    INDEX `idx_seat_online` (`online`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='坐席库（智能分配候选坐席池）';
+
+INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current_load`, `online`, `seat_group`, `created_at_ms`, `updated_at_ms`) VALUES
+('SEAT-1001', '退款专员-小赵', 'refund,invoice', 5, 1, 1, 'aftersales', 1779235200000, 1779235200000),
+('SEAT-1002', '物流专员-小钱', 'logistics', 5, 3, 1, 'logistics', 1779235200000, 1779235200000),
+('SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
+('SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
+('SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);
+
+-- 人机切换工单智能分配增强列（cw_handoff_ticket 已在上文建表时含 category/required_skill/priority/emotion/suggested_assignees；
+-- 旧库存量表可手工执行下列 ALTER 补列，MySQL 无 ADD COLUMN IF NOT EXISTS，重复执行报 Duplicate column 可忽略）：
+-- ALTER TABLE `cw_handoff_ticket`
+--   ADD COLUMN `category` VARCHAR(64) NULL COMMENT '工单分类（LLM 分类，可空）',
+--   ADD COLUMN `required_skill` VARCHAR(64) NULL COMMENT '所需坐席技能标签（LLM 分类，可空）',
+--   ADD COLUMN `priority` VARCHAR(16) NULL COMMENT '优先级 LOW/MEDIUM/HIGH/URGENT（LLM 分类，可空）',
+--   ADD COLUMN `emotion` VARCHAR(32) NULL COMMENT '用户情绪（LLM 分类，可空）',
+--   ADD COLUMN `suggested_assignees` TEXT NULL COMMENT '推荐坐席列表 JSON（HITL 推荐，可空）';


### PR DESCRIPTION
## 变更说明 / What

智能路由中控中心（演示功能）三块能力，架构上不做单体"中控"——三块处在会话生命周期不同节点、失败语义相反，各挂已有 SPI（Middleware / Store / 一次性 LLM 调用），默认全关、零启动开销。

| 块 | 提交 | 形态 | 失败语义 |
|---|---|---|---|
| **敏感词一次拦截** | `2433c1e` | 入站+出站中间件，自研 AC 自动机 + 归一化，命中即拦 | **fail-CLOSED**（拦不住宁可拦一切） |
| **会话总结建议** | `9c646de` | 升级 AgentAssistService（规则→LLM 整段结构化摘要），转人工异步触发 | fail-OPEN（挂了退回规则版） |
| **工单智能分配** | `9c646de` | LLM 分类 + 确定性打分器 + HITL 推荐 top-N 坐席（不自动派单） | fail-OPEN（挂了退回现有拉取 claim） |

### 敏感词（`2433c1e`）
自研 Aho-Corasick（零第三方依赖）+ TextNormalizer（全角/大小写/去干扰符，`敏*感*词` 也命中）；双向拦截（入站照 PromptInjectionGuard、出站照 MaskingMiddleware）；Store SPI 词库 + `cw_sensitive_word` 表；热重建 volatile 原子替换、匹配无锁；**fail-closed 三分支**（读成功原子替换 / 读失败保留旧词表不冲空 / 首次读失败装"拦截一切"哨兵，DB 恢复自动解除）。

### 会话总结（`9c646de`）
ConversationSummaryService：拉整段历史 → 一次性 LLM → 结构化 ConversationSummary（摘要/意图/情绪/已尝试/待解决/建议下一步/建议话术）；三档降级永不抛异常；有界缓存。端点 `GET /api/customer/assist/summary`（boundedElastic 不占事件循环）。原规则版端点不动。

### 工单分配（`9c646de`）
新建坐席模型 SeatAgent + Store SPI（`cw_seat_agent`）；HandoffTicket 扩 5 字段（可空、9 参 reconstruct 重载保兼容）；TicketClassifier（LLM 分类）+ SeatRoutingScorer（纯函数：技能×负载×优先级×在线，离线排除、同分 tie-break、可解释 top-N、无除零）；HandoffCreatedEnricher 转人工后**异步派线程池**跑摘要+分类+打分回写，主建单链路零阻塞、每步 fail-open。端点 `GET /api/customer/handoffs/{id}/routing-suggestions`（请求期零 LLM，人工点选走现有 claim HITL 闭环）。

## 类型 / Type
- [x] feat 新功能
- [ ] fix / docs / refactor / test / chore

## 质量证据
- starter **645** + app-server **78** 测试全绿（+69 新测试，含敏感词真连 MySQL 4 个 + fail-closed 3 个、路由真连 MySQL 门控 2 个实跑）；LLM 全 mock 隔离。
- 每块独立交叉审查 + 修复。敏感词修过 fail-closed 契约违背（读失败静默放行 + 热重载冲空好词表）；后两块审查确认异步不阻塞主链路、@Lazy 循环依赖 sound、store 回写读取一致。

## 自查 / Checklist
- [x] `mvn test` 全绿（新增功能均附单元测试，含真连 MySQL 门控）
- [x] 未在代码/配置硬编码密钥
- [x] 新增后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"（Store SPI 再套 2 次）
- [x] schema 两处同步（starter 副本 + mysql/01）

## Reviewer 注意
1. **待真实模型 key 端到端验收**：三块默认关；开 `customer-work.sensitive-word.enabled` / `assist.summary-enabled` / `routing.assign-enabled` 后需真实 LLM 验摘要 JSON 质量与分类；坐席工作台联调两端点。
2. **一个 pre-existing 项（非本 PR 引入，建议另行专修）**：`HandoffService` 两构造器均未标 `@Autowired`，Spring 回退无参构造恒用 `InMemoryHandoffStore`，致 `human-handoff.store-mode=jdbc` 空转。本特性 InMemory 下功能完整（回写读取同一 store，一致性无分裂）；jdbc 落库持久化待该 bean 修复后生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
