### PR TITLE
test(starter): 修复 AgentAccessCredentialTest 篡改签名的偶发失败

### DIFF
--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/security/AgentAccessCredentialTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/security/AgentAccessCredentialTest.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.security;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Base64;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,10 +39,13 @@ class AgentAccessCredentialTest {
         long now = System.currentTimeMillis();
         String token = AgentAccessCredential.sign("agent-1", now + 60_000, SECRET);
 
-        // 翻转签名最后一个字符
-        char last = token.charAt(token.length() - 1);
-        char replacement = last == 'A' ? 'B' : 'A';
-        String tampered = token.substring(0, token.length() - 1) + replacement;
+        // 对签名解码后的首字节翻一位再重新编码：base64url 尾字符的低位落在未用填充比特上，直接翻转尾字符
+        // 可能解码出完全相同的字节（验签仍通过，测试偶发失败）；改从字节层面翻位，保证解码字节一定不同。
+        String[] parts = token.split(":");
+        byte[] signature = Base64.getUrlDecoder().decode(parts[2]);
+        signature[0] ^= 0x01;
+        String tampered = parts[0] + ":" + parts[1] + ":"
+            + Base64.getUrlEncoder().withoutPadding().encodeToString(signature);
 
         assertTrue(AgentAccessCredential.verify(tampered, SECRET, now).isEmpty());
     }


### PR DESCRIPTION
## 背景

`customer-work-starter` 的 `AgentAccessCredentialTest.verify_tamperedSignature_shouldReject` 是一个 pre-existing 的 flaky 测试：隔离单跑通常 7/7 过，全量跑偶发变红。

## 根因

`AgentAccessCredential` 的签名是 HMAC-SHA256（32 字节 = 256 bit），base64url 无填充编码成 43 个字符。但 **43 字符可承载 258 bit，尾字符只有 4 个有效 bit，另 2 个是未用填充位**。

原测试通过"翻转签名最后一个 base64 字符（A↔B）"构造篡改，只改动 1 个低位。对某些随机签名，这一位恰好落在尾字符那 2 个未用填充 bit 上 → base64 解码回来的 32 字节**完全不变** → "篡改"后的 token 仍验签通过 → `assertTrue(...isEmpty())` 随机失败。

## 修复

把"翻转 base64 尾字符"改成**字节层面翻位**：对签名解码后的首字节 `^= 0x01`，再重新 base64url 编码。直接改真实字节数组，从源头保证解码字节一定不同，`MessageDigest.isEqual` 一定不相等，确定性拒绝，无随机性。

```java
byte[] signature = Base64.getUrlDecoder().decode(parts[2]);
signature[0] ^= 0x01;
String tampered = parts[0] + ":" + parts[1] + ":"
    + Base64.getUrlEncoder().withoutPadding().encodeToString(signature);
```

## 说明 / Reviewer 关注点

- **只改测试的篡改构造，未动生产代码**。`AgentAccessCredential` 的验签逻辑本身是对的，本 PR 不触碰。
- 验证：单类 7/7 通过；`customer-work-starter` 全量（排除环境不一致的 `RedisSessionPersistenceTest`）**连跑 3 次，均 647 通过 / 0 失败 / BUILD SUCCESS**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)