### PR TITLE
chore(release): 版本号提升至 2.2.0

### DIFF
--- a/customer-admin-server/pom.xml
+++ b/customer-admin-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-starter</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/customer-channel/pom.xml
+++ b/customer-channel/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-starter</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/customer-work-app-server/pom.xml
+++ b/customer-work-app-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.github.richardfyoung</groupId>
             <artifactId>customer-work-starter</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
 
         <!-- 测试 -->

--- a/customer-work-gateway/pom.xml
+++ b/customer-work-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/customer-work-starter/pom.xml
+++ b/customer-work-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.richardfyoung</groupId>
         <artifactId>customer-work-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.richardfyoung</groupId>
     <artifactId>customer-work-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>pom</packaging>
     <name>customer-work-parent</name>
     <description>基于 AgentScope Java 的生产级智能客服系统（多模块：可复用 starter + 可运行应用）</description>


### PR DESCRIPTION
## 变更说明 / What

发布 v2.2.0 的版本号提升：全部 6 个 pom（parent + 5 模块）`2.1.0` → `2.2.0`，共 9 处，无任何代码变更。

本版本相对 v2.1.0 包含 3 个 PR：#40（CI 修复）、#41（分布式锁 + 工作区会话保留等）、#43（开发者工具箱）。合入后将在 merge commit 上打 tag `v2.2.0` 并发布 GitHub Release。

## 类型 / Type
- [x] chore

## 自查 / Checklist
- [x] `mvn clean install -Dmaven.test.skip=true` 全量 reactor 构建通过（纯版本号变更，测试以 CI 为准）
- [x] 未在代码 / 配置中硬编码任何密钥

🤖 Generated with [Claude Code](https://claude.com/claude-code)