### PR TITLE
feat: 开发者工具箱（devtoolbox 系统工具 + admin 前端本地计算工具页）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/DevToolboxConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/DevToolboxConfig.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.tool;
+
+import com.richard.fyoung.customerwork.tool.devtool.DevToolboxTools;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 开发者工具箱系统工具装配。
+ *
+ * <p>admin-server 排除了 starter 的自动装配（{@code spring.autoconfigure.exclude}），需要 starter 能力时
+ * 在自己的 {@code @Configuration} 里显式 new（沿用 {@code CustomerWorkClientConfig} 等惯例），不假设容器里
+ * 已有现成 Bean。</p>
+ *
+ * <p>Bean 名精确等于 {@code ai_system_tool.tool_code}（"devtoolbox"）：运行时
+ * {@code AdminAgentInstanceFactory#buildSystemTools} 通过 {@code applicationContext.getBean("devtoolbox")}
+ * 按名取本 Bean 注册进智能体的 Toolkit，故 Bean 名不可改。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class DevToolboxConfig {
+
+    /** 开发者工具箱工具 Bean（名称 = tool_code "devtoolbox"，纯本地计算无外部依赖，直接 new）。 */
+    @Bean(name = "devtoolbox")
+    public DevToolboxTools devtoolbox() {
+        return new DevToolboxTools();
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V27__dev_toolbox.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V27__dev_toolbox.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- 开发者工具箱（Flyway V27，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 新增一个系统工具 devtoolbox（开发者工具箱），沿用 V15 定的"系统工具目录"范式：工具实现是代码
+-- 定义的（@Tool 注解的 Spring Bean，bean name 精确等于 tool_code），库里只存启停 + 展示名/描述。
+-- 该工具聚合一组纯本地计算能力：JSON 格式化/压缩/校验、时间戳转换、Base64/URL 编解码、
+-- 哈希(HMAC)、UUID 生成、AES 加解密、正则测试；均为本地计算，不访问外部资源，无 SSRF 面。
+--
+-- 前端页面是纯本地计算（不依赖后端接口），因此本菜单只需一个"查看"可见性权限点，不设 add/edit/delete。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+--
+-- 菜单/权限种子：菜单 id=150（当前显式 id 最大为 141，跳到 150 留安全间隔），parent_id=1 挂在
+-- "系统管理"目录下，sort=6（现有子菜单 user/role/log/menu/ai-audit 最大 sort=5，顺延取 6）。
+-- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接放行
+-- 全部权限点（沿用 V15 同款做法，普通角色需在角色管理页手工授权）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+-- 种子：开发者工具箱（tool_code 精确等于 @Bean(name="devtoolbox") 的 Bean 名）。id 取当前最大 id(1)+1=2。
+INSERT INTO `ai_system_tool` (`id`, `tool_code`, `tool_name`, `description`, `enabled`, `remark`)
+VALUES (2, 'devtoolbox', '开发者工具箱',
+        '开发者常用本地工具集：JSON格式化/压缩/校验、时间戳转换、Base64/URL编解码、哈希(HMAC)、UUID生成、AES加解密、正则测试',
+        1, '纯本地计算，无外部依赖');
+
+-- 菜单：开发者工具箱（挂系统管理 id=1 下，sort=6）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (150, 1, '开发者工具箱', 'devtools', 1, '/system/devtools', 'Tools', 'library', 6);
+
+-- 按钮/接口权限点（type=2）：仅一条 view（前端纯本地计算，只需菜单可见性权限）。
+INSERT INTO `sys_permission` (`parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (150, '查看开发者工具箱', 'devtools:view', 2, 1);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/DevToolboxConfigTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/DevToolboxConfigTest.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customeradmin.aiconfig.systemtool.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.tool.devtool.DevToolboxTools;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * {@link DevToolboxConfig} 单测：不起 Spring 容器，直接验证 {@code devtoolbox()} 返回可用实例，
+ * 并随手调一个工具方法（json_format）确认走通。
+ * @author owlzhangfq@gmail.com
+ */
+class DevToolboxConfigTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void devtoolbox_shouldReturnUsableInstance() throws Exception {
+        DevToolboxTools tools = new DevToolboxConfig().devtoolbox();
+        assertNotNull(tools, "应返回可用的 DevToolboxTools 实例");
+
+        // 随手调一个工具方法走通：json_format 把格式化文本作为 JSON 字符串字面量回传
+        String raw = tools.jsonFormat("{\"a\":1}", 2).block();
+        String formatted = mapper.readTree(raw).asText();
+        assertEquals(1, mapper.readTree(formatted).get("a").asInt());
+    }
+}

--- a/customer-admin-web/package-lock.json
+++ b/customer-admin-web/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.2",
+        "@types/crypto-js": "^4.2.2",
         "axios": "^1.18.1",
+        "crypto-js": "^4.2.0",
         "element-plus": "^2.14.2",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.3.0",
@@ -534,6 +536,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmmirror.com/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz",
@@ -930,6 +938,12 @@
       "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
     "node_modules/csstype": {

--- a/customer-admin-web/package.json
+++ b/customer-admin-web/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",
+    "@types/crypto-js": "^4.2.2",
     "axios": "^1.18.1",
+    "crypto-js": "^4.2.0",
     "element-plus": "^2.14.2",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.3.0",

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -11,6 +11,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/log': () => import('@/views/system/OperationLog.vue'),
   '/system/ai-audit': () => import('@/views/system/AiCodingAudit.vue'),
   '/system/menu': () => import('@/views/system/MenuManage.vue'),
+  '/system/devtools': () => import('@/views/system/DevToolboxView.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),

--- a/customer-admin-web/src/views/system/DevToolboxView.vue
+++ b/customer-admin-web/src/views/system/DevToolboxView.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+// 开发者工具箱：左侧工具导航（带搜索）+ 右侧当前工具面板。全部本地计算，不调任何后端接口。
+// 当前工具用 route query ?tool= 同步，支持浏览器收藏直达/刷新保持；query 缺失或指向不存在的工具时
+// 兜底规整成默认工具（第一个），保持 URL 与实际展示始终一致。
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { defaultToolKey, devTools } from './devtools/toolRegistry'
+
+const route = useRoute()
+const router = useRouter()
+const search = ref('')
+
+const filteredTools = computed(() => {
+  const keyword = search.value.trim().toLowerCase()
+  if (!keyword) return devTools
+  return devTools.filter(
+    (tool) => tool.label.toLowerCase().includes(keyword) || tool.description.toLowerCase().includes(keyword),
+  )
+})
+
+function queryToolKey(): string | undefined {
+  const q = route.query.tool
+  const value = Array.isArray(q) ? q[0] : q
+  return value ?? undefined
+}
+
+const activeKey = computed(() => {
+  const key = queryToolKey()
+  return key && devTools.some((t) => t.key === key) ? key : defaultToolKey
+})
+
+const activeTool = computed(() => devTools.find((t) => t.key === activeKey.value) ?? devTools[0])
+
+const activeComponent = computed(() => defineAsyncComponent(activeTool.value.component))
+
+function selectTool(key: string) {
+  if (key === activeKey.value) return
+  router.replace({ query: { ...route.query, tool: key } })
+}
+
+// query.tool 缺失或非法（如手改成不存在的 key）时，规整到默认工具，避免展示与地址栏不一致
+watch(
+  () => route.query.tool,
+  (q) => {
+    const key = Array.isArray(q) ? q[0] : q
+    if (!key || !devTools.some((t) => t.key === key)) {
+      router.replace({ query: { ...route.query, tool: defaultToolKey } })
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div class="devtoolbox-page">
+    <div class="devtoolbox-sidebar">
+      <el-input v-model="search" placeholder="搜索工具" clearable :prefix-icon="'Search'" class="devtoolbox-search" />
+      <el-scrollbar class="devtoolbox-list">
+        <div
+          v-for="tool in filteredTools"
+          :key="tool.key"
+          class="devtoolbox-item"
+          :class="{ active: tool.key === activeKey }"
+          @click="selectTool(tool.key)"
+        >
+          <div class="devtoolbox-item-label">{{ tool.label }}</div>
+          <div class="devtoolbox-item-desc">{{ tool.description }}</div>
+        </div>
+        <el-empty v-if="filteredTools.length === 0" description="没有匹配的工具" :image-size="60" />
+      </el-scrollbar>
+    </div>
+
+    <div class="devtoolbox-panel">
+      <el-card shadow="never">
+        <template #header>
+          <span class="panel-title">{{ activeTool.label }}</span>
+        </template>
+        <component :is="activeComponent" :key="activeTool.key" />
+      </el-card>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.devtoolbox-page {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.devtoolbox-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  padding: 12px;
+  height: calc(100vh - 140px);
+}
+
+.devtoolbox-search {
+  flex-shrink: 0;
+}
+
+.devtoolbox-list {
+  flex: 1;
+}
+
+.devtoolbox-item {
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-bottom: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.devtoolbox-item:hover {
+  background: var(--el-fill-color-light);
+}
+
+.devtoolbox-item.active {
+  background: var(--theme-primary-lighter, var(--el-color-primary-light-9));
+}
+
+.devtoolbox-item.active .devtoolbox-item-label {
+  color: var(--theme-primary, var(--el-color-primary));
+  font-weight: 600;
+}
+
+.devtoolbox-item-label {
+  font-size: 14px;
+  color: var(--el-text-color-primary);
+}
+
+.devtoolbox-item-desc {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.devtoolbox-panel {
+  flex: 1;
+  min-width: 0;
+}
+
+.panel-title {
+  font-size: 15px;
+  font-weight: 600;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/AesTool.vue
+++ b/customer-admin-web/src/views/system/devtools/AesTool.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+// AES 加解密：参数较多、误触发代价高（密钥/IV 没配对时结果就是乱码），按验收要求用显式"加密/解密"
+// 按钮，不接自动 debounce 计算。密钥与 IV 是敏感输入，明确不接入 usePersistedRef（不落 localStorage）。
+import { computed, ref, watch } from 'vue'
+import type { AesMode, AesPadding, BinaryEncoding, OutputFormat } from './composables/aesCrypto'
+import { aesDecrypt, aesEncrypt, decodeToWordArray, validateIvLength, validateKeyLength } from './composables/aesCrypto'
+import { usePersistedRef } from './composables/useToolStorage'
+import CopyButton from './CopyButton.vue'
+
+const mode = usePersistedRef<AesMode>('aes:mode', 'CBC')
+const padding = usePersistedRef<AesPadding>('aes:padding', 'Pkcs7')
+const outputFormat = usePersistedRef<OutputFormat>('aes:outputFormat', 'hex')
+const activeTab = usePersistedRef<'encrypt' | 'decrypt'>('aes:activeTab', 'encrypt')
+
+const keyEncoding = usePersistedRef<BinaryEncoding>('aes:keyEncoding', 'utf8')
+const ivEncoding = usePersistedRef<BinaryEncoding>('aes:ivEncoding', 'utf8')
+// 密钥/IV 属于敏感输入，用普通 ref，刷新页面即清空，不落 localStorage
+const keyText = ref('')
+const ivText = ref('')
+
+const encryptInput = usePersistedRef('aes:encryptInput', '')
+const decryptInput = usePersistedRef('aes:decryptInput', '')
+const encryptOutput = ref('')
+const decryptOutput = ref('')
+const encryptError = ref('')
+const decryptError = ref('')
+
+const needsIv = computed(() => mode.value !== 'ECB')
+
+// CTR 是流密码模式，块填充语义在此不适用；切到 CTR 时强制无填充并禁用选择器，避免误配置
+watch(mode, (m) => {
+  if (m === 'CTR') {
+    padding.value = 'NoPadding'
+  }
+})
+
+const keyByteLengthHint = computed(() => {
+  try {
+    return decodeToWordArray(keyText.value, keyEncoding.value).sigBytes
+  } catch {
+    return null
+  }
+})
+
+/** 校验并解码密钥/IV，任一失败时返回错误文案（null 表示全部通过）。 */
+function validateAndBuildParams(): { key: CryptoJS.lib.WordArray; iv?: CryptoJS.lib.WordArray } | string {
+  if (!keyText.value) {
+    return '请输入密钥'
+  }
+  let keyWords: CryptoJS.lib.WordArray
+  try {
+    keyWords = decodeToWordArray(keyText.value, keyEncoding.value)
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e)
+  }
+  const keyErr = validateKeyLength(keyWords, keyEncoding.value)
+  if (keyErr) return keyErr
+
+  if (!needsIv.value) {
+    return { key: keyWords }
+  }
+  if (!ivText.value) {
+    return '请输入 IV'
+  }
+  let ivWords: CryptoJS.lib.WordArray
+  try {
+    ivWords = decodeToWordArray(ivText.value, ivEncoding.value)
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e)
+  }
+  const ivErr = validateIvLength(ivWords, ivEncoding.value)
+  if (ivErr) return ivErr
+
+  return { key: keyWords, iv: ivWords }
+}
+
+function handleEncrypt() {
+  encryptError.value = ''
+  encryptOutput.value = ''
+  if (!encryptInput.value) {
+    encryptError.value = '请输入待加密的明文'
+    return
+  }
+  const params = validateAndBuildParams()
+  if (typeof params === 'string') {
+    encryptError.value = params
+    return
+  }
+  try {
+    encryptOutput.value = aesEncrypt(encryptInput.value, outputFormat.value, {
+      mode: mode.value,
+      padding: padding.value,
+      key: params.key,
+      iv: params.iv,
+    })
+  } catch (e) {
+    encryptError.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+function handleDecrypt() {
+  decryptError.value = ''
+  decryptOutput.value = ''
+  if (!decryptInput.value) {
+    decryptError.value = '请输入待解密的密文'
+    return
+  }
+  const params = validateAndBuildParams()
+  if (typeof params === 'string') {
+    decryptError.value = params
+    return
+  }
+  try {
+    decryptOutput.value = aesDecrypt(decryptInput.value, outputFormat.value, {
+      mode: mode.value,
+      padding: padding.value,
+      key: params.key,
+      iv: params.iv,
+    })
+  } catch (e) {
+    decryptError.value = e instanceof Error ? e.message : String(e)
+  }
+}
+</script>
+
+<template>
+  <div class="aes-tool">
+    <el-form label-width="100px" class="param-form">
+      <el-form-item label="模式">
+        <el-radio-group v-model="mode">
+          <el-radio-button value="CBC">CBC</el-radio-button>
+          <el-radio-button value="ECB">ECB</el-radio-button>
+          <el-radio-button value="CTR">CTR</el-radio-button>
+        </el-radio-group>
+      </el-form-item>
+
+      <el-form-item label="填充">
+        <el-radio-group v-model="padding" :disabled="mode === 'CTR'">
+          <el-radio-button value="Pkcs7">PKCS7</el-radio-button>
+          <el-radio-button value="NoPadding">NoPadding</el-radio-button>
+        </el-radio-group>
+        <span v-if="mode === 'CTR'" class="form-tip">CTR 是流密码模式，不使用块填充，固定 NoPadding</span>
+      </el-form-item>
+
+      <el-form-item label="输出格式">
+        <el-radio-group v-model="outputFormat">
+          <el-radio-button value="hex">Hex</el-radio-button>
+          <el-radio-button value="base64">Base64</el-radio-button>
+        </el-radio-group>
+      </el-form-item>
+
+      <el-form-item label="密钥">
+        <div class="key-row">
+          <el-input v-model="keyText" placeholder="输入密钥" clearable style="flex: 1" />
+          <el-select v-model="keyEncoding" style="width: 110px">
+            <el-option label="UTF-8" value="utf8" />
+            <el-option label="Hex" value="hex" />
+            <el-option label="Base64" value="base64" />
+          </el-select>
+        </div>
+        <span v-if="keyText && keyByteLengthHint !== null" class="form-tip">解码后 {{ keyByteLengthHint }} 字节</span>
+      </el-form-item>
+
+      <el-form-item label="IV">
+        <div class="key-row">
+          <el-input v-model="ivText" :disabled="!needsIv" placeholder="输入 IV（16 字节）" clearable style="flex: 1" />
+          <el-select v-model="ivEncoding" :disabled="!needsIv" style="width: 110px">
+            <el-option label="UTF-8" value="utf8" />
+            <el-option label="Hex" value="hex" />
+            <el-option label="Base64" value="base64" />
+          </el-select>
+        </div>
+        <span v-if="!needsIv" class="form-tip">ECB 模式不使用 IV</span>
+      </el-form-item>
+    </el-form>
+
+    <el-tabs v-model="activeTab">
+      <el-tab-pane label="加密" name="encrypt">
+        <div class="panes">
+          <div class="pane">
+            <div class="pane-header"><span>明文</span></div>
+            <textarea v-model="encryptInput" class="code-textarea" spellcheck="false" placeholder="输入待加密的明文…" />
+          </div>
+          <div class="pane">
+            <div class="pane-header">
+              <span>密文（{{ outputFormat === 'hex' ? 'Hex' : 'Base64' }}）</span>
+              <CopyButton :text="encryptOutput" label="密文" />
+            </div>
+            <textarea class="code-textarea" readonly spellcheck="false" :value="encryptOutput" />
+          </div>
+        </div>
+        <div v-if="encryptError" class="field-error">{{ encryptError }}</div>
+        <el-button type="primary" class="action-button" @click="handleEncrypt">加密</el-button>
+      </el-tab-pane>
+
+      <el-tab-pane label="解密" name="decrypt">
+        <div class="panes">
+          <div class="pane">
+            <div class="pane-header"><span>密文（{{ outputFormat === 'hex' ? 'Hex' : 'Base64' }}）</span></div>
+            <textarea v-model="decryptInput" class="code-textarea" spellcheck="false" placeholder="输入待解密的密文…" />
+          </div>
+          <div class="pane">
+            <div class="pane-header">
+              <span>明文</span>
+              <CopyButton :text="decryptOutput" label="明文" />
+            </div>
+            <textarea class="code-textarea" readonly spellcheck="false" :value="decryptOutput" />
+          </div>
+        </div>
+        <div v-if="decryptError" class="field-error">{{ decryptError }}</div>
+        <el-button type="primary" class="action-button" @click="handleDecrypt">解密</el-button>
+      </el-tab-pane>
+    </el-tabs>
+  </div>
+</template>
+
+<style scoped>
+.aes-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.param-form {
+  max-width: 720px;
+}
+
+.key-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.form-tip {
+  margin-left: 12px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.code-textarea {
+  min-height: 220px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.code-textarea[readonly] {
+  background: var(--el-fill-color-light);
+}
+
+.field-error {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+
+.action-button {
+  margin-top: 12px;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/CodecModePanel.vue
+++ b/customer-admin-web/src/views/system/devtools/CodecModePanel.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+// Base64/URL/Hex 三个"编码↔解码"面板共用的展示壳：模式切换 + 输入 + 实时输出，逻辑全在
+// useEncodeDecodeTool 里，本组件只负责渲染，保持"组件薄"。
+import { useEncodeDecodeTool } from './composables/useEncodeDecodeTool'
+import CopyButton from './CopyButton.vue'
+
+const props = defineProps<{
+  toolKey: string
+  encodeFn: (input: string) => string
+  decodeFn: (input: string) => string
+  placeholder?: string
+}>()
+
+const { mode, input, output, error } = useEncodeDecodeTool(props.toolKey, props.encodeFn, props.decodeFn)
+</script>
+
+<template>
+  <div class="codec-panel">
+    <el-radio-group v-model="mode" size="default" class="mode-group">
+      <el-radio-button value="encode">编码</el-radio-button>
+      <el-radio-button value="decode">解码</el-radio-button>
+    </el-radio-group>
+
+    <div class="panes">
+      <div class="pane">
+        <div class="pane-header"><span>输入</span></div>
+        <textarea
+          v-model="input"
+          class="code-textarea"
+          spellcheck="false"
+          :placeholder="placeholder || (mode === 'encode' ? '输入原文…' : '输入待解码内容…')"
+        />
+        <div v-if="error" class="field-error">{{ error }}</div>
+      </div>
+      <div class="pane">
+        <div class="pane-header">
+          <span>输出</span>
+          <CopyButton :text="output" label="结果" />
+        </div>
+        <textarea class="code-textarea" readonly spellcheck="false" :value="output" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.codec-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mode-group {
+  align-self: flex-start;
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.code-textarea {
+  min-height: 220px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.code-textarea[readonly] {
+  background: var(--el-fill-color-light);
+}
+
+.field-error {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/CopyButton.vue
+++ b/customer-admin-web/src/views/system/devtools/CopyButton.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { copyText } from './composables/useCopy'
+
+// 每个输出区域右上角统一用这一个小组件承载"一键复制"，样式与交互全工具箱保持一致
+const props = withDefaults(defineProps<{ text: string; label?: string }>(), {
+  label: '内容',
+})
+
+function handleCopy() {
+  copyText(props.text, props.label)
+}
+</script>
+
+<template>
+  <el-button link type="primary" size="small" class="copy-button" :disabled="!text" @click="handleCopy">
+    <el-icon><DocumentCopy /></el-icon>
+    复制
+  </el-button>
+</template>
+
+<style scoped>
+.copy-button {
+  padding: 0;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/EncodeHashTool.vue
+++ b/customer-admin-web/src/views/system/devtools/EncodeHashTool.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+// 编解码/哈希工具：Base64/URL/Hex 复用同一套"编码↔解码"展示壳（CodecModePanel），
+// 哈希与 UUID 各自逻辑差异较大，单独成组件；本文件只负责 Tab 布局。
+import { usePersistedRef } from './composables/useToolStorage'
+import { base64DecodeUtf8, base64EncodeUtf8, hexToText, textToHex, urlDecode, urlEncode } from './composables/codecUtils'
+import CodecModePanel from './CodecModePanel.vue'
+import HashPanel from './HashPanel.vue'
+import UuidPanel from './UuidPanel.vue'
+
+const activeTab = usePersistedRef('codec:activeTab', 'base64')
+</script>
+
+<template>
+  <div class="encode-hash-tool">
+    <el-tabs v-model="activeTab">
+      <el-tab-pane label="Base64" name="base64">
+        <CodecModePanel
+          tool-key="base64"
+          :encode-fn="base64EncodeUtf8"
+          :decode-fn="base64DecodeUtf8"
+          placeholder="输入原文，UTF-8 安全，支持中文…"
+        />
+      </el-tab-pane>
+      <el-tab-pane label="URL" name="url">
+        <CodecModePanel tool-key="url" :encode-fn="urlEncode" :decode-fn="urlDecode" />
+      </el-tab-pane>
+      <el-tab-pane label="Hex" name="hex">
+        <CodecModePanel tool-key="hex" :encode-fn="textToHex" :decode-fn="hexToText" placeholder="编码：输入原文；解码：输入十六进制字符串…" />
+      </el-tab-pane>
+      <el-tab-pane label="哈希 / HMAC" name="hash">
+        <HashPanel />
+      </el-tab-pane>
+      <el-tab-pane label="UUID" name="uuid">
+        <UuidPanel />
+      </el-tab-pane>
+    </el-tabs>
+  </div>
+</template>

--- a/customer-admin-web/src/views/system/devtools/HashPanel.vue
+++ b/customer-admin-web/src/views/system/devtools/HashPanel.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import CryptoJS from 'crypto-js'
+import { usePersistedRef } from './composables/useToolStorage'
+import { useDebouncedEffect } from './composables/useDebouncedEffect'
+import CopyButton from './CopyButton.vue'
+
+// 只有 AES 工具的密钥/IV 明确要求不落 localStorage；这里的 HMAC 密钥按验收要求的通用规则持久化
+const input = usePersistedRef('hash:input', '')
+const hmacKey = usePersistedRef('hash:hmacKey', '')
+
+interface HashResults {
+  md5: string
+  sha1: string
+  sha256: string
+  sha512: string
+}
+
+const results = ref<HashResults>({ md5: '', sha1: '', sha256: '', sha512: '' })
+
+function compute() {
+  if (!input.value) {
+    results.value = { md5: '', sha1: '', sha256: '', sha512: '' }
+    return
+  }
+  // crypto-js 对普通字符串入参默认按 UTF-8 处理，中文等多字节字符无需额外转换
+  if (hmacKey.value) {
+    results.value = {
+      md5: CryptoJS.HmacMD5(input.value, hmacKey.value).toString(),
+      sha1: CryptoJS.HmacSHA1(input.value, hmacKey.value).toString(),
+      sha256: CryptoJS.HmacSHA256(input.value, hmacKey.value).toString(),
+      sha512: CryptoJS.HmacSHA512(input.value, hmacKey.value).toString(),
+    }
+  } else {
+    results.value = {
+      md5: CryptoJS.MD5(input.value).toString(),
+      sha1: CryptoJS.SHA1(input.value).toString(),
+      sha256: CryptoJS.SHA256(input.value).toString(),
+      sha512: CryptoJS.SHA512(input.value).toString(),
+    }
+  }
+}
+
+useDebouncedEffect([input, hmacKey], compute)
+
+const rows: Array<{ key: keyof HashResults; label: string }> = [
+  { key: 'md5', label: 'MD5' },
+  { key: 'sha1', label: 'SHA1' },
+  { key: 'sha256', label: 'SHA256' },
+  { key: 'sha512', label: 'SHA512' },
+]
+</script>
+
+<template>
+  <div class="hash-panel">
+    <el-form label-width="90px">
+      <el-form-item label="待计算内容">
+        <textarea v-model="input" class="code-textarea" spellcheck="false" placeholder="输入需要计算哈希的文本…" />
+      </el-form-item>
+      <el-form-item label="HMAC 密钥">
+        <el-input v-model="hmacKey" placeholder="留空则计算普通哈希，非空则计算 HMAC" clearable style="max-width: 360px" />
+      </el-form-item>
+    </el-form>
+
+    <div class="hash-results">
+      <div v-for="row in rows" :key="row.key" class="hash-row">
+        <span class="hash-label">{{ row.label }}</span>
+        <code class="hash-value">{{ results[row.key] || '—' }}</code>
+        <CopyButton :text="results[row.key]" :label="row.label" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.hash-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.code-textarea {
+  min-height: 100px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.hash-results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hash-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--el-fill-color-light);
+  border-radius: 6px;
+}
+
+.hash-label {
+  flex-shrink: 0;
+  width: 70px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+}
+
+.hash-value {
+  flex: 1;
+  min-width: 0;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  overflow-wrap: break-word;
+  word-break: break-all;
+  color: var(--el-text-color-primary);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/JsonTool.vue
+++ b/customer-admin-web/src/views/system/devtools/JsonTool.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import { computed, nextTick, ref } from 'vue'
+import hljs from 'highlight.js/lib/core'
+import json from 'highlight.js/lib/languages/json'
+import { usePersistedRef } from './composables/useToolStorage'
+import { useDebouncedEffect } from './composables/useDebouncedEffect'
+import { getLineContent, lineColToIndex, locateJsonError } from './composables/jsonLint'
+import { decodeUnicodeEscapes, escapeJsonText, unescapeJsonText } from './composables/jsonTransform'
+import CopyButton from './CopyButton.vue'
+
+hljs.registerLanguage('json', json)
+
+// 超过 1MB 只给性能提示，不阻断计算（验收要求：大文本不阻断）
+const LARGE_TEXT_THRESHOLD_BYTES = 1024 * 1024
+
+type OperationKey = 'format' | 'compress' | 'escape' | 'unescape' | 'unicode'
+
+const operations: Array<{ key: OperationKey; label: string }> = [
+  { key: 'format', label: '格式化' },
+  { key: 'compress', label: '压缩' },
+  { key: 'escape', label: '转义' },
+  { key: 'unescape', label: '去转义' },
+  { key: 'unicode', label: 'Unicode→中文' },
+]
+
+const input = usePersistedRef('json:input', '')
+const operation = usePersistedRef<OperationKey>('json:operation', 'format')
+const indentSize = usePersistedRef<2 | 4>('json:indent', 2)
+
+const output = ref('')
+const highlightedOutput = ref('')
+const errorInfo = ref<{ line: number; col: number; message: string } | null>(null)
+const inputRef = ref<HTMLTextAreaElement>()
+
+const inputSizeBytes = computed(() => new Blob([input.value]).size)
+const isLargeText = computed(() => inputSizeBytes.value > LARGE_TEXT_THRESHOLD_BYTES)
+
+/** 需要先验证是合法 JSON 才能继续的操作（格式化/压缩/去转义复用同一套语法定位）。 */
+function needsValidJson(op: OperationKey): boolean {
+  return op === 'format' || op === 'compress'
+}
+
+function compute() {
+  errorInfo.value = null
+  if (!input.value) {
+    output.value = ''
+    highlightedOutput.value = ''
+    return
+  }
+
+  try {
+    if (operation.value === 'escape') {
+      output.value = escapeJsonText(input.value)
+    } else if (operation.value === 'unescape') {
+      // 去转义复用 JSON 语法扫描器统一定位错误：先按"应为合法转义串"扫一遍，拿不到明确行列时退化为纯文案提示
+      output.value = unescapeJsonText(input.value)
+    } else if (operation.value === 'unicode') {
+      output.value = decodeUnicodeEscapes(input.value)
+    } else if (needsValidJson(operation.value)) {
+      const failure = locateJsonError(input.value)
+      if (failure) {
+        errorInfo.value = failure
+        output.value = ''
+        highlightedOutput.value = ''
+        return
+      }
+      const parsed = JSON.parse(input.value)
+      output.value = operation.value === 'format' ? JSON.stringify(parsed, null, indentSize.value) : JSON.stringify(parsed)
+    }
+  } catch (e) {
+    errorInfo.value = { line: 1, col: 1, message: e instanceof Error ? e.message : String(e) }
+    output.value = ''
+    highlightedOutput.value = ''
+    return
+  }
+
+  try {
+    highlightedOutput.value = hljs.highlight(output.value, { language: 'json' }).value
+  } catch {
+    highlightedOutput.value = output.value
+  }
+}
+
+useDebouncedEffect([input, operation, indentSize], compute)
+
+const errorLinePreview = computed(() => {
+  if (!errorInfo.value) return ''
+  return getLineContent(input.value, errorInfo.value.line)
+})
+
+/** 错误行预览下方的插入符号（^），指向具体列，帮助在长行里快速定位。 */
+const errorCaretPadding = computed(() => {
+  if (!errorInfo.value) return ''
+  return ' '.repeat(Math.max(0, errorInfo.value.col - 1))
+})
+
+/** "定位到输入框"：把错误位置对应的字符选中并滚动到可视区域，不在计算过程中抢焦点，只在用户主动点击时触发。 */
+async function locateInInput() {
+  if (!errorInfo.value || !inputRef.value) return
+  const index = lineColToIndex(input.value, errorInfo.value.line, errorInfo.value.col)
+  await nextTick()
+  inputRef.value.focus()
+  inputRef.value.setSelectionRange(index, index + 1)
+}
+</script>
+
+<template>
+  <div class="json-tool">
+    <div class="toolbar">
+      <el-radio-group v-model="operation" size="default">
+        <el-radio-button v-for="op in operations" :key="op.key" :value="op.key">{{ op.label }}</el-radio-button>
+      </el-radio-group>
+      <el-radio-group v-if="operation === 'format'" v-model="indentSize" size="default" class="indent-group">
+        <el-radio-button :value="2">缩进 2</el-radio-button>
+        <el-radio-button :value="4">缩进 4</el-radio-button>
+      </el-radio-group>
+    </div>
+
+    <el-alert
+      v-if="isLargeText"
+      type="info"
+      :closable="false"
+      show-icon
+      class="perf-hint"
+      :title="`文本较大（约 ${(inputSizeBytes / 1024 / 1024).toFixed(1)} MB），实时计算可能有明显延迟，但不会阻断`"
+    />
+
+    <div class="panes">
+      <div class="pane">
+        <div class="pane-header">
+          <span>输入</span>
+        </div>
+        <textarea
+          ref="inputRef"
+          v-model="input"
+          class="code-textarea"
+          spellcheck="false"
+          placeholder="粘贴 JSON 或任意文本…"
+        />
+        <div v-if="errorInfo" class="error-hint">
+          <div class="error-message">
+            第 {{ errorInfo.line }} 行第 {{ errorInfo.col }} 列：{{ errorInfo.message }}
+            <el-button link type="primary" size="small" @click="locateInInput">定位到输入框</el-button>
+          </div>
+          <pre class="error-line-preview">{{ errorLinePreview }}</pre>
+          <pre class="error-caret">{{ errorCaretPadding }}^</pre>
+        </div>
+      </div>
+
+      <div class="pane">
+        <div class="pane-header">
+          <span>输出</span>
+          <CopyButton :text="output" label="结果" />
+        </div>
+        <el-scrollbar class="output-scroll">
+          <pre class="code-block"><code v-html="highlightedOutput || '&nbsp;'" /></pre>
+        </el-scrollbar>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.json-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.perf-hint {
+  margin: 0;
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+  min-height: 480px;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.code-textarea {
+  flex: 1;
+  min-height: 440px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.output-scroll {
+  flex: 1;
+  min-height: 440px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-fill-color-lighter);
+}
+
+.code-block {
+  margin: 0;
+  padding: 10px 12px;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.error-hint {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--el-color-danger-light-9, rgba(245, 108, 108, 0.08));
+  border: 1px solid var(--el-color-danger-light-5, rgba(245, 108, 108, 0.3));
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--el-color-danger);
+}
+
+.error-line-preview,
+.error-caret {
+  margin: 4px 0 0;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--el-text-color-secondary);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.error-caret {
+  color: var(--el-color-danger);
+  font-weight: 700;
+}
+
+.indent-group {
+  margin-left: 4px;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/RegexTool.vue
+++ b/customer-admin-web/src/views/system/devtools/RegexTool.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { usePersistedRef } from './composables/useToolStorage'
+import { useDebouncedEffect } from './composables/useDebouncedEffect'
+import { buildHighlightHtml, findAllMatches, toMatchRows } from './composables/regexUtils'
+import type { MatchRow } from './composables/regexUtils'
+import CopyButton from './CopyButton.vue'
+
+const FLAG_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'g', label: 'g（全局）' },
+  { value: 'i', label: 'i（忽略大小写）' },
+  { value: 'm', label: 'm（多行）' },
+  { value: 's', label: 's（. 匹配换行）' },
+]
+
+const pattern = usePersistedRef('regex:pattern', '')
+const flagList = usePersistedRef<string[]>('regex:flags', ['g'])
+const testText = usePersistedRef('regex:testText', '')
+const replacement = usePersistedRef('regex:replacement', '')
+
+const patternError = ref('')
+const highlightHtml = ref('')
+const matchRows = ref<MatchRow[]>([])
+const replaceResult = ref('')
+const replaceError = ref('')
+
+const flags = computed(() => [...flagList.value].sort().join(''))
+
+function compute() {
+  patternError.value = ''
+  replaceError.value = ''
+  highlightHtml.value = ''
+  matchRows.value = []
+  replaceResult.value = ''
+
+  if (!pattern.value) {
+    highlightHtml.value = escapeForEmpty(testText.value)
+    return
+  }
+
+  let re: RegExp
+  try {
+    re = new RegExp(pattern.value, flags.value)
+  } catch (e) {
+    patternError.value = `正则表达式非法：${e instanceof Error ? e.message : String(e)}`
+    highlightHtml.value = escapeForEmpty(testText.value)
+    return
+  }
+
+  const matches = findAllMatches(re, testText.value)
+  highlightHtml.value = buildHighlightHtml(testText.value, matches)
+  matchRows.value = toMatchRows(matches)
+
+  if (replacement.value !== '') {
+    try {
+      const reForReplace = new RegExp(pattern.value, flags.value)
+      replaceResult.value = testText.value.replace(reForReplace, replacement.value)
+    } catch (e) {
+      replaceError.value = e instanceof Error ? e.message : String(e)
+    }
+  }
+}
+
+// 简单转义，无匹配/无 pattern 时仍要把原文安全地渲染进高亮预览区
+function escapeForEmpty(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+useDebouncedEffect([pattern, flagList, testText, replacement], compute)
+</script>
+
+<template>
+  <div class="regex-tool">
+    <el-form label-width="90px">
+      <el-form-item label="正则表达式">
+        <el-input v-model="pattern" placeholder="不含分隔符，如 \\d+" clearable>
+          <template #prepend>/</template>
+          <template #append>/{{ flags }}</template>
+        </el-input>
+        <div v-if="patternError" class="field-error">{{ patternError }}</div>
+      </el-form-item>
+
+      <el-form-item label="标志位">
+        <el-checkbox-group v-model="flagList">
+          <el-checkbox v-for="opt in FLAG_OPTIONS" :key="opt.value" :value="opt.value">{{ opt.label }}</el-checkbox>
+        </el-checkbox-group>
+      </el-form-item>
+
+      <el-form-item label="测试文本">
+        <textarea v-model="testText" class="code-textarea" spellcheck="false" placeholder="输入待测试文本…" />
+      </el-form-item>
+    </el-form>
+
+    <div class="result-section">
+      <div class="result-block">
+        <div class="pane-header"><span>高亮预览</span></div>
+        <div class="highlight-preview" v-html="highlightHtml || '&nbsp;'" />
+      </div>
+
+      <div class="result-block">
+        <div class="pane-header"><span>匹配列表（{{ matchRows.length }} 项）</span></div>
+        <el-table :data="matchRows" size="small" border max-height="260">
+          <el-table-column prop="index" label="序号" width="60" />
+          <el-table-column prop="position" label="位置" width="100" />
+          <el-table-column prop="content" label="内容" show-overflow-tooltip />
+          <el-table-column prop="groups" label="捕获组" show-overflow-tooltip />
+        </el-table>
+        <el-empty v-if="matchRows.length === 0 && !patternError" description="暂无匹配" :image-size="50" />
+      </div>
+    </div>
+
+    <el-form label-width="90px" class="replace-form">
+      <el-form-item label="替换表达式">
+        <el-input v-model="replacement" placeholder="支持 $1 $2 等分组引用，$&amp; 表示整体匹配" clearable />
+      </el-form-item>
+    </el-form>
+
+    <div class="result-block">
+      <div class="pane-header">
+        <span>替换预览</span>
+        <CopyButton :text="replaceResult" label="替换结果" />
+      </div>
+      <div v-if="replaceError" class="field-error">{{ replaceError }}</div>
+      <pre class="code-block">{{ replaceResult || '（替换表达式为空时不展示结果）' }}</pre>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.regex-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.code-textarea {
+  min-height: 160px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.result-section {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.result-block {
+  flex: 1;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.highlight-preview {
+  flex: 1;
+  min-height: 160px;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-fill-color-lighter);
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow: auto;
+}
+
+.highlight-preview :deep(mark) {
+  background: var(--el-color-warning-light-5, #f3d19e);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.replace-form {
+  max-width: 640px;
+}
+
+.code-block {
+  margin: 0;
+  padding: 10px 12px;
+  min-height: 60px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-fill-color-lighter);
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.field-error {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/TimestampTool.vue
+++ b/customer-admin-web/src/views/system/devtools/TimestampTool.vue
@@ -1,0 +1,277 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { copyText } from './composables/useCopy'
+import { usePersistedRef } from './composables/useToolStorage'
+import {
+  detectTimestampUnit,
+  formatEpochMs,
+  parseLenientDateTime,
+  parsedDateTimeToEpochMs,
+  resolveLocalTimeZone,
+  timestampTextToEpochMs,
+} from './composables/timezoneMath'
+
+type TimezoneOption = 'local' | 'Asia/Shanghai' | 'UTC'
+
+const localZoneName = resolveLocalTimeZone()
+
+// ---- 顶部实时走秒的"当前时间戳" ----
+const nowSeconds = ref(Math.floor(Date.now() / 1000))
+const nowMillis = ref(Date.now())
+let tickTimer: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  tickTimer = setInterval(() => {
+    nowMillis.value = Date.now()
+    nowSeconds.value = Math.floor(nowMillis.value / 1000)
+  }, 1000)
+})
+onUnmounted(() => {
+  if (tickTimer) clearInterval(tickTimer)
+})
+
+function copyNow(kind: 'seconds' | 'millis') {
+  const text = kind === 'seconds' ? String(nowSeconds.value) : String(nowMillis.value)
+  copyText(text, kind === 'seconds' ? '当前时间戳（秒）' : '当前时间戳（毫秒）')
+}
+
+// ---- 时间戳 <-> 日期时间双向联动 ----
+const timestampText = usePersistedRef('timestamp:tsText', '')
+const datetimeText = usePersistedRef('timestamp:dtText', '')
+const timezone = usePersistedRef<TimezoneOption>('timestamp:tz', 'local')
+
+const epochMs = ref<number | null>(null)
+const tsError = ref('')
+const dtError = ref('')
+
+const effectiveTimeZone = computed(() => (timezone.value === 'local' ? localZoneName : timezone.value))
+const detectedUnit = computed(() => detectTimestampUnit(timestampText.value))
+
+/**
+ * 双向联动的核心难点：任一边变化都要"即时更新另一边"，但另一边被程序性赋值又会触发它自己的 watch，
+ * 容易形成互相触发的死循环。这里用一个同步标记 + `flush: 'sync'` 的组合解决：程序性写入时先把标记
+ * 置真，watch 用同步 flush（赋值语句执行期间就会跑到回调里），回调看到标记为真就直接跳过——
+ * 不依赖"值相同就不触发"这种隐式行为，也不依赖定时器时序，逻辑始终确定。
+ */
+let programmatic = false
+
+function setTimestampTextSilently(v: string) {
+  programmatic = true
+  timestampText.value = v
+  programmatic = false
+}
+function setDatetimeTextSilently(v: string) {
+  programmatic = true
+  datetimeText.value = v
+  programmatic = false
+}
+
+function handleTimestampInput(val: string) {
+  if (!val.trim()) {
+    tsError.value = ''
+    return
+  }
+  const ms = timestampTextToEpochMs(val)
+  if (ms === null) {
+    tsError.value = '不是合法的时间戳（应为纯数字，可带负号表示 1970 年之前）'
+    return
+  }
+  tsError.value = ''
+  epochMs.value = ms
+  dtError.value = ''
+  setDatetimeTextSilently(formatEpochMs(ms, effectiveTimeZone.value))
+}
+
+function handleDatetimeInput(val: string) {
+  if (!val.trim()) {
+    dtError.value = ''
+    return
+  }
+  const parsed = parseLenientDateTime(val)
+  if (!parsed) {
+    dtError.value = '无法识别的日期时间格式，支持 ISO8601（可带 Z/±HH:mm 时区偏移）/ yyyy-MM-dd HH:mm:ss / yyyy-MM-dd'
+    return
+  }
+  dtError.value = ''
+  const ms = parsedDateTimeToEpochMs(parsed, effectiveTimeZone.value)
+  epochMs.value = ms
+  tsError.value = ''
+  // 派生回时间戳字段时沿用当前识别到的位数单位（没有则默认秒），避免两个字段间来回跳变位数
+  const unit = detectedUnit.value ?? 'seconds'
+  setTimestampTextSilently(unit === 'seconds' ? String(Math.round(ms / 1000)) : String(ms))
+}
+
+let tsTimer: ReturnType<typeof setTimeout> | null = null
+watch(
+  timestampText,
+  (val) => {
+    if (programmatic) return
+    if (tsTimer) clearTimeout(tsTimer)
+    tsTimer = setTimeout(() => handleTimestampInput(val), 300)
+  },
+  { flush: 'sync' },
+)
+
+let dtTimer: ReturnType<typeof setTimeout> | null = null
+watch(
+  datetimeText,
+  (val) => {
+    if (programmatic) return
+    if (dtTimer) clearTimeout(dtTimer)
+    dtTimer = setTimeout(() => handleDatetimeInput(val), 300)
+  },
+  { flush: 'sync' },
+)
+
+// 时区切换：时间戳（UTC 瞬时值）不变，只需要重新格式化日期时间字段与下方对照表
+watch(timezone, () => {
+  if (epochMs.value != null) {
+    setDatetimeTextSilently(formatEpochMs(epochMs.value, effectiveTimeZone.value))
+  }
+})
+
+onMounted(() => {
+  // 首次打开且两个字段都是空的（无持久化历史），用当前时间预填，避免联动区/对照表一片空白
+  if (!timestampText.value && !datetimeText.value) {
+    setTimestampTextSilently(String(Math.floor(Date.now() / 1000)))
+    handleTimestampInput(timestampText.value)
+  } else if (timestampText.value) {
+    handleTimestampInput(timestampText.value)
+  } else if (datetimeText.value) {
+    handleDatetimeInput(datetimeText.value)
+  }
+})
+
+// ---- 下方多时区对照 ----
+const comparisonRows = computed(() => {
+  if (epochMs.value === null) return []
+  const zones: Array<{ label: string; zone: string }> = [
+    { label: `本地（${localZoneName}）`, zone: localZoneName },
+    { label: 'UTC', zone: 'UTC' },
+    { label: '东八区', zone: 'Asia/Shanghai' },
+  ]
+  const seen = new Set<string>()
+  return zones
+    .filter((z) => {
+      if (seen.has(z.zone)) return false
+      seen.add(z.zone)
+      return true
+    })
+    .map((z) => ({ label: z.label, value: formatEpochMs(epochMs.value as number, z.zone) }))
+})
+</script>
+
+<template>
+  <div class="timestamp-tool">
+    <el-card shadow="never" class="now-card">
+      <div class="now-row">
+        <span class="now-label">当前时间戳（秒）</span>
+        <span class="now-value" title="点击复制" @click="copyNow('seconds')">{{ nowSeconds }}</span>
+      </div>
+      <div class="now-row">
+        <span class="now-label">当前时间戳（毫秒）</span>
+        <span class="now-value" title="点击复制" @click="copyNow('millis')">{{ nowMillis }}</span>
+      </div>
+    </el-card>
+
+    <el-form label-width="110px" class="link-form">
+      <el-form-item label="时区">
+        <el-select v-model="timezone" style="width: 220px">
+          <el-option label="本地" value="local" />
+          <el-option label="东八区（UTC+8）" value="Asia/Shanghai" />
+          <el-option label="UTC" value="UTC" />
+        </el-select>
+      </el-form-item>
+
+      <el-form-item label="时间戳">
+        <div class="field-with-hint">
+          <el-input v-model="timestampText" placeholder="输入 10 位秒或 13 位毫秒时间戳" clearable />
+          <el-tag v-if="detectedUnit" size="small" type="info" class="unit-tag">
+            识别为：{{ detectedUnit === 'seconds' ? '秒' : '毫秒' }}
+          </el-tag>
+        </div>
+        <div v-if="tsError" class="field-error">{{ tsError }}</div>
+      </el-form-item>
+
+      <el-form-item label="日期时间">
+        <el-input v-model="datetimeText" placeholder="yyyy-MM-dd HH:mm:ss / yyyy-MM-dd / ISO8601" clearable />
+        <div v-if="dtError" class="field-error">{{ dtError }}</div>
+      </el-form-item>
+    </el-form>
+
+    <div class="comparison">
+      <div class="comparison-title">多时区对照</div>
+      <el-table :data="comparisonRows" size="small" border>
+        <el-table-column prop="label" label="时区" width="220" />
+        <el-table-column prop="value" label="日期时间" />
+      </el-table>
+      <el-empty v-if="comparisonRows.length === 0" description="输入合法的时间戳或日期时间后显示对照" :image-size="60" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.timestamp-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.now-card {
+  background: var(--el-fill-color-light);
+}
+
+.now-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.now-label {
+  width: 150px;
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+}
+
+.now-value {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--theme-primary, var(--el-color-primary));
+  cursor: pointer;
+  user-select: all;
+}
+
+.now-value:hover {
+  text-decoration: underline;
+}
+
+.link-form {
+  max-width: 640px;
+}
+
+.field-with-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.unit-tag {
+  flex-shrink: 0;
+}
+
+.field-error {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+
+.comparison-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 8px;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/UuidPanel.vue
+++ b/customer-admin-web/src/views/system/devtools/UuidPanel.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { generateUuid } from '@/utils/uuid'
+import { usePersistedRef } from './composables/useToolStorage'
+import CopyButton from './CopyButton.vue'
+
+// UUID 生成带随机性，按验收要求用显式"重新生成"按钮，不接自动 debounce 计算
+const count = usePersistedRef('uuid:count', 5)
+const noDash = usePersistedRef('uuid:noDash', false)
+const uppercase = usePersistedRef('uuid:uppercase', false)
+
+const uuids = ref<string[]>([])
+
+function format(raw: string): string {
+  const value = noDash.value ? raw.replace(/-/g, '') : raw
+  return uppercase.value ? value.toUpperCase() : value
+}
+
+function regenerate() {
+  uuids.value = Array.from({ length: count.value }, () => format(generateUuid()))
+}
+
+const joined = computed(() => uuids.value.join('\n'))
+
+regenerate()
+</script>
+
+<template>
+  <div class="uuid-panel">
+    <el-form label-width="90px" inline>
+      <el-form-item label="数量">
+        <el-input-number v-model="count" :min="1" :max="20" />
+      </el-form-item>
+      <el-form-item label="去横线">
+        <el-switch v-model="noDash" />
+      </el-form-item>
+      <el-form-item label="大写">
+        <el-switch v-model="uppercase" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" @click="regenerate">重新生成</el-button>
+      </el-form-item>
+    </el-form>
+
+    <div class="uuid-output">
+      <div class="output-header">
+        <span>生成结果（{{ uuids.length }} 条）</span>
+        <CopyButton :text="joined" label="全部 UUID" />
+      </div>
+      <div class="uuid-list">
+        <div v-for="(uuid, idx) in uuids" :key="idx" class="uuid-row">
+          <code class="uuid-value">{{ uuid }}</code>
+          <CopyButton :text="uuid" label="UUID" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.uuid-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.uuid-output {
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--el-fill-color-lighter);
+}
+
+.output-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 8px;
+}
+
+.uuid-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.uuid-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.uuid-value {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/composables/aesCrypto.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/aesCrypto.ts
@@ -1,0 +1,85 @@
+import CryptoJS from 'crypto-js'
+
+export type AesMode = 'CBC' | 'ECB' | 'CTR'
+export type AesPadding = 'Pkcs7' | 'NoPadding'
+export type BinaryEncoding = 'utf8' | 'hex' | 'base64'
+export type OutputFormat = 'hex' | 'base64'
+
+const modeMap: Record<AesMode, unknown> = {
+  CBC: CryptoJS.mode.CBC,
+  ECB: CryptoJS.mode.ECB,
+  CTR: CryptoJS.mode.CTR,
+}
+const paddingMap: Record<AesPadding, unknown> = {
+  Pkcs7: CryptoJS.pad.Pkcs7,
+  NoPadding: CryptoJS.pad.NoPadding,
+}
+
+const encodingLabel: Record<BinaryEncoding, string> = { utf8: 'UTF-8', hex: 'Hex', base64: 'Base64' }
+
+/** 按选定编码把文本解析成 WordArray；编码本身不合法（如 Hex 里混了非十六进制字符）时给出具体原因。 */
+export function decodeToWordArray(raw: string, encoding: BinaryEncoding): CryptoJS.lib.WordArray {
+  try {
+    if (encoding === 'utf8') return CryptoJS.enc.Utf8.parse(raw)
+    if (encoding === 'hex') return CryptoJS.enc.Hex.parse(raw)
+    return CryptoJS.enc.Base64.parse(raw)
+  } catch {
+    throw new Error(`不是合法的 ${encodingLabel[encoding]} 内容`)
+  }
+}
+
+/** 校验密钥字节数是否为 AES 合法的 16/24/32（对应 AES-128/192/256），不合法返回具体提示文案。 */
+export function validateKeyLength(wordArray: CryptoJS.lib.WordArray, encoding: BinaryEncoding): string | null {
+  const bytes = wordArray.sigBytes
+  if (bytes === 16 || bytes === 24 || bytes === 32) return null
+  if (encoding === 'utf8') {
+    return `密钥长度不合法：UTF-8 字节数需为 16/24/32，当前 ${bytes}`
+  }
+  return `密钥长度不合法：按 ${encodingLabel[encoding]} 解码后字节数需为 16/24/32，当前 ${bytes}`
+}
+
+/** 校验 IV 字节数必须为 16（AES 分组长度）；ECB 模式不使用 IV，不需要走这项校验。 */
+export function validateIvLength(wordArray: CryptoJS.lib.WordArray, encoding: BinaryEncoding): string | null {
+  const bytes = wordArray.sigBytes
+  if (bytes === 16) return null
+  return `IV 长度不合法：按 ${encodingLabel[encoding]} 解码后字节数需为 16，当前 ${bytes}`
+}
+
+export interface AesCipherParams {
+  mode: AesMode
+  padding: AesPadding
+  key: CryptoJS.lib.WordArray
+  iv?: CryptoJS.lib.WordArray
+}
+
+function buildCipherConfig(params: AesCipherParams): Record<string, unknown> {
+  const cfg: Record<string, unknown> = { mode: modeMap[params.mode], padding: paddingMap[params.padding] }
+  if (params.mode !== 'ECB' && params.iv) {
+    cfg.iv = params.iv
+  }
+  return cfg
+}
+
+export function aesEncrypt(plainText: string, outputFormat: OutputFormat, params: AesCipherParams): string {
+  const encrypted = CryptoJS.AES.encrypt(CryptoJS.enc.Utf8.parse(plainText), params.key, buildCipherConfig(params))
+  return outputFormat === 'hex' ? encrypted.ciphertext.toString(CryptoJS.enc.Hex) : encrypted.ciphertext.toString(CryptoJS.enc.Base64)
+}
+
+export function aesDecrypt(cipherText: string, inputFormat: OutputFormat, params: AesCipherParams): string {
+  let ciphertextWords: CryptoJS.lib.WordArray
+  try {
+    ciphertextWords = inputFormat === 'hex' ? CryptoJS.enc.Hex.parse(cipherText) : CryptoJS.enc.Base64.parse(cipherText)
+  } catch {
+    throw new Error(`密文不是合法的 ${inputFormat === 'hex' ? 'Hex' : 'Base64'} 内容`)
+  }
+  const cipherParams = CryptoJS.lib.CipherParams.create({ ciphertext: ciphertextWords })
+  const decrypted = CryptoJS.AES.decrypt(cipherParams, params.key, buildCipherConfig(params))
+  try {
+    const text = decrypted.toString(CryptoJS.enc.Utf8)
+    // crypto-js 遇到错误密钥/IV/模式时通常不主动抛错，只会产出乱码字节；乱码字节大概率不是合法 UTF-8，
+    // 转 Utf8 字符串时 crypto-js 自身会抛 "Malformed UTF-8 data"，这里统一收敛成更明确的排查提示
+    return text
+  } catch {
+    throw new Error('解密失败：结果不是合法的 UTF-8 文本，请检查密钥/IV/模式/填充方式是否正确')
+  }
+}

--- a/customer-admin-web/src/views/system/devtools/composables/codecUtils.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/codecUtils.ts
@@ -1,0 +1,69 @@
+/**
+ * 编解码纯函数集合：Base64（UTF-8 安全）、URL、Hex。均用浏览器内置能力实现，出错时抛出
+ * 具体原因的 Error，由调用方统一展示（不弹窗，走输入框下方红字）。
+ */
+
+/** 文本 -> UTF-8 安全的 Base64（经典 btoa 只认 Latin1，中文等多字节字符需要先转成字节再编码）。 */
+export function base64EncodeUtf8(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+/** Base64 -> 文本，非法 Base64 或解码后不是合法 UTF-8 都给出具体原因。 */
+export function base64DecodeUtf8(base64: string): string {
+  let binary: string
+  try {
+    binary = atob(base64.trim())
+  } catch {
+    throw new Error('不是合法的 Base64 字符串')
+  }
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch {
+    throw new Error('Base64 解码后的字节不是合法的 UTF-8 文本')
+  }
+}
+
+/** URL 编码（encodeURIComponent，覆盖中文/特殊字符）。 */
+export function urlEncode(text: string): string {
+  return encodeURIComponent(text)
+}
+
+/** URL 解码，%后缺两位十六进制等非法序列会明确报错。 */
+export function urlDecode(text: string): string {
+  try {
+    return decodeURIComponent(text)
+  } catch {
+    throw new Error('不是合法的 URL 编码内容（% 后必须跟随两位十六进制数字）')
+  }
+}
+
+/** 文本 -> 十六进制（UTF-8 字节，小写）。 */
+export function textToHex(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** 十六进制 -> 文本（按 UTF-8 解码），格式或编码非法都给出具体原因。 */
+export function hexToText(hex: string): string {
+  const cleaned = hex.replace(/\s+/g, '')
+  if (!cleaned) return ''
+  if (!/^[0-9a-fA-F]*$/.test(cleaned)) {
+    throw new Error('包含非十六进制字符（只允许 0-9、a-f、A-F，空白会被忽略）')
+  }
+  if (cleaned.length % 2 !== 0) {
+    throw new Error(`十六进制字符串长度必须是偶数（每两位表示一个字节），当前 ${cleaned.length} 位`)
+  }
+  const bytes = new Uint8Array(cleaned.length / 2)
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = parseInt(cleaned.substring(i * 2, i * 2 + 2), 16)
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch {
+    throw new Error('解码后的字节不是合法的 UTF-8 文本')
+  }
+}

--- a/customer-admin-web/src/views/system/devtools/composables/jsonLint.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/jsonLint.ts
@@ -1,0 +1,251 @@
+/**
+ * 极简 JSON 语法扫描器：只用于 JSON.parse 失败后定位错误的行/列与具体原因。
+ *
+ * 为什么不直接解析 JSON.parse 抛出的 error.message 拿位置：不同 JS 引擎/版本的报错文案差异很大，
+ * 较新 V8 部分错误会带 "at position N (line X column Y)"，但另一部分（如 token 类错误）只给一段
+ * 上下文摘要、完全不带数字位置，无法可靠跨浏览器解析。这里牺牲一点性能（只在报错分支才跑一遍
+ * 手写扫描器）换取行列定位在任意浏览器上都稳定准确——合法 JSON 的主链路仍然用原生 JSON.parse，
+ * 不受影响。
+ */
+export interface JsonSyntaxError {
+  line: number
+  col: number
+  message: string
+}
+
+class ScanFailure {
+  line: number
+  col: number
+  message: string
+
+  constructor(line: number, col: number, message: string) {
+    this.line = line
+    this.col = col
+    this.message = message
+  }
+}
+
+class JsonScanner {
+  private readonly text: string
+  private i = 0
+  private line = 1
+  private col = 1
+
+  constructor(text: string) {
+    this.text = text
+  }
+
+  private fail(message: string): never {
+    throw new ScanFailure(this.line, this.col, message)
+  }
+
+  private peek(): string | undefined {
+    return this.text[this.i]
+  }
+
+  private advance(): string {
+    const ch = this.text[this.i]
+    this.i += 1
+    if (ch === '\n') {
+      this.line += 1
+      this.col = 1
+    } else {
+      this.col += 1
+    }
+    return ch
+  }
+
+  private eof(): boolean {
+    return this.i >= this.text.length
+  }
+
+  private skipWhitespace() {
+    while (!this.eof() && /[ \t\n\r]/.test(this.peek() as string)) {
+      this.advance()
+    }
+  }
+
+  scan() {
+    this.skipWhitespace()
+    this.parseValue()
+    this.skipWhitespace()
+    if (!this.eof()) {
+      this.fail(`结尾存在多余内容："${this.text.slice(this.i, this.i + 10)}"`)
+    }
+  }
+
+  private parseValue() {
+    this.skipWhitespace()
+    if (this.eof()) {
+      this.fail('内容为空或提前结束，此处应有一个值')
+    }
+    const ch = this.peek() as string
+    if (ch === '{') return this.parseObject()
+    if (ch === '[') return this.parseArray()
+    if (ch === '"') return this.parseString()
+    if (ch === '-' || (ch >= '0' && ch <= '9')) return this.parseNumber()
+    if (this.text.startsWith('true', this.i)) return this.parseLiteral('true')
+    if (this.text.startsWith('false', this.i)) return this.parseLiteral('false')
+    if (this.text.startsWith('null', this.i)) return this.parseLiteral('null')
+    this.fail(`意外字符 "${ch}"，此处应为值（对象/数组/字符串/数字/true/false/null 之一）`)
+  }
+
+  private parseLiteral(word: string) {
+    for (let k = 0; k < word.length; k += 1) {
+      this.advance()
+    }
+  }
+
+  private parseObject() {
+    this.advance() // {
+    this.skipWhitespace()
+    if (this.peek() === '}') {
+      this.advance()
+      return
+    }
+    for (;;) {
+      this.skipWhitespace()
+      if (this.peek() !== '"') {
+        this.fail(`对象的键必须是双引号包裹的字符串，实际遇到 "${this.peek() ?? '文件结尾'}"`)
+      }
+      this.parseString()
+      this.skipWhitespace()
+      if (this.peek() !== ':') {
+        this.fail(`键后面缺少冒号 ":"，实际遇到 "${this.peek() ?? '文件结尾'}"`)
+      }
+      this.advance() // :
+      this.parseValue()
+      this.skipWhitespace()
+      const ch = this.peek()
+      if (ch === ',') {
+        this.advance()
+        this.skipWhitespace()
+        if (this.peek() === '}') {
+          this.fail('多余的逗号：对象最后一个属性后不能再跟逗号')
+        }
+        continue
+      }
+      if (ch === '}') {
+        this.advance()
+        return
+      }
+      this.fail(`对象缺少逗号 "," 或右花括号 "}"，实际遇到 "${ch ?? '文件结尾'}"`)
+    }
+  }
+
+  private parseArray() {
+    this.advance() // [
+    this.skipWhitespace()
+    if (this.peek() === ']') {
+      this.advance()
+      return
+    }
+    for (;;) {
+      this.parseValue()
+      this.skipWhitespace()
+      const ch = this.peek()
+      if (ch === ',') {
+        this.advance()
+        this.skipWhitespace()
+        if (this.peek() === ']') {
+          this.fail('多余的逗号：数组最后一个元素后不能再跟逗号')
+        }
+        continue
+      }
+      if (ch === ']') {
+        this.advance()
+        return
+      }
+      this.fail(`数组缺少逗号 "," 或右方括号 "]"，实际遇到 "${ch ?? '文件结尾'}"`)
+    }
+  }
+
+  private parseString() {
+    const startLine = this.line
+    const startCol = this.col
+    this.advance() // 开引号
+    for (;;) {
+      if (this.eof()) {
+        this.line = startLine
+        this.col = startCol
+        this.fail('字符串缺少结束的双引号')
+      }
+      const ch = this.advance()
+      if (ch === '"') return
+      if (ch === '\\') {
+        if (this.eof()) {
+          this.fail('字符串末尾的转义符 "\\" 不完整')
+        }
+        const esc = this.advance()
+        if (esc === 'u') {
+          for (let k = 0; k < 4; k += 1) {
+            if (this.eof() || !/[0-9a-fA-F]/.test(this.peek() as string)) {
+              this.fail('\\u 转义后必须紧跟 4 位十六进制数字')
+            }
+            this.advance()
+          }
+        } else if (!'"\\/bfnrt'.includes(esc)) {
+          this.fail(`非法的转义字符 "\\${esc}"`)
+        }
+      } else if (ch.charCodeAt(0) < 0x20) {
+        this.fail('字符串中包含未转义的控制字符（如换行），需要用 \\n 等转义表示')
+      }
+    }
+  }
+
+  private parseNumber() {
+    const start = this.i
+    if (this.peek() === '-') this.advance()
+    if (this.peek() === '0') {
+      this.advance()
+    } else if ((this.peek() ?? '') >= '1' && (this.peek() ?? '') <= '9') {
+      while (!this.eof() && /[0-9]/.test(this.peek() as string)) this.advance()
+    } else {
+      this.fail('数字格式非法（负号后必须紧跟数字，且不能有多余前导零）')
+    }
+    if (this.peek() === '.') {
+      this.advance()
+      if (!/[0-9]/.test(this.peek() ?? '')) this.fail('小数点后必须至少有一位数字')
+      while (!this.eof() && /[0-9]/.test(this.peek() as string)) this.advance()
+    }
+    if (this.peek() === 'e' || this.peek() === 'E') {
+      this.advance()
+      if (this.peek() === '+' || this.peek() === '-') this.advance()
+      if (!/[0-9]/.test(this.peek() ?? '')) this.fail('指数部分必须至少有一位数字')
+      while (!this.eof() && /[0-9]/.test(this.peek() as string)) this.advance()
+    }
+    if (this.i === start) this.fail('数字格式非法')
+  }
+}
+
+/** 定位 JSON 文本中第一处语法错误；文本合法时返回 null。 */
+export function locateJsonError(text: string): JsonSyntaxError | null {
+  try {
+    new JsonScanner(text).scan()
+    return null
+  } catch (e) {
+    if (e instanceof ScanFailure) {
+      return { line: e.line, col: e.col, message: e.message }
+    }
+    return { line: 1, col: 1, message: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+/** 取文本中某一行的原始内容，用于错误提示旁的定位预览（行号从 1 开始）。 */
+export function getLineContent(text: string, line: number): string {
+  const lines = text.split('\n')
+  return lines[line - 1] ?? ''
+}
+
+/**
+ * 把 (line, col) 换算成文本中的绝对字符下标（从 0 开始），用于在 textarea 里 setSelectionRange
+ * 定位错误位置。col 从 1 开始计数，与扫描器保持一致。
+ */
+export function lineColToIndex(text: string, line: number, col: number): number {
+  const lines = text.split('\n')
+  let index = 0
+  for (let i = 0; i < line - 1 && i < lines.length; i += 1) {
+    index += lines[i].length + 1 // +1 是被 split 吃掉的换行符
+  }
+  return index + (col - 1)
+}

--- a/customer-admin-web/src/views/system/devtools/composables/jsonTransform.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/jsonTransform.ts
@@ -1,0 +1,35 @@
+/**
+ * JSON 工具的转义/去转义/Unicode 转换纯函数，从组件里抽出来便于单测与复用。
+ *
+ * 转义/去转义的语义（与主流 JSON 在线工具一致）：
+ * - 转义：把任意原文文本变成一个"可以安全地当成 JSON 字符串值内容"的转义串，用 JSON.stringify
+ *   实现（自动处理引号/反斜杠/控制字符，并整体加上外层双引号）。
+ * - 去转义：把一个转义串（可以带外层双引号，也可以不带）还原成原文——不带外层引号时视为"转义串
+ *   本体"，补上引号后按 JSON 字符串语法解析。
+ */
+
+/** 转义：原文 -> 可安全嵌入 JSON 的转义字符串（含外层双引号）。 */
+export function escapeJsonText(raw: string): string {
+  return JSON.stringify(raw)
+}
+
+/** 去转义：转义字符串（带或不带外层双引号）-> 还原后的原文。 */
+export function unescapeJsonText(raw: string): string {
+  const trimmed = raw.trim()
+  const alreadyWrapped = trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')
+  const candidate = alreadyWrapped ? trimmed : `"${trimmed}"`
+  try {
+    const value = JSON.parse(candidate)
+    if (typeof value !== 'string') {
+      throw new Error('解析结果不是字符串')
+    }
+    return value
+  } catch {
+    throw new Error('内容不是合法的转义字符串（无法按 JSON 字符串语法解析，检查引号/反斜杠是否匹配）')
+  }
+}
+
+/** Unicode 转义序列（\uXXXX）解码成真实字符（如中文），不影响其它内容。 */
+export function decodeUnicodeEscapes(raw: string): string {
+  return raw.replace(/\\u([0-9a-fA-F]{4})/g, (_match, hex) => String.fromCharCode(parseInt(hex, 16)))
+}

--- a/customer-admin-web/src/views/system/devtools/composables/regexUtils.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/regexUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * 正则测试工具的纯函数：枚举匹配、构造高亮 HTML。
+ *
+ * 是否枚举"全部"匹配严格遵循用户勾选的 flags（不偷偷加 g）——这是刻意的设计选择：
+ * 与主流正则测试站点（如 regex101）行为一致，g 未勾选时只出现第一个匹配，不勾选 g 却看到
+ * "全部高亮"反而会让用户误判 replace（不带 g 只替换第一个）等其它场景的真实行为。
+ */
+export function buildRegExp(pattern: string, flags: string): RegExp {
+  return new RegExp(pattern, flags)
+}
+
+/** 按 flags 枚举匹配：非全局正则只返回第一个匹配（与原生 String.match 行为一致）。 */
+export function findAllMatches(re: RegExp, text: string): RegExpExecArray[] {
+  const results: RegExpExecArray[] = []
+  if (re.global) {
+    let m: RegExpExecArray | null
+    while ((m = re.exec(text)) !== null) {
+      results.push(m)
+      if (m[0].length === 0) {
+        re.lastIndex += 1 // 零宽匹配（如 /a*/g）不推进 lastIndex 会死循环，手动前移一位
+      }
+    }
+  } else {
+    const m = re.exec(text)
+    if (m) results.push(m)
+  }
+  return results
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/** 把原文按匹配位置切片，未匹配部分转义、匹配部分包 <mark>，拼成可直接 v-html 的字符串。 */
+export function buildHighlightHtml(text: string, matches: RegExpExecArray[]): string {
+  if (matches.length === 0) return escapeHtml(text)
+  let html = ''
+  let cursor = 0
+  for (const m of matches) {
+    const start = m.index
+    const end = start + m[0].length
+    if (start < cursor) continue // 理论上不会出现重叠，防御一下避免拼出乱序 HTML
+    html += escapeHtml(text.slice(cursor, start))
+    html += `<mark>${escapeHtml(m[0])}</mark>`
+    cursor = end
+  }
+  html += escapeHtml(text.slice(cursor))
+  return html
+}
+
+export interface MatchRow {
+  index: number
+  position: string
+  content: string
+  groups: string
+}
+
+/** 把匹配数组整理成表格行：序号/位置/内容/捕获组（含命名分组）。 */
+export function toMatchRows(matches: RegExpExecArray[]): MatchRow[] {
+  return matches.map((m, idx) => {
+    const start = m.index
+    const end = start + m[0].length
+    const numberedGroups = m.slice(1).map((g, i) => `$${i + 1}=${g ?? '(未匹配)'}`)
+    const namedGroups = m.groups ? Object.entries(m.groups).map(([name, value]) => `${name}=${value ?? '(未匹配)'}`) : []
+    const groupParts = [...numberedGroups, ...namedGroups]
+    return {
+      index: idx + 1,
+      position: `${start}-${end}`,
+      content: m[0],
+      groups: groupParts.length > 0 ? groupParts.join(', ') : '无',
+    }
+  })
+}

--- a/customer-admin-web/src/views/system/devtools/composables/timezoneMath.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/timezoneMath.ts
@@ -1,0 +1,160 @@
+/**
+ * 时间戳 <-> 日期时间字符串的时区换算，纯用浏览器内置 Intl.DateTimeFormat 实现，不引入日期库。
+ *
+ * 核心难点：JS 原生 Date 只认识"本机系统时区"和"UTC"两种输入语境，没有内置办法把
+ * "2026-07-21 10:00:00 这个挂钟时间，按 Asia/Shanghai 时区解释"直接转换成时间戳。
+ * 这里用标准技巧绕过：先把该挂钟时间当成 UTC 拼出一个"猜测时刻"，再用 Intl 把这个猜测时刻格式化到
+ * 目标时区、看看格式化出来的挂钟时间和我们想要的差多少，这个差值就是目标时区在该时刻的 UTC 偏移，
+ * 用它修正一次即可（时区偏移在同一时刻是恒定值，不存在收敛问题，一次修正就是精确解）。
+ */
+
+export interface DateTimeParts {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+}
+
+/** 浏览器解析出的本地 IANA 时区名（如 Asia/Shanghai），用于"本地"选项。 */
+export function resolveLocalTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  } catch {
+    return 'UTC'
+  }
+}
+
+/** 把某一时刻格式化成指定时区下的挂钟时间各字段。 */
+export function getZonedParts(epochMs: number, timeZone: string): DateTimeParts {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+  const map: Record<string, string> = {}
+  for (const part of dtf.formatToParts(new Date(epochMs))) {
+    map[part.type] = part.value
+  }
+  return {
+    year: Number(map.year),
+    month: Number(map.month),
+    day: Number(map.day),
+    // h23 下午夜会格式化成 "24"，需要归零，否则会多算一天
+    hour: map.hour === '24' ? 0 : Number(map.hour),
+    minute: Number(map.minute),
+    second: Number(map.second),
+  }
+}
+
+/** 把"某时区下的挂钟时间"换算成 UTC 时间戳（毫秒）。 */
+export function zonedPartsToEpochMs(parts: DateTimeParts, timeZone: string): number {
+  const utcGuess = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second)
+  const guessedZonedParts = getZonedParts(utcGuess, timeZone)
+  const guessedAsUtc = Date.UTC(
+    guessedZonedParts.year,
+    guessedZonedParts.month - 1,
+    guessedZonedParts.day,
+    guessedZonedParts.hour,
+    guessedZonedParts.minute,
+    guessedZonedParts.second,
+  )
+  const offsetMs = guessedAsUtc - utcGuess
+  return utcGuess - offsetMs
+}
+
+/** 把毫秒时间戳格式化成 'yyyy-MM-dd HH:mm:ss'（指定时区）。 */
+export function formatEpochMs(epochMs: number, timeZone: string): string {
+  const p = getZonedParts(epochMs, timeZone)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${p.year}-${pad(p.month)}-${pad(p.day)} ${pad(p.hour)}:${pad(p.minute)}:${pad(p.second)}`
+}
+
+export interface ParsedDateTime extends DateTimeParts {
+  /** 字符串里自带时区偏移（Z 或 ±HH:mm）时为 true，此时忽略"时区选择"，按自带偏移换算 */
+  hasOffset: boolean
+  offsetMinutes?: number
+}
+
+/** 宽容解析：支持 ISO8601（可带 T/空格分隔、可带毫秒、可带 Z/±HH:mm 偏移）、'yyyy-MM-dd HH:mm:ss'、'yyyy-MM-dd'。 */
+export function parseLenientDateTime(raw: string): ParsedDateTime | null {
+  const text = raw.trim()
+
+  let m = text.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/)
+  if (m) {
+    const [, y, mo, d, h, mi, s, offset] = m
+    const result: ParsedDateTime = {
+      year: Number(y),
+      month: Number(mo),
+      day: Number(d),
+      hour: Number(h),
+      minute: Number(mi),
+      second: s ? Number(s) : 0,
+      hasOffset: false,
+    }
+    if (offset) {
+      result.hasOffset = true
+      if (offset === 'Z') {
+        result.offsetMinutes = 0
+      } else {
+        const om = offset.match(/^([+-])(\d{2}):?(\d{2})$/)
+        if (om) {
+          result.offsetMinutes = (om[1] === '-' ? -1 : 1) * (Number(om[2]) * 60 + Number(om[3]))
+        }
+      }
+    }
+    if (!isValidDateTime(result)) return null
+    return result
+  }
+
+  m = text.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (m) {
+    const [, y, mo, d] = m
+    const result: ParsedDateTime = { year: Number(y), month: Number(mo), day: Number(d), hour: 0, minute: 0, second: 0, hasOffset: false }
+    if (!isValidDateTime(result)) return null
+    return result
+  }
+
+  return null
+}
+
+/** 基本范围校验，拦截"2026-13-40"这种格式对但数值非法的输入。 */
+function isValidDateTime(p: DateTimeParts): boolean {
+  if (p.month < 1 || p.month > 12) return false
+  if (p.day < 1 || p.day > 31) return false
+  if (p.hour > 23) return false
+  if (p.minute > 59) return false
+  if (p.second > 59) return false
+  return true
+}
+
+/** 解析结果换算成 UTC 时间戳（毫秒）：自带偏移的按偏移算，否则按传入的时区解释挂钟时间。 */
+export function parsedDateTimeToEpochMs(parsed: ParsedDateTime, timeZone: string): number {
+  if (parsed.hasOffset) {
+    const utcGuess = Date.UTC(parsed.year, parsed.month - 1, parsed.day, parsed.hour, parsed.minute, parsed.second)
+    return utcGuess - (parsed.offsetMinutes ?? 0) * 60000
+  }
+  return zonedPartsToEpochMs(parsed, timeZone)
+}
+
+/** 按数字位数识别时间戳单位：10 位及以下按秒，超过 10 位按毫秒（覆盖到公元 2286 年，足够实用）。 */
+export function detectTimestampUnit(raw: string): 'seconds' | 'millis' | null {
+  const digits = raw.trim().replace(/^-/, '')
+  if (!digits || !/^\d+$/.test(digits)) return null
+  return digits.length <= 10 ? 'seconds' : 'millis'
+}
+
+/** 把时间戳字符串（按识别出的单位）转换成毫秒；输入非法返回 null。 */
+export function timestampTextToEpochMs(raw: string): number | null {
+  const unit = detectTimestampUnit(raw)
+  if (!unit) return null
+  const n = Number(raw.trim())
+  if (!Number.isFinite(n)) return null
+  return unit === 'seconds' ? n * 1000 : n
+}

--- a/customer-admin-web/src/views/system/devtools/composables/useCopy.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/useCopy.ts
@@ -1,0 +1,40 @@
+/**
+ * 复制文本到剪贴板，统一走这一处（fast fail 原则里"防御式编程只留一处"的体现）。
+ *
+ * `navigator.clipboard` 要求安全上下文（HTTPS 或 localhost），局域网 IP + 纯 HTTP 访问时该 API
+ * 不存在（与 utils/uuid.ts 里 crypto.randomUUID 踩过的坑同源）；退化到 execCommand('copy') 兜底，
+ * 两者都不可用才提示用户手动复制。
+ */
+export async function copyText(text: string, label = '内容'): Promise<void> {
+  if (!text) {
+    ElMessage.info('没有可复制的内容')
+    return
+  }
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text)
+      ElMessage.success(`${label}已复制`)
+      return
+    } catch {
+      // 落到下面的兼容兜底方案
+    }
+  }
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.opacity = '0'
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    if (ok) {
+      ElMessage.success(`${label}已复制`)
+    } else {
+      ElMessage.error('复制失败，请手动选择文本复制')
+    }
+  } catch {
+    ElMessage.error('复制失败，请手动选择文本复制')
+  }
+}

