### PR TITLE
fix: HandoffService 单参构造补 @Autowired，修 store-mode=jdbc 空转

### DIFF
--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/HandoffService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/handoff/HandoffService.java
@@ -41,7 +41,15 @@ public class HandoffService {
      */
     private HandoffCreatedEnricher enricher;
 
-    /** Spring 注入构造：使用自动装配的 HandoffStore Bean。 */
+    /**
+     * Spring 注入构造：使用自动装配的 {@link HandoffStore} Bean（memory 模式为 {@link InMemoryHandoffStore}，
+     * jdbc 模式为 {@link MybatisHandoffStore}，均由 {@link HandoffConfig} 提供）。
+     *
+     * <p>必须标 {@code @Autowired}：本类同时存在无参构造，Spring 对"多构造器 + 存在无参 + 无
+     * {@code @Autowired}"会回退到无参构造 → 永远用内存实现、{@code human-handoff.store-mode=jdbc} 空转。
+     * 显式标注让容器选中本构造，真正注入配置好的 Store Bean。</p>
+     */
+    @Autowired
     public HandoffService(HandoffStore store) {
         this.store = store;
     }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/handoff/HandoffServiceWiringTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/handoff/HandoffServiceWiringTest.java
@@ -1,0 +1,101 @@
+package com.richard.fyoung.customerwork.handoff;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.handoff.mapper.HandoffMapper;
+import com.richard.fyoung.customerwork.support.MybatisTestSupport;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * {@link HandoffService} 与 {@link HandoffConfig} 的 Spring 装配回归单测（特性「人机切换」）。
+ *
+ * <p>回归的 bug：{@link HandoffService} 同时存在无参与单参构造，单参构造此前<b>未标</b>
+ * {@code @Autowired}——Spring 对"多构造器 + 存在无参 + 无 @Autowired"会回退无参构造，导致
+ * HandoffService 永远 {@code new InMemoryHandoffStore()}、{@code human-handoff.store-mode=jdbc}
+ * 空转、{@link HandoffConfig} 装配的 Store Bean 成孤儿。本测试<b>不</b>断言构造器注解本身，而是断言
+ * 真实容器里 HandoffService 用的就是那个被装配的 Store Bean（行为等价、反注解实现细节）。</p>
+ *
+ * <p>验证手段：往容器里的 {@link HandoffStore} Bean 写一张工单，再经 HandoffService 读——只有二者共享
+ * 同一实例（即单参构造被选中）才读得到。回退无参构造时 HandoffService 持有另一个 InMemory 实例 → 读不到。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class HandoffServiceWiringTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 3306;
+
+    /** memory 模式（默认）：Store Bean 是 InMemory，且 HandoffService 用的就是它（非自建实例）。 */
+    @Test
+    void memoryMode_handoffServiceShouldUseInjectedInMemoryStoreBean() {
+        new ApplicationContextRunner()
+            .withBean(CustomerWorkProperties.class)
+            .withUserConfiguration(HandoffConfig.class)
+            .withBean(HandoffService.class)
+            .run(context -> {
+                HandoffStore store = context.getBean(HandoffStore.class);
+                assertInstanceOf(InMemoryHandoffStore.class, store,
+                    "memory 模式（默认）应装配 InMemoryHandoffStore");
+
+                HandoffService service = context.getBean(HandoffService.class);
+                String id = "HO-wiring-mem-" + UUID.randomUUID();
+                store.save(new HandoffTicket(id, "s1", "test", System.currentTimeMillis()));
+                assertTrue(service.find(id).isPresent(),
+                    "HandoffService 必须用注入的 Store Bean（回退无参构造则读不到该工单）");
+            });
+    }
+
+    /** jdbc 模式：Store Bean 是 MybatisHandoffStore，HandoffService 经它把工单真正落库 cw_handoff_ticket。 */
+    @Test
+    void jdbcMode_handoffServiceShouldUseInjectedMybatisStoreBean() {
+        assumeTrue(reachable(HOST, PORT), "MySQL 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+
+        HikariDataSource dataSource = MybatisTestSupport.mysqlDataSource("test-handoff-wiring-pool");
+        try {
+            MybatisTestSupport.ensureSchema(dataSource);
+            HandoffMapper mapper = MybatisTestSupport.mapper(dataSource, HandoffMapper.class);
+
+            CustomerWorkProperties props = new CustomerWorkProperties();
+            props.getHumanHandoff().setStoreMode("jdbc");
+
+            new ApplicationContextRunner()
+                .withBean(CustomerWorkProperties.class, () -> props)
+                .withBean(HandoffMapper.class, () -> mapper)
+                .withUserConfiguration(HandoffConfig.class)
+                .withBean(HandoffService.class)
+                .run(context -> {
+                    HandoffStore store = context.getBean(HandoffStore.class);
+                    assertInstanceOf(MybatisHandoffStore.class, store,
+                        "store-mode=jdbc 应装配 MybatisHandoffStore");
+
+                    HandoffService service = context.getBean(HandoffService.class);
+                    String session = "wiring-jdbc-" + UUID.randomUUID();
+                    HandoffTicket created = service.create(session, "wiring-test");
+
+                    // 经独立 Mybatis 存储按 id 回读，证明 HandoffService 确实把工单落到了 cw_handoff_ticket
+                    MybatisHandoffStore probe = new MybatisHandoffStore(mapper);
+                    assertTrue(probe.find(created.getId()).isPresent(),
+                        "HandoffService 应经注入的 MybatisHandoffStore 把工单落库 cw_handoff_ticket");
+                });
+        } finally {
+            dataSource.close();
+        }
+    }
+
+    private static boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明 / What

修一个 **pre-existing bug**（交叉审查智能路由中控中心时发现，非本次特性引入）：`HandoffService` 单参构造 `HandoffService(HandoffStore)` 未标 `@Autowired`，配合无参构造，Spring 回退到无参构造 → 永远 `new InMemoryHandoffStore()`，导致 **`human-handoff.store-mode=jdbc` 空转**（工单只活进程内、重启即丢、多实例互不可见，与类 Javadoc "工单重启不丢失" 矛盾），`HandoffConfig` 的 `@ConditionalOnMissingBean HandoffStore` bean 成为从未被消费的孤儿。

## 类型 / Type
- [x] fix 修复

## 修复
- 给 `HandoffService(HandoffStore)` 标 `@Autowired`，容器改选单参构造、真正注入 `HandoffStore` bean。
- 核实 `HandoffConfig` 两种模式**都**提供 bean（memory→`InMemoryHandoffStore` / jdbc→`MybatisHandoffStore`），加注解不会"无 bean 可注"启动失败，无需补 memory 默认 bean。
- 无参构造保留（`grep` 确认仅 test 用、无生产 `new` 调用点），标注后不再被容器选中，旧测试不受影响。

## 行为影响
- **memory 模式（默认）零变化**：仍是 InMemory，仅注入路径变正确。
- **jdbc 模式真正生效**：工单落 `cw_handoff_ticket`、重启/多实例不丢。

## 质量证据
- 新增 `HandoffServiceWiringTest`（`ApplicationContextRunner` 断言真实注入的 store bean，非断言注解；jdbc 用例真连本机 MySQL，经 `service.create` 落库后独立 probe 回读命中）。
- handoff 相关 37 测试全绿。

## Reviewer 注意
jdbc 模式真正生效后，`MybatisHandoffStore` 读写 `cw_handoff_ticket` 的 5 个路由列（`category/required_skill/priority/emotion/suggested_assignees`，PR #32 引入）。SchemaInitializer 建**新表**已含这些列；**存量老表需手工 ALTER 补列**（schema 注释已有指引）。未改 SchemaInitializer 行为。
🤖 Generated with [Claude Code](https://claude.com/claude-code)
