### PR TITLE
fix(workspace): LLM 同步接口超时从全局 30s 放开至前端 180s/后端 170s

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
@@ -71,8 +71,8 @@ public class KnowledgeService {
         ".git", "node_modules", "target", "dist", "build", ".idea", ".gradle", "out", ".mvn");
     /** 检索命中片段展示上限。 */
     private static final int SNIPPET_MAX_CHARS = 800;
-    /** 问答一次性模型调用超时。 */
-    private static final long ASK_TIMEOUT_SECONDS = 45;
+    /** 问答一次性模型调用超时：需小于前端 LLM_TIMEOUT_MS(180s)，保证超时时前端收到结构化错误而非 axios 超时。 */
+    private static final long ASK_TIMEOUT_SECONDS = 170;
     /** 问答系统提示词：限定角色 + 抑制幻觉（检索片段里没有依据的就明说不知道，不编造）。 */
     private static final String ASK_SYSTEM_PROMPT = "你是一个知识库检索专家和助手，不知道的就回答不知道。";
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -63,7 +63,8 @@ public class GitAssistantService {
     private static final int MAX_DIFF_CHARS_FOR_MODEL = 20_000;
     /** Review 场景的 diff 上限（需求 §4.2.3：超大 diff 截断并在 summary 中声明）。 */
     private static final int MAX_DIFF_CHARS_FOR_REVIEW = 100_000;
-    private static final long AI_CALL_TIMEOUT_SECONDS = 30;
+    /** AI 调用超时：review 的 diff 上限 100k 字符，模型侧分钟级耗时属常态；取值需小于前端 LLM_TIMEOUT_MS(180s)，保证超时时前端收到的是本服务的结构化错误而非 axios 超时。 */
+    private static final long AI_CALL_TIMEOUT_SECONDS = 170;
     /** Review 系统提示词内置的团队规范（需求 §4.2.2，后续可由 RAG 注入团队文档替换/增强）。 */
     private static final String REVIEW_SYSTEM_PROMPT =
         "你是一名资深 Java 代码审查专家。请对以下 git diff 做代码审查，严格按团队规范逐条给出问题：\n"

--- a/customer-admin-web/src/api/knowledge.ts
+++ b/customer-admin-web/src/api/knowledge.ts
@@ -1,4 +1,4 @@
-import { request } from './request'
+import { LLM_TIMEOUT_MS, request } from './request'
 import type { KnowledgeAskResponse, KnowledgeIndex, KnowledgeSearchHit } from '@/types/api'
 
 /** 代码知识库索引列表（P3-2）。 */
@@ -32,5 +32,5 @@ export function searchKnowledge(indexId: number, query: string, topK?: number) {
 
 /** 基于代码知识库的问答（RAG）。 */
 export function askKnowledge(data: { indexId: number; question: string; topK?: number }) {
-  return request<KnowledgeAskResponse>({ url: '/knowledge/ask', method: 'post', data })
+  return request<KnowledgeAskResponse>({ url: '/knowledge/ask', method: 'post', data, timeout: LLM_TIMEOUT_MS })
 }

--- a/customer-admin-web/src/api/request.ts
+++ b/customer-admin-web/src/api/request.ts
@@ -7,6 +7,9 @@ import type { Result } from '@/types/api'
 const CODE_UNAUTHORIZED = 10001
 const CODE_FORCE_CHANGE_PASSWORD = 20002
 
+/** 同步 LLM 接口专用超时：模型调用远慢于普通 CRUD，30s 全局默认不够用（对齐定时任务手动触发的 180s）。 */
+export const LLM_TIMEOUT_MS = 180000
+
 const http = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 30000,

--- a/customer-admin-web/src/api/scheduled-task.ts
+++ b/customer-admin-web/src/api/scheduled-task.ts
@@ -1,4 +1,4 @@
-import { request } from './request'
+import { LLM_TIMEOUT_MS, request } from './request'
 import type { MpPageQuery, MpPageResult, ScheduledTaskRunVO, ScheduledTaskSaveRequest, ScheduledTaskVO } from '@/types/api'
 
 const BASE_URL = '/aiconfig/scheduled-task'
@@ -32,7 +32,7 @@ export function disableScheduledTask(id: number) {
  * 单独放宽超时时间，避免被 axios 实例的全局 30s 超时提前掐断、被前端拦截器误判为网络异常。
  */
 export function triggerScheduledTask(id: number) {
-  return request<ScheduledTaskRunVO>({ url: `${BASE_URL}/${id}/trigger`, method: 'post', timeout: 180000 })
+  return request<ScheduledTaskRunVO>({ url: `${BASE_URL}/${id}/trigger`, method: 'post', timeout: LLM_TIMEOUT_MS })
 }
 
 export function pageScheduledTaskRuns(id: number, query: MpPageQuery) {

--- a/customer-admin-web/src/api/vibecoding.ts
+++ b/customer-admin-web/src/api/vibecoding.ts
@@ -1,4 +1,4 @@
-import { request } from './request'
+import { LLM_TIMEOUT_MS, request } from './request'
 import { streamSse, type SseHandlers } from '@/utils/sse'
 import type {
   ChatRequest,
@@ -87,6 +87,7 @@ export function getGitDiffSummary(agentCode: string, sessionId: string) {
     url: `/workspace/${agentCode}/vibecoding/git-diff`,
     method: 'get',
     params: { sessionId },
+    timeout: LLM_TIMEOUT_MS,
   })
 }
 
@@ -96,6 +97,7 @@ export function generateCommitMessage(agentCode: string, req: CommitMessageReque
     url: `/workspace/${agentCode}/vibecoding/commit-message`,
     method: 'post',
     data: req,
+    timeout: LLM_TIMEOUT_MS,
   })
 }
 
@@ -105,6 +107,7 @@ export function generatePrDescription(agentCode: string, sessionId: string) {
     url: `/workspace/${agentCode}/vibecoding/pr-description`,
     method: 'post',
     data: { sessionId },
+    timeout: LLM_TIMEOUT_MS,
   })
 }
 