--- a/customer-admin-web/src/views/system/devtools/composables/useDebouncedEffect.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/useDebouncedEffect.ts
@@ -1,0 +1,24 @@
+import { watch } from 'vue'
+import type { WatchSource } from 'vue'
+
+/**
+ * 通用"输入变化 debounce 300ms 后自动重算"效果：只关心"该重算了"这个时机，不关心具体变化了什么值
+ * （回调里直接读闭包捕获的 ref.value 即可），因此不需要泛型化 watch 的值类型，一个 sources 数组即可
+ * 同时覆盖"多个输入共同驱动一次计算"的场景（如 JSON 工具的 输入文本+格式化模式+缩进位数）。
+ *
+ * 用于开发者工具箱里"实时计算"类工具（JSON/时间戳/编解码/正则等），显式排除 UUID 生成、AES 加解密
+ * 这类"有随机性/参数较多，误触发代价高"的工具——那两个工具按验收要求使用显式按钮，不接入本 effect。
+ */
+export function useDebouncedEffect(sources: WatchSource<unknown>[], callback: () => void, delay = 300) {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  watch(
+    sources,
+    () => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+      timer = setTimeout(callback, delay)
+    },
+    { immediate: true },
+  )
+}

--- a/customer-admin-web/src/views/system/devtools/composables/useEncodeDecodeTool.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/useEncodeDecodeTool.ts
@@ -1,0 +1,37 @@
+import { ref } from 'vue'
+import { usePersistedRef } from './useToolStorage'
+import { useDebouncedEffect } from './useDebouncedEffect'
+
+export type CodecMode = 'encode' | 'decode'
+
+/**
+ * "编码/解码模式切换 + 实时输出"这一类工具（Base64/URL/Hex）共用的状态机：
+ * 输入与模式变化 debounce 300ms 后自动重算，出错时只填 error、不抛到组件外。
+ */
+export function useEncodeDecodeTool(
+  toolKey: string,
+  encodeFn: (input: string) => string,
+  decodeFn: (input: string) => string,
+) {
+  const mode = usePersistedRef<CodecMode>(`${toolKey}:mode`, 'encode')
+  const input = usePersistedRef(`${toolKey}:input`, '')
+  const output = ref('')
+  const error = ref('')
+
+  useDebouncedEffect([mode, input], () => {
+    if (!input.value) {
+      output.value = ''
+      error.value = ''
+      return
+    }
+    try {
+      output.value = mode.value === 'encode' ? encodeFn(input.value) : decodeFn(input.value)
+      error.value = ''
+    } catch (e) {
+      output.value = ''
+      error.value = e instanceof Error ? e.message : String(e)
+    }
+  })
+
+  return { mode, input, output, error }
+}

