### PR TITLE
docs: 补齐 customer-work.distributed-lock.* 配置项文档

### DIFF
--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -121,6 +121,7 @@
 | **对话附件多格式解析**（图片视觉 OCR + Tika/POI 文档 + 直读文本，落盘落库） | `AttachmentParseService` + `AttachmentStore` SPI | 开 | `customer-work.attachment.*`（默认开、`store-mode=jdbc`），三入口：admin 对话/VibeCoding、用户端 H5，见 §6.23 |
 | **坐席 HMAC 接入凭证** | `AgentAccessCredential`（HmacSHA256）+ `AgentAuthWebFilter` | 开 | REST 头 `X-Agent-Token` / WS query `token`，env `CW_AGENT_WS_SECRET`（8080+8082 共享） |
 | **真实业务后端（订单/商品/售后/会员/投诉/知识库）** | `MybatisOrderBackend` / `MybatisProductBackend` / `MybatisAfterSalesBackend` / `MybatisMemberBackend` / `MybatisComplaintBackend` / `MybatisKnowledgeBackend` | 关 | `customer-work.tool-backend.mode=jdbc`（8 张 `cw_*` 表含种子，MyBatis-Plus 实现），六域后端整体替换内存 Mock |
+| **分布式锁（跨实例互斥）** | `DistributedLockExecutor` SPI + `RedissonDistributedLockExecutor`（Redisson 单机模式，惰性连接） | 开 | `customer-work.distributed-lock.redis.*`；`@ConditionalOnMissingBean` 可整体替换；切哨兵/集群只改 `DistributedLockConfig#buildRedissonClient` 一处；admin-server 关闭了自动装配，在 `AdminDistributedLockConfig` 手动装配复用 `admin.redis.*`（用于菜单拖拽排序防并发乱序，锁冲突返回 40032） |
 
 ### ⚠️ 不可迁移 / 沿用说明（1.x→2.0 备注）
 
@@ -1057,6 +1058,7 @@ customer-admin-server：`spring.servlet.multipart.max-file-size`/`max-request-si
 | `agent-access` | secret(${CW_AGENT_WS_SECRET}), expire-hours(12) |
 | `tool-backend` | mode(mock)：mock=starter 内存 Mock \| jdbc=订单/商品/售后/会员/投诉/知识库六域 MyBatis-Plus 后端（8 张 `cw_*` 表） |
 | `attachment` | enabled(true), store-mode(jdbc), base-dir(./data/attachments), storage.type(代码默认 local / yml 默认 minio), storage.minio.endpoint(http://localhost:9000), storage.minio.access-key/secret-key(minioadmin), storage.minio.bucket(customer-work-attachments / admin 覆写 customer-admin-attachments), storage.minio.auto-create-bucket(true), max-file-size-mb(10), max-parsed-chars(20000), extra-text-extensions(空), ocr.provider(dashscope), ocr.model-name(qwen-vl-max), ocr.api-key(空，回落 model.api-key→DASHSCOPE_API_KEY), ocr.base-url(空), ocr.timeout-seconds(60), ocr.prompt(内置中文 OCR 提示词)，见 §6.23 |
+| `distributed-lock` | redis.{host(localhost), port(6379), password(空)}——`DistributedLockExecutor` 底层 RedissonClient 连接的 Redis（单机模式，惰性连接：Redis 不可达不影响应用启动，首次 tryLock 才建连并暴露失败）；下游声明同类型 Bean 可整体覆盖（`@ConditionalOnMissingBean`） |
 
 ---
 


### PR DESCRIPTION
## 变更说明 / What

补上 #41 引入的分布式锁组件在 `docs/功能与配置全量参考.md` 的两处缺口（即 #41 自查清单未勾的那项）：

- **二、功能总表**：新增「分布式锁（跨实例互斥）」能力行——SPI 组件构成、`@ConditionalOnMissingBean` 覆盖方式、切哨兵/集群的单点改动位置、admin-server 手动装配说明；
- **七、配置项总表**：新增 `distributed-lock` 前缀行——`redis.{host,port,password}` 默认值与惰性连接语义（Redis 不可达不影响启动）。

**base 指向 `feature/dev-20260720`**（stacked：文档描述的功能在 #41 里，随其一并进 main，避免文档先于功能合入）。

## 类型 / Type
- [ ] feat 新功能
- [ ] fix 修复
- [x] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（纯文档变更，无代码改动）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定（不适用）
- [x] 必要时更新了 README / 配置项说明（本 PR 即是）

🤖 Generated with [Claude Code](https://claude.com/claude-code)