### PR TITLE
chore(release): 版本号提升至 2.0.1

### DIFF
--- a/customer-admin-server/pom.xml
+++ b/customer-admin-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-starter</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/customer-channel/pom.xml
+++ b/customer-channel/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-starter</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/customer-work-app-server/pom.xml
+++ b/customer-work-app-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-starter</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </dependency>
 
         <!-- 测试 -->

--- a/customer-work-gateway/pom.xml
+++ b/customer-work-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/customer-work-starter/pom.xml
+++ b/customer-work-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.richardfyoung</groupId>
     <artifactId>customer-work-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
     <name>customer-work-parent</name>
     <description>基于 AgentScope Java 的生产级智能客服系统（多模块：可复用 starter + 可运行应用）</description>


### PR DESCRIPTION
## 目的

发布 v2.0.1：全部 Maven 模块版本号 2.0.0 → 2.0.1（9 处，含父 POM、5 个子模块 parent 引用与模块间依赖坐标）。合并后在 main 上打 tag `v2.0.1` 并发布 GitHub Release。

## 变更内容

- `pom.xml` 及 5 个子模块 pom：`<version>2.0.0</version>` → `<version>2.0.1</version>`
- 无任何代码改动

## 验证

- 全仓 `mvn clean test`（JDK 17，`-Djacoco.skip=true`）：除 `RedisSessionPersistenceTest`（CLAUDE.local.md 已记录的本机 Redis 无密码环境不一致，非代码问题）外全部通过
- 版本引用检查：`grep -rn '2\.0\.0' --include=pom.xml` 无残留项目版本引用；前端 package.json 按 v2.0.0 先例不动

🤖 Generated with [Claude Code](https://claude.com/claude-code)