@@ -123,6 +126,7 @@ export function reviewVibeCoding(agentCode: string, sessionId: string) {
     url: `/workspace/${agentCode}/vibecoding/review`,
     method: 'post',
     data: { sessionId },
+    timeout: LLM_TIMEOUT_MS,
   })
 }
 


### PR DESCRIPTION
## 变更说明 / What

工作区「AI 代码审查」等功能频繁报 `timeout of 30000ms exceeded`（axios 全局 30s 超时）。排查发现超时共两层，只改前端会被后端顶住：

1. **前端**（[request.ts](https://github.com/liulangjietou/customer_work/blob/fix/llm-sync-timeout/customer-admin-web/src/api/request.ts) 全局 `timeout: 30000`）：新增导出常量 `LLM_TIMEOUT_MS = 180000`，5 个同步 LLM 接口按接口覆盖——代码审查、PR description、commit message、diff 摘要（vibecoding.ts）、知识库问答（knowledge.ts）；**全局 30s 不动**，普通 CRUD 保持快失败。scheduled-task.ts 原有内联 `180000` 顺手统一为该常量，消除魔法值。
2. **后端**：`GitAssistantService.AI_CALL_TIMEOUT_SECONDS` 30 → 170（四个功能的 `orTimeout` 与 `callModelOnce` 的 `block` 共用）；`KnowledgeService.ASK_TIMEOUT_SECONDS` 45 → 170。

**取值设计**：后端 170s 略小于前端 180s——超时时后端先失败，前端收到的是后端结构化错误（含错误码与描述），而非 axios 干巴巴的超时文案。

## 类型 / Type
- [x] fix 修复

## 自查 / Checklist
- [x] `mvn test` 全绿（GitAssistantServiceTest 12/12 + KnowledgeServiceTest 4/4；前端 vue-tsc + vite build 零错误；全量以 CI 为准）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循约定（不适用，纯超时参数调整）
- [x] 必要时更新了 README / 配置项说明（不适用，常量含注释说明取值依据）

🤖 Generated with [Claude Code](https://claude.com/claude-code)