--- a/customer-admin-web/src/views/system/devtools/composables/useToolStorage.ts
+++ b/customer-admin-web/src/views/system/devtools/composables/useToolStorage.ts
@@ -1,0 +1,37 @@
+import { ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+const STORAGE_PREFIX = 'devtools:'
+
+/**
+ * 单个工具输入字段的 localStorage 持久化 ref：刷新/重开页面不丢，key 统一带 `devtools:` 前缀。
+ *
+ * 约定：AES 工具的密钥/IV 属于敏感信息，不接入本函数，直接用普通 ref——这是本工具箱唯一的
+ * 持久化例外，其余所有工具输入（含哈希 HMAC 密钥）按验收要求一律持久化。
+ */
+export function usePersistedRef<T>(key: string, defaultValue: T): Ref<T> {
+  const storageKey = STORAGE_PREFIX + key
+  let initial = defaultValue
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (raw !== null) {
+      initial = JSON.parse(raw) as T
+    }
+  } catch {
+    // 历史脏数据或手工改过导致解析失败，静默回退默认值，不影响工具正常使用
+  }
+
+  const state = ref(initial) as Ref<T>
+  watch(
+    state,
+    (value) => {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(value))
+      } catch {
+        // 隐私模式/容量超限等导致写入失败，静默忽略——持久化是体验增强，不是功能前提
+      }
+    },
+    { deep: true },
+  )
+  return state
+}

