### PR TITLE
feat: 菜单排序分布式锁 + 工作区进行中会话跨页面保留 + 若干 UI/提示词优化

### DIFF
--- a/customer-admin-server/pom.xml
+++ b/customer-admin-server/pom.xml
@@ -123,6 +123,15 @@
             <version>3.3.2</version>
         </dependency>
 
+        <!-- 分布式锁（AdminDistributedLockConfig 手动装配 starter 的 DistributedLockExecutor）；
+             已经通过 starter 传递可用，这里显式声明便于直接引用 RedissonClient 类。agentscope-bom
+             未管理该版本（同 xxl-job-core），需与 starter 保持一致的显式版本号。 -->
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson</artifactId>
+            <version>3.52.0</version>
+        </dependency>
+
         <!-- SQL 查询结果导出 xlsx（SqlQueryController#export）。项目原本无 POI，EasyExcel 传递
              引入 poi/poi-ooxml 4.1.2；选本地仓库已存在的稳定版 3.3.2，避免额外下载/版本冲突。 -->
         <!-- SQL 查询结果导出 xlsx。easyexcel 必须用 4.x（基于 POI 5.x）：starter 经

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -70,6 +70,7 @@ public enum ResultCode {
     KNOWLEDGE_INDEX_NOT_FOUND(40029, "代码知识库索引不存在"),
     KNOWLEDGE_PATH_NOT_ALLOWED(40030, "指定的源码路径不在允许的根目录范围内，已被安全策略拦截"),
     KNOWLEDGE_INDEX_BUILDING(40031, "该索引正在构建中，请等待构建完成后再操作"),
+    MENU_REORDER_CONFLICT(40032, "菜单排序正在被其他管理员调整，请稍后重试"),
 
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminDistributedLockConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminDistributedLockConfig.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customeradmin.config;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.lock.DistributedLockConfig;
+import com.richard.fyoung.customerwork.lock.DistributedLockExecutor;
+import com.richard.fyoung.customerwork.lock.RedissonDistributedLockExecutor;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 分布式锁装配（仿 {@link AdminRedisConfig}/{@link AdminAgentRuntimeConfig} 手法）：本模块已
+ * {@code spring.autoconfigure.exclude} 关闭 starter 自动装配，故 starter 的
+ * {@code DistributedLockConfig} 不会加载，这里手动 new，复用本模块已有的 {@code admin.redis.*}
+ * 配置（与 {@link AdminRedisConfig} 指向同一个 Redis 实例，物理上不新开一路连接配置），
+ * 直接调用 starter 暴露的 {@link DistributedLockConfig#buildRedissonClient} 复用同一套接线逻辑。
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class AdminDistributedLockConfig {
+
+    @Value("${admin.redis.host}")
+    private String host;
+
+    @Value("${admin.redis.port}")
+    private int port;
+
+    @Value("${admin.redis.password}")
+    private String password;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        CustomerWorkProperties.DistributedLock.Redis r = new CustomerWorkProperties.DistributedLock.Redis();
+        r.setHost(host);
+        r.setPort(port);
+        r.setPassword(password);
+        return DistributedLockConfig.buildRedissonClient(r);
+    }
+
+    @Bean
+    public DistributedLockExecutor distributedLockExecutor(RedissonClient redissonClient) {
+        return new RedissonDistributedLockExecutor(redissonClient);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/permission/service/PermissionService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/permission/service/PermissionService.java
@@ -10,9 +10,13 @@ import com.richard.fyoung.customeradmin.system.permission.dto.PermissionSaveRequ
 import com.richard.fyoung.customeradmin.system.permission.dto.PermissionVO;
 import com.richard.fyoung.customeradmin.system.permission.entity.SysPermission;
 import com.richard.fyoung.customeradmin.system.permission.mapper.SysPermissionMapper;
+import com.richard.fyoung.customerwork.lock.DistributedLockExecutor;
+import com.richard.fyoung.customerwork.lock.LockAcquireTimeoutException;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,16 +41,29 @@ public class PermissionService {
     private static final String ACTION_DELETE = "DELETE";
     private static final String ACTION_MOVE = "MOVE";
     private static final String DEFAULT_ICON_TYPE = "library";
+    /** 菜单树全局互斥锁：拖拽排序影响面可能跨越树上任意层级，粒度按"整棵树"而非单个节点，
+     * 避免两个管理员分别调整不相交子树时，各自基于过期的兄弟节点 sort 值算出的新序号仍然冲突。 */
+    private static final String REORDER_LOCK_KEY = "admin:menu:reorder:lock";
+    /** 不等待，立即失败（fast fail）：宁可让第二个管理员的拖拽操作直接提示"稍后重试"，
+     * 也不让请求线程排队阻塞。 */
+    private static final Duration REORDER_LOCK_WAIT = Duration.ZERO;
+    /** 持锁上限，覆盖一次拖拽排序涉及节点数的更新耗时；超时自动释放，防止持锁方异常退出后锁不释放。 */
+    private static final Duration REORDER_LOCK_LEASE = Duration.ofSeconds(10);
 
     private final SysPermissionMapper permissionMapper;
     private final MenuChangeLogService changeLogService;
     private final MenuVersionHolder menuVersionHolder;
+    private final DistributedLockExecutor lockExecutor;
+    private final PermissionService self;
 
     public PermissionService(SysPermissionMapper permissionMapper, MenuChangeLogService changeLogService,
-                             MenuVersionHolder menuVersionHolder) {
+                             MenuVersionHolder menuVersionHolder, DistributedLockExecutor lockExecutor,
+                             @Lazy PermissionService self) {
         this.permissionMapper = permissionMapper;
         this.changeLogService = changeLogService;
         this.menuVersionHolder = menuVersionHolder;
+        this.lockExecutor = lockExecutor;
+        this.self = self;
     }
 
     /** 全量权限树，按 sort 升序。 */
@@ -103,9 +120,29 @@ public class PermissionService {
         changeLogService.record(id, ACTION_DELETE, before, null);
     }
 
-    /** 拖拽排序：逐条更新受影响节点的 parentId/sort；只对 parentId 真变化的节点记 MOVE 流水（同层纯调顺序不算移动）。 */
-    @Transactional
+    /**
+     * 拖拽排序入口：先抢 {@link #REORDER_LOCK_KEY} 分布式锁再落库，串行化多个管理员的并发拖拽，
+     * 避免后提交的一批更新基于过期的兄弟节点 sort 值覆盖先提交的结果（乱序合并）。拿不到锁直接
+     * 转换为 {@link ResultCode#MENU_REORDER_CONFLICT} 业务错误，不排队等待。
+     *
+     * <p>真正落库经 {@link #self} 转一次自注入代理调用 {@link #applyReorder}——{@code @Transactional}
+     * 是 Spring AOP 代理拦截的，本类内部直接 {@code this.applyReorder(...)} 属于自调用会绕过代理导致
+     * 事务不生效；同时这个转发顺序也保证了锁释放严格发生在事务提交之后：{@link DistributedLockExecutor#execute}
+     * 的 finally 解锁在 {@code action.get()}（即 {@code self.applyReorder(...)} 这次代理调用，事务已随之
+     * 提交完毕）返回之后才执行，不会出现"锁已释放但改动还没提交"的窗口期。</p>
+     */
     public void reorder(MenuReorderRequest request) {
+        try {
+            lockExecutor.execute(REORDER_LOCK_KEY, REORDER_LOCK_WAIT, REORDER_LOCK_LEASE,
+                () -> self.applyReorder(request));
+        } catch (LockAcquireTimeoutException e) {
+            throw new BizException(ResultCode.MENU_REORDER_CONFLICT);
+        }
+    }
+
+    /** 拖拽排序落库：逐条更新受影响节点的 parentId/sort；只对 parentId 真变化的节点记 MOVE 流水（同层纯调顺序不算移动）。 */
+    @Transactional
+    public void applyReorder(MenuReorderRequest request) {
         for (MenuReorderRequest.Item item : request.items()) {
             SysPermission before = requirePermission(item.id());
             boolean parentChanged = !before.getParentId().equals(item.parentId());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
@@ -73,6 +73,8 @@ public class KnowledgeService {
     private static final int SNIPPET_MAX_CHARS = 800;
     /** 问答一次性模型调用超时。 */
     private static final long ASK_TIMEOUT_SECONDS = 45;
+    /** 问答系统提示词：限定角色 + 抑制幻觉（检索片段里没有依据的就明说不知道，不编造）。 */
+    private static final String ASK_SYSTEM_PROMPT = "你是一个知识库检索专家和助手，不知道的就回答不知道。";
     /**
      * 构建池与查询池分离：建索引是分钟级长任务（全量扫描 + Embedding），与 search/ask 共池时并发构建
      * 会把查询请求饿死。构建池保持小（限制并发构建数与对 Embedding API 的压力），查询池独立承载
@@ -346,11 +348,13 @@ public class KnowledgeService {
             cryptoUtil.decrypt(config.getApiKey()), config.getModel());
     }
 
-    /** 一次性模型调用（与 GitAssistantService/CollaborativeCodingService 同手法）。 */
+    /** 一次性模型调用（与 GitAssistantService/CollaborativeCodingService 同手法），带知识库问答系统提示词。 */
     private String callModelOnce(Model model, String prompt) {
+        Msg systemMsg = Msg.builder().role(MsgRole.SYSTEM).name("system")
+            .content(TextBlock.builder().text(ASK_SYSTEM_PROMPT).build()).build();
         Msg userMsg = Msg.builder().role(MsgRole.USER).name("user")
             .content(TextBlock.builder().text(prompt).build()).build();
-        List<ChatResponse> responses = model.stream(List.of(userMsg), List.of(), GenerateOptions.builder().build())
+        List<ChatResponse> responses = model.stream(List.of(systemMsg, userMsg), List.of(), GenerateOptions.builder().build())
             .collectList()
             .block(Duration.ofSeconds(ASK_TIMEOUT_SECONDS));
         if (CollectionUtils.isEmpty(responses)) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/permission/service/PermissionServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/permission/service/PermissionServiceTest.java
@@ -8,14 +8,19 @@ import com.richard.fyoung.customeradmin.system.menu.service.MenuChangeLogService
 import com.richard.fyoung.customeradmin.system.permission.dto.PermissionSaveRequest;
 import com.richard.fyoung.customeradmin.system.permission.entity.SysPermission;
 import com.richard.fyoung.customeradmin.system.permission.mapper.SysPermissionMapper;
+import com.richard.fyoung.customerwork.lock.DistributedLockExecutor;
+import com.richard.fyoung.customerwork.lock.LockAcquireTimeoutException;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -50,7 +55,17 @@ class PermissionServiceTest {
         mapper = mock(SysPermissionMapper.class);
         changeLogService = mock(MenuChangeLogService.class);
         menuVersionHolder = mock(MenuVersionHolder.class);
-        service = new PermissionService(mapper, changeLogService, menuVersionHolder);
+        // 直接执行 action、不真正连 Redis：单测只关心加锁失败时的分支，成功路径视为锁总能拿到。
+        DistributedLockExecutor lockExecutor = new DistributedLockExecutor() {
+            @Override
+            public <T> T execute(String lockKey, Duration waitTime, Duration leaseTime, Supplier<T> action) {
+                return action.get();
+            }
+        };
+        service = new PermissionService(mapper, changeLogService, menuVersionHolder, lockExecutor, null);
+        // self 字段生产环境靠 @Lazy 自注入拿到 Spring AOP 代理（绕开 @Transactional 自调用失效问题）；
+        // 单测不经过容器、没有真实代理，反射回填成 service 自身即可等价验证业务逻辑。
+        ReflectionTestUtils.setField(service, "self", service);
     }
 
     @Test
@@ -161,6 +176,27 @@ class PermissionServiceTest {
         verify(changeLogService, never()).record(eq(1L), eq("MOVE"), any(), any());
         verify(changeLogService).record(eq(2L), eq("MOVE"), any(), any());
         verify(mapper, times(2)).updateById(any(SysPermission.class));
+    }
+
+    @Test
+    void reorder_shouldThrowMenuReorderConflict_whenLockNotAcquired() {
+        // 另一个管理员正在拖拽排序、持有分布式锁：本次请求应立即失败（fast fail），
+        // 而不是阻塞等待或悄悄不加保护地继续落库。
+        DistributedLockExecutor contendedLockExecutor = new DistributedLockExecutor() {
+            @Override
+            public <T> T execute(String lockKey, Duration waitTime, Duration leaseTime, Supplier<T> action) {
+                throw new LockAcquireTimeoutException(lockKey);
+            }
+        };
+        PermissionService contended =
+            new PermissionService(mapper, changeLogService, menuVersionHolder, contendedLockExecutor, null);
+        ReflectionTestUtils.setField(contended, "self", contended);
+
+        BizException ex = assertThrows(BizException.class, () -> contended.reorder(
+            new MenuReorderRequest(List.of(new MenuReorderRequest.Item(1L, 2L, 1)))));
+
+        assertEquals(com.richard.fyoung.customeradmin.common.result.ResultCode.MENU_REORDER_CONFLICT, ex.getResultCode());
+        verify(mapper, never()).updateById(any(SysPermission.class));
     }
 
     @Test

--- a/customer-admin-web/src/components/ChatHistorySidebar.vue
+++ b/customer-admin-web/src/components/ChatHistorySidebar.vue
@@ -1,14 +1,63 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { listChatSessions } from '@/api/chat'
 import AddToProjectDialog from './AddToProjectDialog.vue'
-import type { ChatSessionSummary } from '@/types/api'
+import type { ChatSessionSummary, LiveSession } from '@/types/api'
 
-const props = defineProps<{ agentCode: string; activeSessionId: string }>()
+/** liveSessions：父面板内存里"活着"的会话（进行中/本次加载过的），默认空数组兼容尚未接入的调用方。 */
+const props = withDefaults(
+  defineProps<{ agentCode: string; activeSessionId: string; liveSessions?: LiveSession[] }>(),
+  { liveSessions: () => [] },
+)
 const emit = defineEmits<{ select: [sessionId: string] }>()
 
 const sessions = ref<ChatSessionSummary[]>([])
 const loading = ref(false)
+
+/** 侧边栏展示项：在后端已落库列表基础上叠加内存 streaming 标记。 */
+interface DisplaySession {
+  sessionId: string
+  preview: string
+  messageCount: number
+  lastMessageTime: string | null
+  streaming: boolean
+}
+
+/**
+ * 合并后端已落库列表与内存活跃会话：
+ * - 进行中的会话（含第一轮还没落库的新会话）后端可能拉不到，用 liveSessions 补进来，保证「找得到」；
+ * - 两边都有的同一 sessionId 以后端摘要为准（内容更完整），只把内存的 streaming 标记叠加上去；
+ * - 进行中的会话统一置顶，其余保持后端返回的时间倒序。
+ */
+const displaySessions = computed<DisplaySession[]>(() => {
+  const liveById = new Map(props.liveSessions.map((s) => [s.sessionId, s]))
+  const merged = new Map<string, DisplaySession>()
+  for (const s of sessions.value) {
+    const live = liveById.get(s.sessionId)
+    merged.set(s.sessionId, {
+      sessionId: s.sessionId,
+      preview: s.preview,
+      messageCount: s.messageCount,
+      lastMessageTime: s.lastMessageTime,
+      streaming: live?.streaming ?? false,
+    })
+  }
+  // 后端还没有的内存会话（进行中的新会话）补进列表
+  for (const live of props.liveSessions) {
+    if (!merged.has(live.sessionId)) {
+      merged.set(live.sessionId, {
+        sessionId: live.sessionId,
+        preview: live.preview,
+        messageCount: live.messageCount,
+        lastMessageTime: null,
+        streaming: live.streaming,
+      })
+    }
+  }
+  const list = Array.from(merged.values())
+  // 进行中置顶；同为进行中/同为非进行中时维持既有顺序（后端已按时间倒序，内存补充项排其后）
+  return list.sort((a, b) => Number(b.streaming) - Number(a.streaming))
+})
 
 async function refresh() {
   loading.value = true
@@ -40,11 +89,11 @@ function openAddToProject(sessionId: string) {
       <span>历史对话</span>
       <el-button link type="primary" :loading="loading" @click="refresh">刷新</el-button>
     </div>
-    <el-empty v-if="!loading && sessions.length === 0" description="暂无历史对话" :image-size="50" />
+    <el-empty v-if="!loading && displaySessions.length === 0" description="暂无历史对话" :image-size="50" />
     <el-scrollbar v-else height="100%">
       <ul class="session-list">
         <li
-          v-for="session in sessions"
+          v-for="session in displaySessions"
           :key="session.sessionId"
           class="session-item"
           :class="{ active: session.sessionId === activeSessionId }"
@@ -52,8 +101,12 @@ function openAddToProject(sessionId: string) {
         >
           <div class="session-row">
             <div class="session-main">
-              <div class="session-preview">{{ session.preview || '（空会话）' }}</div>
+              <div class="session-preview">
+                <span v-if="session.streaming" class="streaming-dot" />
+                {{ session.preview || '（空会话）' }}
+              </div>
               <div class="session-meta">
+                <el-tag v-if="session.streaming" type="warning" size="small" effect="light" class="streaming-tag">进行中</el-tag>
                 <span>{{ session.messageCount }} 条</span>
                 <span v-if="session.lastMessageTime">{{ session.lastMessageTime }}</span>
               </div>
@@ -147,9 +200,30 @@ function openAddToProject(sessionId: string) {
 
 .session-meta {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
   color: #999;
   margin-top: 2px;
+}
+
+.streaming-tag {
+  margin-right: 2px;
+}
+
+/* 进行中会话标题前的闪烁小圆点，配合「进行中」tag 强化辨识 */
+.streaming-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 4px;
+  border-radius: 50%;
+  background: var(--el-color-warning);
+  animation: streaming-blink 1s ease-in-out infinite;
+}
+
+@keyframes streaming-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
 }
 </style>

--- a/customer-admin-web/src/components/ThemeToolbar.vue
+++ b/customer-admin-web/src/components/ThemeToolbar.vue
@@ -53,24 +53,26 @@ const showPicker = ref(false)
   position: relative;
 }
 
-/* 主题色胶囊按钮：白底细边框，悬浮时边框染上主题色并轻微上浮 */
+/* 主题色胶囊按钮：浅黄底，规格与代码知识库/新建会话一致（34px 高/17px 圆角/0 18px 内距） */
 .theme-btn {
   display: inline-flex;
   align-items: center;
   gap: 7px;
   height: 34px;
-  padding: 0 14px;
+  padding: 0 18px;
   border-radius: 17px;
-  border: 1px solid var(--el-border-color);
-  background: var(--el-bg-color);
+  border: none;
+  background: #fdf0cd;
   cursor: pointer;
   font-size: 13px;
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  font-weight: 500;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
 }
 
 .theme-btn:hover {
-  border-color: var(--theme-primary, var(--el-color-primary));
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  filter: brightness(1.03);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
   transform: translateY(-1px);
 }
 
@@ -83,13 +85,14 @@ const showPicker = ref(false)
 }
 
 .color-label {
-  color: var(--el-text-color-regular);
+  /* 浅黄底上固定深棕字保证可读性，不随明暗模式切换 */
+  color: #8a6116;
   font-weight: 500;
 }
 
 .arrow {
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: #8a6116;
   transition: transform 0.2s;
 }
 
@@ -131,32 +134,28 @@ const showPicker = ref(false)
   box-shadow: 0 0 0 2px var(--theme-primary, var(--el-color-primary));
 }
 
-/* 新建会话：主题色渐变胶囊按钮，悬浮提亮并上浮 */
+/* 新建会话：白底细边框胶囊，规格与代码知识库/主题色按钮一致；悬浮时描主题色边 */
 .new-session-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   height: 34px;
   padding: 0 18px;
-  border: none;
+  border: 1px solid var(--el-border-color);
   border-radius: 17px;
-  background: linear-gradient(
-    135deg,
-    var(--theme-primary, var(--el-color-primary)),
-    var(--theme-primary-light, #79bbff)
-  );
-  /* 主题色渐变底上的文字固定用白色，不随明暗模式切换 */
-  color: #fff;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
 }
 
 .new-session-btn:hover {
-  filter: brightness(1.08);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  border-color: var(--theme-primary, var(--el-color-primary));
+  color: var(--theme-primary, var(--el-color-primary));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   transform: translateY(-1px);
 }
 

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -86,7 +86,17 @@ async function handleLogout() {
       <TabsBar />
       <AppBreadcrumb />
       <el-main class="layout-main">
-        <router-view />
+        <!-- 只精确缓存 WorkspaceView：TabsBar 让"已打开的标签"在视觉上常驻，但底下的路由组件此前没配
+             keep-alive，标签切走再切回其实是整个组件重新 mount——WorkspaceView 里的对话/VibeCoding
+             面板state 全在组件本地 ref，一销毁就清空，进行中的 SSE 流也被 onUnmounted 里的 abortStream
+             打断。这里不做成全局 include（tabsStore.tabs 覆盖的其它页面，如表格/表单页，未必对"数据
+             保持不刷新重进"这件事做过设计，贸然全量 keep-alive 影响面不可控），只精确点名
+             WorkspaceView，需要时再按同样方式给其它页面加白名单。 -->
+        <router-view v-slot="{ Component }">
+          <keep-alive :include="['WorkspaceView']">
+            <component :is="Component" />
+          </keep-alive>
+        </router-view>
       </el-main>
       <el-footer class="layout-footer" height="36px">
         <FooterCopyright />

--- a/customer-admin-web/src/router/index.ts
+++ b/customer-admin-web/src/router/index.ts
@@ -1,6 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/store/auth'
 import { useMenuStore } from '@/store/menu'
+// WorkspaceView 特意同步导入（其余路由仍懒加载）：MainLayout 的 <keep-alive :include="['WorkspaceView']">
+// 按组件 name 字符串匹配，而懒加载 `() => import()` 交给 router-view 的是异步组件包装，KeepAlive 取不到
+// 里面真实组件的 name，include 匹配落空、缓存失效——对话/VibeCoding 面板切菜单再回来就被销毁重建、
+// 进行中的会话随之丢失。同步导入让 include 拿到真实 name，keep-alive 才真正生效。
+import WorkspaceView from '@/views/workspace/WorkspaceView.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -41,7 +46,8 @@ const router = createRouter({
           // 动态智能体工作区节点：path 形如 /workspace/{agentCode}，运行时拼进菜单，不落库、不预注册
           path: 'workspace/:agentCode',
           name: 'Workspace',
-          component: () => import('@/views/workspace/WorkspaceView.vue'),
+          // 同步导入（见文件顶部 import 注释）：keep-alive 按 name 匹配缓存此页，懒加载会导致匹配失效。
+          component: WorkspaceView,
           props: true,
         },
         {

--- a/customer-admin-web/src/store/chatConversations.ts
+++ b/customer-admin-web/src/store/chatConversations.ts
@@ -1,0 +1,231 @@
+import { defineStore } from 'pinia'
+import { getChatSessionMessages, interruptChat, streamChat } from '@/api/chat'
+import { generateUuid } from '@/utils/uuid'
+import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
+import type { TraceNode } from '@/components/TraceTimeline.vue'
+import type { LiveSession } from '@/types/api'
+
+export interface ChatMessage {
+  role: 'user' | 'assistant'
+  text: string
+  nodes: TraceNode[]
+}
+
+/** localId 是前端本地生成的临时 key，用于 v-for/移除定位（上传过程中后端 id 还不存在）；
+ * status 驱动 tag 的 loading/失败态展示，失败附件不参与拼接。 */
+export interface ChatAttachmentItem {
+  localId: string
+  id?: string
+  name: string
+  content: string
+  status: 'uploading' | 'success' | 'failed'
+  errorMessage?: string
+}
+
+/**
+ * 单个会话的全部状态。历史演进：最初是面板级单份 ref（切会话即覆盖丢失）→ 组件内按 sessionId 分组
+ * （切菜单靠 keep-alive 保命，但切智能体时组件按 :key 重建仍会全丢）→ 现在提到 Pinia 全局 store，
+ * 会话与组件生命周期彻底解耦：切页面、切智能体、组件销毁重建都不影响进行中的会话与 SSE 流。
+ */
+export interface ChatConversation {
+  sessionId: string
+  messages: ChatMessage[]
+  input: string
+  attachments: ChatAttachmentItem[]
+  streaming: boolean
+  interrupting: boolean // 已点终止，等后端真正停下来（协作式中断，不保证立即生效）
+  interrupted: boolean // 上一轮是被终止结束的，可以点"继续"续跑挂起的工具调用
+  abort: (() => void) | null
+}
+
+/** 某个智能体名下的全部会话 + 当前激活会话。 */
+interface AgentChatState {
+  conversations: Record<string, ChatConversation>
+  activeId: string
+}
+
+const PREVIEW_MAX_LENGTH = 40
+
+export function createChatConversation(sessionId: string, messages: ChatMessage[] = []): ChatConversation {
+  return { sessionId, messages, input: '', attachments: [], streaming: false, interrupting: false, interrupted: false, abort: null }
+}
+
+/** 会话预览文案：取首条有内容的用户消息。 */
+export function previewOfMessages(messages: ChatMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user' && m.text.trim().length > 0)
+  if (!firstUser) return ''
+  const text = firstUser.text
+  return text.length > PREVIEW_MAX_LENGTH ? text.slice(0, PREVIEW_MAX_LENGTH) + '...' : text
+}
+
+/**
+ * 工作区"对话"面板的会话状态（全局，跨组件生命周期存活）。
+ *
+ * <p>SSE 回调闭包持有 (agentCode, sessionId) 直接写回 store 里对应会话——组件卸载不影响流的继续接收；
+ * 组件只是"当前正在看哪个智能体的哪个会话"的视图。historyVersion 在每轮流结束时自增，
+ * 侧边栏 watch 它来刷新已落库列表。</p>
+ */
+export const useChatConversationsStore = defineStore('chatConversations', {
+  state: () => ({
+    byAgent: {} as Record<string, AgentChatState>,
+    /** 每轮对话流结束自增（按 agentCode），侧边栏 watch 它刷新后端历史列表。 */
+    historyVersion: {} as Record<string, number>,
+  }),
+  getters: {
+    /** 某智能体当前激活的会话（未初始化时 undefined，组件应先 ensureAgent）。 */
+    activeOf: (state) => (agentCode: string): ChatConversation | undefined => {
+      const agent = state.byAgent[agentCode]
+      return agent ? agent.conversations[agent.activeId] : undefined
+    },
+    /** 供历史侧边栏合并展示的内存会话（只含非空或进行中的，空白新会话不进列表）。 */
+    liveSessionsOf: (state) => (agentCode: string): LiveSession[] => {
+      const agent = state.byAgent[agentCode]
+      if (!agent) return []
+      return Object.values(agent.conversations)
+        .map((c) => ({
+          sessionId: c.sessionId,
+          preview: previewOfMessages(c.messages),
+          messageCount: c.messages.length,
+          streaming: c.streaming,
+        }))
+        .filter((c) => c.messageCount > 0 || c.streaming)
+    },
+    activeIdOf: (state) => (agentCode: string): string => state.byAgent[agentCode]?.activeId ?? '',
+  },
+  actions: {
+    /** 确保某智能体的状态已初始化（至少有一个空会话作为激活会话），组件挂载时调用。 */
+    ensureAgent(agentCode: string) {
+      if (this.byAgent[agentCode]) return
+      const sid = generateUuid()
+      this.byAgent[agentCode] = { conversations: { [sid]: createChatConversation(sid) }, activeId: sid }
+    },
+
+    /**
+     * 新建会话：不 abort 当前会话（进行中的旧会话留在 store 里后台继续流式，可从历史列表找回）。
+     * 若当前激活会话本就是空白且没在跑，直接复用它，避免连点"新建"堆一堆空会话。
+     */
+    newSession(agentCode: string) {
+      this.ensureAgent(agentCode)
+      const agent = this.byAgent[agentCode]
+      const cur = agent.conversations[agent.activeId]
+      if (cur && cur.messages.length === 0 && !cur.streaming) {
+        cur.input = ''
+        cur.attachments = []
+        return
+      }
+      const sid = generateUuid()
+      agent.conversations[sid] = createChatConversation(sid)
+      agent.activeId = sid
+    },
+
+    /**
+     * 打开会话：store 里已有（进行中或本次加载过的）直接切激活，保留实时增量不回源覆盖；
+     * 只有没有的纯历史会话才回源拉消息。返回是否发生了网络加载（供组件控制 loading 态）。
+     */
+    async openSession(agentCode: string, targetSessionId: string): Promise<void> {
+      this.ensureAgent(agentCode)
+      const agent = this.byAgent[agentCode]
+      if (agent.conversations[targetSessionId]) {
+        agent.activeId = targetSessionId
+        return
+      }
+      const history = await getChatSessionMessages(agentCode, targetSessionId)
+      agent.conversations[targetSessionId] = createChatConversation(
+        targetSessionId,
+        history.map((msg) => ({ role: msg.role, text: msg.text, nodes: [] })),
+      )
+      agent.activeId = targetSessionId
+    },
+
+    /**
+     * 发送当前激活会话的输入。SSE 回调按 (agentCode, sessionId) 写回 store 对应会话——用户切走、
+     * 组件销毁都不影响；onScroll 由组件传入，仅当该会话仍是激活会话时组件才滚动视图。
+     */
+    send(agentCode: string, buildMessage: (conv: ChatConversation, text: string) => string, onScroll?: () => void) {
+      const agent = this.byAgent[agentCode]
+      const conv = agent?.conversations[agent.activeId]
+      if (!conv) return
+      const text = conv.input.trim()
+      if (!text || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
+      conv.interrupted = false
+      const messageToSend = buildMessage(conv, text)
+      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
+      // 用户气泡只展示原始输入 + 附件文件名提示，不把拼进正文的附件全文也显示出来（那部分只是发给模型看的）。
+      conv.messages.push({
+        role: 'user',
+        text: attachedNames.length > 0 ? `${text}\n📎 ${attachedNames.join('、')}` : text,
+        nodes: [],
+      })
+      conv.messages.push({ role: 'assistant', text: '', nodes: [] })
+      // 坑：不能拿 push 前创建的原始对象引用去改——响应式数组对存进去的对象是"读取时才转代理"，
+      // 改原始对象绕过代理 setter，视图不会增量刷新。push 完再从数组里取，拿到的才是代理本身。
+      const assistantMessage = conv.messages[conv.messages.length - 1]
+      conv.input = ''
+      conv.attachments = []
+      conv.streaming = true
+      const sid = conv.sessionId
+
+      conv.abort = streamChat(agentCode, { sessionId: sid, message: messageToSend }, {
+        onEvent: (event) => {
+          const c = this.byAgent[agentCode]?.conversations[sid]
+          if (!c) return
+          if (event.event === 'done') {
+            c.streaming = false
+            return
+          }
+          if (event.event.startsWith('node:')) {
+            const kind = event.event.slice('node:'.length)
+            const payload = parseChatStreamPayload(event.data)
+            appendChatStreamNode(assistantMessage.nodes, kind, payload.text, payload.source, payload.subagentName)
+          } else if (event.event === 'message') {
+            const payload = parseChatStreamPayload(event.data)
+            if (payload.source) {
+              // 带 source 的正文增量是子Agent 内部产出，复用 ANSWER kind 挂进对应嵌套面板
+              appendChatStreamNode(assistantMessage.nodes, ANSWER_KIND, payload.text, payload.source, payload.subagentName)
+            } else {
+              assistantMessage.text += payload.text
+            }
+          }
+          // 其余未知事件静默忽略：后端新增 SSE 事件类型时旧前端不受影响（需求 §5.5 向后兼容）
+          if (this.byAgent[agentCode]?.activeId === sid) onScroll?.()
+        },
+        onError: (error) => {
+          const c = this.byAgent[agentCode]?.conversations[sid]
+          if (c) {
+            c.streaming = false
+            c.interrupting = false
+          }
+          ElMessage.error('对话失败：' + (error instanceof Error ? error.message : String(error)))
+        },
+        onComplete: () => {
+          const c = this.byAgent[agentCode]?.conversations[sid]
+          if (c) {
+            c.streaming = false
+            // 若这轮是用户主动点了"终止"后自然结束的，翻转成"可继续"状态，冒出继续按钮
+            if (c.interrupting) {
+              c.interrupting = false
+              c.interrupted = true
+            }
+          }
+          this.historyVersion[agentCode] = (this.historyVersion[agentCode] ?? 0) + 1
+        },
+      })
+      onScroll?.()
+    },
+
+    /** 点击"终止"：只通知后端安全中断（协作式），不 abort 前端连接——让 onComplete/onError 在
+     * 后端真正停止、SSE 自然结束时收尾，避免界面"已停止"但后端还在跑的假象。 */
+    async interrupt(agentCode: string) {
+      const agent = this.byAgent[agentCode]
+      const conv = agent?.conversations[agent.activeId]
+      if (!conv) return
+      conv.interrupting = true
+      try {
+        await interruptChat(agentCode, conv.sessionId)
+      } catch (error) {
+        conv.interrupting = false
+        ElMessage.error('终止失败：' + (error instanceof Error ? error.message : String(error)))
+      }
+    },
+  },
+})

--- a/customer-admin-web/src/store/vibeConversations.ts
+++ b/customer-admin-web/src/store/vibeConversations.ts
@@ -1,0 +1,406 @@
+import { defineStore } from 'pinia'
+import { getSandboxMode, interruptVibeCoding, listWorkspaceFiles, streamVibeCoding } from '@/api/vibecoding'
+import { getChatSessionMessages } from '@/api/chat'
+import { generateUuid } from '@/utils/uuid'
+import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
+import type { TraceNode } from '@/components/TraceTimeline.vue'
+import type {
+  FileChangeEvent,
+  LiveSession,
+  PlanEvent,
+  PlanResultEvent,
+  RoleStageEvent,
+  TestReport,
+  WorkspaceFileNode,
+} from '@/types/api'
+import { previewOfMessages } from '@/store/chatConversations'
+
+/** Plan Mode 确认卡片（P1-1 HITL）：一条 plan 事件对应一张卡片，用户批准/拒绝或超时后翻成终态。 */
+export interface PlanCard {
+  planId: string
+  actions: PlanEvent['actions']
+  reason: string
+  status: 'PENDING' | 'APPROVED' | 'REJECTED' | 'TIMEOUT'
+  remainingSeconds: number
+  submitting: boolean
+}
+
+export interface VibeChatMessage {
+  role: 'user' | 'assistant'
+  text: string
+  nodes: TraceNode[]
+  // 本条助手消息内累积的沙箱编译/测试报告（P0-3），按到达顺序渲染成测试报告卡片时间线
+  testReports?: TestReport[]
+  // 本条助手消息内的 Plan Mode 确认卡片（P1-1），高风险操作待人工确认
+  plans?: PlanCard[]
+  // 协作模式多角色阶段进度（P3-1），按 role_stage 事件到达顺序累积
+  stages?: RoleStageEvent[]
+}
+
+/** localId 是前端本地生成的临时 key；status 驱动 loading/失败态展示，失败附件不参与拼接。 */
+export interface VibeAttachmentItem {
+  localId: string
+  id?: string
+  name: string
+  content: string
+  status: 'uploading' | 'success' | 'failed'
+  errorMessage?: string
+}
+
+/**
+ * 单个 VibeCoding 会话的全部状态（比 chat 多：文件变更时间线、产物树、Plan 待确认、沙箱模式）。
+ * 提到全局 store 的动机同 chatConversations：会话与组件生命周期解耦，切页面/切智能体都不丢。
+ */
+export interface VibeConversation {
+  sessionId: string
+  messages: VibeChatMessage[]
+  input: string
+  attachments: VibeAttachmentItem[]
+  streaming: boolean
+  interrupting: boolean
+  interrupted: boolean
+  abort: (() => void) | null
+  fileChanges: Array<FileChangeEvent & { time: number }>
+  pendingPlans: Map<string, PlanCard>
+  fileNodes: WorkspaceFileNode[]
+  filesLoading: boolean
+  filesLoaded: boolean
+  sandboxMode: 'local' | 'docker' | null
+  rollingBack: boolean
+}
+
+interface AgentVibeState {
+  conversations: Record<string, VibeConversation>
+  activeId: string
+}
+
+export function createVibeConversation(sessionId: string, messages: VibeChatMessage[] = []): VibeConversation {
+  return {
+    sessionId,
+    messages,
+    input: '',
+    attachments: [],
+    streaming: false,
+    interrupting: false,
+    interrupted: false,
+    abort: null,
+    fileChanges: [],
+    pendingPlans: new Map(),
+    fileNodes: [],
+    filesLoading: false,
+    filesLoaded: false,
+    sandboxMode: null,
+    rollingBack: false,
+  }
+}
+
+/** 从会话首条用户消息里解析出发送时用的沙箱模式，解析不出来（更早期版本的历史记录）返回 null。 */
+export function parseSandboxModeFromMessage(text: string): 'local' | 'docker' | null {
+  const match = text.match(/^\[VibeCoding指引-(docker|local)]/)
+  return match ? (match[1] as 'local' | 'docker') : null
+}
+
+/**
+ * VibeCoding 面板的会话状态（全局，跨组件生命周期存活），设计同 {@link useChatConversationsStore}。
+ * Plan 倒计时是全局单定时器扫全部会话的 pendingPlans，不随组件卸载中断。
+ */
+export const useVibeConversationsStore = defineStore('vibeConversations', {
+  state: () => ({
+    byAgent: {} as Record<string, AgentVibeState>,
+    historyVersion: {} as Record<string, number>,
+    planCountdownTimer: null as ReturnType<typeof setInterval> | null,
+  }),
+  getters: {
+    activeOf: (state) => (agentCode: string): VibeConversation | undefined => {
+      const agent = state.byAgent[agentCode]
+      return agent ? agent.conversations[agent.activeId] : undefined
+    },
+    liveSessionsOf: (state) => (agentCode: string): LiveSession[] => {
+      const agent = state.byAgent[agentCode]
+      if (!agent) return []
+      return Object.values(agent.conversations)
+        .map((c) => ({
+          sessionId: c.sessionId,
+          preview: previewOfMessages(c.messages),
+          messageCount: c.messages.length,
+          streaming: c.streaming,
+        }))
+        .filter((c) => c.messageCount > 0 || c.streaming)
+    },
+    activeIdOf: (state) => (agentCode: string): string => state.byAgent[agentCode]?.activeId ?? '',
+  },
+  actions: {
+    /** 确保某智能体的状态已初始化，并给初始空会话拉一次全局沙箱模式。 */
+    ensureAgent(agentCode: string) {
+      if (this.byAgent[agentCode]) return
+      const sid = generateUuid()
+      this.byAgent[agentCode] = { conversations: { [sid]: createVibeConversation(sid) }, activeId: sid }
+      this.loadCurrentSandboxMode(agentCode)
+    },
+
+    /** 新建会话（空白空闲会话直接复用，不 abort 进行中的旧会话）。新会话用当前全局沙箱配置。 */
+    newSession(agentCode: string) {
+      this.ensureAgent(agentCode)
+      const agent = this.byAgent[agentCode]
+      const cur = agent.conversations[agent.activeId]
+      if (cur && cur.messages.length === 0 && !cur.streaming) {
+        cur.input = ''
+        cur.attachments = []
+        cur.fileChanges = []
+        cur.fileNodes = []
+        cur.filesLoaded = false
+        this.loadCurrentSandboxMode(agentCode)
+        return
+      }
+      const sid = generateUuid()
+      agent.conversations[sid] = createVibeConversation(sid)
+      agent.activeId = sid
+      this.loadCurrentSandboxMode(agentCode)
+    },
+
+    /**
+     * 当前全局沙箱配置（admin.sandbox.mode），代表"新会话将会使用的模式"，写入当前激活会话。
+     * 一旦切到历史会话，标签改为从那条会话消息里解析出的"当时真正用的模式"，两者含义不同不能互替。
+     */
+    loadCurrentSandboxMode(agentCode: string) {
+      const agent = this.byAgent[agentCode]
+      if (!agent) return
+      const sid = agent.activeId
+      getSandboxMode(agentCode)
+        .then((res) => { const c = this.byAgent[agentCode]?.conversations[sid]; if (c) c.sandboxMode = res.mode })
+        .catch(() => { const c = this.byAgent[agentCode]?.conversations[sid]; if (c) c.sandboxMode = null })
+    },
+
+    /** 打开会话：store 已有直接切激活（保留实时增量与文件树）；纯历史会话才回源拉消息 + 产物文件。 */
+    async openSession(agentCode: string, targetSessionId: string): Promise<void> {
+      this.ensureAgent(agentCode)
+      const agent = this.byAgent[agentCode]
+      if (agent.conversations[targetSessionId]) {
+        agent.activeId = targetSessionId
+        return
+      }
+      const history = await getChatSessionMessages(agentCode, targetSessionId)
+      const conv = createVibeConversation(
+        targetSessionId,
+        history.map((msg) => ({ role: msg.role, text: msg.text, nodes: [] })),
+      )
+      const firstUserMessage = history.find((msg) => msg.role === 'user')
+      conv.sandboxMode = firstUserMessage ? parseSandboxModeFromMessage(firstUserMessage.text) : null
+      agent.conversations[targetSessionId] = conv
+      agent.activeId = targetSessionId
+      // 切到历史会话时该会话可能已有产物文件，无需等用户手动点"刷新"
+      this.loadFiles(agentCode, targetSessionId)
+    },
+
+    /** 加载（刷新）指定会话的 workspace 目录树。 */
+    async loadFiles(agentCode: string, sessionId: string) {
+      const conv = this.byAgent[agentCode]?.conversations[sessionId]
+      if (!conv) return
+      conv.filesLoading = true
+      try {
+        conv.fileNodes = await listWorkspaceFiles(agentCode, sessionId)
+        conv.filesLoaded = true
+      } catch (error) {
+        ElMessage.error('目录加载失败：' + (error instanceof Error ? error.message : String(error)))
+      } finally {
+        conv.filesLoading = false
+      }
+    },
+
+    /** 发送当前激活会话的输入；SSE 事件按 (agentCode, sessionId) 写回原会话，切走不受影响。 */
+    send(
+      agentCode: string,
+      collaboration: boolean,
+      buildMessage: (conv: VibeConversation, text: string) => string,
+      onScroll?: () => void,
+    ) {
+      const agent = this.byAgent[agentCode]
+      const conv = agent?.conversations[agent.activeId]
+      if (!conv) return
+      const text = conv.input.trim()
+      if (!text || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
+      conv.interrupted = false
+      const messageToSend = buildMessage(conv, text)
+      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
+      conv.messages.push({
+        role: 'user',
+        text: attachedNames.length > 0 ? `${text}\n📎 ${attachedNames.join('、')}` : text,
+        nodes: [],
+      })
+      conv.messages.push({ role: 'assistant', text: '', nodes: [], testReports: [] })
+      // 同 chat store：push 完再取，拿响应式代理而不是原始对象
+      const assistantMessage = conv.messages[conv.messages.length - 1]
+      conv.input = ''
+      conv.attachments = []
+      conv.streaming = true
+      const sid = conv.sessionId
+
+      conv.abort = streamVibeCoding(agentCode, { sessionId: sid, message: messageToSend, collaboration }, {
+        onEvent: (event) => {
+          const c = this.byAgent[agentCode]?.conversations[sid]
+          if (!c) return
+          const isActive = () => this.byAgent[agentCode]?.activeId === sid
+          if (event.event === 'done') {
+            c.streaming = false
+            // 对话结束后自动刷新该会话文件目录树
+            this.loadFiles(agentCode, sid)
+            return
+          }
+          if (event.event === 'file_change') {
+            try {
+              const parsed = JSON.parse(event.data) as FileChangeEvent
+              c.fileChanges.push({ ...parsed, time: Date.now() })
+            } catch { /* 解析失败不影响主对话流程，静默丢弃 */ }
+            return
+          }
+          if (event.event === 'test_report') {
+            try {
+              const parsed = JSON.parse(event.data) as TestReport
+              ;(assistantMessage.testReports ??= []).push(parsed)
+            } catch { /* 静默丢弃 */ }
+            if (isActive()) onScroll?.()
+            return
+          }
+          if (event.event === 'role_stage') {
+            this.applyRoleStage(assistantMessage, event.data)
+            if (isActive()) onScroll?.()
+            return
+          }
+          if (event.event === 'plan') {
+            this.applyPlanEvent(c, assistantMessage, event.data)
+            if (isActive()) onScroll?.()
+            return
+          }
+          if (event.event === 'plan_result') {
+            try {
+              const parsed = JSON.parse(event.data) as PlanResultEvent
+              const card = c.pendingPlans.get(parsed.planId)
+              if (card) {
+                card.status = parsed.status
+                card.submitting = false
+                c.pendingPlans.delete(parsed.planId)
+              }
+            } catch { /* 静默丢弃 */ }
+            return
+          }
+          if (event.event.startsWith('node:')) {
+            const kind = event.event.slice('node:'.length)
+            const payload = parseChatStreamPayload(event.data)
+            appendChatStreamNode(assistantMessage.nodes, kind, payload.text, payload.source, payload.subagentName)
+          } else if (event.event === 'message') {
+            const payload = parseChatStreamPayload(event.data)
+            if (payload.source) {
+              // 带 source 的正文增量是子Agent 内部产出，复用 ANSWER kind 挂进对应嵌套面板
+              appendChatStreamNode(assistantMessage.nodes, ANSWER_KIND, payload.text, payload.source, payload.subagentName)
+            } else {
+              assistantMessage.text += payload.text
+            }
+          }
+          // 其余未知事件静默忽略（需求 §5.5 向后兼容）
+          if (isActive()) onScroll?.()
+        },
+        onError: (error) => {
+          const c = this.byAgent[agentCode]?.conversations[sid]
+          if (c) {
+            c.streaming = false
+            c.interrupting = false
+          }
+          ElMessage.error('对话失败：' + (error instanceof Error ? error.message : String(error)))
+        },
+        onComplete: () => {
+          const c = this.byAgent[agentCode]?.conversations[sid]
+          if (c) {
+            c.streaming = false
+            if (c.interrupting) {
+              c.interrupting = false
+              c.interrupted = true
+            }
+          }
+          this.historyVersion[agentCode] = (this.historyVersion[agentCode] ?? 0) + 1
+        },
+      })
+      onScroll?.()
+    },
+
+    /** role_stage 事件（P3-1）：START 追加新阶段；DONE/FAILED 按 index 更新（找不到则补插）。 */
+    applyRoleStage(assistantMessage: VibeChatMessage, raw: string) {
+      try {
+        const parsed = JSON.parse(raw) as RoleStageEvent
+        const stages = (assistantMessage.stages ??= [])
+        if (parsed.status === 'START') {
+          stages.push({ ...parsed, output: null })
+          return
+        }
+        const existing = stages.find((s) => s.index === parsed.index)
+        if (existing) {
+          existing.status = parsed.status
+          existing.output = parsed.output
+          existing.role = parsed.role
+          existing.type = parsed.type
+        } else {
+          stages.push({ ...parsed })
+        }
+      } catch { /* 静默丢弃 */ }
+    },
+
+    /** plan 事件（P1-1 HITL）：追加待确认卡片并确保全局倒计时在跑。 */
+    applyPlanEvent(conv: VibeConversation, assistantMessage: VibeChatMessage, raw: string) {
+      try {
+        const parsed = JSON.parse(raw) as PlanEvent
+        const card: PlanCard = {
+          planId: parsed.planId,
+          actions: parsed.actions ?? [],
+          reason: parsed.reason ?? '',
+          status: 'PENDING',
+          remainingSeconds: parsed.timeoutSeconds ?? 300,
+          submitting: false,
+        }
+        const plans = (assistantMessage.plans ??= [])
+        plans.push(card)
+        // 存响应式代理引用（push 后再取），否则定时器/plan_result 改原始对象视图不更新
+        conv.pendingPlans.set(card.planId, plans[plans.length - 1])
+        this.ensurePlanCountdown()
+      } catch { /* 静默丢弃 */ }
+    },
+
+    /** 全局单定时器：每秒扫全部智能体全部会话的待确认卡片递减，归零本地标记超时；无剩余时自停。 */
+    ensurePlanCountdown() {
+      if (this.planCountdownTimer) return
+      this.planCountdownTimer = setInterval(() => {
+        let anyPending = false
+        for (const agent of Object.values(this.byAgent)) {
+          for (const conv of Object.values(agent.conversations)) {
+            for (const card of conv.pendingPlans.values()) {
+              anyPending = true
+              card.remainingSeconds -= 1
+              if (card.remainingSeconds <= 0) {
+                // 本地倒计时归零：先行标记超时（服务端也会补发 plan_result=TIMEOUT，二者幂等）
+                card.status = 'TIMEOUT'
+                card.remainingSeconds = 0
+                conv.pendingPlans.delete(card.planId)
+              }
+            }
+          }
+        }
+        if (!anyPending && this.planCountdownTimer) {
+          clearInterval(this.planCountdownTimer)
+          this.planCountdownTimer = null
+        }
+      }, 1000)
+    },
+
+    /** 点击"终止"：只通知后端安全中断，不 abort 前端连接（同 chat store 的注释）。 */
+    async interrupt(agentCode: string) {
+      const agent = this.byAgent[agentCode]
+      const conv = agent?.conversations[agent.activeId]
+      if (!conv) return
+      conv.interrupting = true
+      try {
+        await interruptVibeCoding(agentCode, conv.sessionId)
+      } catch (error) {
+        conv.interrupting = false
+        ElMessage.error('终止失败：' + (error instanceof Error ? error.message : String(error)))
+      }
+    },
+  },
+})

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -576,6 +576,18 @@ export interface ChatSessionSummary {
   messageCount: number
 }
 
+/**
+ * 前端内存里"活着"的会话（进行中或本次加载过的），供历史侧边栏与后端已落库列表合并展示。
+ * 进行中的新会话（尤其第一轮还没落库）后端列表拉不到，全靠这份内存登记让它在侧边栏可见并标「进行中」。
+ */
+export interface LiveSession {
+  sessionId: string
+  preview: string
+  messageCount: number
+  /** 是否正在流式生成中——决定是否置顶并打「进行中」标。 */
+  streaming: boolean
+}
+
 export interface ChatMessageVO {
   role: 'user' | 'assistant'
   text: string

--- a/customer-admin-web/src/views/aiconfig/ModelManage.vue
+++ b/customer-admin-web/src/views/aiconfig/ModelManage.vue
@@ -101,7 +101,12 @@ onMounted(loadList)
 
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column prop="modelName" label="名称" />
-        <el-table-column prop="provider" label="厂商" width="100" />
+        <!-- provider 是接入协议/SDK 通道（openai=所有 OpenAI 兼容端点，智谱/DeepSeek 等第三方模型
+             走兼容协议时同样是 openai），不是"模型出品公司"——列名叫"厂商"会让人误读成数据错了。
+             单元格复用编辑表单 providerPresets 的友好文案（如「OpenAI 兼容」），不裸显枚举 code。 -->
+        <el-table-column label="接入协议" width="200">
+          <template #default="{ row }">{{ presetOf(row.provider).label }}</template>
+        </el-table-column>
         <el-table-column prop="model" label="模型标识" />
         <el-table-column label="AppKey" width="140">
           <template #default="{ row }">{{ row.apiKeyMasked }}</template>

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -1,60 +1,44 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { computed, nextTick, onActivated, onMounted, ref, watch } from 'vue'
 import type { UploadRequestOptions } from 'element-plus'
-import { getChatSessionMessages, interruptChat, parseChatAttachment, streamChat } from '@/api/chat'
+import { parseChatAttachment } from '@/api/chat'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
-import TraceTimeline, { type TraceNode } from '@/components/TraceTimeline.vue'
+import TraceTimeline from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import { useThemeStore } from '@/store/theme'
+import {
+  useChatConversationsStore,
+  type ChatAttachmentItem,
+  type ChatConversation,
+} from '@/store/chatConversations'
 import { generateUuid } from '@/utils/uuid'
-import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
 
 const props = defineProps<{ agentCode: string; initialSessionId?: string }>()
-
-interface ChatMessage {
-  role: 'user' | 'assistant'
-  text: string
-  nodes: TraceNode[]
-}
-
-/** localId 是前端本地生成的临时 key，用于 v-for/移除定位（上传过程中后端 id 还不存在）；
- * status 驱动 tag 的 loading/失败态展示，失败附件不参与 buildMessageWithAttachments 拼接。 */
-interface Attachment {
-  localId: string
-  id?: string
-  name: string
-  content: string
-  status: 'uploading' | 'success' | 'failed'
-  errorMessage?: string
-}
 
 // 与 starter AttachmentParseService 的白名单/大小限制保持一致（后端 customer-work.attachment.max-file-size-mb=10）
 const ATTACHMENT_ACCEPT = '.md,.txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.proto,.properties,.ini,.conf,.cfg,.log,.env,.sql,.sh,.bash,.zsh,.bat,.ps1,.java,.kt,.kts,.groovy,.gradle,.scala,.py,.js,.ts,.jsx,.tsx,.vue,.css,.scss,.less,.c,.h,.cpp,.hpp,.cs,.go,.rs,.rb,.php,.swift,.lua,.r,.dart,.html,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.bmp,.webp'
 const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
-const sessionId = ref(generateUuid())
-const messages = ref<ChatMessage[]>([])
-const input = ref('')
-const streaming = ref(false)
-const interrupting = ref(false) // 已点终止，等后端真正停下来（协作式中断，不保证立即生效）
-const interrupted = ref(false) // 上一轮是被终止结束的，可以点"继续"续跑挂起的工具调用
+/**
+ * 会话状态全部在 Pinia store（chatConversations）里，本组件只是"当前正在看哪个会话"的视图：
+ * 切页面、切智能体、组件销毁重建都不影响 store 里进行中的会话与 SSE 流——这正是"进行中的会话
+ * 换个地方回来还能找到、还在继续跑"的根本保障。组件自己只保留纯视图状态（滚动容器、loading）。
+ */
+const store = useChatConversationsStore()
+store.ensureAgent(props.agentCode)
+
+const active = computed<ChatConversation | undefined>(() => store.activeOf(props.agentCode))
+const liveSessions = computed(() => store.liveSessionsOf(props.agentCode))
+const activeSessionId = computed(() => store.activeIdOf(props.agentCode))
+const anyAttachmentUploading = computed(() => active.value?.attachments.some((a) => a.status === 'uploading') ?? false)
+
 const historyLoading = ref(false)
-const attachments = ref<Attachment[]>([])
-const anyAttachmentUploading = computed(() => attachments.value.some((a) => a.status === 'uploading'))
 const scrollRef = ref<HTMLElement>()
 const historySidebar = ref<InstanceType<typeof ChatHistorySidebar>>()
-let abortStream: (() => void) | null = null
 const themeStore = useThemeStore()
 
 function newSession() {
-  abortStream?.()
-  streaming.value = false
-  interrupting.value = false
-  interrupted.value = false
-  sessionId.value = generateUuid()
-  messages.value = []
-  input.value = ''
-  attachments.value = []
+  store.newSession(props.agentCode)
 }
 
 /** 前端先拦超限文件，与后端 max-file-size-mb 对齐，减少无谓上传请求。 */
@@ -67,12 +51,15 @@ function beforeAttachmentUpload(file: File) {
 }
 
 async function handleAttachmentUpload(options: UploadRequestOptions) {
+  // 绑定发起上传时所在的会话：上传是异步的，期间用户可能切走，结果要回填到原会话而不是当前激活会话。
+  const conv = active.value
+  if (!conv) return
   const file = options.file as File
-  const attachment: Attachment = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
-  attachments.value.push(attachment)
+  const attachment: ChatAttachmentItem = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
+  conv.attachments.push(attachment)
   try {
     const result = await parseChatAttachment(props.agentCode, file, 'admin_chat')
-    const target = attachments.value.find((a) => a.localId === attachment.localId)
+    const target = conv.attachments.find((a) => a.localId === attachment.localId)
     if (!target) {
       return // 结果返回前用户已手动移除该附件，迟到的结果直接丢弃
     }
@@ -86,7 +73,7 @@ async function handleAttachmentUpload(options: UploadRequestOptions) {
       target.status = 'success'
     }
   } catch (error) {
-    const target = attachments.value.find((a) => a.localId === attachment.localId)
+    const target = conv.attachments.find((a) => a.localId === attachment.localId)
     const message = error instanceof Error ? error.message : String(error)
     if (target) {
       target.status = 'failed'
@@ -97,13 +84,15 @@ async function handleAttachmentUpload(options: UploadRequestOptions) {
 }
 
 function removeAttachment(localId: string) {
-  attachments.value = attachments.value.filter((a) => a.localId !== localId)
+  const conv = active.value
+  if (!conv) return
+  conv.attachments = conv.attachments.filter((a) => a.localId !== localId)
 }
 
 /** 把附件内容拼进消息正文——用清晰的分隔符包起来，让模型分得清"附件材料"和"用户实际问题"。
  * 只拼成功解析的附件，上传中/失败的附件不参与（失败的已经在上传回调里提示过用户）。 */
-function buildMessageWithAttachments(text: string): string {
-  const successful = attachments.value.filter((a) => a.status === 'success')
+function buildMessageWithAttachments(conv: ChatConversation, text: string): string {
+  const successful = conv.attachments.filter((a) => a.status === 'success')
   if (successful.length === 0) {
     return text
   }
@@ -114,18 +103,9 @@ function buildMessageWithAttachments(text: string): string {
 }
 
 async function openSession(targetSessionId: string) {
-  if (streaming.value) {
-    return
-  }
-  abortStream?.()
-  interrupting.value = false
-  interrupted.value = false
   historyLoading.value = true
   try {
-    const history = await getChatSessionMessages(props.agentCode, targetSessionId)
-    sessionId.value = targetSessionId
-    messages.value = history.map((msg) => ({ role: msg.role, text: msg.text, nodes: [] }))
-    input.value = ''
+    await store.openSession(props.agentCode, targetSessionId)
     scrollToBottom()
   } catch (error) {
     ElMessage.error('历史会话加载失败：' + (error instanceof Error ? error.message : String(error)))
@@ -141,128 +121,79 @@ function scrollToBottom() {
 }
 
 function send() {
-  const text = input.value.trim()
-  if (!text || streaming.value || anyAttachmentUploading.value) {
-    return
-  }
-  interrupted.value = false
-  const messageToSend = buildMessageWithAttachments(text)
-  const attachedNames = attachments.value.filter((a) => a.status === 'success').map((a) => a.name)
-  // 用户气泡只展示原始输入 + 附件文件名提示，不把拼进正文的附件全文也显示出来（那部分只是发给模型看的）。
-  messages.value.push({
-    role: 'user',
-    text: attachedNames.length > 0 ? `${text}\n📎 ${attachedNames.join('、')}` : text,
-    nodes: [],
-  })
-  messages.value.push({ role: 'assistant', text: '', nodes: [] })
-  // 坑：不能拿 push 前创建的原始对象引用去改——Vue 的响应式数组对存进去的对象是"读取时才转成响应式
-  // 代理"，闭包里这个原始对象跟模板 v-for 里读到的 msg 不是同一个代理，直接改原始对象的属性绕过了
-  // 代理的 setter，Vue 感知不到，界面不会增量刷新（只有等 streaming 这类真正的响应式变量变化触发整体
-  // 重新渲染时才会一次性显示全部内容）。push 完再从数组里取出来，这时候拿到的才是响应式代理本身。
-  const assistantMessage = messages.value[messages.value.length - 1]
-  input.value = ''
-  attachments.value = []
-  streaming.value = true
-  scrollToBottom()
-
-  abortStream = streamChat(props.agentCode, { sessionId: sessionId.value, message: messageToSend }, {
-    onEvent: (event) => {
-      if (event.event === 'done') {
-        streaming.value = false
-        return
-      }
-      if (event.event.startsWith('node:')) {
-        const kind = event.event.slice('node:'.length)
-        const payload = parseChatStreamPayload(event.data)
-        appendChatStreamNode(assistantMessage.nodes, kind, payload.text, payload.source, payload.subagentName)
-      } else if (event.event === 'message') {
-        const payload = parseChatStreamPayload(event.data)
-        if (payload.source) {
-          // 带 source 的正文增量是子Agent 内部产出，复用 ANSWER kind 挂进对应嵌套面板，
-          // 不算进主回答正文（主回答正文只承载主 Agent 自己的 message 事件，source 缺省）
-          appendChatStreamNode(assistantMessage.nodes, ANSWER_KIND, payload.text, payload.source, payload.subagentName)
-        } else {
-          assistantMessage.text += payload.text
-        }
-      }
-      // 其余未知事件静默忽略：后端新增 SSE 事件类型时旧前端不受影响（需求 §5.5 向后兼容）
-      scrollToBottom()
-    },
-    onError: (error) => {
-      streaming.value = false
-      interrupting.value = false
-      ElMessage.error('对话失败：' + (error instanceof Error ? error.message : String(error)))
-    },
-    onComplete: () => {
-      streaming.value = false
-      // 若这轮是用户主动点了"终止"后自然结束的，翻转成"可继续"状态，冒出继续按钮
-      if (interrupting.value) {
-        interrupting.value = false
-        interrupted.value = true
-      }
-      historySidebar.value?.refresh()
-    },
-  })
+  store.send(props.agentCode, buildMessageWithAttachments, scrollToBottom)
 }
 
-/** 点击"终止"：只通知后端安全中断（协作式，不保证立即生效），不调 abortStream() 断开前端连接——
- * 让现有的 onComplete/onError 在后端真正停止、SSE 自然结束时收尾，避免界面显示"已停止"但后端其实
- * 还在跑的假象。 */
-async function handleInterrupt() {
-  interrupting.value = true
-  try {
-    await interruptChat(props.agentCode, sessionId.value)
-  } catch (error) {
-    interrupting.value = false
-    ElMessage.error('终止失败：' + (error instanceof Error ? error.message : String(error)))
-  }
+function handleInterrupt() {
+  store.interrupt(props.agentCode)
 }
 
 /** 点击"继续"：发一句非空续接文案触发框架续跑被打断的挂起工具调用（后端 ChatRequest.message 要求非空，
  * 且续跑逻辑本就挂在正常的 chatStream 调用里，无需专门的续跑接口）。 */
 function resumeInterrupted() {
-  interrupted.value = false
-  input.value = '请继续刚才的任务。'
+  const conv = active.value
+  if (!conv) return
+  conv.interrupted = false
+  conv.input = '请继续刚才的任务。'
   send()
 }
 
 onMounted(() => {
   themeStore.apply()
-  // 从 Project 详情页跳转过来时带上目标会话 id，直接打开对应历史会话，不用用户再手动点一遍。
-  if (props.initialSessionId) {
-    openSession(props.initialSessionId)
-  }
 })
 
-onUnmounted(() => {
-  abortStream?.()
+// 每轮对话流结束（store 里自增版本号）刷新侧边栏的后端历史列表——流的 onComplete 在 store 里执行，
+// 不再直接持有组件 ref，组件通过 watch 版本号补上这层联动。
+watch(
+  () => store.historyVersion[props.agentCode],
+  () => historySidebar.value?.refresh(),
+)
+
+// 从 Project 详情页跳转过来时带上目标会话 id，直接打开对应历史会话。用 watch 而非 onMounted 一次性
+// 读取：本页处于 keep-alive 下，二次带新 sessionId 跳进来不会重新 mount。immediate 保留首挂载即打开。
+watch(
+  () => props.initialSessionId,
+  (id) => {
+    if (id) {
+      openSession(id)
+    }
+  },
+  { immediate: true },
+)
+
+// 从 keep-alive 缓存里重新激活时滚到最新内容——离开期间进行中的会话仍在后台追加增量。
+onActivated(() => {
+  scrollToBottom()
 })
+
+// 注意：这里刻意没有 onUnmounted abort——会话与 SSE 流属于全局 store，组件销毁（切智能体/关标签）
+// 不应终止后台会话；流的生命周期终点是自然完成、用户点"终止"或整页刷新。
 
 // newSession 供 WorkspaceView 上提后的工具栏"新建会话"按钮按激活 Tab 分发调用
-defineExpose({ sessionId, newSession })
+defineExpose({ newSession })
 </script>
 
 <template>
   <div class="chat-panel">
     <div class="chat-column">
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
-        <div v-for="(msg, index) in messages" :key="index" class="message-row" :class="msg.role">
+        <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
           <div class="bubble">
             <TraceTimeline
               v-if="msg.role === 'assistant' && msg.nodes.length > 0"
               :nodes="msg.nodes"
-              :active="streaming && index === messages.length - 1 && !msg.text"
+              :active="(active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1 && !msg.text"
             />
             <MarkdownRenderer v-if="msg.role === 'assistant'" :text="msg.text" />
             <template v-else>{{ msg.text }}</template>
-            <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && streaming && index === messages.length - 1">思考中…</span>
+            <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && (active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1">思考中…</span>
           </div>
         </div>
-        <el-empty v-if="messages.length === 0" description="开始和智能体对话吧" />
+        <el-empty v-if="(active?.messages.length ?? 0) === 0" description="开始和智能体对话吧" />
       </div>
-      <div v-if="attachments.length > 0" class="attachment-tags">
+      <div v-if="active && active.attachments.length > 0" class="attachment-tags">
         <el-tag
-          v-for="a in attachments"
+          v-for="a in active.attachments"
           :key="a.localId"
           :closable="a.status !== 'uploading'"
           :type="a.status === 'failed' ? 'danger' : undefined"
@@ -280,25 +211,32 @@ defineExpose({ sessionId, newSession })
           :before-upload="beforeAttachmentUpload"
           :accept="ATTACHMENT_ACCEPT"
         >
-          <el-button :disabled="streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
+          <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
             <el-icon><Paperclip /></el-icon>
           </el-button>
         </el-upload>
         <el-input
-          v-model="input"
+          v-if="active"
+          v-model="active.input"
           placeholder="输入消息，回车发送"
-          :disabled="streaming"
+          :disabled="active.streaming"
           @keyup.enter="send"
         />
-        <el-button v-if="!streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
-        <el-button v-else type="danger" :loading="interrupting" @click="handleInterrupt">
-          {{ interrupting ? '终止中…' : '终止' }}
+        <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
+        <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">
+          {{ active?.interrupting ? '终止中…' : '终止' }}
         </el-button>
-        <el-button v-if="interrupted && !streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
+        <el-button v-if="active?.interrupted && !active?.streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
       </div>
     </div>
     <div class="history-column">
-      <ChatHistorySidebar ref="historySidebar" :agent-code="agentCode" :active-session-id="sessionId" @select="openSession" />
+      <ChatHistorySidebar
+        ref="historySidebar"
+        :agent-code="agentCode"
+        :active-session-id="activeSessionId"
+        :live-sessions="liveSessions"
+        @select="openSession"
+      />
     </div>
   </div>
 </template>

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,31 +1,30 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { computed, nextTick, onActivated, onMounted, ref, watch } from 'vue'
 import type { UploadRequestOptions } from 'element-plus'
 import {
   confirmVibeCodingPlan,
   generateCommitMessage,
   generatePrDescription,
   getGitDiffSummary,
-  getSandboxMode,
-  interruptVibeCoding,
-  listWorkspaceFiles,
   readWorkspaceFileContent,
   reviewVibeCoding,
   rollbackVibeCoding,
   saveWorkspaceFileContent,
-  streamVibeCoding,
 } from '@/api/vibecoding'
-import { getChatSessionMessages, parseChatAttachment } from '@/api/chat'
+import { parseChatAttachment } from '@/api/chat'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
-import TraceTimeline, { type TraceNode } from '@/components/TraceTimeline.vue'
+import TraceTimeline from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import { useThemeStore } from '@/store/theme'
+import {
+  useVibeConversationsStore,
+  type PlanCard,
+  type VibeAttachmentItem,
+  type VibeConversation,
+} from '@/store/vibeConversations'
 import { generateUuid } from '@/utils/uuid'
 import type {
-  FileChangeEvent,
   GitDiffSummary,
-  PlanEvent,
-  PlanResultEvent,
   ReviewIssue,
   ReviewResult,
   RoleStageEvent,
@@ -33,83 +32,39 @@ import type {
   WorkspaceFileContent,
   WorkspaceFileNode,
 } from '@/types/api'
-import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
 import hljs from 'highlight.js'
 import 'highlight.js/styles/github.css'
 
 const props = defineProps<{ agentCode: string }>()
 
-/** Plan Mode 确认卡片（P1-1 HITL）：一条 plan 事件对应一张卡片，用户批准/拒绝或超时后翻成终态。 */
-interface PlanCard {
-  planId: string
-  actions: PlanEvent['actions']
-  reason: string
-  status: 'PENDING' | 'APPROVED' | 'REJECTED' | 'TIMEOUT'
-  remainingSeconds: number
-  submitting: boolean
-}
-
-interface ChatMessage {
-  role: 'user' | 'assistant'
-  text: string
-  nodes: TraceNode[]
-  // 本条助手消息内累积的沙箱编译/测试报告（P0-3），按到达顺序渲染成测试报告卡片时间线
-  testReports?: TestReport[]
-  // 本条助手消息内的 Plan Mode 确认卡片（P1-1），高风险操作待人工确认
-  plans?: PlanCard[]
-  // 协作模式多角色阶段进度（P3-1），按 role_stage 事件到达顺序累积
-  stages?: RoleStageEvent[]
-}
-
-/** localId 是前端本地生成的临时 key，用于 v-for/移除定位（上传过程中后端 id 还不存在）；
- * status 驱动 tag 的 loading/失败态展示，失败附件不参与 buildMessageWithAttachments 拼接。 */
-interface Attachment {
-  localId: string
-  id?: string
-  name: string
-  content: string
-  status: 'uploading' | 'success' | 'failed'
-  errorMessage?: string
-}
-
 // 与 starter AttachmentParseService 的白名单/大小限制保持一致（后端 customer-work.attachment.max-file-size-mb=10）
 const ATTACHMENT_ACCEPT = '.md,.txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.proto,.properties,.ini,.conf,.cfg,.log,.env,.sql,.sh,.bash,.zsh,.bat,.ps1,.java,.kt,.kts,.groovy,.gradle,.scala,.py,.js,.ts,.jsx,.tsx,.vue,.css,.scss,.less,.c,.h,.cpp,.hpp,.cs,.go,.rs,.rb,.php,.swift,.lua,.r,.dart,.html,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.bmp,.webp'
 const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
-const sessionId = ref(generateUuid())
-const messages = ref<ChatMessage[]>([])
-const input = ref('')
-// 协作模式开关（P3-1）：开启后按 需求分析→方案设计→编码实现→自测审查 多角色顺序协作
+/**
+ * 会话状态全部在 Pinia store（vibeConversations）里，本组件只是视图：切页面、切智能体、组件销毁
+ * 重建都不影响 store 里进行中的会话与 SSE 流。组件保留的只有纯 UI 状态（抽屉、预览、滚动容器）。
+ */
+const store = useVibeConversationsStore()
+store.ensureAgent(props.agentCode)
+
+const active = computed<VibeConversation | undefined>(() => store.activeOf(props.agentCode))
+const liveSessions = computed(() => store.liveSessionsOf(props.agentCode))
+const activeSessionId = computed(() => store.activeIdOf(props.agentCode))
+const anyAttachmentUploading = computed(() => active.value?.attachments.some((a) => a.status === 'uploading') ?? false)
+
+const input = computed({
+  get: () => active.value?.input ?? '',
+  set: (v) => { if (active.value) active.value.input = v },
+})
+// 协作模式开关（P3-1）：发送选项，面板级
 const collaborationMode = ref(false)
-const streaming = ref(false)
-const interrupting = ref(false) // 已点终止，等后端真正停下来（协作式中断，不保证立即生效）
-const interrupted = ref(false) // 上一轮是被终止结束的，可以点"继续"续跑挂起的工具调用
 const historyLoading = ref(false)
-const attachments = ref<Attachment[]>([])
-const anyAttachmentUploading = computed(() => attachments.value.some((a) => a.status === 'uploading'))
 const scrollRef = ref<HTMLElement>()
 const historySidebar = ref<InstanceType<typeof ChatHistorySidebar>>()
-let abortStream: (() => void) | null = null
 const themeStore = useThemeStore()
 
-// 目录树相关
-const fileNodes = ref<WorkspaceFileNode[]>([])
-const filesLoading = ref(false)
-const filesLoaded = ref(false)
-
-// 沙箱模式（local/docker，全局配置，进面板时查一次即可，不随会话变化）
-const sandboxMode = ref<'local' | 'docker' | null>(null)
-
-// 实时文件变更时间线（本轮对话内累积，切会话/新建会话时清空）
-const fileChanges = ref<Array<FileChangeEvent & { time: number }>>([])
-// 会话一键回滚进行中
-const rollingBack = ref(false)
-
-// Plan Mode（P1-1 HITL）：待确认计划的 planId -> 卡片，供 plan_result 快速定位；倒计时统一由一个定时器驱动
-const pendingPlans = new Map<string, PlanCard>()
-let planCountdownTimer: ReturnType<typeof setInterval> | null = null
-
-// Git 助手抽屉
+// Git 助手抽屉（面板级，操作对象是当前激活会话）
 const gitDrawerVisible = ref(false)
 const gitDiffLoading = ref(false)
 const gitDiff = ref<GitDiffSummary | null>(null)
@@ -133,29 +88,7 @@ const editContent = ref('')
 const saving = ref(false)
 
 function newSession() {
-  abortStream?.()
-  streaming.value = false
-  interrupting.value = false
-  interrupted.value = false
-  sessionId.value = generateUuid()
-  messages.value = []
-  input.value = ''
-  attachments.value = []
-  fileNodes.value = []
-  filesLoaded.value = false
-  fileChanges.value = []
-  clearPendingPlans()
-  // 新会话会用当前全局配置，不是上一个（可能是历史会话解析出的）沙箱模式
-  loadCurrentSandboxMode()
-}
-
-/** 清空待确认计划与倒计时（切会话/新建会话/卸载时）。 */
-function clearPendingPlans() {
-  pendingPlans.clear()
-  if (planCountdownTimer) {
-    clearInterval(planCountdownTimer)
-    planCountdownTimer = null
-  }
+  store.newSession(props.agentCode)
 }
 
 /** 前端先拦超限文件，与后端 max-file-size-mb 对齐，减少无谓上传请求。 */
@@ -168,12 +101,15 @@ function beforeAttachmentUpload(file: File) {
 }
 
 async function handleAttachmentUpload(options: UploadRequestOptions) {
+  // 绑定发起上传时所在的会话：上传是异步的，期间用户可能切走，结果要回填到原会话而不是当前激活会话。
+  const conv = active.value
+  if (!conv) return
   const file = options.file as File
-  const attachment: Attachment = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
-  attachments.value.push(attachment)
+  const attachment: VibeAttachmentItem = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
+  conv.attachments.push(attachment)
   try {
     const result = await parseChatAttachment(props.agentCode, file, 'vibecoding')
-    const target = attachments.value.find((a) => a.localId === attachment.localId)
+    const target = conv.attachments.find((a) => a.localId === attachment.localId)
     if (!target) {
       return // 结果返回前用户已手动移除该附件，迟到的结果直接丢弃
     }
@@ -187,7 +123,7 @@ async function handleAttachmentUpload(options: UploadRequestOptions) {
       target.status = 'success'
     }
   } catch (error) {
-    const target = attachments.value.find((a) => a.localId === attachment.localId)
+    const target = conv.attachments.find((a) => a.localId === attachment.localId)
     const message = error instanceof Error ? error.message : String(error)
     if (target) {
       target.status = 'failed'
@@ -198,12 +134,14 @@ async function handleAttachmentUpload(options: UploadRequestOptions) {
 }
 
 function removeAttachment(localId: string) {
-  attachments.value = attachments.value.filter((a) => a.localId !== localId)
+  const conv = active.value
+  if (!conv) return
+  conv.attachments = conv.attachments.filter((a) => a.localId !== localId)
 }
 
 /** 只拼成功解析的附件，上传中/失败的附件不参与（失败的已经在上传回调里提示过用户）。 */
-function buildMessageWithAttachments(text: string): string {
-  const successful = attachments.value.filter((a) => a.status === 'success')
+function buildMessageWithAttachments(conv: VibeConversation, text: string): string {
+  const successful = conv.attachments.filter((a) => a.status === 'success')
   if (successful.length === 0) return text
   const attachmentText = successful
     .map((a) => `【附件：${a.name}】\n---\n${a.content}\n---`)
@@ -212,27 +150,10 @@ function buildMessageWithAttachments(text: string): string {
 }
 
 async function openSession(targetSessionId: string) {
-  if (streaming.value) return
-  abortStream?.()
-  interrupting.value = false
-  interrupted.value = false
   historyLoading.value = true
   try {
-    const history = await getChatSessionMessages(props.agentCode, targetSessionId)
-    sessionId.value = targetSessionId
-    messages.value = history.map((msg) => ({ role: msg.role, text: msg.text, nodes: [] }))
-    input.value = ''
-    fileNodes.value = []
-    filesLoaded.value = false
-    fileChanges.value = []
-    clearPendingPlans()
-    // 标签要反映"这条会话当时真正用的模式"，从首条用户消息里解析；更早期没有该前缀的历史记录
-    // 解析不出来，此时不展示误导性的标签（不回退成当前全局配置，两者含义不同不能互相替代）
-    const firstUserMessage = history.find((msg) => msg.role === 'user')
-    sandboxMode.value = firstUserMessage ? parseSandboxModeFromMessage(firstUserMessage.text) : null
+    await store.openSession(props.agentCode, targetSessionId)
     scrollToBottom()
-    // 切到历史会话时该会话可能已有产物文件，无需等用户手动点“刷新”
-    loadFiles()
   } catch (error) {
     ElMessage.error('历史会话加载失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
@@ -247,155 +168,26 @@ function scrollToBottom() {
 }
 
 function send() {
-  const text = input.value.trim()
-  if (!text || streaming.value || anyAttachmentUploading.value) return
-  interrupted.value = false
-  const messageToSend = buildMessageWithAttachments(text)
-  const attachedNames = attachments.value.filter((a) => a.status === 'success').map((a) => a.name)
-  messages.value.push({
-    role: 'user',
-    text: attachedNames.length > 0 ? `${text}\n📎 ${attachedNames.join('、')}` : text,
-    nodes: [],
-  })
-  messages.value.push({ role: 'assistant', text: '', nodes: [], testReports: [] })
-  const assistantMessage = messages.value[messages.value.length - 1]
-  input.value = ''
-  attachments.value = []
-  streaming.value = true
-  scrollToBottom()
-
-  abortStream = streamVibeCoding(props.agentCode, { sessionId: sessionId.value, message: messageToSend, collaboration: collaborationMode.value }, {
-    onEvent: (event) => {
-      if (event.event === 'done') {
-        streaming.value = false
-        // 对话结束后自动刷新文件目录树
-        loadFiles()
-        return
-      }
-      if (event.event === 'file_change') {
-        handleFileChange(event.data)
-        return
-      }
-      if (event.event === 'test_report') {
-        handleTestReport(assistantMessage, event.data)
-        scrollToBottom()
-        return
-      }
-      if (event.event === 'role_stage') {
-        handleRoleStage(assistantMessage, event.data)
-        scrollToBottom()
-        return
-      }
-      if (event.event === 'plan') {
-        handlePlanEvent(assistantMessage, event.data)
-        scrollToBottom()
-        return
-      }
-      if (event.event === 'plan_result') {
-        handlePlanResult(event.data)
-        return
-      }
-      if (event.event.startsWith('node:')) {
-        const kind = event.event.slice('node:'.length)
-        const payload = parseChatStreamPayload(event.data)
-        appendChatStreamNode(assistantMessage.nodes, kind, payload.text, payload.source, payload.subagentName)
-      } else if (event.event === 'message') {
-        const payload = parseChatStreamPayload(event.data)
-        if (payload.source) {
-          // 带 source 的正文增量是子Agent 内部产出，复用 ANSWER kind 挂进对应嵌套面板，
-          // 不算进主回答正文（主回答正文只承载主 Agent 自己的 message 事件，source 缺省）
-          appendChatStreamNode(assistantMessage.nodes, ANSWER_KIND, payload.text, payload.source, payload.subagentName)
-        } else {
-          assistantMessage.text += payload.text
-        }
-      }
-      // 其余未知事件静默忽略：后端新增 SSE 事件类型（如 test_report/plan）时旧前端不受影响，
-      // 避免把结构化 JSON 拼进对话正文（需求 §5.5 向后兼容）
-      scrollToBottom()
-    },
-    onError: (error) => {
-      streaming.value = false
-      interrupting.value = false
-      ElMessage.error('对话失败：' + (error instanceof Error ? error.message : String(error)))
-    },
-    onComplete: () => {
-      streaming.value = false
-      // 若这轮是用户主动点了"终止"后自然结束的，翻转成"可继续"状态，冒出继续按钮
-      if (interrupting.value) {
-        interrupting.value = false
-        interrupted.value = true
-      }
-      historySidebar.value?.refresh()
-    },
-  })
+  store.send(props.agentCode, collaborationMode.value, buildMessageWithAttachments, scrollToBottom)
 }
 
-/** 点击"终止"：只通知后端安全中断（协作式，不保证立即生效），不调 abortStream() 断开前端连接——
- * 让现有的 onComplete/onError 在后端真正停止、SSE 自然结束时收尾，避免界面显示"已停止"但后端其实
- * 还在跑的假象。 */
-async function handleInterrupt() {
-  interrupting.value = true
-  try {
-    await interruptVibeCoding(props.agentCode, sessionId.value)
-  } catch (error) {
-    interrupting.value = false
-    ElMessage.error('终止失败：' + (error instanceof Error ? error.message : String(error)))
-  }
+function handleInterrupt() {
+  store.interrupt(props.agentCode)
 }
 
-/** 点击"继续"：发一句非空续接文案触发框架续跑被打断的挂起工具调用（后端 ChatRequest.message 要求非空，
- * 且续跑逻辑本就挂在正常的 stream 调用里，无需专门的续跑接口）。 */
+/** 点击"继续"：发一句非空续接文案触发框架续跑被打断的挂起工具调用。 */
 function resumeInterrupted() {
-  interrupted.value = false
-  input.value = '请继续刚才的任务。'
+  const conv = active.value
+  if (!conv) return
+  conv.interrupted = false
+  conv.input = '请继续刚才的任务。'
   send()
 }
 
-/** 解析 file_change SSE 事件，追加到变更时间线（不按路径去重，同一文件多次改动各自成一条，还原真实操作顺序）。 */
-function handleFileChange(raw: string) {
-  try {
-    const parsed = JSON.parse(raw) as FileChangeEvent
-    fileChanges.value.push({ ...parsed, time: Date.now() })
-  } catch {
-    // 解析失败不影响主对话流程，静默丢弃
-  }
-}
-
-/** 解析 test_report SSE 事件，追加到该助手消息的测试报告时间线（每轮验证一张卡片）。 */
-function handleTestReport(assistantMessage: ChatMessage, raw: string) {
-  try {
-    const parsed = JSON.parse(raw) as TestReport
-    ;(assistantMessage.testReports ??= []).push(parsed)
-  } catch {
-    // 解析失败不影响主对话流程，静默丢弃
-  }
-}
-
-/**
- * 解析 role_stage SSE 事件（P3-1 协作模式）：维护该助手消息的多角色阶段进度列表。
- * START 追加一条新阶段；DONE/FAILED 按 index 匹配已存在阶段并更新其状态与产物（找不到则补插一条）。
- */
-function handleRoleStage(assistantMessage: ChatMessage, raw: string) {
-  try {
-    const parsed = JSON.parse(raw) as RoleStageEvent
-    const stages = (assistantMessage.stages ??= [])
-    if (parsed.status === 'START') {
-      stages.push({ ...parsed, output: null })
-      return
-    }
-    // DONE / FAILED：按 index 更新已有阶段的状态与产物
-    const existing = stages.find((s) => s.index === parsed.index)
-    if (existing) {
-      existing.status = parsed.status
-      existing.output = parsed.output
-      existing.role = parsed.role
-      existing.type = parsed.type
-    } else {
-      stages.push({ ...parsed })
-    }
-  } catch {
-    // 解析失败不影响主对话流程，静默丢弃
-  }
+function refreshFiles() {
+  const conv = active.value
+  if (!conv) return
+  store.loadFiles(props.agentCode, conv.sessionId)
 }
 
 /** 阶段状态标签文案。 */
@@ -425,88 +217,30 @@ function roleStageTypeText(type: RoleStageEvent['type']): string {
   return map[type]
 }
 
-/** 解析 plan SSE 事件，追加一张待确认卡片并启动倒计时（P1-1 HITL）。 */
-function handlePlanEvent(assistantMessage: ChatMessage, raw: string) {
-  try {
-    const parsed = JSON.parse(raw) as PlanEvent
-    const card: PlanCard = {
-      planId: parsed.planId,
-      actions: parsed.actions ?? [],
-      reason: parsed.reason ?? '',
-      status: 'PENDING',
-      remainingSeconds: parsed.timeoutSeconds ?? 300,
-      submitting: false,
-    }
-    const plans = (assistantMessage.plans ??= [])
-    plans.push(card)
-    // 存入 pendingPlans 的必须是"push 进响应式数组后"的响应式代理引用，否则定时器/plan_result 修改
-    // 原始对象不会触发视图更新（Vue3 响应式经典坑：修改未经代理的原对象不触发依赖收集）
-    pendingPlans.set(card.planId, plans[plans.length - 1])
-    ensurePlanCountdown()
-  } catch {
-    // 解析失败不影响主对话流程，静默丢弃
-  }
-}
-
-/** 解析 plan_result SSE 事件，把对应卡片翻成终态（含服务端超时自动拒绝）。 */
-function handlePlanResult(raw: string) {
-  try {
-    const parsed = JSON.parse(raw) as PlanResultEvent
-    const card = pendingPlans.get(parsed.planId)
-    if (card) {
-      card.status = parsed.status
-      card.submitting = false
-      pendingPlans.delete(parsed.planId)
-    }
-  } catch {
-    // 解析失败静默丢弃
-  }
-}
-
-/** 启动（若未启动）统一倒计时定时器：每秒递减所有待确认卡片，归零即本地标记超时。 */
-function ensurePlanCountdown() {
-  if (planCountdownTimer) return
-  planCountdownTimer = setInterval(() => {
-    if (pendingPlans.size === 0) {
-      clearInterval(planCountdownTimer!)
-      planCountdownTimer = null
-      return
-    }
-    for (const card of pendingPlans.values()) {
-      card.remainingSeconds -= 1
-      if (card.remainingSeconds <= 0) {
-        // 本地倒计时归零：先行标记超时（服务端也会补发 plan_result=TIMEOUT，二者幂等）
-        card.status = 'TIMEOUT'
-        card.remainingSeconds = 0
-        pendingPlans.delete(card.planId)
-      }
-    }
-  }, 1000)
-}
-
-/** 用户对某个计划卡片点批准/拒绝：调后端确认接口，成功后翻成终态。 */
+/** 用户对某个计划卡片点批准/拒绝：调后端确认接口，成功后翻成终态。卡片属于当前激活会话（视图只渲染 active）。 */
 async function handlePlanDecision(card: PlanCard, approved: boolean) {
-  if (card.status !== 'PENDING' || card.submitting) return
+  const conv = active.value
+  if (!conv || card.status !== 'PENDING' || card.submitting) return
   card.submitting = true
   try {
     await confirmVibeCodingPlan(props.agentCode, {
-      sessionId: sessionId.value,
+      sessionId: conv.sessionId,
       planId: card.planId,
       approved,
     })
     card.status = approved ? 'APPROVED' : 'REJECTED'
-    pendingPlans.delete(card.planId)
+    conv.pendingPlans.delete(card.planId)
   } catch (error) {
     // 失败常见于挂起项已失效（超时/服务重启）：提示并按拒绝态收尾，避免卡片永久停在"等待确认"
     ElMessage.error('计划确认失败：' + (error instanceof Error ? error.message : String(error)))
     card.status = 'TIMEOUT'
-    pendingPlans.delete(card.planId)
+    conv.pendingPlans.delete(card.planId)
   } finally {
     card.submitting = false
   }
 }
 
-/** 计划卡片操作类型 → 中文标签 + Element tag 着色。 */
+/** 计划卡片操作类型 → 中文标签。 */
 function planActionLabel(type: string): string {
   switch (type) {
     case 'DELETE': return '删除文件'
@@ -540,6 +274,8 @@ function testReportTitle(report: TestReport): string {
  * 破坏性操作，二次确认后调用；成功后清空变更时间线、刷新文件树与 diff，并在对话流插入系统提示。
  */
 async function handleRollback() {
+  const conv = active.value
+  if (!conv) return
   try {
     await ElMessageBox.confirm(
       '此操作将丢弃本次会话对工作区的全部文件改动：新增文件将被删除，修改/删除的文件将恢复到对话前的状态。操作不可撤销，是否继续？',
@@ -549,15 +285,15 @@ async function handleRollback() {
   } catch {
     return // 用户取消
   }
-  rollingBack.value = true
+  conv.rollingBack = true
   try {
-    const res = await rollbackVibeCoding(props.agentCode, sessionId.value)
-    fileChanges.value = []
-    await loadFiles()
+    const res = await rollbackVibeCoding(props.agentCode, conv.sessionId)
+    conv.fileChanges = []
+    await store.loadFiles(props.agentCode, conv.sessionId)
     // Git 助手抽屉开着则刷新 diff（回滚后应无变更）
     if (gitDrawerVisible.value) await loadGitDiff()
     // 对话流插入一条系统提示（需求 §4.1.2）
-    messages.value.push({
+    conv.messages.push({
       role: 'assistant',
       text: `🔄 已撤销本次会话的全部修改（恢复 ${res.restoredFiles.length} 个文件，删除 ${res.deletedFiles.length} 个新增文件）。`,
       nodes: [],
@@ -567,7 +303,7 @@ async function handleRollback() {
   } catch (error) {
     ElMessage.error('撤销失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
-    rollingBack.value = false
+    conv.rollingBack = false
   }
 }
 
@@ -582,9 +318,11 @@ async function openGitAssistant() {
 }
 
 async function loadGitDiff() {
+  const conv = active.value
+  if (!conv) return
   gitDiffLoading.value = true
   try {
-    gitDiff.value = await getGitDiffSummary(props.agentCode, sessionId.value)
+    gitDiff.value = await getGitDiffSummary(props.agentCode, conv.sessionId)
   } catch (error) {
     ElMessage.error('diff 摘要加载失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
@@ -593,9 +331,11 @@ async function loadGitDiff() {
 }
 
 async function handleGenerateCommitMessage() {
+  const conv = active.value
+  if (!conv) return
   commitLoading.value = true
   try {
-    const res = await generateCommitMessage(props.agentCode, { sessionId: sessionId.value, style: commitStyle.value })
+    const res = await generateCommitMessage(props.agentCode, { sessionId: conv.sessionId, style: commitStyle.value })
     commitMessageText.value = res.message
   } catch (error) {
     ElMessage.error('commit message 生成失败：' + (error instanceof Error ? error.message : String(error)))
@@ -605,9 +345,11 @@ async function handleGenerateCommitMessage() {
 }
 
 async function handleGeneratePrDescription() {
+  const conv = active.value
+  if (!conv) return
   prLoading.value = true
   try {
-    const res = await generatePrDescription(props.agentCode, sessionId.value)
+    const res = await generatePrDescription(props.agentCode, conv.sessionId)
     prDescriptionText.value = res.description
   } catch (error) {
     ElMessage.error('PR description 生成失败：' + (error instanceof Error ? error.message : String(error)))
@@ -618,9 +360,11 @@ async function handleGeneratePrDescription() {
 
 /** 触发 AI 代码审查：对本轮 diff 输出结构化审查意见。 */
 async function handleReview() {
+  const conv = active.value
+  if (!conv) return
   reviewLoading.value = true
   try {
-    reviewResult.value = await reviewVibeCoding(props.agentCode, sessionId.value)
+    reviewResult.value = await reviewVibeCoding(props.agentCode, conv.sessionId)
   } catch (error) {
     ElMessage.error('代码审查失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
@@ -654,6 +398,8 @@ async function openIssueFile(issue: ReviewIssue) {
  * 由 Agent 走既有 VibeCoding 链路修复（天然带 file_change 与回滚保障）。
  */
 function generateFixFromReview() {
+  const conv = active.value
+  if (!conv) return
   const result = reviewResult.value
   if (!result || result.issues.length === 0) return
   const actionable = result.issues.filter((i) => i.severity === 'CRITICAL' || i.severity === 'WARNING')
@@ -664,7 +410,7 @@ function generateFixFromReview() {
   const lines = actionable.map(
     (i) => `- [${i.severity}] ${i.file}${i.line ? `:${i.line}` : ''} ${i.message}（建议：${i.suggestion}）`,
   )
-  input.value = `请根据以下代码审查意见修复问题，并在沙箱内重新验证：\n${lines.join('\n')}`
+  conv.input = `请根据以下代码审查意见修复问题，并在沙箱内重新验证：\n${lines.join('\n')}`
   gitDrawerVisible.value = false
   send()
 }
@@ -679,29 +425,17 @@ async function copyToClipboard(text: string, label: string) {
   }
 }
 
-/** 加载（刷新）会话 workspace 目录树。 */
-async function loadFiles() {
-  filesLoading.value = true
-  try {
-    fileNodes.value = await listWorkspaceFiles(props.agentCode, sessionId.value)
-    filesLoaded.value = true
-  } catch (error) {
-    ElMessage.error('目录加载失败：' + (error instanceof Error ? error.message : String(error)))
-  } finally {
-    filesLoading.value = false
-  }
-}
-
 /** 点击文件节点，打开预览抽屉并加载内容。 */
 async function openFilePreview(node: WorkspaceFileNode) {
-  if (node.directory) return
+  const conv = active.value
+  if (!conv || node.directory) return
   previewVisible.value = true
   previewLoading.value = true
   previewFile.value = null
   editMode.value = false
   editContent.value = ''
   try {
-    previewFile.value = await readWorkspaceFileContent(props.agentCode, sessionId.value, node.relativePath)
+    previewFile.value = await readWorkspaceFileContent(props.agentCode, conv.sessionId, node.relativePath)
     // 等 DOM 更新后触发代码高亮
     await nextTick()
     highlightPreview()
@@ -730,11 +464,12 @@ async function cancelEdit() {
 
 /** 保存编辑内容到服务端文件。 */
 async function saveEdit() {
-  if (!previewFile.value) return
+  const conv = active.value
+  if (!conv || !previewFile.value) return
   saving.value = true
   try {
     await saveWorkspaceFileContent(props.agentCode, {
-      sessionId: sessionId.value,
+      sessionId: conv.sessionId,
       relativePath: previewFile.value.relativePath,
       content: editContent.value,
     })
@@ -759,33 +494,23 @@ function highlightPreview() {
   }
 }
 
-/**
- * 当前全局沙箱配置（admin.sandbox.mode），代表"新会话将会使用的模式"。
- * 仅用于 newSession/挂载时的预览——一旦切到某条历史会话，标签要改成从那条会话消息里解析出的
- * "当时真正用的模式"，不能一直显示"现在的全局配置"，否则历史记录和当前配置不一致时会互相矛盾
- * （比如切到一条 local 时期的历史记录，标题却显示当前是 docker，误导用户以为这条记录也在容器里）。
- */
-function loadCurrentSandboxMode() {
-  getSandboxMode(props.agentCode)
-    .then((res) => { sandboxMode.value = res.mode })
-    .catch(() => { sandboxMode.value = null })
-}
-
-/** 从会话首条用户消息里解析出发送时用的沙箱模式，解析不出来（更早期版本的历史记录）返回 null。 */
-function parseSandboxModeFromMessage(text: string): 'local' | 'docker' | null {
-  const match = text.match(/^\[VibeCoding指引-(docker|local)]/)
-  return match ? (match[1] as 'local' | 'docker') : null
-}
-
 onMounted(() => {
   themeStore.apply()
-  loadCurrentSandboxMode()
 })
 
-onUnmounted(() => {
-  abortStream?.()
-  clearPendingPlans()
+// 每轮对话流结束（store 里自增版本号）刷新侧边栏的后端历史列表。
+watch(
+  () => store.historyVersion[props.agentCode],
+  () => historySidebar.value?.refresh(),
+)
+
+// 从 keep-alive 缓存里重新激活时滚到最新内容——离开期间进行中的会话仍在后台追加增量。
+onActivated(() => {
+  scrollToBottom()
 })
+
+// 注意：刻意没有 onUnmounted abort/清定时器——会话、SSE 流、plan 倒计时都属于全局 store，
+// 组件销毁（切智能体/关标签）不应终止后台会话。
 
 // newSession 供 WorkspaceView 上提后的工具栏"新建会话"按钮按激活 Tab 分发调用
 defineExpose({ newSession })
@@ -796,12 +521,12 @@ defineExpose({ newSession })
     <!-- 左列：对话区 -->
     <div class="chat-column">
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
-        <div v-for="(msg, index) in messages" :key="index" class="message-row" :class="msg.role">
+        <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
           <div class="bubble">
             <TraceTimeline
               v-if="msg.role === 'assistant' && msg.nodes.length > 0"
               :nodes="msg.nodes"
-              :active="streaming && index === messages.length - 1 && !msg.text"
+              :active="(active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1 && !msg.text"
             />
             <MarkdownRenderer v-if="msg.role === 'assistant'" :text="msg.text" />
             <!-- 沙箱编译/测试报告卡片时间线（P0-3）：每轮验证一张，通过绿/失败红，可展开看失败明细 -->
@@ -925,14 +650,14 @@ defineExpose({ newSession })
               </div>
             </div>
             <template v-if="msg.role === 'user'">{{ msg.text }}</template>
-            <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && streaming && index === messages.length - 1">生成中…</span>
+            <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && (active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1">生成中…</span>
           </div>
         </div>
-        <el-empty v-if="messages.length === 0" description="描述你想让智能体生成/修改的代码" />
+        <el-empty v-if="(active?.messages.length ?? 0) === 0" description="描述你想让智能体生成/修改的代码" />
       </div>
-      <div v-if="attachments.length > 0" class="attachment-tags">
+      <div v-if="active && active.attachments.length > 0" class="attachment-tags">
         <el-tag
-          v-for="a in attachments"
+          v-for="a in active.attachments"
           :key="a.localId"
           :closable="a.status !== 'uploading'"
           :type="a.status === 'failed' ? 'danger' : undefined"
@@ -945,27 +670,27 @@ defineExpose({ newSession })
       </div>
       <div class="input-bar">
         <el-upload :show-file-list="false" :http-request="handleAttachmentUpload" :before-upload="beforeAttachmentUpload" :accept="ATTACHMENT_ACCEPT">
-          <el-button :disabled="streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
+          <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
             <el-icon><Paperclip /></el-icon>
           </el-button>
         </el-upload>
-        <el-input v-model="input" placeholder="描述需求，回车发送" :disabled="streaming" @keyup.enter="send" />
+        <el-input v-model="input" placeholder="描述需求，回车发送" :disabled="active?.streaming" @keyup.enter="send" />
         <el-tooltip
           placement="top"
           content="开启后按 需求分析→方案设计→编码实现→自测审查 多角色顺序协作"
         >
           <el-switch
             v-model="collaborationMode"
-            :disabled="streaming"
+            :disabled="active?.streaming"
             active-text="协作模式"
             class="collaboration-switch"
           />
         </el-tooltip>
-        <el-button v-if="!streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
-        <el-button v-else type="danger" :loading="interrupting" @click="handleInterrupt">
-          {{ interrupting ? '终止中…' : '终止' }}
+        <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
+        <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">
+          {{ active?.interrupting ? '终止中…' : '终止' }}
         </el-button>
-        <el-button v-if="interrupted && !streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
+        <el-button v-if="active?.interrupted && !active?.streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
       </div>
     </div>
 
@@ -974,26 +699,26 @@ defineExpose({ newSession })
       <div class="artifacts-header">
         <span>
           产物文件
-          <el-tag v-if="sandboxMode" size="small" :type="sandboxMode === 'docker' ? 'warning' : 'info'" class="sandbox-mode-tag">
-            {{ sandboxMode === 'docker' ? 'docker' : 'local' }}
+          <el-tag v-if="active?.sandboxMode" size="small" :type="active.sandboxMode === 'docker' ? 'warning' : 'info'" class="sandbox-mode-tag">
+            {{ active.sandboxMode === 'docker' ? 'docker' : 'local' }}
           </el-tag>
         </span>
         <div class="artifacts-header-actions">
           <el-button link type="primary" @click="openGitAssistant">Git 助手</el-button>
-          <el-button link type="primary" :loading="filesLoading" @click="loadFiles">刷新</el-button>
+          <el-button link type="primary" :loading="active?.filesLoading" @click="refreshFiles">刷新</el-button>
         </div>
       </div>
 
       <!-- 实时文件变更时间线 -->
-      <div v-if="fileChanges.length > 0" class="file-change-timeline">
+      <div v-if="active && active.fileChanges.length > 0" class="file-change-timeline">
         <div class="file-change-timeline-header">
           <span class="file-change-timeline-title">本轮变更</span>
           <el-button
             link
             type="danger"
             size="small"
-            :loading="rollingBack"
-            :disabled="streaming"
+            :loading="active?.rollingBack"
+            :disabled="active?.streaming"
             title="撤销本次会话的全部文件改动，恢复到对话前状态"
             @click="handleRollback"
           >
@@ -1001,7 +726,7 @@ defineExpose({ newSession })
           </el-button>
         </div>
         <el-scrollbar max-height="120px">
-          <div v-for="(fc, idx) in fileChanges" :key="idx" class="file-change-item">
+          <div v-for="(fc, idx) in active.fileChanges" :key="idx" class="file-change-item">
             <el-icon v-if="fc.operation === 'CREATE'" style="color:#67c23a"><CirclePlus /></el-icon>
             <el-icon v-else-if="fc.operation === 'MODIFY'" style="color:#e6a23c"><EditPen /></el-icon>
             <el-icon v-else style="color:#f56c6c"><Delete /></el-icon>
@@ -1012,12 +737,12 @@ defineExpose({ newSession })
 
       <!-- 空状态 -->
       <el-empty
-        v-if="!filesLoaded"
+        v-if="!active?.filesLoaded"
         description="对话结束后自动刷新"
         :image-size="50"
       />
       <el-empty
-        v-else-if="filesLoaded && fileNodes.length === 0"
+        v-else-if="active?.filesLoaded && active.fileNodes.length === 0"
         description="本次会话暂无产出文件"
         :image-size="50"
       />
@@ -1025,7 +750,7 @@ defineExpose({ newSession })
       <!-- 目录树 -->
       <el-scrollbar v-else height="100%">
         <el-tree
-          :data="fileNodes"
+          :data="active?.fileNodes ?? []"
           :props="{ label: 'name', children: 'children', isLeaf: (n: WorkspaceFileNode) => !n.directory }"
           node-key="relativePath"
           default-expand-all
@@ -1045,7 +770,13 @@ defineExpose({ newSession })
 
     <!-- 右列：历史会话 -->
     <div class="history-column">
-      <ChatHistorySidebar ref="historySidebar" :agent-code="agentCode" :active-session-id="sessionId" @select="openSession" />
+      <ChatHistorySidebar
+        ref="historySidebar"
+        :agent-code="agentCode"
+        :active-session-id="activeSessionId"
+        :live-sessions="liveSessions"
+        @select="openSession"
+      />
     </div>
 
     <!-- 文件内容预览抽屉 -->
@@ -1206,7 +937,7 @@ defineExpose({ newSession })
               type="warning"
               size="small"
               class="review-fix-btn"
-              :disabled="streaming"
+              :disabled="active?.streaming"
               @click="generateFixFromReview"
             >
               一键生成修复

--- a/customer-admin-web/src/views/workspace/WorkspaceView.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useMenuStore } from '@/store/menu'
 import type { MenuNode } from '@/types/api'
@@ -7,6 +7,11 @@ import ChatPanel from './ChatPanel.vue'
 import VibeCodingPanel from './VibeCodingPanel.vue'
 import KnowledgeDrawer from './KnowledgeDrawer.vue'
 import ThemeToolbar from '@/components/ThemeToolbar.vue'
+
+// 供 MainLayout 的 <keep-alive :include> 按组件名精确命中——离开本页（切到其它菜单）时不销毁，
+// 只是 deactivated；SSE 流不会被 onUnmounted 打断，切回来消息能接着看，见 ChatPanel/VibeCodingPanel
+// 的 onUnmounted 注释。
+defineOptions({ name: 'WorkspaceView' })
 
 const props = defineProps<{ agentCode: string }>()
 const menuStore = useMenuStore()
@@ -33,6 +38,16 @@ const supportsVibeCoding = computed(() => agentNode.value?.capabilities?.include
 
 // 主题色/新建会话工具栏上提到 Tab 上方后，"新建会话"要按当前激活的 Tab 分发到对应面板
 const activeTab = ref<'chat' | 'vibecoding'>('chat')
+
+// keep-alive 复用同一实例后，切智能体不再重建本组件，activeTab 会带着上一个智能体的值——
+// 从支持 vibecoding 的智能体的 VibeCoding tab 切到不支持的智能体时，'vibecoding' 这个 tab-pane
+// 不渲染，el-tabs 的 v-model 指向不存在的 pane，整个 tab 内容区直接空白（实测踩过）。
+// 旧代码每次切换都销毁重建、activeTab 隐式重置，keep-alive 把这个隐式重置保没了，这里补成显式的。
+watch(supportsVibeCoding, (supported) => {
+  if (!supported && activeTab.value === 'vibecoding') {
+    activeTab.value = 'chat'
+  }
+})
 const chatPanelRef = ref<InstanceType<typeof ChatPanel>>()
 const vibeCodingPanelRef = ref<InstanceType<typeof VibeCodingPanel>>()
 
@@ -53,7 +68,8 @@ const knowledgeVisible = ref(false)
     <div class="workspace-header">
       <h2 class="agent-title">{{ agentNode?.name ?? agentCode }}</h2>
       <div class="header-actions">
-        <el-button size="small" @click="knowledgeVisible = true">代码知识库</el-button>
+        <!-- 与 ThemeToolbar 里两个按钮保持同一胶囊规格（34px 高/17px 圆角/13px 字号），蓝底白字 -->
+        <button type="button" class="knowledge-btn" @click="knowledgeVisible = true">代码知识库</button>
         <ThemeToolbar :on-new-session="newSession" />
       </div>
     </div>
@@ -94,7 +110,36 @@ const knowledgeVisible = ref(false)
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+}
+
+/* 代码知识库：蓝底白字胶囊，规格与 ThemeToolbar 的主题色/新建会话按钮一致（34px 高/17px 圆角） */
+.knowledge-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 18px;
+  border: none;
+  border-radius: 17px;
+  background: #409eff;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
+}
+
+.knowledge-btn:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  transform: translateY(-1px);
+}
+
+.knowledge-btn:active {
+  transform: translateY(0);
+  filter: brightness(0.96);
 }
 
 .workspace-tabs {

--- a/customer-work-starter/pom.xml
+++ b/customer-work-starter/pom.xml
@@ -183,6 +183,16 @@
             <version>3.3.2</version>
         </dependency>
 
+        <!-- 分布式锁（DistributedLockExecutor，见 lock 包）：用 Redisson 而非已引入的 Jedis——
+             加锁语义（可重入、CAS 安全解锁、连接失败即时抛错）不是简单 SET NX 能等价替代的，
+             与"读缓存用 Jedis 直连"是两类不同的正确性要求，分开选型不复用同一客户端。
+             agentscope-bom 未管理其版本，同 xxl-job-core，需显式声明。 -->
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson</artifactId>
+            <version>3.52.0</version>
+        </dependency>
+
         <!-- 长期记忆扩展：Mem0 / ReMe / 百炼 -->
         <dependency>
             <groupId>io.agentscope</groupId>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -101,6 +101,9 @@ public class CustomerWorkProperties {
     /** 工单智能分配（LLM 分类 + 打分器 + HITL 推荐，智能路由中控第二块之二）。 */
     private final Routing routing = new Routing();
 
+    /** 分布式锁（跨实例互斥场景，如后台管理并发写操作互斥），基于 Redisson。 */
+    private final DistributedLock distributedLock = new DistributedLock();
+
     /**
      * 会话总结建议配置。默认关闭。
      *
@@ -137,6 +140,19 @@ public class CustomerWorkProperties {
         private int topN = 3;
         /** 单次工单分类 LLM 调用超时（秒）。 */
         private long classifyTimeoutSeconds = 30;
+    }
+
+    /** 分布式锁配置：{@code DistributedLockExecutor} 底层 RedissonClient 连接的 Redis。 */
+    @Data
+    public static class DistributedLock {
+        private final Redis redis = new Redis();
+
+        @Data
+        public static class Redis {
+            private String host = "localhost";
+            private int port = 6379;
+            private String password = "";
+        }
     }
 
     /**

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/DistributedLockConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/DistributedLockConfig.java
@@ -1,0 +1,58 @@
+package com.richard.fyoung.customerwork.lock;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 分布式锁自动装配：随 {@code CustomerWorkAutoConfiguration} 的组件扫描一并生效，下游应用引入
+ * starter 依赖即可直接注入 {@link DistributedLockExecutor} 使用，无需关心 Redisson 接线细节。
+ *
+ * <p>{@code customer-admin-server} 关闭了 starter 自动装配（见其 {@code spring.autoconfigure.exclude}），
+ * 需要本能力时在自己的 {@code @Configuration} 里仿此手动 new，复用自身已有的 Redis 连接配置——
+ * 与 Store SPI / AgentStateStore 等既有能力的接入方式一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class DistributedLockConfig {
+
+    @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean
+    public RedissonClient redissonClient(CustomerWorkProperties properties) {
+        return buildRedissonClient(properties.getDistributedLock().getRedis());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DistributedLockExecutor distributedLockExecutor(RedissonClient redissonClient) {
+        return new RedissonDistributedLockExecutor(redissonClient);
+    }
+
+    /**
+     * 按 host/port/password 构建单机模式 RedissonClient（抽出静态方法，供 admin-server 手动装配时复用同一套逻辑）。
+     *
+     * <p>当前用 {@code useSingleServer()} 对接单实例 Redis；生产环境若切成哨兵/集群部署，只需把这一处
+     * 换成 {@code config.useSentinelServers()...} / {@code config.useClusterServers()...}，调用方
+     * （{@code PermissionService} 等业务代码、admin-server 的手动装配）完全无感知，不用改。</p>
+     */
+    public static RedissonClient buildRedissonClient(CustomerWorkProperties.DistributedLock.Redis r) {
+        Config config = new Config();
+        // 惰性连接：与本项目 JedisPool 的既有约定一致（构造本身不真正连 Redis），Redisson 默认在
+        // create() 时就同步建连、连不上直接抛异常，会导致 Redis 不可达时整个应用直接启动失败——
+        // 而分布式锁只是保护单个并发场景的旁路能力，不该拖垮主链路的可启动性；真正连接延后到
+        // 第一次 tryLock 才发生，届时连不上就在那次调用里失败，由调用方按业务语义处理（见
+        // RedissonDistributedLockExecutor 对基础设施异常"不吞、原样上抛"的注释）。
+        config.setLazyInitialization(true);
+        SingleServerConfig serverConfig = config.useSingleServer()
+            .setAddress("redis://" + r.getHost() + ":" + r.getPort());
+        if (r.getPassword() != null && !r.getPassword().isBlank()) {
+            serverConfig.setPassword(r.getPassword());
+        }
+        return Redisson.create(config);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/DistributedLockExecutor.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/DistributedLockExecutor.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customerwork.lock;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * 分布式锁执行器：同一个 {@code lockKey} 在跨进程/跨实例范围内互斥执行 {@code action}。
+ *
+ * <p>用于保护"多个调用方可能并发操作同一资源、需要串行化"的业务场景（如后台管理并发写操作），
+ * 不是通用限流/幂等组件——action 内部逻辑仍需自行保证幂等或事务完整性，本组件只保证同一时刻
+ * 至多一个调用方持有锁。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface DistributedLockExecutor {
+
+    /**
+     * 尝试加锁并执行 {@code action}，返回其结果。
+     *
+     * @param lockKey   锁资源标识，调用方自行规划命名空间前缀，避免跨业务碰撞
+     * @param waitTime  等待获取锁的最长时间；{@link Duration#ZERO} 表示不等待，立即失败（fast fail）
+     * @param leaseTime 持锁最长时间，超时自动释放（防止持锁方异常退出后锁永久不释放）；
+     *                  必须覆盖 {@code action} 的预期最长执行时间
+     * @throws LockAcquireTimeoutException 在 {@code waitTime} 内未能获取到锁
+     */
+    <T> T execute(String lockKey, Duration waitTime, Duration leaseTime, Supplier<T> action);
+
+    /** 无返回值版本，见 {@link #execute(String, Duration, Duration, Supplier)}。 */
+    default void execute(String lockKey, Duration waitTime, Duration leaseTime, Runnable action) {
+        execute(lockKey, waitTime, leaseTime, () -> {
+            action.run();
+            return null;
+        });
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/LockAcquireTimeoutException.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/LockAcquireTimeoutException.java
@@ -1,0 +1,13 @@
+package com.richard.fyoung.customerwork.lock;
+
+/**
+ * 在指定等待时间内未能获取到分布式锁：调用方据此判断"资源正被并发占用"，
+ * 转换为业务侧"请稍后重试"提示，而不是当作系统故障处理。
+ * @author owlzhangfq@gmail.com
+ */
+public class LockAcquireTimeoutException extends RuntimeException {
+
+    public LockAcquireTimeoutException(String lockKey) {
+        super("acquire distributed lock timeout, lockKey=" + lockKey);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/RedissonDistributedLockExecutor.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/RedissonDistributedLockExecutor.java
@@ -1,0 +1,52 @@
+package com.richard.fyoung.customerwork.lock;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * {@link DistributedLockExecutor} 的 Redisson 实现。
+ *
+ * <p>解锁前用 {@link RLock#isHeldByCurrentThread()} 判断，避免 {@code leaseTime} 到期后锁已被
+ * Redisson 自动释放（甚至被其它线程重新持有）时，本线程再调用 {@code unlock} 抛
+ * {@code IllegalMonitorStateException} 或误删别人的锁——Redisson 内部已用线程标识做 CAS 校验，
+ * 这里只是提前短路，避免无意义的一次远程调用。</p>
+ *
+ * <p>加锁失败只归一为 {@link LockAcquireTimeoutException} 一种情况（超时未获取到锁，含被中断）；
+ * Redis 连接不可达等基础设施异常不在此吞掉，直接向上抛出——分布式锁场景下"连不上 Redis"和
+ * "锁被别人持有"是完全不同性质的失败，不能混为一谈退化成同一个"稍后重试"提示。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class RedissonDistributedLockExecutor implements DistributedLockExecutor {
+
+    private final RedissonClient redissonClient;
+
+    public RedissonDistributedLockExecutor(RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
+    }
+
+    @Override
+    public <T> T execute(String lockKey, Duration waitTime, Duration leaseTime, Supplier<T> action) {
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(waitTime.toMillis(), leaseTime.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LockAcquireTimeoutException(lockKey);
+        }
+        if (!acquired) {
+            throw new LockAcquireTimeoutException(lockKey);
+        }
+        try {
+            return action.get();
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明 / What

本 PR 包含本轮开发分支的四块改动（各自独立 commit）：

1. **分布式锁（starter 组件化 + 菜单排序加锁）**：`MenuAdminController#reorder` 多管理员并发拖拽会基于过期兄弟节点 sort 值互相覆盖（乱序合并）。starter 新增 `lock` 包（`DistributedLockExecutor` 接口 + Redisson 实现 + 自动装配，惰性连接不影响 Redis 不可达时的应用启动），admin-server 手动装配复用 `admin.redis.*`。`PermissionService.reorder` 拆为加锁外层 + `@Lazy` 自注入代理调用的 `@Transactional` 内层，保证**锁释放严格晚于事务提交**；fast fail，锁冲突返回新错误码 `MENU_REORDER_CONFLICT(40032)`。
2. **工作区进行中会话跨页面/跨智能体保留**：会话与 SSE 流从组件本地 ref 提升到 Pinia store（`chatConversations`/`vibeConversations`），面板变纯视图；切菜单、切智能体、新建会话都不再中断进行中的流；历史侧边栏合并内存活跃会话并标「进行中」（覆盖第一轮尚未落库、后端列表拉不到的新会话）。配套：MainLayout `keep-alive` 精确缓存 WorkspaceView（路由改同步导入，懒加载异步包装取不到组件 name 会导致 include 匹配落空）；修复 keep-alive 复用实例后 activeTab 残留导致切到不支持 vibecoding 的智能体内容区空白。
3. **模型列表「厂商」列更名「接入协议」**：provider 语义是接入协议（openai=所有 OpenAI 兼容端点），原列名会让智谱/DeepSeek 行被误读为数据错误；单元格复用表单 providerPresets 友好文案。另统一工作区三按钮胶囊规格（蓝/浅黄/白）。
4. **知识库问答注入系统提示词**：`KnowledgeService#callModelOnce` 增加 SYSTEM 角色消息（检索专家定位 + 无依据即答不知道），仅 ask 链路受影响。

## 类型 / Type
- [x] feat 新功能
- [x] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（admin-server 全量 439 个通过；PermissionServiceTest 新增锁冲突 fast-fail 用例；前端 vue-tsc + vite build 通过）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定（DistributedLockExecutor/RedissonClient 均 @ConditionalOnMissingBean）
- [ ] 必要时更新了 README / 配置项说明（`customer-work.distributed-lock.*` 尚未补进 docs/功能与配置全量参考.md，可在本 PR 或后续补）

## 审阅提示 / Notes for reviewer
- 前端会话保留的验证：mock SSE 实测了「发消息生成中 → 切走 → 切回，增量不断、列表标进行中」；真实模型链路请在本地配好模型 key 后复核一遍。
- redisson 版本 3.52.0 在 starter 与 admin-server 两处 pom 显式声明（agentscope-bom 不托管，同 xxl-job-core 处境），升级需两处同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)