### PR TITLE
feat: Nacos 服务注册 + Spring Cloud Gateway 统一路由

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/RuntimePublishProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/RuntimePublishProperties.java
@@ -31,5 +31,16 @@ public class RuntimePublishProperties {
         private String username;
         private String password;
         private long timeoutMs = 3000;
+        /**
+         * 服务注册独立子开关（默认 true）：{@code enabled=true} 时是否把 admin 本实例注册进 Nacos 供网关路由。
+         * 保持「启用 nacos 即自动注册」的默认；置 false 可「只发布运行时配置、不注册服务」，与注册解耦。
+         * 注册器装配条件为 {@code enabled=true 且 registerEnabled≠false}，连接参数复用本 {@code Nacos.*}。
+         */
+        private boolean registerEnabled = true;
+        /**
+         * 服务注册对外暴露的实例 IP（供网关 lb:// 路由回连本实例）。留空则自动探测本机地址。
+         * 多网卡 / 容器场景可显式指定可达 IP。
+         */
+        private String instanceIp;
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminNacosServiceRegistrarConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminNacosServiceRegistrarConfig.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customeradmin.config;
+
+import com.richard.fyoung.customeradmin.aiconfig.channel.RuntimePublishProperties;
+import com.richard.fyoung.customerwork.config.NacosRegistration;
+import com.richard.fyoung.customerwork.config.NacosServiceRegistrar;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * admin-server 侧 Nacos 服务注册装配。
+ *
+ * <p>admin 排除了 starter 的自动装配，故在此显式接一个 starter 的 {@link NacosServiceRegistrar}（可复用普通类），
+ * 复用 admin 现有的 {@code admin.runtime-publish.nacos.*} 连接配置。装配条件为两级：
+ * 类级 {@code enabled=true}（Nacos 总开关）+ 方法级 {@code register-enabled≠false}（服务注册独立子开关，
+ * 默认 true）——保持「启用 nacos 即自动注册」的默认，同时支持「只发布运行时配置、不注册服务」拆分场景。
+ * 服务名固定 {@code customer-admin-server}，供网关 {@code lb://} 发现路由。</p>
+ *
+ * <p>Fail-safe 由 {@link NacosServiceRegistrar} 内部兜底（Nacos 不可达不阻断启动）。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "admin.runtime-publish.nacos", name = "enabled", havingValue = "true")
+public class AdminNacosServiceRegistrarConfig {
+
+    /** admin 服务名（网关按此名路由）。 */
+    private static final String SERVICE_NAME = "customer-admin-server";
+    private static final String SCHEME_HTTP = "http";
+
+    @Bean
+    @ConditionalOnProperty(prefix = "admin.runtime-publish.nacos", name = "register-enabled",
+        havingValue = "true", matchIfMissing = true)
+    public NacosServiceRegistrar adminNacosServiceRegistrar(
+            RuntimePublishProperties properties,
+            @Value("${server.port:8082}") int serverPort) {
+        RuntimePublishProperties.Nacos cfg = properties.getNacos();
+        NacosRegistration registration = NacosRegistration.builder()
+            .serverAddr(cfg.getServerAddr())
+            .namespace(cfg.getNamespace())
+            .group(cfg.getGroup())
+            .username(cfg.getUsername())
+            .password(cfg.getPassword())
+            .serviceName(SERVICE_NAME)
+            .ip(cfg.getInstanceIp())
+            .port(serverPort)
+            .scheme(SCHEME_HTTP)
+            .contextPath("")
+            .build();
+        return new NacosServiceRegistrar(registration);
+    }
+}

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -175,13 +175,21 @@ admin:
     nacos:
       enabled: ${ADMIN_RUNTIME_PUBLISH_NACOS_ENABLED:false}
       server-addr: ${ADMIN_RUNTIME_PUBLISH_NACOS_SERVER_ADDR:localhost:8848}
-      namespace: ${ADMIN_RUNTIME_PUBLISH_NACOS_NAMESPACE:}
+      # namespace 默认对齐 customer-work：须与 app-server(customer-work.nacos.namespace) 及网关发现端一致，
+      # 否则网关发现得到 app-server 却发现不到 admin。别依赖部署时记得设 env。
+      namespace: ${ADMIN_RUNTIME_PUBLISH_NACOS_NAMESPACE:customer-work}
       group: ${ADMIN_RUNTIME_PUBLISH_NACOS_GROUP:DEFAULT_GROUP}
       # dataId 必须与 8080 的 customer-work.nacos.runtime-config-data-id 一致。
       data-id: ${ADMIN_RUNTIME_PUBLISH_NACOS_DATA_ID:customer-work-runtime-config}
       username: ${ADMIN_RUNTIME_PUBLISH_NACOS_USERNAME:}
       password: ${ADMIN_RUNTIME_PUBLISH_NACOS_PASSWORD:}
       timeout-ms: ${ADMIN_RUNTIME_PUBLISH_NACOS_TIMEOUT_MS:3000}
+      # 服务注册独立子开关：enabled=true 时默认(true)即把 admin 本实例（服务名 customer-admin-server）注册进
+      # Nacos 供网关 lb:// 路由——「启用 nacos 就自动注册」的默认行为不变；需要「只发布不注册」时置为 false。
+      # 注册与发布共用上面 runtime-publish.nacos.* 连接参数。
+      register-enabled: ${ADMIN_RUNTIME_PUBLISH_NACOS_REGISTER_ENABLED:true}
+      # instance-ip 留空自动探测本机地址；多网卡/容器场景用环境变量指定网关可达 IP。
+      instance-ip: ${ADMIN_RUNTIME_PUBLISH_NACOS_INSTANCE_IP:}
   collaboration:
     # 多 Agent 协作编程（P3-1 降级版）：VibeCoding「协作模式」开关（默认关，前端逐次开启）开启后一次需求
     # 走多角色顺序流水。roles 留空则用内置默认 4 角色（需求分析→方案设计→编码实现→自测审查）；

--- a/customer-work-app-server/src/main/resources/application.yml
+++ b/customer-work-app-server/src/main/resources/application.yml
@@ -311,6 +311,9 @@ customer-work:
     username: ${NACOS_USERNAME:nacos}
     password: ${NACOS_PASSWORD:nacos}
     timeout-ms: 3000
+    # 服务注册对外 IP：enabled=true 时把本实例注册进 Nacos 供网关 lb:// 路由，服务名=spring.application.name。
+    # 留空自动探测本机地址；多网卡/容器场景用环境变量指定网关可达 IP。
+    instance-ip: ${NACOS_INSTANCE_IP:}
     # 运行时配置热更新：接收 admin(8082) 下发的整份运行时配置（模型/兜底/重试/提示词/MCP/maxIters），
     # 无需重启即热替换模型链并重建 Agent。默认关闭；开启后监听 runtime-config-data-id。
     runtime-config-enabled: ${CUSTOMER_WORK_RUNTIME_CONFIG_ENABLED:false}

--- a/customer-work-gateway/pom.xml
+++ b/customer-work-gateway/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.richardfyoung</groupId>
+        <artifactId>customer-work-parent</artifactId>
+        <version>2.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>customer-work-gateway</artifactId>
+    <name>customer-work-gateway</name>
+    <description>Spring Cloud Gateway 统一路由（Nacos 服务发现）：反向代理 admin(8082) 与 app-server(8080）</description>
+
+    <properties>
+        <!-- Spring Cloud / Spring Cloud Alibaba BOM 版本仅在本模块声明，
+             与 Spring Boot 3.2.x 对齐（2023.0.x 线）。这两个 BOM 绝不进根 pom 的
+             dependencyManagement——避免全局波及其它模块的依赖版本仲裁。 -->
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud-alibaba.version>2023.0.3.2</spring-cloud-alibaba.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Cloud BOM（仅本模块） -->
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Spring Cloud Alibaba BOM（仅本模块，含 nacos-discovery 及其 nacos-client 版本仲裁） -->
+            <dependency>
+                <groupId>com.alibaba.cloud</groupId>
+                <artifactId>spring-cloud-alibaba-dependencies</artifactId>
+                <version>${spring-cloud-alibaba.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- 响应式网关（WebFlux）：WS 升级 / SSE 流式默认友好 -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <!-- Nacos 服务发现（消费端，只发现不注册） -->
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        </dependency>
+        <!-- Spring Cloud LoadBalancer：lb:// 负载均衡 + 会话粘性 -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+        <!-- Actuator：健康检查 / 路由查看端点 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/customer-work-gateway/src/main/java/com/richard/fyoung/customerworkgateway/CustomerWorkGatewayApplication.java
+++ b/customer-work-gateway/src/main/java/com/richard/fyoung/customerworkgateway/CustomerWorkGatewayApplication.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customerworkgateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * customer-work-gateway 启动类（Spring Cloud Gateway 统一路由，端口 8888）。
+ *
+ * <p>经 Nacos 服务发现（namespace={@code customer-work}，group={@code DEFAULT_GROUP}，须与服务端注册对齐）
+ * 把外部流量按路径前缀反向代理到两个后端：{@code /admin/**} → admin-server(8082)、
+ * {@code /app/**} → app-server(8080)、{@code /ws/**} → app-server 的 WebSocket。路由与发现配置见
+ * {@code application.yml}。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@SpringBootApplication
+public class CustomerWorkGatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CustomerWorkGatewayApplication.class, args);
+    }
+}

--- a/customer-work-gateway/src/main/resources/application.yml
+++ b/customer-work-gateway/src/main/resources/application.yml
@@ -1,0 +1,65 @@
+server:
+  # 网关统一入口端口（避开 8080/8082/8081/5174/5175/8848）
+  port: 8888
+
+spring:
+  application:
+    name: customer-work-gateway
+  cloud:
+    nacos:
+      discovery:
+        # 服务发现连接：server-addr / 凭据全部 env 化，本地默认对齐本机 Nacos(nacos/nacos)
+        server-addr: ${NACOS_SERVER_ADDR:localhost:8848}
+        # namespace / group 必须与服务端注册（app-server 的 customer-work.nacos.*、admin 的
+        # admin.runtime-publish.nacos.*）一致，否则发现不到实例——本项目已踩过的坑，务必对齐。
+        namespace: ${NACOS_NAMESPACE:customer-work}
+        group: ${NACOS_GROUP:DEFAULT_GROUP}
+        username: ${NACOS_USERNAME:nacos}
+        password: ${NACOS_PASSWORD:nacos}
+        # 网关自身只做「发现」，不把自己注册进 Nacos
+        register-enabled: false
+    loadbalancer:
+      # 会话粘性（sticky session）：网关给响应加 sc-lb-instance-id cookie，后续请求按该 cookie
+      # 粘到同一后端实例。单实例演示下无害；多实例时保证 WS 连接与有状态会话粘在同一实例。
+      sticky-session:
+        add-service-instance-cookie: true
+    gateway:
+      # 路由规则：按路径前缀反向代理，StripPrefix=1 去掉网关前缀后转发给后端真实路径。
+      routes:
+        # 后台管理 API：/admin/api/system/user → lb://customer-admin-server 的 /api/system/user
+        - id: customer-admin-server
+          uri: lb://customer-admin-server
+          predicates:
+            - Path=/admin/**
+          filters:
+            - StripPrefix=1
+        # 客服 API：StripPrefix=1 去掉 /app 前缀后转发后端真实路径。
+        # 例：/app/api/customer/user → /api/customer/user；/app/chat/stream → /chat/stream。
+        - id: customer-work-app-server
+          uri: lb://customer-work-app-server
+          predicates:
+            - Path=/app/**
+          filters:
+            - StripPrefix=1
+        # WebSocket 透传：/ws/user、/ws/agent 直连 app-server（ws:// scheme + lb 负载均衡）；
+        # 不 StripPrefix（后端 WS 处理器直接映射 /ws/user、/ws/agent）。webflux 网关原生支持 WS 升级握手透传。
+        - id: customer-work-app-server-ws
+          uri: lb:ws://customer-work-app-server
+          predicates:
+            - Path=/ws/**
+
+# SSE/流式：webflux 网关默认不缓冲响应体，chat 流（如 /app/chat/stream → /chat/stream）天然透传，无需额外配置。
+management:
+  endpoints:
+    web:
+      exposure:
+        # gateway 端点用于查看已加载路由（/actuator/gateway/routes），排障用
+        include: health,info,gateway
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    root: INFO
+    com.richard.fyoung.customerworkgateway: INFO

--- a/customer-work-gateway/src/test/java/com/richard/fyoung/customerworkgateway/GatewayRouteConfigTest.java
+++ b/customer-work-gateway/src/test/java/com/richard/fyoung/customerworkgateway/GatewayRouteConfigTest.java
@@ -1,0 +1,43 @@
+package com.richard.fyoung.customerworkgateway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.RouteLocator;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 网关路由配置加载测试：上下文能起、RouteLocator 存在且三条路由（admin/app/ws）正确解析。
+ *
+ * <p>关闭 Nacos 服务发现（{@code spring.cloud.discovery.enabled=false}）以便<b>离线</b>验证路由配置本身——
+ * 路由 URI 为 {@code lb://}，仅在请求到达时才解析实例，故收集路由 id 不需要真实 Nacos。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+        "spring.cloud.nacos.discovery.enabled=false",
+        "spring.cloud.discovery.enabled=false",
+        "spring.cloud.service-registry.auto-registration.enabled=false"
+    })
+class GatewayRouteConfigTest {
+
+    @Autowired
+    private RouteLocator routeLocator;
+
+    @Test
+    void routesLoaded() {
+        assertNotNull(routeLocator, "RouteLocator 应装配");
+        List<String> routeIds = routeLocator.getRoutes().map(Route::getId).collectList().block();
+        assertNotNull(routeIds, "应能收集到路由");
+        assertTrue(routeIds.contains("customer-admin-server"), "应含 admin 路由");
+        assertTrue(routeIds.contains("customer-work-app-server"), "应含 app-server 路由");
+        assertTrue(routeIds.contains("customer-work-app-server-ws"), "应含 WebSocket 路由");
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -741,6 +741,12 @@ public class CustomerWorkProperties {
         private long timeoutMs = 3000;
 
         /**
+         * 服务注册对外暴露的实例 IP（供网关 lb:// 路由回连本实例）。留空则自动探测本机地址
+         * （{@code InetAddress.getLocalHost()}）。多网卡 / 容器场景可用环境变量显式指定可达 IP。
+         */
+        private String instanceIp = "";
+
+        /**
          * 是否启用「运行时配置」热更新（admin 8082 下发的模型/MCP/提示词整体配置）。默认关闭，
          * 不影响任何未接入的下游；开启后启动拉取 + 监听 {@link #runtimeConfigDataId}，热应用到运行中的 8080。
          */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosRegistration.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosRegistration.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customerwork.config;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Nacos 服务注册规格：一个不可变的注册参数载体（连接信息 + 实例信息）。
+ *
+ * <p>作为 {@link NacosServiceRegistrar} 的构造入参，把「连哪个 Nacos」与「注册成什么实例」两组参数聚合，
+ * 使注册器成为可跨模块复用的普通类——starter（app-server）与 admin-server 各自按自身配置构造本对象即可，
+ * 无需各写一套注册逻辑。字段全部 final，构造后不可变。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Builder
+public class NacosRegistration {
+
+    // ===== Nacos 连接（与 NacosPromptService.buildProperties 同源）=====
+    /** Nacos 服务地址，如 {@code localhost:8848}。 */
+    private final String serverAddr;
+    /** 命名空间 ID；留空走 public。须与网关发现端一致（本项目约定 customer-work）。 */
+    private final String namespace;
+    /** 分组，默认 {@code DEFAULT_GROUP}。 */
+    private final String group;
+    /** Nacos 用户名；留空表示不鉴权。 */
+    private final String username;
+    /** Nacos 密码。 */
+    private final String password;
+
+    // ===== 注册实例 =====
+    /** 服务名（= 应用名），网关按此名 lb:// 路由。 */
+    private final String serviceName;
+    /** 对外暴露 IP；留空由注册器自动探测本机地址。 */
+    private final String ip;
+    /** 服务端口。 */
+    private final int port;
+    /** 协议（http / https），写入实例 metadata 供网关按需使用。 */
+    private final String scheme;
+    /** 上下文路径（无则空串），写入实例 metadata 供网关按需使用。 */
+    private final String contextPath;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosServiceRegistrar.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosServiceRegistrar.java
@@ -1,0 +1,149 @@
+package com.richard.fyoung.customerwork.config;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Nacos 服务注册器（裸 nacos-client 的 {@link NamingService}，与 {@code NacosPromptService} 同模式）。
+ *
+ * <p>启动时把当前应用注册为一个<b>临时实例</b>（ephemeral，nacos-client 自带心跳续约），停机时反注册，
+ * 供 Spring Cloud Gateway 经 {@code lb://serviceName} 做服务发现路由。不引入 spring-cloud-alibaba 到
+ * 业务模块——注册只用 {@code NamingService.registerInstance}，连接属性构建方式与 starter 既有 Nacos 服务一致。</p>
+ *
+ * <p><b>Fail-safe</b>：Nacos 不可达 / 鉴权失败时 {@code catch(Exception)} 记 error 后返回，
+ * <b>绝不阻断应用启动</b>（与 {@code NacosPromptService} 的降级语义一致）——注册失败只是网关发现不到本实例，
+ * 不影响本应用自身对外服务。本类为可复用普通类：app-server 与 admin-server 各自按配置构造并交给 Spring
+ * 托管，由容器触发 {@link PostConstruct} / {@link PreDestroy}。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public class NacosServiceRegistrar {
+
+    private static final Logger log = LoggerFactory.getLogger(NacosServiceRegistrar.class);
+
+    private static final String CODE_REGISTER_FAIL = "NACOS-SERVICE-REGISTER-FAIL";
+    private static final String CODE_DEREGISTER_FAIL = "NACOS-SERVICE-DEREGISTER-FAIL";
+    private static final String META_SCHEME = "scheme";
+    private static final String META_CONTEXT_PATH = "contextPath";
+
+    private final NacosRegistration registration;
+    /** 建连后的 NamingService；注册失败时保持 null，反注册即无操作。 */
+    private volatile NamingService namingService;
+    /** 已注册实例快照，反注册时按同一实例撤销。 */
+    private volatile Instance instance;
+
+    public NacosServiceRegistrar(NacosRegistration registration) {
+        this.registration = registration;
+    }
+
+    /** 应用启动时注册临时实例；失败不阻断启动。 */
+    @PostConstruct
+    public void register() {
+        // 局部持有：createNamingService 一旦成功即已启动 gRPC 后台重连线程，若随后 registerInstance 抛异常
+        // （nacos 不可达的 fail-safe 主路径），naming 未赋字段、@PreDestroy 也兜不到——孤儿 NamingService 的
+        // 后台重连线程会无限重试。故 catch 里必须对已建实例 shutDown，确保降级后不留后台线程/资源残留。
+        NamingService naming = null;
+        try {
+            naming = NacosFactory.createNamingService(buildProperties());
+            Instance ins = buildInstance();
+            naming.registerInstance(registration.getServiceName(), registration.getGroup(), ins);
+            this.namingService = naming;
+            this.instance = ins;
+            log.info("[Nacos] service registered, service={}, ip={}, port={}, group={}, namespace={}",
+                registration.getServiceName(), ins.getIp(), ins.getPort(),
+                registration.getGroup(), registration.getNamespace());
+        } catch (Exception e) {
+            // Nacos 不可达不应阻断启动：网关发现不到本实例，但本应用自身对外服务不受影响
+            log.error("nacos service register failed, keep serving without discovery, code={}, service={}",
+                CODE_REGISTER_FAIL, registration.getServiceName(), e);
+            // 释放已创建但注册失败的 NamingService，避免后台重连线程残留（字段仍为 null，@PreDestroy 无操作）
+            shutDownQuietly(naming);
+        }
+    }
+
+    /** 安静释放 NamingService（关闭 gRPC 重连线程池等后台资源）；null 或异常均吞掉，仅用于兜底清理。 */
+    private void shutDownQuietly(NamingService naming) {
+        if (naming == null) {
+            return;
+        }
+        try {
+            naming.shutDown();
+        } catch (Exception ignore) {
+            // 兜底清理本身失败无意义，忽略即可
+        }
+    }
+
+    /** 应用停机时反注册（优雅下线），避免网关把流量路由到已死实例。 */
+    @PreDestroy
+    public void deregister() {
+        NamingService naming = this.namingService;
+        Instance current = this.instance;
+        if (naming == null || current == null) {
+            return;
+        }
+        try {
+            naming.deregisterInstance(registration.getServiceName(), registration.getGroup(), current);
+            naming.shutDown();
+            log.info("[Nacos] service deregistered, service={}", registration.getServiceName());
+        } catch (Exception e) {
+            log.error("nacos service deregister failed, code={}, service={}",
+                CODE_DEREGISTER_FAIL, registration.getServiceName(), e);
+        }
+    }
+
+    /** 包内可见：供单测断言注册失败后未残留 NamingService（字段应为 null，后台线程已 shutDown）。 */
+    NamingService currentNamingService() {
+        return this.namingService;
+    }
+
+    /** 构造临时实例（携带 scheme/contextPath metadata 供网关路由）。 */
+    private Instance buildInstance() throws Exception {
+        Instance ins = new Instance();
+        ins.setIp(resolveIp());
+        ins.setPort(registration.getPort());
+        ins.setEphemeral(true);
+        ins.setHealthy(true);
+        Map<String, String> metadata = new HashMap<>();
+        if (StringUtils.hasText(registration.getScheme())) {
+            metadata.put(META_SCHEME, registration.getScheme());
+        }
+        if (StringUtils.hasText(registration.getContextPath())) {
+            metadata.put(META_CONTEXT_PATH, registration.getContextPath());
+        }
+        ins.setMetadata(metadata);
+        return ins;
+    }
+
+    /** 显式配置 IP 优先；否则自动探测本机地址。 */
+    private String resolveIp() throws Exception {
+        if (StringUtils.hasText(registration.getIp())) {
+            return registration.getIp();
+        }
+        return InetAddress.getLocalHost().getHostAddress();
+    }
+
+    private Properties buildProperties() {
+        Properties props = new Properties();
+        props.put(PropertyKeyConst.SERVER_ADDR, registration.getServerAddr());
+        if (StringUtils.hasText(registration.getNamespace())) {
+            props.put(PropertyKeyConst.NAMESPACE, registration.getNamespace());
+        }
+        if (StringUtils.hasText(registration.getUsername())) {
+            props.put(PropertyKeyConst.USERNAME, registration.getUsername());
+            props.put(PropertyKeyConst.PASSWORD, registration.getPassword());
+        }
+        return props;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosServiceRegistrarConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosServiceRegistrarConfig.java
@@ -1,0 +1,46 @@
+package com.richard.fyoung.customerwork.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+/**
+ * app-server 侧 Nacos 服务注册装配（挂在 Nacos 总开关上）。
+ *
+ * <p>{@code customer-work.nacos.enabled=true} 时自动把本应用注册进 Nacos（服务名 = {@code spring.application.name}，
+ * 取不到用常量兜底），供网关 {@code lb://} 发现路由；<b>不做额外独立开关</b>——「启用 Nacos」即注册。
+ * 默认关闭（{@code enabled=false}）时本配置整体不生效，零行为、零额外连接。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "customer-work.nacos", name = "enabled", havingValue = "true")
+public class NacosServiceRegistrarConfig {
+
+    /** 应用名取不到时的服务名兜底。 */
+    private static final String DEFAULT_SERVICE_NAME = "customer-work-app-server";
+    private static final String SCHEME_HTTP = "http";
+
+    @Bean
+    public NacosServiceRegistrar customerWorkNacosServiceRegistrar(
+            CustomerWorkProperties properties,
+            @Value("${spring.application.name:}") String applicationName,
+            @Value("${server.port:8080}") int serverPort) {
+        CustomerWorkProperties.Nacos cfg = properties.getNacos();
+        NacosRegistration registration = NacosRegistration.builder()
+            .serverAddr(cfg.getServerAddr())
+            .namespace(cfg.getNamespace())
+            .group(cfg.getGroup())
+            .username(cfg.getUsername())
+            .password(cfg.getPassword())
+            .serviceName(StringUtils.hasText(applicationName) ? applicationName : DEFAULT_SERVICE_NAME)
+            .ip(cfg.getInstanceIp())
+            .port(serverPort)
+            .scheme(SCHEME_HTTP)
+            .contextPath("")
+            .build();
+        return new NacosServiceRegistrar(registration);
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/config/NacosServiceRegistrarIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/config/NacosServiceRegistrarIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.richard.fyoung.customerwork.config;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Nacos 服务注册真实集成测试（对接本机 Nacos：localhost:8848，nacos/nacos）。
+ *
+ * <p>Nacos 不可达时<b>自动跳过</b>（assumeTrue），与既有 {@code NacosPromptIntegrationTest} 门控一致。
+ * 在线时真实执行：{@link NacosServiceRegistrar} 注册临时实例 → 查 Nacos NamingService 断言实例出现 →
+ * 反注册 → 断言实例消失。另含一条<b>永远执行</b>的 fail-safe 用例：Nacos 不可达时注册/反注册不抛出、不阻断。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class NacosServiceRegistrarIntegrationTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 8848;
+    private static final String NAMESPACE = "customer-work";
+    private static final String GROUP = "DEFAULT_GROUP";
+    private static final String IP = "127.0.0.1";
+
+    @Test
+    void registerThenDeregister_overRealNacos() throws Exception {
+        assumeTrue(SessionPersistenceTestSupport.reachable(HOST, PORT),
+            "Nacos 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+
+        String serviceName = "it-registrar-" + UUID.randomUUID();
+        int servicePort = 18080;
+
+        NacosRegistration registration = NacosRegistration.builder()
+            .serverAddr(HOST + ":" + PORT)
+            .namespace(NAMESPACE)
+            .group(GROUP)
+            .username("nacos")
+            .password("nacos")
+            .serviceName(serviceName)
+            .ip(IP)
+            .port(servicePort)
+            .scheme("http")
+            .contextPath("")
+            .build();
+
+        NacosServiceRegistrar registrar = new NacosServiceRegistrar(registration);
+        NamingService query = NacosFactory.createNamingService(buildQueryProps());
+        try {
+            registrar.register();
+            assertTrue(waitForInstanceCount(query, serviceName, 1),
+                "注册后应能在 Nacos 查到该实例");
+            Instance found = query.getAllInstances(serviceName, GROUP).get(0);
+            assertEquals(IP, found.getIp(), "实例 IP 应一致");
+            assertEquals(servicePort, found.getPort(), "实例端口应一致");
+            assertEquals("http", found.getMetadata().get("scheme"), "metadata scheme 应写入");
+
+            registrar.deregister();
+            assertTrue(waitForInstanceCount(query, serviceName, 0),
+                "反注册后该实例应从 Nacos 消失");
+        } finally {
+            query.shutDown();
+        }
+    }
+
+    /** fail-safe：Nacos 不可达时注册与反注册均不抛出、不阻断（永远执行，不门控）。 */
+    @Test
+    void register_whenNacosUnreachable_doesNotThrow() {
+        NacosRegistration registration = NacosRegistration.builder()
+            .serverAddr("127.0.0.1:1")   // 无监听端口，模拟不可达
+            .namespace(NAMESPACE)
+            .group(GROUP)
+            .serviceName("it-failsafe-" + UUID.randomUUID())
+            .ip(IP)
+            .port(18081)
+            .scheme("http")
+            .contextPath("")
+            .build();
+
+        NacosServiceRegistrar registrar = new NacosServiceRegistrar(registration);
+        assertDoesNotThrow(registrar::register, "Nacos 不可达注册不应抛出");
+        // 注册失败后不得残留 NamingService（已 shutDown、后台重连线程已释放，字段保持 null）
+        assertNull(registrar.currentNamingService(),
+            "注册失败后应无残留 NamingService（后台重连线程已释放）");
+        assertDoesNotThrow(registrar::deregister, "反注册不应抛出");
+    }
+
+    /** 轮询等待实例数达到期望值（注册/反注册在 Nacos 侧有短暂最终一致延迟）。 */
+    private boolean waitForInstanceCount(NamingService query, String serviceName, int expected) throws Exception {
+        for (int i = 0; i < 20; i++) {
+            List<Instance> instances = query.getAllInstances(serviceName, GROUP);
+            if (instances.size() == expected) {
+                return true;
+            }
+            Thread.sleep(300);
+        }
+        return false;
+    }
+
+    private Properties buildQueryProps() {
+        Properties props = new Properties();
+        props.put(PropertyKeyConst.SERVER_ADDR, HOST + ":" + PORT);
+        props.put(PropertyKeyConst.NAMESPACE, NAMESPACE);
+        props.put(PropertyKeyConst.USERNAME, "nacos");
+        props.put(PropertyKeyConst.PASSWORD, "nacos");
+        return props;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>customer-work-app-server</module>
         <module>customer-channel</module>
         <module>customer-admin-server</module>
+        <module>customer-work-gateway</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## 变更说明 / What

Nacos 服务注册 + 新建 Spring Cloud Gateway 统一路由，让网关动态发现并路由到 admin(8082) 与 app-server(8080)。**服务端"启用 nacos"即自动注册**（用户指令）。核心原则：spring-cloud 栈严格隔离在新网关模块，不污染现有业务模块。

### 服务端注册（裸 nacos-client，不引 spring-cloud 到业务模块）
- starter `NacosServiceRegistrar`：`NamingService.registerInstance` 注册临时实例（心跳自带），`@PostConstruct` 注册 / `@PreDestroy` 反注册；**fail-safe**——nacos 不可达 catch+log 不阻断启动，且失败路径 `shutDown` 释放 gRPC 重连线程不留残留（照 NacosPromptService 模式）。
- app-server 挂现有总开关 `customer-work.nacos.enabled=true` 自动注册；admin 显式接注册器 + 独立子开关 `register-enabled`（默认 true，保持"启用即注册"，可拆分只发布不注册）；三端 namespace 统一 `customer-work`。

### 网关（spring-cloud 栈隔离在本模块）
- 新 `customer-work-gateway` 模块（Spring Cloud 2023.0.3 + Spring Cloud Alibaba 2023.0.3.2，端口 8888）。
- 路由 `/admin/**` → `lb://customer-admin-server`、`/app/**` → `lb://customer-work-app-server`（StripPrefix=1）、`/ws/**` → `lb:ws://customer-work-app-server`（WebSocket 升级透传不 strip）。
- cookie 粘性会话（为多实例预留）；webflux 网关默认流式友好（SSE 不缓冲）。

## 类型 / Type
- [x] feat 新功能

## 质量证据
- **BOM 隔离守住**：根 pom `dependencyManagement` 一字未动，只加一行 `<module>`；spring-cloud/alibaba BOM 全在 gateway 模块自己的 pom。四个业务模块 pom 零 spring-cloud 命中。
- **版本事实**：注册端 nacos-client 3.0.2 / 发现端 2.4.2 / server 2.4.3，跨 client 不直连、都经 server 中转互通（集成测试佐证）。
- 注册器真连本机 Nacos 测试（注册→查证出现→反注册→查证消失）+ fail-safe 无残留断言 + 网关路由加载测试全绿；三模块 test-compile 通过。
- **对现有功能零影响**：条件装配默认 off（`customer-work.nacos.enabled` / `admin.runtime-publish.nacos.enabled` 默认 false），现有服务照旧直连访问。
- 交叉审查修过 3 个 Important：注册失败 NamingService 泄漏后台重连线程、admin namespace 默认不对齐、单开关耦合发布+注册。

## 自查 / Checklist
- [x] `mvn test`/test-compile 全绿
- [x] 未硬编码密钥（nacos 凭据 env 化）
- [x] 服务端注册照既有 Nacos 封装模式（裸 client + 自研）

## Reviewer 注意（待手动 e2e）
本 PR 单测覆盖注册器 + 路由配置加载；**完整反代/WS 透传/粘性会话需起全套手动 e2e**：真实起 app-server(8080)+admin(8082)+gateway(8888)，验证 `/app/**`、`/admin/**` 反代与 `/ws/**` 握手透传、SSE 流。namespace 三端须一致 `customer-work`（已把 admin 默认对齐，不再依赖手动注入 env）。
🤖 Generated with [Claude Code](https://claude.com/claude-code)