--- a/customer-admin-web/src/views/system/devtools/toolRegistry.ts
+++ b/customer-admin-web/src/views/system/devtools/toolRegistry.ts
@@ -1,0 +1,47 @@
+import type { Component } from 'vue'
+
+export interface DevTool {
+  key: string
+  label: string
+  description: string
+  component: () => Promise<Component>
+}
+
+/**
+ * 开发者工具箱的工具清单，供左侧导航渲染与搜索过滤，以及右侧按 key 动态加载对应组件。
+ * 全部本地计算，不调任何后端接口。第一项是默认工具（route query 缺失/非法时兜底展示）。
+ */
+export const devTools: DevTool[] = [
+  {
+    key: 'json',
+    label: 'JSON 工具',
+    description: '格式化/压缩/转义/去转义/Unicode 转中文',
+    component: () => import('./JsonTool.vue'),
+  },
+  {
+    key: 'timestamp',
+    label: '时间戳转换',
+    description: '时间戳与日期时间互转，多时区对照',
+    component: () => import('./TimestampTool.vue'),
+  },
+  {
+    key: 'codec',
+    label: '编解码 / 哈希',
+    description: 'Base64、URL、Hex、MD5/SHA/HMAC、UUID 生成',
+    component: () => import('./EncodeHashTool.vue'),
+  },
+  {
+    key: 'aes',
+    label: 'AES 加解密',
+    description: 'CBC/ECB/CTR，PKCS7/NoPadding',
+    component: () => import('./AesTool.vue'),
+  },
+  {
+    key: 'regex',
+    label: '正则测试',
+    description: '匹配高亮、捕获组列表、替换预览',
+    component: () => import('./RegexTool.vue'),
+  },
+]
+
+export const defaultToolKey = devTools[0].key

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOps.java
@@ -1,0 +1,340 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 编解码与加解密纯函数集：Base64 / URL 编解码、哈希(HMAC)、UUID、AES 加解密。
+ *
+ * <p>无 Spring 依赖、无状态，参数非法入口 fast-fail 抛 {@link IllegalArgumentException}。
+ * 所有二进制输出统一小写 hex 或 Base64 文本，便于跨系统对齐。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class CodecDevToolOps {
+
+    /** 统一字符集。 */
+    private static final java.nio.charset.Charset UTF_8 = StandardCharsets.UTF_8;
+
+    /** 支持的摘要算法。 */
+    private static final Set<String> SUPPORTED_HASH = Set.of("MD5", "SHA-1", "SHA-256", "SHA-512");
+
+    /** UUID 生成数量边界。 */
+    private static final int UUID_MIN_COUNT = 1;
+    private static final int UUID_MAX_COUNT = 20;
+
+    /** AES 相关常量。 */
+    private static final String AES = "AES";
+    private static final String TRANSFORM_CBC = "AES/CBC/PKCS5Padding";
+    private static final String TRANSFORM_ECB = "AES/ECB/PKCS5Padding";
+    private static final String TRANSFORM_GCM = "AES/GCM/NoPadding";
+    private static final String MODE_CBC = "CBC";
+    private static final String MODE_ECB = "ECB";
+    private static final String MODE_GCM = "GCM";
+    private static final int KEY_LEN_128 = 16;
+    private static final int KEY_LEN_192 = 24;
+    private static final int KEY_LEN_256 = 32;
+    private static final int CBC_IV_LENGTH = 16;
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_BITS = 128;
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    // ---------------------------------------------------------------------
+    // Base64 / URL
+    // ---------------------------------------------------------------------
+
+    /** Base64 编码（UTF-8）。允许空串。 */
+    public String base64Encode(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        return Base64.getEncoder().encodeToString(text.getBytes(UTF_8));
+    }
+
+    /** Base64 解码（UTF-8）。非法 Base64 抛出带说明的异常。 */
+    public String base64Decode(String text) {
+        DevToolArgs.requireNonBlank(text, "text");
+        try {
+            return new String(Base64.getDecoder().decode(text.trim()), UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Base64 解码失败，输入不是合法的 Base64：" + e.getMessage(), e);
+        }
+    }
+
+    /** URL 编码（application/x-www-form-urlencoded，UTF-8）。允许空串。 */
+    public String urlEncode(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        return URLEncoder.encode(text, UTF_8);
+    }
+
+    /** URL 解码（UTF-8）。非法编码抛出带说明的异常。 */
+    public String urlDecode(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        try {
+            return URLDecoder.decode(text, UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("URL 解码失败：" + e.getMessage(), e);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Hash / HMAC
+    // ---------------------------------------------------------------------
+
+    /**
+     * 计算摘要，输出小写 hex。
+     *
+     * @param algorithm 摘要算法：MD5 / SHA-1 / SHA-256 / SHA-512
+     * @param text      待摘要文本
+     * @param hmacKey   HMAC 密钥；非空时走 HmacXXX，空时走普通摘要
+     * @return 小写 hex 摘要
+     */
+    public String hash(String algorithm, String text, String hmacKey) {
+        DevToolArgs.requireNonBlank(algorithm, "algorithm");
+        DevToolArgs.requireNonNull(text, "text");
+        String algo = algorithm.trim().toUpperCase(Locale.ROOT);
+        if (!SUPPORTED_HASH.contains(algo)) {
+            throw new IllegalArgumentException("不支持的算法：" + algorithm + "，仅支持 MD5/SHA-1/SHA-256/SHA-512");
+        }
+        try {
+            byte[] digest;
+            if (hmacKey != null && !hmacKey.isEmpty()) {
+                String macAlgo = toMacAlgorithm(algo);
+                Mac mac = Mac.getInstance(macAlgo);
+                mac.init(new SecretKeySpec(hmacKey.getBytes(UTF_8), macAlgo));
+                digest = mac.doFinal(text.getBytes(UTF_8));
+            } else {
+                digest = MessageDigest.getInstance(algo).digest(text.getBytes(UTF_8));
+            }
+            return toHexLower(digest);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("hash 计算失败：" + e.getMessage(), e);
+        }
+    }
+
+    /** 摘要算法名映射为对应的 HMAC 算法名。 */
+    private String toMacAlgorithm(String algo) {
+        switch (algo) {
+            case "MD5":
+                return "HmacMD5";
+            case "SHA-1":
+                return "HmacSHA1";
+            case "SHA-256":
+                return "HmacSHA256";
+            case "SHA-512":
+                return "HmacSHA512";
+            default:
+                // 上游已白名单校验，正常不可达
+                throw new IllegalArgumentException("不支持的算法：" + algo);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // UUID
+    // ---------------------------------------------------------------------
+
+    /** 批量生成 UUID（数量 1~20）。 */
+    public List<String> uuid(int count) {
+        if (count < UUID_MIN_COUNT || count > UUID_MAX_COUNT) {
+            throw new IllegalArgumentException("count 必须在 " + UUID_MIN_COUNT + "~" + UUID_MAX_COUNT + " 之间，当前 " + count);
+        }
+        List<String> list = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            list.add(UUID.randomUUID().toString());
+        }
+        return list;
+    }
+
+    // ---------------------------------------------------------------------
+    // AES
+    // ---------------------------------------------------------------------
+
+    /**
+     * AES 加密，密文以 Base64 输出。
+     *
+     * @param plainText 明文（允许空串）
+     * @param key       密钥，UTF-8 字节长度须为 16/24/32
+     * @param mode      模式 CBC/ECB/GCM，为空默认 CBC
+     * @param iv        IV(Base64)，CBC/GCM 缺省时随机生成并随结果返回；ECB 忽略
+     * @return 加密结果（含 mode、密文 Base64、iv Base64）
+     */
+    public AesResult aesEncrypt(String plainText, String key, String mode, String iv) {
+        DevToolArgs.requireNonNull(plainText, "plainText");
+        byte[] keyBytes = validateKey(key);
+        String normalizedMode = normalizeMode(mode);
+        try {
+            switch (normalizedMode) {
+                case MODE_ECB: {
+                    Cipher cipher = Cipher.getInstance(TRANSFORM_ECB);
+                    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, AES));
+                    byte[] out = cipher.doFinal(plainText.getBytes(UTF_8));
+                    return AesResult.builder().mode(normalizedMode).ciphertext(base64(out)).build();
+                }
+                case MODE_GCM: {
+                    byte[] ivBytes = resolveIvForEncrypt(iv, GCM_IV_LENGTH);
+                    Cipher cipher = Cipher.getInstance(TRANSFORM_GCM);
+                    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, AES), new GCMParameterSpec(GCM_TAG_BITS, ivBytes));
+                    byte[] out = cipher.doFinal(plainText.getBytes(UTF_8));
+                    return AesResult.builder().mode(normalizedMode).ciphertext(base64(out)).iv(base64(ivBytes)).build();
+                }
+                case MODE_CBC:
+                default: {
+                    byte[] ivBytes = resolveIvForEncrypt(iv, CBC_IV_LENGTH);
+                    Cipher cipher = Cipher.getInstance(TRANSFORM_CBC);
+                    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, AES), new IvParameterSpec(ivBytes));
+                    byte[] out = cipher.doFinal(plainText.getBytes(UTF_8));
+                    return AesResult.builder().mode(normalizedMode).ciphertext(base64(out)).iv(base64(ivBytes)).build();
+                }
+            }
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("AES 加密失败：" + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * AES 解密，密文为 Base64。
+     *
+     * @param cipherText 密文 Base64
+     * @param key        密钥，UTF-8 字节长度须为 16/24/32
+     * @param mode       模式 CBC/ECB/GCM，为空默认 CBC
+     * @param iv         IV(Base64)，CBC/GCM 必填；ECB 忽略
+     * @return 明文
+     */
+    public String aesDecrypt(String cipherText, String key, String mode, String iv) {
+        DevToolArgs.requireNonBlank(cipherText, "cipherText");
+        byte[] keyBytes = validateKey(key);
+        String normalizedMode = normalizeMode(mode);
+        byte[] cipherBytes;
+        try {
+            cipherBytes = Base64.getDecoder().decode(cipherText.trim());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("密文必须是合法 Base64：" + e.getMessage(), e);
+        }
+        try {
+            Cipher cipher;
+            switch (normalizedMode) {
+                case MODE_ECB:
+                    cipher = Cipher.getInstance(TRANSFORM_ECB);
+                    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, AES));
+                    break;
+                case MODE_GCM: {
+                    byte[] ivBytes = requireIvForDecrypt(iv, GCM_IV_LENGTH);
+                    cipher = Cipher.getInstance(TRANSFORM_GCM);
+                    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, AES), new GCMParameterSpec(GCM_TAG_BITS, ivBytes));
+                    break;
+                }
+                case MODE_CBC:
+                default: {
+                    byte[] ivBytes = requireIvForDecrypt(iv, CBC_IV_LENGTH);
+                    cipher = Cipher.getInstance(TRANSFORM_CBC);
+                    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, AES), new IvParameterSpec(ivBytes));
+                    break;
+                }
+            }
+            return new String(cipher.doFinal(cipherBytes), UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("AES 解密失败（密钥/IV/模式不匹配或密文损坏）：" + e.getMessage(), e);
+        }
+    }
+
+    /** 校验并返回密钥字节（UTF-8 长度须 16/24/32）。 */
+    private byte[] validateKey(String key) {
+        DevToolArgs.requireNonBlank(key, "key");
+        byte[] bytes = key.getBytes(UTF_8);
+        if (bytes.length != KEY_LEN_128 && bytes.length != KEY_LEN_192 && bytes.length != KEY_LEN_256) {
+            throw new IllegalArgumentException(
+                "AES 密钥 UTF-8 字节长度必须为 16/24/32，当前 " + bytes.length + " 字节");
+        }
+        return bytes;
+    }
+
+    /** 规范化模式，为空默认 CBC，非法抛出。 */
+    private String normalizeMode(String mode) {
+        if (mode == null || mode.trim().isEmpty()) {
+            return MODE_CBC;
+        }
+        String upper = mode.trim().toUpperCase(Locale.ROOT);
+        if (!MODE_CBC.equals(upper) && !MODE_ECB.equals(upper) && !MODE_GCM.equals(upper)) {
+            throw new IllegalArgumentException("mode 仅支持 CBC/ECB/GCM，当前 " + mode);
+        }
+        return upper;
+    }
+
+    /** 加密取 IV：缺省随机生成，提供则按 Base64 解码并校验长度。 */
+    private byte[] resolveIvForEncrypt(String iv, int expectedLen) {
+        if (iv == null || iv.trim().isEmpty()) {
+            byte[] generated = new byte[expectedLen];
+            new SecureRandom().nextBytes(generated);
+            return generated;
+        }
+        return decodeIv(iv, expectedLen);
+    }
+
+    /** 解密取 IV：必填，缺省抛出，提供则按 Base64 解码并校验长度。 */
+    private byte[] requireIvForDecrypt(String iv, int expectedLen) {
+        if (iv == null || iv.trim().isEmpty()) {
+            throw new IllegalArgumentException("该模式解密必须提供 IV（Base64，" + expectedLen + " 字节）");
+        }
+        return decodeIv(iv, expectedLen);
+    }
+
+    /** Base64 解码 IV 并校验字节长度。 */
+    private byte[] decodeIv(String iv, int expectedLen) {
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(iv.trim());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("IV 必须是合法 Base64：" + e.getMessage(), e);
+        }
+        if (decoded.length != expectedLen) {
+            throw new IllegalArgumentException("IV 长度必须为 " + expectedLen + " 字节，当前 " + decoded.length + " 字节");
+        }
+        return decoded;
+    }
+
+    private String base64(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    /** 字节数组转小写 hex。 */
+    private String toHexLower(byte[] bytes) {
+        char[] chars = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xFF;
+            chars[i * 2] = HEX[v >>> 4];
+            chars[i * 2 + 1] = HEX[v & 0x0F];
+        }
+        return new String(chars);
+    }
+
+    /**
+     * AES 结果。ECB 模式 iv 为 null。
+     */
+    @Getter
+    @Builder
+    public static class AesResult {
+        /** 实际采用的模式。 */
+        private final String mode;
+        /** 密文 Base64。 */
+        private final String ciphertext;
+        /** IV Base64（ECB 时为 null）。 */
+        private final String iv;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DevToolArgs.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DevToolArgs.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * 开发者工具箱纯函数入口的参数防御工具（fast-fail 单一收口点）。
+ *
+ * <p>整条工具链只在 Ops 方法入口做一次参数校验，实现内部不再层层判空。参数非法一律抛
+ * {@link IllegalArgumentException}，异常信息带精确中文说明，供上层 {@code DevToolboxTools}
+ * 收敛为可自我纠正的 error JSON 回给 LLM。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+final class DevToolArgs {
+
+    private DevToolArgs() {
+    }
+
+    /** 校验字符串非空白（null/空串/纯空格均非法），返回原值以便链式使用。 */
+    static String requireNonBlank(String value, String name) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException(name + " 不能为空");
+        }
+        return value;
+    }
+
+    /** 校验对象非 null（允许空字符串，如 base64/url 编码空串是合法输入）。 */
+    static <T> T requireNonNull(T value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " 不能为 null");
+        }
+        return value;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxTools.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxTools.java
@@ -1,0 +1,219 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.Callable;
+
+/**
+ * 开发者工具箱系统工具（system tool {@code devtoolbox}）。给挂载本工具的智能体提供一组开发者常用的
+ * 本地计算能力：JSON 格式化/压缩/校验、时间戳转换、Base64/URL 编解码、哈希(HMAC)、UUID 生成、
+ * AES 加解密、正则测试，均为纯本地计算，不访问外部资源。
+ *
+ * <p>本类是暴露给 LLM 的工具 Schema 壳（纯 POJO，不加 {@code @Component}——Spring 装配由 admin-server 侧
+ * 的 {@code DevToolboxConfig} 显式 new）。Bean 名须精确等于 tool_code "devtoolbox"，运行时
+ * {@code AdminAgentInstanceFactory#buildSystemTools} 通过 {@code applicationContext.getBean("devtoolbox")}
+ * 按名取 Bean 注册进该智能体的 Toolkit。</p>
+ *
+ * <p>约定：业务实现委托给同包内 4 个无状态纯函数 Ops；本壳只负责响应式包装、结果序列化、
+ * 异常收敛与输出截断。任何异常都收敛为 {@code {"error":"..."}} 返回而非抛出，错误信息尽量具体到
+ * 可自我纠正（如 JSON 校验失败带行列号）。日志只记工具名与异常，绝不打印用户输入（可能是敏感明文）。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public class DevToolboxTools {
+
+    private static final Logger log = LoggerFactory.getLogger(DevToolboxTools.class);
+
+    /** 统一错误码。 */
+    private static final String ERROR_CODE = "DEVTOOL-EXEC-FAIL";
+
+    /** 结果字符串截断阈值（超过则截断，防止大结果撑爆 LLM 上下文）。 */
+    private static final int TRUNCATE_THRESHOLD = 8000;
+
+    /** JSON 默认缩进宽度。 */
+    private static final int DEFAULT_INDENT = 2;
+
+    /** UUID 默认生成数量。 */
+    private static final int DEFAULT_UUID_COUNT = 1;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final JsonDevToolOps jsonOps = new JsonDevToolOps();
+    private final TimestampDevToolOps timestampOps = new TimestampDevToolOps();
+    private final CodecDevToolOps codecOps = new CodecDevToolOps();
+    private final RegexDevToolOps regexOps = new RegexDevToolOps();
+
+    // =====================================================================
+    // JSON
+    // =====================================================================
+
+    @Tool(name = "json_format", description = "美化(格式化)JSON文本，按指定缩进重排便于阅读。"
+        + "参数 json：待格式化的JSON字符串，如 {\"a\":1,\"b\":[2,3]}；indent：缩进空格数，仅支持2或4，默认2。"
+        + "JSON非法时返回带行列号的error，便于定位。")
+    public Mono<String> jsonFormat(
+        @ToolParam(name = "json", description = "待格式化的JSON字符串") String json,
+        @ToolParam(name = "indent", required = false, description = "缩进空格数，2或4，默认2") Integer indent) {
+        return respond("json_format", () -> jsonOps.format(json, indent == null ? DEFAULT_INDENT : indent));
+    }
+
+    @Tool(name = "json_minify", description = "压缩JSON文本，去除所有多余空白输出最紧凑形式。"
+        + "参数 json：待压缩的JSON字符串。JSON非法时返回带行列号的error。")
+    public Mono<String> jsonMinify(
+        @ToolParam(name = "json", description = "待压缩的JSON字符串") String json) {
+        return respond("json_minify", () -> jsonOps.minify(json));
+    }
+
+    @Tool(name = "json_validate", description = "校验JSON文本是否合法。返回 valid(是否合法)、errorMessage(错误原因)、"
+        + "line/column(出错行列号，合法时为-1)。用于快速判断一段文本是不是合法JSON并定位错误位置。")
+    public Mono<String> jsonValidate(
+        @ToolParam(name = "json", description = "待校验的JSON字符串") String json) {
+        return respond("json_validate", () -> jsonOps.validate(json));
+    }
+
+    // =====================================================================
+    // Timestamp
+    // =====================================================================
+
+    @Tool(name = "timestamp_convert", description = "时间戳与日期时间互转。自动判定方向："
+        + "输入纯数字10位按秒、13位按毫秒转为日期时间；输入日期时间字符串"
+        + "(支持 ISO8601 / yyyy-MM-dd HH:mm:ss / yyyy-MM-dd)转为秒和毫秒时间戳。"
+        + "参数 value：时间戳或日期时间字符串，如 1721520000 或 2026-07-21 10:00:00；"
+        + "timezone：时区ID，如 Asia/Shanghai，默认 Asia/Shanghai。"
+        + "返回 datetime、timestampSeconds、timestampMillis、timezone、dayOfWeek。")
+    public Mono<String> timestampConvert(
+        @ToolParam(name = "value", description = "时间戳(10/13位数字)或日期时间字符串") String value,
+        @ToolParam(name = "timezone", required = false, description = "时区ID，默认 Asia/Shanghai") String timezone) {
+        return respond("timestamp_convert", () -> timestampOps.convert(value, timezone));
+    }
+
+    // =====================================================================
+    // Codec
+    // =====================================================================
+
+    @Tool(name = "base64_encode", description = "对文本做Base64编码(UTF-8)。参数 text：待编码文本。返回 result 字段为编码结果。")
+    public Mono<String> base64Encode(
+        @ToolParam(name = "text", description = "待编码文本") String text) {
+        return respond("base64_encode", () -> wrapResult(codecOps.base64Encode(text)));
+    }
+
+    @Tool(name = "base64_decode", description = "对Base64文本做解码(UTF-8)。参数 text：Base64字符串。"
+        + "输入非法Base64时返回error。返回 result 字段为解码后的文本。")
+    public Mono<String> base64Decode(
+        @ToolParam(name = "text", description = "待解码的Base64字符串") String text) {
+        return respond("base64_decode", () -> wrapResult(codecOps.base64Decode(text)));
+    }
+
+    @Tool(name = "url_encode", description = "对文本做URL编码(application/x-www-form-urlencoded, UTF-8)。"
+        + "参数 text：待编码文本。返回 result 字段为编码结果。")
+    public Mono<String> urlEncode(
+        @ToolParam(name = "text", description = "待编码文本") String text) {
+        return respond("url_encode", () -> wrapResult(codecOps.urlEncode(text)));
+    }
+
+    @Tool(name = "url_decode", description = "对URL编码文本做解码(UTF-8)。参数 text：URL编码字符串。返回 result 字段为解码结果。")
+    public Mono<String> urlDecode(
+        @ToolParam(name = "text", description = "待解码的URL编码字符串") String text) {
+        return respond("url_decode", () -> wrapResult(codecOps.urlDecode(text)));
+    }
+
+    @Tool(name = "text_hash", description = "计算文本摘要，输出小写hex。参数 algorithm：算法，取值 MD5/SHA-1/SHA-256/SHA-512；"
+        + "text：待摘要文本；hmacKey：可选，提供时走对应的HMAC(HmacMD5/HmacSHA1/HmacSHA256/HmacSHA512)。"
+        + "返回 result 字段为hex摘要。")
+    public Mono<String> textHash(
+        @ToolParam(name = "algorithm", description = "算法：MD5/SHA-1/SHA-256/SHA-512") String algorithm,
+        @ToolParam(name = "text", description = "待摘要文本") String text,
+        @ToolParam(name = "hmacKey", required = false, description = "可选HMAC密钥，提供则走HMAC") String hmacKey) {
+        return respond("text_hash", () -> wrapResult(codecOps.hash(algorithm, text, hmacKey)));
+    }
+
+    @Tool(name = "uuid_generate", description = "批量生成随机UUID(v4)。参数 count：生成数量，范围1~20，默认1。"
+        + "返回 result 字段为UUID字符串数组。")
+    public Mono<String> uuidGenerate(
+        @ToolParam(name = "count", required = false, description = "生成数量，1~20，默认1") Integer count) {
+        return respond("uuid_generate", () -> wrapResult(codecOps.uuid(count == null ? DEFAULT_UUID_COUNT : count)));
+    }
+
+    @Tool(name = "aes_encrypt", description = "AES加密，密文以Base64输出。参数 plainText：明文；key：密钥，UTF-8字节长度须为16/24/32；"
+        + "mode：模式 CBC/ECB/GCM，默认CBC；iv：可选Base64编码的IV，CBC/GCM缺省时随机生成并随结果返回，ECB无需IV。"
+        + "返回 mode、ciphertext(Base64)、iv(Base64，ECB时为null)。")
+    public Mono<String> aesEncrypt(
+        @ToolParam(name = "plainText", description = "待加密明文") String plainText,
+        @ToolParam(name = "key", description = "密钥，UTF-8字节长度16/24/32") String key,
+        @ToolParam(name = "mode", required = false, description = "模式 CBC/ECB/GCM，默认CBC") String mode,
+        @ToolParam(name = "iv", required = false, description = "可选IV(Base64)，缺省随机生成") String iv) {
+        return respond("aes_encrypt", () -> codecOps.aesEncrypt(plainText, key, mode, iv));
+    }
+
+    @Tool(name = "aes_decrypt", description = "AES解密，密文为Base64。参数 cipherText：Base64密文；key：密钥，UTF-8字节长度须为16/24/32；"
+        + "mode：模式 CBC/ECB/GCM，默认CBC；iv：Base64编码的IV，CBC/GCM必填，须与加密时一致，ECB无需IV。"
+        + "返回 result 字段为解密后的明文。")
+    public Mono<String> aesDecrypt(
+        @ToolParam(name = "cipherText", description = "待解密的Base64密文") String cipherText,
+        @ToolParam(name = "key", description = "密钥，UTF-8字节长度16/24/32") String key,
+        @ToolParam(name = "mode", required = false, description = "模式 CBC/ECB/GCM，默认CBC") String mode,
+        @ToolParam(name = "iv", required = false, description = "IV(Base64)，CBC/GCM必填") String iv) {
+        return respond("aes_decrypt", () -> wrapResult(codecOps.aesDecrypt(cipherText, key, mode, iv)));
+    }
+
+    // =====================================================================
+    // Regex
+    // =====================================================================
+
+    @Tool(name = "regex_test", description = "正则匹配测试。参数 pattern：正则表达式；text：待匹配文本；"
+        + "flags：可选，任意组合 i(忽略大小写)/m(多行)/s(dotall)。"
+        + "返回 matchCount(匹配总数)、truncated(是否因超100条截断)、matches(每个匹配的start/end/value/groups)。")
+    public Mono<String> regexTest(
+        @ToolParam(name = "pattern", description = "正则表达式") String pattern,
+        @ToolParam(name = "text", description = "待匹配文本") String text,
+        @ToolParam(name = "flags", required = false, description = "标志位组合 i/m/s") String flags) {
+        return respond("regex_test", () -> regexOps.test(pattern, text, flags));
+    }
+
+    // =====================================================================
+    // 内部：响应式包装 + 序列化 + 异常收敛 + 截断
+    // =====================================================================
+
+    /** 纯计算走 fromCallable 即可（不阻塞、无需 boundedElastic）；异常统一收敛为 error JSON。 */
+    private Mono<String> respond(String toolName, Callable<Object> resultSupplier) {
+        return Mono.fromCallable(() -> {
+            try {
+                return serializeWithTruncation(resultSupplier.call());
+            } catch (Exception e) {
+                // 只记工具名与异常，禁止打印用户输入（可能含敏感明文）
+                log.error("dev tool execute failed, code={}, tool={}", ERROR_CODE, toolName, e);
+                return errorJson(e.getMessage());
+            }
+        });
+    }
+
+    /** 把标量结果统一包成 {"result": ...} 便于 LLM 稳定取值。 */
+    private ObjectNode wrapResult(Object value) {
+        return objectMapper.valueToTree(java.util.Collections.singletonMap("result", value));
+    }
+
+    /** 序列化结果；超过阈值截断并标注 truncated 与原始长度。 */
+    private String serializeWithTruncation(Object result) throws Exception {
+        String json = objectMapper.writeValueAsString(result);
+        if (json.length() <= TRUNCATE_THRESHOLD) {
+            return json;
+        }
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("truncated", true);
+        node.put("originalLength", json.length());
+        node.put("result", json.substring(0, TRUNCATE_THRESHOLD));
+        return objectMapper.writeValueAsString(node);
+    }
+
+    /** 构造 error JSON。 */
+    private String errorJson(String message) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("error", message == null ? "unknown error" : message);
+        return node.toString();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOps.java
@@ -1,0 +1,130 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * JSON 处理纯函数集：格式化 / 压缩 / 校验（行列号定位）。
+ *
+ * <p>无 Spring 依赖、无状态。参数非法在方法入口 fast-fail 抛 {@link IllegalArgumentException}，
+ * 内部不再层层判空。JSON 解析错误统一带上 Jackson 提供的行列号，便于 LLM 自我纠正。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class JsonDevToolOps {
+
+    /** 复用同一 ObjectMapper（线程安全，读/写皆无状态使用）。 */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 允许的缩进宽度：2 或 4 个空格。 */
+    private static final int INDENT_TWO = 2;
+    private static final int INDENT_FOUR = 4;
+
+    /** 校验结果中"不适用"的行列号占位值（合法 JSON 时无行列可指）。 */
+    private static final int LOCATION_NOT_APPLICABLE = -1;
+
+    /**
+     * 美化 JSON：按指定缩进（2 或 4 个空格）重排。
+     *
+     * @param json   原始 JSON 文本
+     * @param indent 缩进宽度，仅支持 2 或 4
+     * @return 格式化后的 JSON 文本
+     */
+    public String format(String json, int indent) {
+        DevToolArgs.requireNonBlank(json, "json");
+        if (indent != INDENT_TWO && indent != INDENT_FOUR) {
+            throw new IllegalArgumentException("indent 仅支持 2 或 4，当前为 " + indent);
+        }
+        try {
+            JsonNode node = MAPPER.readTree(json);
+            return MAPPER.writer(buildPrinter(indent)).writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON 解析失败：" + describeLocation(e), e);
+        }
+    }
+
+    /**
+     * 压缩 JSON：去除所有多余空白，输出最紧凑形式。
+     *
+     * @param json 原始 JSON 文本
+     * @return 压缩后的 JSON 文本
+     */
+    public String minify(String json) {
+        DevToolArgs.requireNonBlank(json, "json");
+        try {
+            return MAPPER.writeValueAsString(MAPPER.readTree(json));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON 解析失败：" + describeLocation(e), e);
+        }
+    }
+
+    /**
+     * 校验 JSON 合法性：合法返回 valid=true；非法不抛异常，而是返回带错误信息与行列号的结果对象。
+     *
+     * @param json 待校验 JSON 文本（null/空白仍视为参数非法直接抛出）
+     * @return 校验结果
+     */
+    public ValidationResult validate(String json) {
+        DevToolArgs.requireNonBlank(json, "json");
+        try {
+            MAPPER.readTree(json);
+            return ValidationResult.builder()
+                .valid(true)
+                .line(LOCATION_NOT_APPLICABLE)
+                .column(LOCATION_NOT_APPLICABLE)
+                .build();
+        } catch (JsonProcessingException e) {
+            JsonLocation location = e.getLocation();
+            return ValidationResult.builder()
+                .valid(false)
+                .errorMessage(e.getOriginalMessage())
+                .line(location == null ? LOCATION_NOT_APPLICABLE : location.getLineNr())
+                .column(location == null ? LOCATION_NOT_APPLICABLE : location.getColumnNr())
+                .build();
+        }
+    }
+
+    /** 构造指定空格数的缩进 PrettyPrinter（对象与数组一致缩进）。 */
+    private DefaultPrettyPrinter buildPrinter(int indent) {
+        StringBuilder unit = new StringBuilder();
+        for (int i = 0; i < indent; i++) {
+            unit.append(' ');
+        }
+        DefaultIndenter indenter = new DefaultIndenter(unit.toString(), DefaultIndenter.SYS_LF);
+        DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+        printer.indentObjectsWith(indenter);
+        printer.indentArraysWith(indenter);
+        return printer;
+    }
+
+    /** 拼装"错误原文 + 行列号"的定位描述。 */
+    private String describeLocation(JsonProcessingException e) {
+        JsonLocation location = e.getLocation();
+        if (location == null) {
+            return e.getOriginalMessage();
+        }
+        return e.getOriginalMessage() + " (line " + location.getLineNr() + ", column " + location.getColumnNr() + ")";
+    }
+
+    /**
+     * JSON 校验结果。valid=true 时 line/column 为 -1（不适用）。
+     */
+    @Getter
+    @Builder
+    public static class ValidationResult {
+        /** 是否合法。 */
+        private final boolean valid;
+        /** 错误原因（合法时为 null）。 */
+        private final String errorMessage;
+        /** 出错行号（1 起，合法时为 -1）。 */
+        private final int line;
+        /** 出错列号（1 起，合法时为 -1）。 */
+        private final int column;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/RegexDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/RegexDevToolOps.java
@@ -1,0 +1,128 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * 正则匹配测试纯函数集。
+ *
+ * <p>返回匹配总数与每个匹配的位置/内容/分组，最多返回 {@value #MAX_MATCHES} 个匹配，超出截断并标注。
+ * 无 Spring 依赖、无状态，参数非法入口 fast-fail。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class RegexDevToolOps {
+
+    /** 最多返回的匹配数（超出仅计数、不再收集明细）。 */
+    private static final int MAX_MATCHES = 100;
+
+    /**
+     * 正则测试。
+     *
+     * @param pattern 正则表达式
+     * @param text    待匹配文本（允许空串）
+     * @param flags   标志位，任意组合 i(忽略大小写)/m(多行)/s(dotall)，可空
+     * @return 匹配结果
+     */
+    public RegexResult test(String pattern, String text, String flags) {
+        DevToolArgs.requireNonBlank(pattern, "pattern");
+        DevToolArgs.requireNonNull(text, "text");
+        Pattern compiled = compile(pattern, parseFlags(flags));
+
+        Matcher matcher = compiled.matcher(text);
+        List<RegexMatch> matches = new ArrayList<>();
+        int count = 0;
+        boolean truncated = false;
+        while (matcher.find()) {
+            count++;
+            if (matches.size() < MAX_MATCHES) {
+                List<String> groups = new ArrayList<>();
+                for (int i = 1; i <= matcher.groupCount(); i++) {
+                    groups.add(matcher.group(i));
+                }
+                matches.add(RegexMatch.builder()
+                    .start(matcher.start())
+                    .end(matcher.end())
+                    .value(matcher.group())
+                    .groups(groups)
+                    .build());
+            } else {
+                truncated = true;
+            }
+        }
+        return RegexResult.builder()
+            .matchCount(count)
+            .truncated(truncated)
+            .matches(matches)
+            .build();
+    }
+
+    /** 编译正则，非法语法抛出带说明的异常。 */
+    private Pattern compile(String pattern, int flagBits) {
+        try {
+            return Pattern.compile(pattern, flagBits);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("非法正则表达式：" + e.getMessage(), e);
+        }
+    }
+
+    /** 解析 flags 字符串为 Pattern 标志位。 */
+    private int parseFlags(String flags) {
+        if (flags == null || flags.isEmpty()) {
+            return 0;
+        }
+        int bits = 0;
+        for (char c : flags.toCharArray()) {
+            switch (Character.toLowerCase(c)) {
+                case 'i':
+                    bits |= Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+                    break;
+                case 'm':
+                    bits |= Pattern.MULTILINE;
+                    break;
+                case 's':
+                    bits |= Pattern.DOTALL;
+                    break;
+                default:
+                    throw new IllegalArgumentException("不支持的正则 flag：'" + c + "'，仅支持 i/m/s");
+            }
+        }
+        return bits;
+    }
+
+    /**
+     * 正则测试结果。
+     */
+    @Getter
+    @Builder
+    public static class RegexResult {
+        /** 匹配总数（含被截断未收集的部分）。 */
+        private final int matchCount;
+        /** 是否因超过上限而截断明细。 */
+        private final boolean truncated;
+        /** 匹配明细（最多 100 条）。 */
+        private final List<RegexMatch> matches;
+    }
+
+    /**
+     * 单个匹配明细。
+     */
+    @Getter
+    @Builder
+    public static class RegexMatch {
+        /** 起始下标（含）。 */
+        private final int start;
+        /** 结束下标（不含）。 */
+        private final int end;
+        /** 匹配到的完整文本。 */
+        private final String value;
+        /** 捕获分组（按分组序，可能含 null 表示未参与匹配的可选分组）。 */
+        private final List<String> groups;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/TimestampDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/TimestampDevToolOps.java
@@ -1,0 +1,134 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.Locale;
+
+/**
+ * 时间戳与日期时间互转纯函数集。
+ *
+ * <p>按输入自动判定方向：纯数字 10 位按秒、13 位按毫秒转日期时间；否则按日期时间字符串
+ * （宽容解析 ISO8601 / yyyy-MM-dd HH:mm:ss / yyyy-MM-dd）转秒 + 毫秒时间戳。
+ * 无 Spring 依赖、无状态，参数非法入口 fast-fail。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class TimestampDevToolOps {
+
+    /** 默认时区。 */
+    private static final String DEFAULT_TIMEZONE = "Asia/Shanghai";
+
+    /** 纯数字按秒解析的位数。 */
+    private static final int EPOCH_SECONDS_DIGITS = 10;
+    /** 纯数字按毫秒解析的位数。 */
+    private static final int EPOCH_MILLIS_DIGITS = 13;
+
+    /** 纯数字判定与统一输出格式。 */
+    private static final String DIGITS_REGEX = "\\d+";
+    private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * 时间戳 / 日期时间双向转换。
+     *
+     * @param value    纯数字时间戳（10 位秒 / 13 位毫秒）或日期时间字符串
+     * @param timezone 时区，为空默认 Asia/Shanghai
+     * @return 转换结果（含 datetime、秒/毫秒时间戳、时区、星期）
+     */
+    public TimestampResult convert(String value, String timezone) {
+        DevToolArgs.requireNonBlank(value, "value");
+        ZoneId zoneId = resolveZone(timezone);
+        String trimmed = value.trim();
+
+        ZonedDateTime zonedDateTime = trimmed.matches(DIGITS_REGEX)
+            ? fromEpoch(trimmed, zoneId)
+            : parseDateTime(trimmed, zoneId);
+
+        Instant instant = zonedDateTime.toInstant();
+        return TimestampResult.builder()
+            .datetime(OUTPUT_FORMATTER.format(zonedDateTime))
+            .timestampSeconds(instant.getEpochSecond())
+            .timestampMillis(instant.toEpochMilli())
+            .timezone(zoneId.getId())
+            .dayOfWeek(zonedDateTime.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.ENGLISH))
+            .build();
+    }
+
+    /** 解析时区，非法直接抛出。 */
+    private ZoneId resolveZone(String timezone) {
+        String tz = StringUtils.hasText(timezone) ? timezone.trim() : DEFAULT_TIMEZONE;
+        try {
+            return ZoneId.of(tz);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("非法时区：" + tz, e);
+        }
+    }
+
+    /** 纯数字时间戳（10 位秒 / 13 位毫秒）转带时区时间。 */
+    private ZonedDateTime fromEpoch(String digits, ZoneId zoneId) {
+        long number = Long.parseLong(digits);
+        Instant instant;
+        if (digits.length() == EPOCH_SECONDS_DIGITS) {
+            instant = Instant.ofEpochSecond(number);
+        } else if (digits.length() == EPOCH_MILLIS_DIGITS) {
+            instant = Instant.ofEpochMilli(number);
+        } else {
+            throw new IllegalArgumentException(
+                "纯数字时间戳仅支持 10 位(秒) 或 13 位(毫秒)，当前 " + digits.length() + " 位");
+        }
+        return instant.atZone(zoneId);
+    }
+
+    /** 宽容解析日期时间字符串：依次尝试 ISO8601(带偏移) / ISO本地 / yyyy-MM-dd HH:mm:ss / yyyy-MM-dd。 */
+    private ZonedDateTime parseDateTime(String value, ZoneId zoneId) {
+        try {
+            return OffsetDateTime.parse(value).atZoneSameInstant(zoneId);
+        } catch (Exception ignore) {
+            // 尝试下一种格式
+        }
+        try {
+            return LocalDateTime.parse(value).atZone(zoneId);
+        } catch (Exception ignore) {
+            // 尝试下一种格式
+        }
+        try {
+            return LocalDateTime.parse(value, OUTPUT_FORMATTER).atZone(zoneId);
+        } catch (Exception ignore) {
+            // 尝试下一种格式
+        }
+        try {
+            return LocalDate.parse(value).atStartOfDay(zoneId);
+        } catch (Exception ignore) {
+            // 全部失败，抛出统一说明
+        }
+        throw new IllegalArgumentException(
+            "无法解析日期时间：" + value + "，支持 ISO8601 / yyyy-MM-dd HH:mm:ss / yyyy-MM-dd");
+    }
+
+    /**
+     * 时间转换结果。
+     */
+    @Getter
+    @Builder
+    public static class TimestampResult {
+        /** 格式化后的日期时间（yyyy-MM-dd HH:mm:ss）。 */
+        private final String datetime;
+        /** 秒级时间戳。 */
+        private final long timestampSeconds;
+        /** 毫秒级时间戳。 */
+        private final long timestampMillis;
+        /** 采用的时区 ID。 */
+        private final String timezone;
+        /** 星期（英文全称）。 */
+        private final String dayOfWeek;
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOpsTest.java
@@ -1,0 +1,139 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link CodecDevToolOps} 单测：Base64/URL 编解码、hash/HMAC 已知向量、UUID 边界、
+ * AES 三模式加解密回环、密钥长度与坏输入。
+ * @author owlzhangfq@gmail.com
+ */
+class CodecDevToolOpsTest {
+
+    private final CodecDevToolOps ops = new CodecDevToolOps();
+
+    // -------- Base64 / URL --------
+
+    @Test
+    void base64_shouldRoundTrip() {
+        String encoded = ops.base64Encode("你好 hello");
+        assertEquals("你好 hello", ops.base64Decode(encoded));
+    }
+
+    @Test
+    void base64Decode_shouldThrow_onIllegalInput() {
+        assertThrows(IllegalArgumentException.class, () -> ops.base64Decode("!!!not-base64!!!"));
+    }
+
+    @Test
+    void url_shouldRoundTrip() {
+        String encoded = ops.urlEncode("a b&c=中文");
+        assertEquals("a b&c=中文", ops.urlDecode(encoded));
+    }
+
+    // -------- Hash / HMAC --------
+
+    @Test
+    void hash_md5_shouldMatchKnownVector() {
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", ops.hash("MD5", "abc", null));
+    }
+
+    @Test
+    void hash_sha256_shouldMatchKnownVector() {
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            ops.hash("SHA-256", "abc", null));
+    }
+
+    @Test
+    void hash_hmacSha256_shouldMatchKnownVector() {
+        // RFC 已知向量：HmacSHA256(key="key", "The quick brown fox jumps over the lazy dog")
+        assertEquals("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8",
+            ops.hash("SHA-256", "The quick brown fox jumps over the lazy dog", "key"));
+    }
+
+    @Test
+    void hash_withHmacKey_shouldDifferFromPlainHash() {
+        assertNotEquals(ops.hash("SHA-256", "abc", null), ops.hash("SHA-256", "abc", "secret"));
+    }
+
+    @Test
+    void hash_shouldRejectUnsupportedAlgorithm() {
+        assertThrows(IllegalArgumentException.class, () -> ops.hash("SHA-999", "abc", null));
+    }
+
+    // -------- UUID --------
+
+    @Test
+    void uuid_shouldGenerateRequestedCount() {
+        List<String> list = ops.uuid(5);
+        assertEquals(5, list.size());
+        assertEquals(5, list.stream().distinct().count());
+    }
+
+    @Test
+    void uuid_shouldRejectOutOfRangeCount() {
+        assertThrows(IllegalArgumentException.class, () -> ops.uuid(0));
+        assertThrows(IllegalArgumentException.class, () -> ops.uuid(21));
+    }
+
+    // -------- AES --------
+
+    @Test
+    void aes_cbc_shouldRoundTrip_withGeneratedIv() {
+        String key = "1234567890123456"; // 16 字节
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("secret-明文", key, "CBC", null);
+        assertNotNull(enc.getIv(), "CBC 应返回随机 IV");
+        assertEquals("secret-明文", ops.aesDecrypt(enc.getCiphertext(), key, "CBC", enc.getIv()));
+    }
+
+    @Test
+    void aes_cbc_shouldDefaultMode_whenModeBlank() {
+        String key = "1234567890123456";
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("hello", key, null, null);
+        assertEquals("CBC", enc.getMode());
+        assertEquals("hello", ops.aesDecrypt(enc.getCiphertext(), key, null, enc.getIv()));
+    }
+
+    @Test
+    void aes_ecb_shouldRoundTrip_withoutIv() {
+        String key = "123456789012345678901234"; // 24 字节
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("ecb-明文", key, "ECB", null);
+        assertNull(enc.getIv(), "ECB 不应有 IV");
+        assertEquals("ecb-明文", ops.aesDecrypt(enc.getCiphertext(), key, "ECB", null));
+    }
+
+    @Test
+    void aes_gcm_shouldRoundTrip() {
+        String key = "12345678901234567890123456789012"; // 32 字节
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("gcm-明文", key, "GCM", null);
+        assertNotNull(enc.getIv());
+        assertEquals("gcm-明文", ops.aesDecrypt(enc.getCiphertext(), key, "GCM", enc.getIv()));
+    }
+
+    @Test
+    void aes_shouldRejectIllegalKeyLength() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.aesEncrypt("x", "short-key", "CBC", null));
+        assertTrue(ex.getMessage().contains("16/24/32"));
+    }
+
+    @Test
+    void aesDecrypt_shouldRejectMissingIv_forCbc() {
+        assertThrows(IllegalArgumentException.class,
+            () -> ops.aesDecrypt("YWJj", "1234567890123456", "CBC", null));
+    }
+
+    @Test
+    void aes_shouldRejectIllegalMode() {
+        assertThrows(IllegalArgumentException.class,
+            () -> ops.aesEncrypt("x", "1234567890123456", "XTS", null));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxToolsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxToolsTest.java
@@ -1,0 +1,86 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DevToolboxTools} 单测：@Tool 壳的错误收敛（坏参数返回 error JSON 而非抛异常）、
+ * 正常路径序列化、AES 走通、以及超长结果截断保护。
+ * @author owlzhangfq@gmail.com
+ */
+class DevToolboxToolsTest {
+
+    private final DevToolboxTools tools = new DevToolboxTools();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonNode call(reactor.core.publisher.Mono<String> mono) throws Exception {
+        return mapper.readTree(mono.block());
+    }
+
+    @Test
+    void jsonFormat_shouldReturnFormatted_onValidInput() throws Exception {
+        // 工具输出把格式化文本作为 JSON 字符串字面量回传（外层是 TextNode），取其文本再解析即为原对象
+        String raw = tools.jsonFormat("{\"a\":1}", 2).block();
+        String formatted = mapper.readTree(raw).asText();
+        assertTrue(formatted.contains("\n"), "应为多行格式化文本");
+        assertEquals(1, mapper.readTree(formatted).get("a").asInt());
+    }
+
+    @Test
+    void jsonFormat_shouldConvergeError_onBadJson() throws Exception {
+        JsonNode node = call(tools.jsonFormat("{bad", 2));
+        assertTrue(node.has("error"), "坏 JSON 应收敛为 error 字段而非抛异常");
+        assertTrue(node.get("error").asText().contains("line"), "error 应带行列号便于自我纠正");
+    }
+
+    @Test
+    void jsonValidate_shouldReportInvalid() throws Exception {
+        JsonNode node = call(tools.jsonValidate("{\"a\": }"));
+        assertFalse(node.get("valid").asBoolean());
+        assertTrue(node.get("line").asInt() >= 1);
+    }
+
+    @Test
+    void textHash_shouldReturnResult() throws Exception {
+        JsonNode node = call(tools.textHash("MD5", "abc", null));
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", node.get("result").asText());
+    }
+
+    @Test
+    void aes_shouldRoundTripThroughShell() throws Exception {
+        String key = "1234567890123456";
+        JsonNode enc = call(tools.aesEncrypt("hi-明文", key, "CBC", null));
+        JsonNode dec = call(tools.aesDecrypt(enc.get("ciphertext").asText(), key, "CBC", enc.get("iv").asText()));
+        assertEquals("hi-明文", dec.get("result").asText());
+    }
+
+    @Test
+    void aes_shouldConvergeError_onBadKey() throws Exception {
+        JsonNode node = call(tools.aesEncrypt("x", "short", "CBC", null));
+        assertTrue(node.has("error"));
+        assertFalse(node.has("ciphertext"));
+    }
+
+    @Test
+    void uuidGenerate_shouldDefaultToOne_whenCountNull() throws Exception {
+        JsonNode node = call(tools.uuidGenerate(null));
+        assertEquals(1, node.get("result").size());
+    }
+
+    @Test
+    void largeResult_shouldBeTruncated() throws Exception {
+        // 构造一段长文本，base64 编码后包裹进 {"result":...} 会超过 8000 字符阈值
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 7000; i++) {
+            sb.append('a');
+        }
+        JsonNode node = call(tools.base64Encode(sb.toString()));
+        assertTrue(node.get("truncated").asBoolean(), "超长结果应标注 truncated");
+        assertTrue(node.get("originalLength").asInt() > 8000, "应记录原始长度");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOpsTest.java
@@ -1,0 +1,80 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link JsonDevToolOps} 单测：格式化/压缩正常路径 + 坏 JSON 的行列号定位 + 参数非法。
+ * @author owlzhangfq@gmail.com
+ */
+class JsonDevToolOpsTest {
+
+    private final JsonDevToolOps ops = new JsonDevToolOps();
+
+    @Test
+    void format_shouldPrettyPrint_withTwoSpaceIndent() {
+        String out = ops.format("{\"a\":1,\"b\":[2,3]}", 2);
+        assertTrue(out.contains("\n"), "应包含换行");
+        assertTrue(out.contains("  \"a\""), "应有 2 空格缩进");
+    }
+
+    @Test
+    void format_shouldPrettyPrint_withFourSpaceIndent() {
+        String out = ops.format("{\"a\":1}", 4);
+        assertTrue(out.contains("    \"a\""), "应有 4 空格缩进");
+    }
+
+    @Test
+    void format_shouldRejectIllegalIndent() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> ops.format("{}", 3));
+        assertTrue(ex.getMessage().contains("indent"));
+    }
+
+    @Test
+    void format_shouldThrowWithLineColumn_onBadJson() {
+        // 第 1 行第 8 列附近缺值，Jackson 报错带行列号
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> ops.format("{\"a\": }", 2));
+        assertTrue(ex.getMessage().contains("line"), "错误信息应含 line");
+        assertTrue(ex.getMessage().contains("column"), "错误信息应含 column");
+    }
+
+    @Test
+    void minify_shouldRemoveWhitespace() {
+        String out = ops.minify("{\n  \"a\": 1,\n  \"b\": 2\n}");
+        assertEquals("{\"a\":1,\"b\":2}", out);
+    }
+
+    @Test
+    void minify_shouldThrow_onBadJson() {
+        assertThrows(IllegalArgumentException.class, () -> ops.minify("{bad"));
+    }
+
+    @Test
+    void validate_shouldReturnValid_forGoodJson() {
+        JsonDevToolOps.ValidationResult result = ops.validate("{\"a\":[1,2,3]}");
+        assertTrue(result.isValid());
+        assertNotNull(result);
+        assertEquals(-1, result.getLine());
+    }
+
+    @Test
+    void validate_shouldReportLineColumn_forBadJson() {
+        JsonDevToolOps.ValidationResult result = ops.validate("{\"a\": }");
+        assertFalse(result.isValid());
+        assertNotNull(result.getErrorMessage());
+        assertTrue(result.getLine() >= 1, "行号应可用");
+        assertTrue(result.getColumn() >= 1, "列号应可用");
+    }
+
+    @Test
+    void anyOp_shouldRejectBlankInput() {
+        assertThrows(IllegalArgumentException.class, () -> ops.format("  ", 2));
+        assertThrows(IllegalArgumentException.class, () -> ops.minify(null));
+        assertThrows(IllegalArgumentException.class, () -> ops.validate(""));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/RegexDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/RegexDevToolOpsTest.java
@@ -1,0 +1,70 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link RegexDevToolOps} 单测：匹配计数/分组、flags、截断保护与非法输入。
+ * @author owlzhangfq@gmail.com
+ */
+class RegexDevToolOpsTest {
+
+    private final RegexDevToolOps ops = new RegexDevToolOps();
+
+    @Test
+    void test_shouldCountAndCaptureMatches() {
+        RegexDevToolOps.RegexResult r = ops.test("\\d+", "a1b22c333", null);
+        assertEquals(3, r.getMatchCount());
+        assertFalse(r.isTruncated());
+        assertEquals("1", r.getMatches().get(0).getValue());
+        assertEquals("22", r.getMatches().get(1).getValue());
+        assertEquals("333", r.getMatches().get(2).getValue());
+        assertEquals(1, r.getMatches().get(0).getStart());
+    }
+
+    @Test
+    void test_shouldReturnCaptureGroups() {
+        RegexDevToolOps.RegexResult r = ops.test("(\\w)(\\d)", "a1b2", null);
+        assertEquals(2, r.getMatchCount());
+        assertEquals(2, r.getMatches().get(0).getGroups().size());
+        assertEquals("a", r.getMatches().get(0).getGroups().get(0));
+        assertEquals("1", r.getMatches().get(0).getGroups().get(1));
+    }
+
+    @Test
+    void test_shouldApplyCaseInsensitiveFlag() {
+        RegexDevToolOps.RegexResult r = ops.test("abc", "ABC", "i");
+        assertEquals(1, r.getMatchCount());
+    }
+
+    @Test
+    void test_shouldTruncateAtOneHundredMatches() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 150; i++) {
+            sb.append('a');
+        }
+        RegexDevToolOps.RegexResult r = ops.test(".", sb.toString(), null);
+        assertEquals(150, r.getMatchCount());
+        assertTrue(r.isTruncated());
+        assertEquals(100, r.getMatches().size());
+    }
+
+    @Test
+    void test_shouldRejectInvalidPattern() {
+        assertThrows(IllegalArgumentException.class, () -> ops.test("(unclosed", "x", null));
+    }
+
+    @Test
+    void test_shouldRejectUnsupportedFlag() {
+        assertThrows(IllegalArgumentException.class, () -> ops.test("a", "a", "x"));
+    }
+
+    @Test
+    void test_shouldRejectBlankPattern() {
+        assertThrows(IllegalArgumentException.class, () -> ops.test("  ", "text", null));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/TimestampDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/TimestampDevToolOpsTest.java
@@ -1,0 +1,75 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link TimestampDevToolOps} 单测：10/13 位自动识别、日期时间宽容解析、时区与非法输入。
+ * @author owlzhangfq@gmail.com
+ */
+class TimestampDevToolOpsTest {
+
+    private final TimestampDevToolOps ops = new TimestampDevToolOps();
+
+    @Test
+    void convert_shouldParse10DigitsAsSeconds() {
+        TimestampDevToolOps.TimestampResult r = ops.convert("1721520000", null);
+        assertEquals(1721520000L, r.getTimestampSeconds());
+        assertEquals(1721520000000L, r.getTimestampMillis());
+        assertEquals("Asia/Shanghai", r.getTimezone());
+        assertNotNull(r.getDatetime());
+        assertTrue(r.getDayOfWeek() != null && !r.getDayOfWeek().isEmpty());
+    }
+
+    @Test
+    void convert_shouldParse13DigitsAsMillis() {
+        TimestampDevToolOps.TimestampResult r = ops.convert("1721520000000", null);
+        assertEquals(1721520000L, r.getTimestampSeconds());
+        assertEquals(1721520000000L, r.getTimestampMillis());
+    }
+
+    @Test
+    void convert_shouldParseDateTimeString_andRoundTrip() {
+        TimestampDevToolOps.TimestampResult r = ops.convert("2026-07-21 10:00:00", "Asia/Shanghai");
+        assertEquals("2026-07-21 10:00:00", r.getDatetime());
+        // 用返回的秒时间戳（10 位）反向再转，datetime 应一致
+        TimestampDevToolOps.TimestampResult back = ops.convert(String.valueOf(r.getTimestampSeconds()), "Asia/Shanghai");
+        assertEquals("2026-07-21 10:00:00", back.getDatetime());
+    }
+
+    @Test
+    void convert_shouldParseDateOnly() {
+        TimestampDevToolOps.TimestampResult r = ops.convert("2026-07-21", "Asia/Shanghai");
+        assertEquals("2026-07-21 00:00:00", r.getDatetime());
+    }
+
+    @Test
+    void convert_shouldParseIso8601WithOffset() {
+        TimestampDevToolOps.TimestampResult r = ops.convert("2026-07-21T10:00:00+08:00", "Asia/Shanghai");
+        assertEquals("2026-07-21 10:00:00", r.getDatetime());
+    }
+
+    @Test
+    void convert_shouldRejectIllegalDigitLength() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("123", null));
+    }
+
+    @Test
+    void convert_shouldRejectUnparseableDateTime() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("not-a-date", null));
+    }
+
+    @Test
+    void convert_shouldRejectIllegalTimezone() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("1721520000", "Not/AZone"));
+    }
+
+    @Test
+    void convert_shouldRejectBlank() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("  ", null));
+    }
+}


### PR DESCRIPTION
## 变更说明 / What

新增「开发者工具箱」：JSON 格式化/校验、时间戳转换、Base64/URL/Hex 编解码、哈希(HMAC)/UUID、AES 加解密、正则测试。同一套能力提供两个出口：

- **Agent 出口（复用 V15 系统工具机制，零侵入）**：starter 新增 `tool/devtool/` 包——四组纯函数 Ops + `DevToolboxTools` 壳（13 个 `@Tool` 方法）。admin-server 以 `@Bean("devtoolbox")` 显式装配（`DevToolboxConfig`），bean 名 = `ai_system_tool.tool_code`，`AdminAgentInstanceFactory#buildSystemTools` 现有逻辑按名注册，**不改 ToolRegistrar、不进 8080 主链路**，智能体配置页勾选即挂载。
- **admin 前端出口（纯本地计算，不新增后端接口）**：`/system/devtools` 工具箱页面，300ms debounce 实时计算、一键复制、localStorage 历史（AES 密钥/IV 不落存储）、`?tool=` 直达路由；JSON 校验带行列定位、时间戳双向联动+多时区对照、AES 支持 CBC/ECB/CTR 与多种密钥/IV 编码；新增依赖 crypto-js。
- **Flyway V27**：`ai_system_tool` 种子 devtoolbox；「系统管理」下挂菜单 id=150 `/system/devtools`（显式 id 现最大 141，跳到 150 留间隔）；权限点仅 `devtools:view` 一条（页面纯本地计算，只需菜单可见性）。

## 类型 / Type
- [x] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（新增功能附了单元测试）——starter 新增 50 个单测；全量 starter 700 个中唯一失败为 `RedisSessionPersistenceTest`（本机 Redis 无密码的已知环境不一致，见 CLAUDE.local 记录，与本 PR 无关）；admin-server 全量 439/439；前端 `vue-tsc + vite build` 零错误
- [x] 未在代码 / 配置中硬编码任何密钥（AES 密钥全部由使用者输入；工具日志不打印用户输入，防敏感明文落日志）
- [x] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定——本 PR 无外部后端：工具为无状态纯函数，Agent 出口走系统工具目录（`ai_system_tool`）既有机制
- [ ] 必要时更新了 README / 配置项说明——按需求明确不写文档，本 PR 不含文档变更

## 审阅提示 / Reviewer notes

- LLM 出口做了两项防护：异常统一收敛为 `{"error":...}` 返回（信息具体到可自我纠正，如 JSON 错误带行列号）；结果超 8000 字符截断并标注 `truncated`，防大 JSON 撑爆上下文。
- 前端 AES 用 crypto-js（无 GCM，界面只提供 CBC/ECB/CTR）；后端 Java 侧 AES 含 GCM。两侧能力集不完全一致是已知取舍。
- `db/migration` 版本号存在历史断档（缺 V22/V23），V27 为当前最高号，已核对未占用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)