### PR TITLE
feat(admin): 通用站内消息中心 + AI 代码审查异步化

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/controller/SiteMessageController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/controller/SiteMessageController.java
@@ -1,0 +1,58 @@
+package com.richard.fyoung.customeradmin.message.controller;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.message.dto.SiteMessageVO;
+import com.richard.fyoung.customeradmin.message.service.SiteMessageService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 站内消息中心：当前登录用户的消息分页/未读数/标记已读。登录即可访问，不新增权限点。
+ * 当前用户统一取自 Sa-Token 登录态。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/message")
+public class SiteMessageController {
+
+    private final SiteMessageService siteMessageService;
+
+    public SiteMessageController(SiteMessageService siteMessageService) {
+        this.siteMessageService = siteMessageService;
+    }
+
+    /** 分页查询当前用户站内消息：readFlag 可选（不传查全部），未读优先、时间倒序。 */
+    @GetMapping("/page")
+    public Result<PageResult<SiteMessageVO>> page(
+            @RequestParam(defaultValue = "1") long page,
+            @RequestParam(defaultValue = "10") long size,
+            @RequestParam(required = false) Integer readFlag) {
+        return Result.success(siteMessageService.page(StpUtil.getLoginIdAsLong(), readFlag, page, size));
+    }
+
+    /** 当前用户未读消息数（前端消息角标）。 */
+    @GetMapping("/unread-count")
+    public Result<Long> unreadCount() {
+        return Result.success(siteMessageService.unreadCount(StpUtil.getLoginIdAsLong()));
+    }
+
+    /** 标记单条消息已读（校验归属，非本人快速失败）。 */
+    @PostMapping("/{id}/read")
+    public Result<Void> read(@PathVariable Long id) {
+        siteMessageService.markRead(id, StpUtil.getLoginIdAsLong());
+        return Result.success();
+    }
+
+    /** 标记当前用户全部未读消息为已读。 */
+    @PostMapping("/read-all")
+    public Result<Void> readAll() {
+        siteMessageService.markAllRead(StpUtil.getLoginIdAsLong());
+        return Result.success();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/dto/SiteMessageVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/dto/SiteMessageVO.java
@@ -1,0 +1,41 @@
+package com.richard.fyoung.customeradmin.message.dto;
+
+import com.richard.fyoung.customeradmin.message.entity.SiteMessage;
+
+import java.time.LocalDateTime;
+
+/**
+ * 站内消息展示对象：只暴露前端消息中心需要的字段（不含接收人/更新时间等内部字段）。
+ *
+ * @param id        消息 id
+ * @param title     标题
+ * @param content   正文
+ * @param bizType   业务类型（如 {@code CODE_REVIEW}）
+ * @param bizId     业务主键
+ * @param link      前端跳转路由（可空）
+ * @param readFlag  已读标记：0未读/1已读
+ * @param createTime 创建时间
+ * @author owlzhangfq@gmail.com
+ */
+public record SiteMessageVO(
+        Long id,
+        String title,
+        String content,
+        String bizType,
+        String bizId,
+        String link,
+        Integer readFlag,
+        LocalDateTime createTime) {
+
+    public static SiteMessageVO from(SiteMessage message) {
+        return new SiteMessageVO(
+            message.getId(),
+            message.getTitle(),
+            message.getContent(),
+            message.getBizType(),
+            message.getBizId(),
+            message.getLink(),
+            message.getReadFlag(),
+            message.getCreateTime());
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/entity/SiteMessage.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/entity/SiteMessage.java
@@ -1,0 +1,52 @@
+package com.richard.fyoung.customeradmin.message.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 通用站内消息（贫血 DO）：一条消息一个接收人，任意业务域通过
+ * {@link com.richard.fyoung.customeradmin.message.service.SiteMessageService#send} 投递，
+ * {@code bizType} 区分来源（如 {@code CODE_REVIEW}），前端消息中心统一拉取。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_site_message")
+public class SiteMessage {
+
+    /** 已读标记：未读。 */
+    public static final int UNREAD = 0;
+    /** 已读标记：已读。 */
+    public static final int READ = 1;
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 接收人（admin 用户 id）。 */
+    private Long userId;
+
+    private String title;
+    private String content;
+
+    /** 业务类型（如 {@code CODE_REVIEW}），供前端按来源过滤/图标区分。 */
+    private String bizType;
+    /** 业务主键（如审查任务 id），前端跳转时携带。 */
+    private String bizId;
+    /** 前端跳转路由（可空）。 */
+    private String link;
+
+    /** 已读标记：{@link #UNREAD} / {@link #READ}。 */
+    private Integer readFlag;
+    /** 标记已读的时间，未读时为空。 */
+    private LocalDateTime readTime;
+
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/mapper/SiteMessageMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/mapper/SiteMessageMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.message.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.message.entity.SiteMessage;
+
+/**
+ * 站内消息 Mapper（写入 + 分页/条件查询，无自定义 SQL）。
+ * @author owlzhangfq@gmail.com
+ */
+public interface SiteMessageMapper extends BaseMapper<SiteMessage> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/service/SiteMessageService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/message/service/SiteMessageService.java
@@ -1,0 +1,112 @@
+package com.richard.fyoung.customeradmin.message.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.message.dto.SiteMessageVO;
+import com.richard.fyoung.customeradmin.message.entity.SiteMessage;
+import com.richard.fyoung.customeradmin.message.mapper.SiteMessageMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+
+/**
+ * 通用站内消息服务：投递（供任意业务域调用）、当前用户的分页查询、未读数、标记已读。
+ *
+ * <p>投递入口 {@link #send} 不依赖 Web 上下文（接收人 userId 由调用方显式传入），可在后台异步
+ * 线程里安全调用（如 AI 代码审查异步完成后的回调线程）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class SiteMessageService {
+
+    private static final Logger log = LoggerFactory.getLogger(SiteMessageService.class);
+
+    private final SiteMessageMapper siteMessageMapper;
+
+    public SiteMessageService(SiteMessageMapper siteMessageMapper) {
+        this.siteMessageMapper = siteMessageMapper;
+    }
+
+    /**
+     * 投递一条站内消息（通用入口）。title/bizType 为必填业务约束，交由调用方保证；这里只做落库。
+     *
+     * @param userId  接收人（admin 用户 id）
+     * @param title   标题
+     * @param content 正文（可空）
+     * @param bizType 业务类型（如 {@code CODE_REVIEW}）
+     * @param bizId   业务主键（可空）
+     * @param link    前端跳转路由（可空）
+     */
+    public void send(Long userId, String title, String content, String bizType, String bizId, String link) {
+        SiteMessage message = new SiteMessage();
+        message.setUserId(userId);
+        message.setTitle(title);
+        message.setContent(content);
+        message.setBizType(bizType);
+        message.setBizId(bizId);
+        message.setLink(link);
+        message.setReadFlag(SiteMessage.UNREAD);
+        siteMessageMapper.insert(message);
+        log.info("site message sent, userId={}, bizType={}, bizId={}", userId, bizType, bizId);
+    }
+
+    /**
+     * 分页查询当前用户的站内消息：可选按已读标记过滤，未读优先、同组按创建时间倒序。
+     *
+     * @param userId   当前用户
+     * @param readFlag 已读标记过滤（null 表示不过滤）
+     */
+    public PageResult<SiteMessageVO> page(Long userId, Integer readFlag, long pageNum, long pageSize) {
+        LambdaQueryWrapper<SiteMessage> wrapper = new LambdaQueryWrapper<SiteMessage>()
+            .eq(SiteMessage::getUserId, userId)
+            .eq(readFlag != null, SiteMessage::getReadFlag, readFlag)
+            .orderByAsc(SiteMessage::getReadFlag)
+            .orderByDesc(SiteMessage::getCreateTime);
+        IPage<SiteMessage> page = siteMessageMapper.selectPage(new Page<>(pageNum, pageSize), wrapper);
+        return PageResult.of(page.convert(SiteMessageVO::from));
+    }
+
+    /** 当前用户的未读消息数。 */
+    public long unreadCount(Long userId) {
+        return siteMessageMapper.selectCount(new LambdaQueryWrapper<SiteMessage>()
+            .eq(SiteMessage::getUserId, userId)
+            .eq(SiteMessage::getReadFlag, SiteMessage.UNREAD));
+    }
+
+    /** 标记单条消息已读：校验归属，非本人/不存在快速失败。已读幂等。 */
+    public void markRead(Long id, Long userId) {
+        SiteMessage message = siteMessageMapper.selectById(id);
+        if (message == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "消息不存在: " + id);
+        }
+        if (!message.getUserId().equals(userId)) {
+            throw new BizException(ResultCode.FORBIDDEN, "无权操作他人消息");
+        }
+        if (SiteMessage.READ == message.getReadFlag()) {
+            return;
+        }
+        SiteMessage update = new SiteMessage();
+        update.setId(id);
+        update.setReadFlag(SiteMessage.READ);
+        update.setReadTime(LocalDateTime.now());
+        siteMessageMapper.updateById(update);
+    }
+
+    /** 标记当前用户全部未读消息为已读。 */
+    public void markAllRead(Long userId) {
+        LambdaUpdateWrapper<SiteMessage> wrapper = new LambdaUpdateWrapper<SiteMessage>()
+            .eq(SiteMessage::getUserId, userId)
+            .eq(SiteMessage::getReadFlag, SiteMessage.UNREAD)
+            .set(SiteMessage::getReadFlag, SiteMessage.READ)
+            .set(SiteMessage::getReadTime, LocalDateTime.now());
+        siteMessageMapper.update(null, wrapper);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/controller/VibeCodingController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/controller/VibeCodingController.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.controller;
 
 import cn.dev33.satoken.annotation.SaCheckPermission;
+import cn.dev33.satoken.stp.StpUtil;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatRequest;
@@ -11,7 +12,7 @@ import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PlanConfirmRequ
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PrDescriptionRequest;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PrDescriptionResponse;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewRequest;
-import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewResult;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewTaskVO;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.RollbackRequest;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.RollbackResult;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.SandboxModeResponse;
@@ -164,15 +165,25 @@ public class VibeCodingController {
     }
 
     /**
-     * Git 助手 · AI 代码审查（需求 P0-2）：对本轮 diff 输出结构化审查意见
-     * （CRITICAL/WARNING/SUGGESTION 逐条带文件/行号/建议）。同步返回，无变更时报 {@code NO_FILE_CHANGES}。
+     * Git 助手 · 提交 AI 代码审查（需求 P0-2，提交-轮询模型）：模型分钟级调用不再阻塞前端，
+     * 立即返回 taskId，前端凭此轮询 {@link #reviewTask}。无变更等校验失败在提交同步段即报错。
+     * 提交人取自当前登录态并透传到异步链路（异步线程拿不到 Sa-Token 上下文）。
      */
     @SaCheckPermission("workspace")
     @OperationLog(operation = "VibeCoding代码审查", target = "vibecoding_git_assistant")
     @PostMapping("/review")
-    public CompletableFuture<Result<ReviewResult>> review(
-            @PathVariable String agentCode, @Valid @RequestBody ReviewRequest request) {
-        return gitAssistantService.review(agentCode, request.sessionId()).thenApply(Result::success);
+    public Result<Long> review(@PathVariable String agentCode, @Valid @RequestBody ReviewRequest request) {
+        return Result.success(gitAssistantService.submitReview(agentCode, request.sessionId(), StpUtil.getLoginIdAsLong()));
+    }
+
+    /**
+     * Git 助手 · 轮询 AI 代码审查任务：RUNNING 表示进行中，SUCCESS 携带结构化结果，FAILED 携带错误。
+     * 校验任务归属，非本人快速失败。
+     */
+    @SaCheckPermission("workspace")
+    @GetMapping("/review-task/{taskId}")
+    public Result<ReviewTaskVO> reviewTask(@PathVariable String agentCode, @PathVariable Long taskId) {
+        return Result.success(gitAssistantService.getReviewTask(taskId, StpUtil.getLoginIdAsLong()));
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/dto/ReviewTaskVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/dto/ReviewTaskVO.java
@@ -1,0 +1,24 @@
+package com.richard.fyoung.customeradmin.workspace.vibecoding.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * AI 代码审查任务视图（提交-轮询模型的轮询响应）：前端据 {@link #status} 决定是否继续轮询，
+ * SUCCESS 时展示 {@link #result}，FAILED 时展示 {@link #errorMsg}。
+ *
+ * @param id         任务 id
+ * @param status     状态：RUNNING/SUCCESS/FAILED
+ * @param result     审查结果（仅 SUCCESS 时非空）
+ * @param errorMsg   失败原因（仅 FAILED 时非空）
+ * @param createTime 提交时间
+ * @param finishTime 完成时间（RUNNING 时为空）
+ * @author owlzhangfq@gmail.com
+ */
+public record ReviewTaskVO(
+        Long id,
+        String status,
+        ReviewResult result,
+        String errorMsg,
+        LocalDateTime createTime,
+        LocalDateTime finishTime) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/entity/CodeReviewTask.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/entity/CodeReviewTask.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customeradmin.workspace.vibecoding.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * AI 代码审查异步任务（贫血 DO）：AI 代码审查从"同步等结果"改为"提交-轮询"，模型分钟级调用不再
+ * 阻塞前端。提交即落 {@link #STATUS_RUNNING} 行返回 taskId，异步完成后回写
+ * {@link #STATUS_SUCCESS}/{@link #STATUS_FAILED} 与结果，并发站内信通知提交人。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_code_review_task")
+public class CodeReviewTask {
+
+    /** 状态：执行中。 */
+    public static final String STATUS_RUNNING = "RUNNING";
+    /** 状态：成功。 */
+    public static final String STATUS_SUCCESS = "SUCCESS";
+    /** 状态：失败。 */
+    public static final String STATUS_FAILED = "FAILED";
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String agentCode;
+    private String sessionId;
+
+    /** 提交人（admin 用户 id）。 */
+    private Long userId;
+
+    /** 状态：{@link #STATUS_RUNNING} / {@link #STATUS_SUCCESS} / {@link #STATUS_FAILED}。 */
+    private String status;
+
+    /** 审查结果 JSON（{@code ReviewResult} 序列化，SUCCESS 才有）。 */
+    private String resultJson;
+    /** 失败原因（FAILED 才有）。 */
+    private String errorMsg;
+
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+
+    /** 完成时间（SUCCESS/FAILED 时写入）。 */
+    private LocalDateTime finishTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/mapper/CodeReviewTaskMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/mapper/CodeReviewTaskMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.workspace.vibecoding.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.entity.CodeReviewTask;
+
+/**
+ * AI 代码审查任务 Mapper（写入 + 按 id 查询，无自定义 SQL）。
+ * @author owlzhangfq@gmail.com
+ */
+public interface CodeReviewTaskMapper extends BaseMapper<CodeReviewTask> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -1,12 +1,14 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.message.service.SiteMessageService;
 import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
 import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
 import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
@@ -16,6 +18,9 @@ import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.GitDiffSummary;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PrDescriptionResponse;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewIssue;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewResult;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewTaskVO;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.entity.CodeReviewTask;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.mapper.CodeReviewTaskMapper;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -26,10 +31,12 @@ import io.agentscope.core.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -85,6 +92,15 @@ public class GitAssistantService {
     private static final String DEFAULT_SEVERITY = "SUGGESTION";
     /** 模型输出的 category 不在合法集合内时的兜底分类（STYLE 语义最中性）。 */
     private static final String DEFAULT_CATEGORY = "STYLE";
+    /** 站内消息业务类型：AI 代码审查（前端消息中心据此分组/跳转）。 */
+    private static final String BIZ_TYPE_CODE_REVIEW = "CODE_REVIEW";
+    /** 审查完成/失败站内信标题。 */
+    private static final String REVIEW_MSG_TITLE_SUCCESS = "AI 代码审查完成";
+    private static final String REVIEW_MSG_TITLE_FAILED = "AI 代码审查失败";
+    /** 站内信正文中 summary 预览的最大长度（需求：含 summary 前 200 字）。 */
+    private static final int SUMMARY_PREVIEW_LIMIT = 200;
+    /** error_msg 列宽上限（VARCHAR(1000)），落库前截断避免超长。 */
+    private static final int ERROR_MSG_MAX_LEN = 1000;
     private static final ExecutorService GIT_ASSISTANT_EXECUTOR = Executors.newFixedThreadPool(8, r -> {
         Thread thread = new Thread(r, "git-assistant-worker");
         thread.setDaemon(true);
@@ -95,16 +111,21 @@ public class GitAssistantService {
     private final AdminAgentInstanceFactory agentInstanceFactory;
     private final GitWorkspaceService gitWorkspaceService;
     private final AiCodingAuditService auditService;
+    private final CodeReviewTaskMapper reviewTaskMapper;
+    private final SiteMessageService siteMessageService;
     /** Review 结果 JSON 解析用（宽松：忽略模型多吐的未知字段），窄用途、不依赖容器注入。 */
     private final ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public GitAssistantService(AiAgentMapper agentMapper, AdminAgentInstanceFactory agentInstanceFactory,
-                                GitWorkspaceService gitWorkspaceService, AiCodingAuditService auditService) {
+                                GitWorkspaceService gitWorkspaceService, AiCodingAuditService auditService,
+                                CodeReviewTaskMapper reviewTaskMapper, SiteMessageService siteMessageService) {
         this.agentMapper = agentMapper;
         this.agentInstanceFactory = agentInstanceFactory;
         this.gitWorkspaceService = gitWorkspaceService;
         this.auditService = auditService;
+        this.reviewTaskMapper = reviewTaskMapper;
+        this.siteMessageService = siteMessageService;
     }
 
     /** diff 摘要：无变更时直接返回空摘要，不额外调用模型。 */
@@ -174,31 +195,145 @@ public class GitAssistantService {
     }
 
     /**
-     * AI 代码审查（需求 P0-2 §4.2）：对本轮 diff 一次性调用模型，输出结构化审查意见。
-     * 无变更时直接抛 {@link ResultCode#NO_FILE_CHANGES}，不调用模型。
+     * 提交 AI 代码审查任务（需求 P0-2 §4.2，提交-轮询模型）：模型分钟级调用不再阻塞前端。
+     * 同步段完成校验并落 {@link CodeReviewTask#STATUS_RUNNING} 任务行、立即返回 taskId；
+     * 真正的模型审查在 {@link #GIT_ASSISTANT_EXECUTOR} 异步执行，完成后回写结果并发站内信通知。
      *
-     * <p>模型输出 JSON 解析失败时降级（§4.2.3）：{@code issues} 为空、模型原文放进 {@code summary}，
-     * 仍返回成功结果不抛裸异常；只有模型调用本身失败/超时才归一成 {@link ResultCode#AI_REVIEW_FAILED}
-     * 快速失败（"明确错误码，不吞掉"）。</p>
+     * <p>{@code userId} 必须在同步段（Web 请求线程）由调用方捕获传入——异步线程脱离 Sa-Token 上下文，
+     * 拿不到当前登录用户。</p>
+     *
+     * @return 审查任务 id（前端据此轮询 {@link #getReviewTask}）
      */
-    public CompletableFuture<ReviewResult> review(String agentCode, String sessionId) {
+    public Long submitReview(String agentCode, String sessionId, Long userId) {
         requireVibeCodingCapable(agentCode);
         Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        // 无变更在同步段快速失败（NO_FILE_CHANGES，与原同步 review 一致）：避免为"本轮无内容可审查"
+        // 创建 FAILED 任务并推送误导性的失败站内信。git diff 是子进程读取、非分钟级模型调用，同步执行可接受
+        String diff = requireNonEmptyDiff(workspace);
+        // 审计条目在请求线程同步段创建（操作人依赖 Sa-Token ThreadLocal），异步链路里只补结果
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.REVIEW, agentCode, sessionId);
-        return CompletableFuture.supplyAsync(() -> {
-            String diff = requireNonEmptyDiff(workspace);
-            boolean truncated = diff.length() > MAX_DIFF_CHARS_FOR_REVIEW;
-            String diffForModel = truncated ? diff.substring(0, MAX_DIFF_CHARS_FOR_REVIEW) : diff;
-            Model model = agentInstanceFactory.buildModelForAgent(agentCode);
-            ModelCallOutcome outcome = callModelOnce(model, REVIEW_SYSTEM_PROMPT + "git diff:\n" + diffForModel);
-            auditService.applyUsage(audit, outcome.usage());
-            return parseReviewResult(outcome.text(), truncated);
-        }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .exceptionally(ex -> rethrow(ex, ResultCode.AI_REVIEW_FAILED, "AI_CODE_REVIEW_FAIL", agentCode, sessionId))
-            .whenComplete((result, error) -> auditService.finish(audit, error));
+
+        // 同步落 RUNNING 任务行，拿到自增 id 先返回给前端
+        CodeReviewTask task = new CodeReviewTask();
+        task.setAgentCode(agentCode);
+        task.setSessionId(sessionId);
+        task.setUserId(userId);
+        task.setStatus(CodeReviewTask.STATUS_RUNNING);
+        reviewTaskMapper.insert(task);
+        Long taskId = task.getId();
+        log.info("code review task submitted, taskId={}, agentCode={}, sessionId={}", taskId, agentCode, sessionId);
+
+        CompletableFuture.supplyAsync(() -> doReview(agentCode, diff, audit), GIT_ASSISTANT_EXECUTOR)
+            .orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .whenComplete((result, error) -> {
+                auditService.finish(audit, error);
+                if (error == null) {
+                    completeReviewTask(taskId, agentCode, userId, result);
+                } else {
+                    failReviewTask(taskId, agentCode, userId, error);
+                }
+            });
+        return taskId;
+    }
+
+    /**
+     * 查询审查任务（轮询入口）：校验归属，非本人/不存在快速失败。SUCCESS 时反序列化结果一并返回。
+     */
+    public ReviewTaskVO getReviewTask(Long taskId, Long userId) {
+        CodeReviewTask task = reviewTaskMapper.selectById(taskId);
+        if (task == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "审查任务不存在: " + taskId);
+        }
+        if (!task.getUserId().equals(userId)) {
+            throw new BizException(ResultCode.FORBIDDEN, "无权查看他人的审查任务");
+        }
+        ReviewResult result = null;
+        if (CodeReviewTask.STATUS_SUCCESS.equals(task.getStatus()) && StringUtils.hasText(task.getResultJson())) {
+            try {
+                result = objectMapper.readValue(task.getResultJson(), ReviewResult.class);
+            } catch (JsonProcessingException e) {
+                log.error("deserialize review result failed, code={}, taskId={}", "AI-REVIEW-RESULT-READ-FAIL", taskId, e);
+            }
+        }
+        return new ReviewTaskVO(task.getId(), task.getStatus(), result, task.getErrorMsg(),
+            task.getCreateTime(), task.getFinishTime());
     }
 
     // ---------------------- private helpers ----------------------
+
+    /**
+     * 审查计算主体（在异步线程执行）：diff 已在同步段校验非空。模型输出 JSON 解析失败时降级（§4.2.3）
+     * ——{@code issues} 为空、原文进 {@code summary}，不抛裸异常；只有模型调用本身失败/超时才抛异常，
+     * 由 {@link #failReviewTask} 落库为 FAILED 并发失败站内信。
+     */
+    private ReviewResult doReview(String agentCode, String diff, AiCodingAuditLog audit) {
+        boolean truncated = diff.length() > MAX_DIFF_CHARS_FOR_REVIEW;
+        String diffForModel = truncated ? diff.substring(0, MAX_DIFF_CHARS_FOR_REVIEW) : diff;
+        Model model = agentInstanceFactory.buildModelForAgent(agentCode);
+        ModelCallOutcome outcome = callModelOnce(model, REVIEW_SYSTEM_PROMPT + "git diff:\n" + diffForModel);
+        auditService.applyUsage(audit, outcome.usage());
+        return parseReviewResult(outcome.text(), truncated);
+    }
+
+    /** 审查成功：结果落库（SUCCESS + finish_time），并发站内信通知提交人。 */
+    private void completeReviewTask(Long taskId, String agentCode, Long userId, ReviewResult result) {
+        CodeReviewTask update = new CodeReviewTask();
+        update.setId(taskId);
+        update.setStatus(CodeReviewTask.STATUS_SUCCESS);
+        update.setFinishTime(LocalDateTime.now());
+        try {
+            update.setResultJson(objectMapper.writeValueAsString(result));
+        } catch (JsonProcessingException e) {
+            log.error("serialize review result failed, code={}, taskId={}", "AI-REVIEW-RESULT-JSON-FAIL", taskId, e);
+        }
+        reviewTaskMapper.updateById(update);
+        siteMessageService.send(userId, REVIEW_MSG_TITLE_SUCCESS, buildSuccessContent(result),
+            BIZ_TYPE_CODE_REVIEW, String.valueOf(taskId), reviewTaskLink(agentCode, taskId));
+        log.info("code review task succeeded, taskId={}, agentCode={}", taskId, agentCode);
+    }
+
+    /** 审查失败：错误落库（FAILED + error_msg + finish_time），并发站内信告知（带跳转，可查看错误）。 */
+    private void failReviewTask(Long taskId, String agentCode, Long userId, Throwable error) {
+        String errorMsg = describeError(error);
+        CodeReviewTask update = new CodeReviewTask();
+        update.setId(taskId);
+        update.setStatus(CodeReviewTask.STATUS_FAILED);
+        update.setErrorMsg(truncate(errorMsg, ERROR_MSG_MAX_LEN));
+        update.setFinishTime(LocalDateTime.now());
+        reviewTaskMapper.updateById(update);
+        siteMessageService.send(userId, REVIEW_MSG_TITLE_FAILED, "审查执行失败：" + errorMsg,
+            BIZ_TYPE_CODE_REVIEW, String.valueOf(taskId), reviewTaskLink(agentCode, taskId));
+        log.error("code review task failed, code={}, taskId={}, agentCode={}", "AI-CODE-REVIEW-TASK-FAIL", taskId, agentCode, error);
+    }
+
+    /** 站内信正文：summary 前 200 字 + 各级别问题数（降级无 issues 时问题数均为 0）。 */
+    private String buildSuccessContent(ReviewResult result) {
+        long critical = countBySeverity(result, "CRITICAL");
+        long warning = countBySeverity(result, "WARNING");
+        long suggestion = countBySeverity(result, "SUGGESTION");
+        String summary = result.summary() == null ? "" : result.summary();
+        String preview = summary.length() > SUMMARY_PREVIEW_LIMIT ? summary.substring(0, SUMMARY_PREVIEW_LIMIT) : summary;
+        return preview + "\n严重(CRITICAL): " + critical + "，警告(WARNING): " + warning + "，建议(SUGGESTION): " + suggestion;
+    }
+
+    private long countBySeverity(ReviewResult result, String severity) {
+        if (CollectionUtils.isEmpty(result.issues())) {
+            return 0;
+        }
+        return result.issues().stream().filter(issue -> severity.equals(issue.severity())).count();
+    }
+
+    /** 前端跳转路由：定位到该会话工作区并自动打开对应审查任务。 */
+    private String reviewTaskLink(String agentCode, Long taskId) {
+        return "/workspace/" + agentCode + "?reviewTask=" + taskId;
+    }
+
+    private String truncate(String text, int maxLen) {
+        if (text == null || text.length() <= maxLen) {
+            return text;
+        }
+        return text.substring(0, maxLen);
+    }
 
     /**
      * 解析模型返回的审查 JSON。剥离可能包裹的 Markdown 代码块，截取首个 {@code {} 到末个 }} 之间的

--- a/customer-admin-server/src/main/resources/db/migration/V28__site_message_and_review_task.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V28__site_message_and_review_task.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- 通用站内消息 + AI 代码审查异步任务（Flyway V28）
+-- =============================================================================
+-- 站内消息（ai_site_message）：面向后台 admin 用户的通用消息中心，任意业务域可通过
+-- SiteMessageService.send 投递（biz_type 区分来源，如 CODE_REVIEW），前端消息中心统一拉取。
+-- 代码审查任务（ai_code_review_task）：AI 代码审查从"同步等结果"改为"提交-轮询"，模型分钟级
+-- 调用不再阻塞前端；提交即落 RUNNING 行返回 taskId，异步完成后回写结果并发站内信。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+-- 通用站内消息：一条消息一个接收人（admin 用户），未读优先展示。
+CREATE TABLE IF NOT EXISTS `ai_site_message` (
+    `id`          BIGINT       NOT NULL AUTO_INCREMENT COMMENT '主键',
+    `user_id`     BIGINT       NOT NULL COMMENT '接收人（admin 用户 id）',
+    `title`       VARCHAR(200) NOT NULL COMMENT '消息标题',
+    `content`     VARCHAR(2000)         DEFAULT NULL COMMENT '消息正文',
+    `biz_type`    VARCHAR(50)  NOT NULL COMMENT '业务类型（如 CODE_REVIEW）',
+    `biz_id`      VARCHAR(64)           DEFAULT NULL COMMENT '业务主键',
+    `link`        VARCHAR(500)          DEFAULT NULL COMMENT '前端跳转路由（可空）',
+    `read_flag`   TINYINT      NOT NULL DEFAULT 0 COMMENT '已读标记：0未读/1已读',
+    `read_time`   DATETIME              DEFAULT NULL COMMENT '标记已读时间',
+    `create_time` DATETIME     NOT NULL COMMENT '创建时间',
+    `update_time` DATETIME     NOT NULL COMMENT '更新时间',
+    PRIMARY KEY (`id`),
+    KEY `idx_user_read` (`user_id`, `read_flag`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='通用站内消息';
+
+-- AI 代码审查异步任务：提交即 RUNNING，异步完成回写 SUCCESS/FAILED 与结果。
+CREATE TABLE IF NOT EXISTS `ai_code_review_task` (
+    `id`          BIGINT      NOT NULL AUTO_INCREMENT COMMENT '主键',
+    `agent_code`  VARCHAR(64) NOT NULL COMMENT '智能体编码',
+    `session_id`  VARCHAR(64) NOT NULL COMMENT '会话 id',
+    `user_id`     BIGINT      NOT NULL COMMENT '提交人（admin 用户 id）',
+    `status`      VARCHAR(20) NOT NULL COMMENT '状态：RUNNING/SUCCESS/FAILED',
+    `result_json` MEDIUMTEXT           DEFAULT NULL COMMENT '审查结果 JSON（SUCCESS 才有）',
+    `error_msg`   VARCHAR(1000)        DEFAULT NULL COMMENT '失败原因（FAILED 才有）',
+    `create_time` DATETIME    NOT NULL COMMENT '创建时间',
+    `update_time` DATETIME    NOT NULL COMMENT '更新时间',
+    `finish_time` DATETIME             DEFAULT NULL COMMENT '完成时间（SUCCESS/FAILED 时写入）',
+    PRIMARY KEY (`id`),
+    KEY `idx_user` (`user_id`),
+    KEY `idx_session` (`session_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='AI 代码审查异步任务';

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/message/controller/SiteMessageControllerTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/message/controller/SiteMessageControllerTest.java
@@ -1,0 +1,78 @@
+package com.richard.fyoung.customeradmin.message.controller;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.message.dto.SiteMessageVO;
+import com.richard.fyoung.customeradmin.message.service.SiteMessageService;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link SiteMessageController} 单测：当前用户统一取自 Sa-Token，接口透传给 service 并用 {@link Result} 封装。
+ * @author owlzhangfq@gmail.com
+ */
+class SiteMessageControllerTest {
+
+    private static final long CURRENT_USER = 7L;
+
+    private final SiteMessageService service = mock(SiteMessageService.class);
+    private final SiteMessageController controller = new SiteMessageController(service);
+
+    @Test
+    void page_shouldQueryCurrentUserWithReadFlag() {
+        PageResult<SiteMessageVO> pageResult = new PageResult<>();
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(CURRENT_USER);
+            when(service.page(CURRENT_USER, 0, 2, 20)).thenReturn(pageResult);
+
+            Result<PageResult<SiteMessageVO>> result = controller.page(2, 20, 0);
+
+            assertEquals(ResultCode.SUCCESS.getCode(), result.getCode());
+            assertEquals(pageResult, result.getData());
+            verify(service).page(CURRENT_USER, 0, 2, 20);
+        }
+    }
+
+    @Test
+    void unreadCount_shouldReturnCurrentUserCount() {
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(CURRENT_USER);
+            when(service.unreadCount(CURRENT_USER)).thenReturn(5L);
+
+            Result<Long> result = controller.unreadCount();
+
+            assertEquals(5L, result.getData());
+        }
+    }
+
+    @Test
+    void read_shouldDelegateWithCurrentUser() {
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(CURRENT_USER);
+
+            controller.read(11L);
+
+            verify(service).markRead(eq(11L), eq(CURRENT_USER));
+        }
+    }
+
+    @Test
+    void readAll_shouldDelegateWithCurrentUser() {
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(CURRENT_USER);
+
+            controller.readAll();
+
+            verify(service).markAllRead(CURRENT_USER);
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/message/service/SiteMessageServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/message/service/SiteMessageServiceTest.java
@@ -1,0 +1,151 @@
+package com.richard.fyoung.customeradmin.message.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.message.dto.SiteMessageVO;
+import com.richard.fyoung.customeradmin.message.entity.SiteMessage;
+import com.richard.fyoung.customeradmin.message.mapper.SiteMessageMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link SiteMessageService} 单测：投递落库、未读数、分页 VO 映射、标记已读的归属校验与幂等。
+ * {@link SiteMessageMapper} 用 mock 代替（不依赖真实库）。
+ * @author owlzhangfq@gmail.com
+ */
+class SiteMessageServiceTest {
+
+    private SiteMessageMapper siteMessageMapper;
+    private SiteMessageService service;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), SiteMessage.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        siteMessageMapper = mock(SiteMessageMapper.class);
+        service = new SiteMessageService(siteMessageMapper);
+    }
+
+    @Test
+    void send_shouldInsertUnreadMessage_withAllFields() {
+        service.send(7L, "标题", "正文", "CODE_REVIEW", "99", "/workspace/coder?reviewTask=99");
+
+        ArgumentCaptor<SiteMessage> captor = ArgumentCaptor.forClass(SiteMessage.class);
+        verify(siteMessageMapper).insert(captor.capture());
+        SiteMessage saved = captor.getValue();
+        assertEquals(7L, saved.getUserId());
+        assertEquals("标题", saved.getTitle());
+        assertEquals("CODE_REVIEW", saved.getBizType());
+        assertEquals("99", saved.getBizId());
+        assertEquals("/workspace/coder?reviewTask=99", saved.getLink());
+        assertEquals(SiteMessage.UNREAD, saved.getReadFlag(), "新消息应为未读");
+    }
+
+    @Test
+    void unreadCount_shouldDelegateToMapperCount() {
+        when(siteMessageMapper.selectCount(any())).thenReturn(3L);
+
+        assertEquals(3L, service.unreadCount(7L));
+    }
+
+    @Test
+    void page_shouldMapEntitiesToVO() {
+        SiteMessage message = new SiteMessage();
+        message.setId(1L);
+        message.setUserId(7L);
+        message.setTitle("t");
+        message.setBizType("CODE_REVIEW");
+        message.setReadFlag(SiteMessage.UNREAD);
+        Page<SiteMessage> page = new Page<>(1, 10);
+        page.setRecords(List.of(message));
+        page.setTotal(1);
+        when(siteMessageMapper.selectPage(any(IPage.class), any())).thenReturn(page);
+
+        PageResult<SiteMessageVO> result = service.page(7L, null, 1, 10);
+
+        assertEquals(1, result.getTotal());
+        assertEquals(1, result.getList().size());
+        assertEquals("t", result.getList().get(0).title());
+        assertEquals("CODE_REVIEW", result.getList().get(0).bizType());
+    }
+
+    @Test
+    void markRead_shouldThrowNotFound_whenMessageMissing() {
+        when(siteMessageMapper.selectById(1L)).thenReturn(null);
+
+        BizException ex = assertThrows(BizException.class, () -> service.markRead(1L, 7L));
+        assertEquals(ResultCode.RESOURCE_NOT_FOUND, ex.getResultCode());
+    }
+
+    @Test
+    void markRead_shouldThrowForbidden_whenNotOwner() {
+        SiteMessage message = new SiteMessage();
+        message.setId(1L);
+        message.setUserId(999L);
+        message.setReadFlag(SiteMessage.UNREAD);
+        when(siteMessageMapper.selectById(1L)).thenReturn(message);
+
+        BizException ex = assertThrows(BizException.class, () -> service.markRead(1L, 7L));
+        assertEquals(ResultCode.FORBIDDEN, ex.getResultCode());
+        verify(siteMessageMapper, never()).updateById(any(SiteMessage.class));
+    }
+
+    @Test
+    void markRead_shouldUpdateReadFlagAndTime_whenOwnedAndUnread() {
+        SiteMessage message = new SiteMessage();
+        message.setId(1L);
+        message.setUserId(7L);
+        message.setReadFlag(SiteMessage.UNREAD);
+        when(siteMessageMapper.selectById(1L)).thenReturn(message);
+
+        service.markRead(1L, 7L);
+
+        ArgumentCaptor<SiteMessage> captor = ArgumentCaptor.forClass(SiteMessage.class);
+        verify(siteMessageMapper).updateById(captor.capture());
+        assertEquals(SiteMessage.READ, captor.getValue().getReadFlag());
+        assertNotNull(captor.getValue().getReadTime());
+    }
+
+    @Test
+    void markRead_shouldBeIdempotent_whenAlreadyRead() {
+        SiteMessage message = new SiteMessage();
+        message.setId(1L);
+        message.setUserId(7L);
+        message.setReadFlag(SiteMessage.READ);
+        when(siteMessageMapper.selectById(1L)).thenReturn(message);
+
+        service.markRead(1L, 7L);
+
+        verify(siteMessageMapper, never()).updateById(any(SiteMessage.class));
+    }
+
+    @Test
+    void markAllRead_shouldIssueBulkUpdate() {
+        service.markAllRead(7L);
+
+        verify(siteMessageMapper).update(eq(null), any());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/controller/VibeCodingControllerReviewTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/controller/VibeCodingControllerReviewTest.java
@@ -1,0 +1,59 @@
+package com.richard.fyoung.customeradmin.workspace.vibecoding.controller;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewRequest;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewTaskVO;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.entity.CodeReviewTask;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.service.CollaborativeCodingService;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.service.GitAssistantService;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.service.VibeCodingService;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link VibeCodingController} 代码审查异步接口单测：提交返回 taskId、轮询透传归属校验参数。
+ * @author owlzhangfq@gmail.com
+ */
+class VibeCodingControllerReviewTest {
+
+    private static final long CURRENT_USER = 7L;
+
+    private final GitAssistantService gitAssistantService = mock(GitAssistantService.class);
+    private final VibeCodingController controller = new VibeCodingController(
+        mock(VibeCodingService.class), gitAssistantService, mock(CollaborativeCodingService.class));
+
+    @Test
+    void review_shouldSubmitWithCurrentUser_andReturnTaskId() {
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(CURRENT_USER);
+            when(gitAssistantService.submitReview("coder", "s1", CURRENT_USER)).thenReturn(88L);
+
+            Result<Long> result = controller.review("coder", new ReviewRequest("s1"));
+
+            assertEquals(88L, result.getData());
+            verify(gitAssistantService).submitReview(eq("coder"), eq("s1"), eq(CURRENT_USER));
+        }
+    }
+
+    @Test
+    void reviewTask_shouldQueryWithCurrentUser() {
+        ReviewTaskVO vo = new ReviewTaskVO(88L, CodeReviewTask.STATUS_RUNNING, null, null, null, null);
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(CURRENT_USER);
+            when(gitAssistantService.getReviewTask(88L, CURRENT_USER)).thenReturn(vo);
+
+            Result<ReviewTaskVO> result = controller.reviewTask("coder", 88L);
+
+            assertEquals(vo, result.getData());
+            verify(gitAssistantService).getReviewTask(eq(88L), eq(CURRENT_USER));
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
@@ -1,16 +1,21 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.message.service.SiteMessageService;
 import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.CommitMessageResponse;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.GitDiffSummary;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PrDescriptionResponse;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewResult;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewTaskVO;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.entity.CodeReviewTask;
+import com.richard.fyoung.customeradmin.workspace.vibecoding.mapper.CodeReviewTaskMapper;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
@@ -20,6 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 
 import java.nio.file.Path;
@@ -27,11 +33,17 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -42,9 +54,13 @@ import static org.mockito.Mockito.when;
  */
 class GitAssistantServiceTest {
 
+    private static final ObjectMapper TEST_OBJECT_MAPPER = new ObjectMapper();
+
     private AiAgentMapper agentMapper;
     private AdminAgentInstanceFactory agentInstanceFactory;
     private GitWorkspaceService gitWorkspaceService;
+    private CodeReviewTaskMapper reviewTaskMapper;
+    private SiteMessageService siteMessageService;
     private Model model;
     private GitAssistantService service;
 
@@ -61,13 +77,23 @@ class GitAssistantServiceTest {
         agentMapper = mock(AiAgentMapper.class);
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
         gitWorkspaceService = mock(GitWorkspaceService.class);
+        reviewTaskMapper = mock(CodeReviewTaskMapper.class);
+        siteMessageService = mock(SiteMessageService.class);
         model = mock(Model.class);
         // 审计服务用 mock（旁路能力，埋点行为由 AiCodingAuditServiceTest 单独覆盖）
         service = new GitAssistantService(agentMapper, agentInstanceFactory, gitWorkspaceService,
-            mock(AiCodingAuditService.class));
+            mock(AiCodingAuditService.class), reviewTaskMapper, siteMessageService);
 
         when(agentInstanceFactory.resolveSessionWorkspace(anyString(), anyString())).thenReturn(sessionWorkspace);
         when(agentInstanceFactory.buildModelForAgent(anyString())).thenReturn(model);
+    }
+
+    /** mock 的 insert 不会回填自增 id，异步链路要用 taskId 回写，故 stub 成插入即赋 id。 */
+    private void stubReviewTaskInsertAssignsId(long taskId) {
+        when(reviewTaskMapper.insert(any(CodeReviewTask.class))).thenAnswer(invocation -> {
+            invocation.<CodeReviewTask>getArgument(0).setId(taskId);
+            return 1;
+        });
     }
 
     private AiAgent vibeCodingAgent() {
@@ -178,56 +204,92 @@ class GitAssistantServiceTest {
         assertTrue(response.description().contains("Foo.java"));
     }
 
-    // ===== code review (P0-2) =====
+    // ===== code review 异步化 (提交-轮询) =====
 
-    @Test
-    void review_shouldThrowNoFileChanges_whenDiffEmpty() {
-        when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace)).thenReturn("");
+    /** 从异步回写 updateById 捕获任务并反序列化 result_json，避免各用例重复模板。 */
+    private CodeReviewTask captureReviewTaskUpdate() {
+        ArgumentCaptor<CodeReviewTask> captor = ArgumentCaptor.forClass(CodeReviewTask.class);
+        verify(reviewTaskMapper, timeout(2000)).updateById(captor.capture());
+        return captor.getValue();
+    }
 
-        CompletionException ex = assertThrows(CompletionException.class,
-            () -> service.review("coder", "s1").join());
-        assertEquals(ResultCode.NO_FILE_CHANGES, unwrap(ex).getResultCode());
+    private ReviewResult parseResultJson(String json) throws Exception {
+        return TEST_OBJECT_MAPPER.readValue(json, ReviewResult.class);
     }
 
     @Test
-    void review_shouldParseStructuredIssues_whenModelReturnsJson() {
+    void submitReview_shouldFastFailNoFileChanges_synchronously_whenDiffEmpty() {
+        when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
+        when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace)).thenReturn("");
+
+        // 无变更同步快速失败：既不建任务行、也不发站内信
+        BizException ex = assertThrows(BizException.class, () -> service.submitReview("coder", "s1", 7L));
+        assertEquals(ResultCode.NO_FILE_CHANGES, ex.getResultCode());
+        verify(reviewTaskMapper, never()).insert(any(CodeReviewTask.class));
+    }
+
+    @Test
+    void submitReview_shouldReturnTaskIdImmediately_andPersistRunningRow() {
+        when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
+        when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
+            .thenReturn("diff --git a/Foo.java b/Foo.java\n+class Foo {}");
+        stubReviewTaskInsertAssignsId(42L);
+        mockModelReply("{\"issues\":[],\"summary\":\"ok\"}");
+
+        Long taskId = service.submitReview("coder", "s1", 7L);
+
+        assertEquals(42L, taskId, "同步段应立即返回插入后回填的 taskId");
+    }
+
+    @Test
+    void submitReview_shouldPersistSuccessAndSendMessage_whenModelReturnsJson() throws Exception {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
             .thenReturn("diff --git a/Foo.java b/Foo.java\n+String sql = \"select * where id=\"+id;");
+        stubReviewTaskInsertAssignsId(99L);
         // 模型在 JSON 外还夹了 Markdown 代码块标记，解析器应能剥离
         mockModelReply("```json\n{\"issues\":[{\"severity\":\"CRITICAL\",\"file\":\"Foo.java\",\"line\":1,"
             + "\"category\":\"SECURITY\",\"message\":\"SQL 注入\",\"suggestion\":\"用参数化查询\"}],"
             + "\"summary\":\"发现 1 个严重问题\"}\n```");
 
-        ReviewResult result = service.review("coder", "s1").join();
+        service.submitReview("coder", "s1", 7L);
 
+        CodeReviewTask updated = captureReviewTaskUpdate();
+        assertEquals(CodeReviewTask.STATUS_SUCCESS, updated.getStatus());
+        assertNotNull(updated.getFinishTime());
+        ReviewResult result = parseResultJson(updated.getResultJson());
         assertEquals(1, result.issues().size());
         assertEquals("CRITICAL", result.issues().get(0).severity());
-        assertEquals("Foo.java", result.issues().get(0).file());
-        assertEquals(1, result.issues().get(0).line());
         assertEquals("SECURITY", result.issues().get(0).category());
-        assertTrue(result.summary().contains("严重问题"));
+        // 成功站内信：接收人=提交人、bizType=CODE_REVIEW、bizId=taskId、link 携带 reviewTask=taskId
+        verify(siteMessageService, timeout(2000)).send(eq(7L), eq("AI 代码审查完成"), anyString(),
+            eq("CODE_REVIEW"), eq("99"), contains("reviewTask=99"));
     }
 
     @Test
-    void review_shouldDegradeToSummary_whenModelReturnsNonJson() {
+    void submitReview_shouldPersistDegradedSummary_whenModelReturnsNonJson() throws Exception {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
             .thenReturn("diff --git a/Foo.java b/Foo.java\n+class Foo {}");
+        stubReviewTaskInsertAssignsId(99L);
         mockModelReply("这段代码看起来没什么问题，整体不错。");
 
-        ReviewResult result = service.review("coder", "s1").join();
+        service.submitReview("coder", "s1", 7L);
 
+        CodeReviewTask updated = captureReviewTaskUpdate();
+        // 解析失败仍算成功（降级），不当作硬失败
+        assertEquals(CodeReviewTask.STATUS_SUCCESS, updated.getStatus());
+        ReviewResult result = parseResultJson(updated.getResultJson());
         assertTrue(result.issues().isEmpty(), "解析失败降级为空 issues");
         assertTrue(result.summary().contains("整体不错"), "模型原文进 summary");
     }
 
     @Test
-    void review_shouldNormalizeSeverityAndCategory_lowercaseMixedcaseAndUnknown() {
+    void submitReview_shouldNormalizeSeverityAndCategory_lowercaseMixedcaseAndUnknown() throws Exception {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
             .thenReturn("diff --git a/Foo.java b/Foo.java\n+class Foo {}");
+        stubReviewTaskInsertAssignsId(99L);
         // 三种非规范值：全小写 / 混合大小写 / 未知值（blocker、smell 不在合法集合内）
         mockModelReply("{\"issues\":["
             + "{\"severity\":\"critical\",\"file\":\"A.java\",\"line\":1,\"category\":\"security\",\"message\":\"m1\",\"suggestion\":\"s1\"},"
@@ -235,8 +297,9 @@ class GitAssistantServiceTest {
             + "{\"severity\":\"blocker\",\"file\":\"C.java\",\"line\":3,\"category\":\"smell\",\"message\":\"m3\",\"suggestion\":\"s3\"}],"
             + "\"summary\":\"3 项\"}");
 
-        ReviewResult result = service.review("coder", "s1").join();
+        service.submitReview("coder", "s1", 7L);
 
+        ReviewResult result = parseResultJson(captureReviewTaskUpdate().getResultJson());
         assertEquals(3, result.issues().size(), "非规范值不能导致 issue 丢失");
         assertEquals("CRITICAL", result.issues().get(0).severity(), "全小写应归一为大写");
         assertEquals("SECURITY", result.issues().get(0).category());
@@ -247,16 +310,73 @@ class GitAssistantServiceTest {
     }
 
     @Test
-    void review_shouldUnifyErrorCode_whenModelReturnsNothing() {
+    void submitReview_shouldPersistFailedAndSendFailureMessage_whenModelReturnsNothing() {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
             .thenReturn("diff --git a/Foo.java b/Foo.java\n+class Foo {}");
-        // 模型空响应：callModelOnce 内部抛通用 GIT_ASSISTANT_AI_FAILED，review 链路必须统一改写成 40019
+        stubReviewTaskInsertAssignsId(99L);
+        // 模型空响应：callModelOnce 内部抛异常 → 异步链路落 FAILED 并发失败站内信（不抛给调用方）
         when(model.stream(any(), any(), any())).thenReturn(Flux.empty());
 
-        CompletionException ex = assertThrows(CompletionException.class,
-            () -> service.review("coder", "s1").join());
-        assertEquals(ResultCode.AI_REVIEW_FAILED, unwrap(ex).getResultCode(),
-            "review 链路全部 AI 硬失败对外只有 AI_REVIEW_FAILED 一个码");
+        service.submitReview("coder", "s1", 7L);
+
+        CodeReviewTask updated = captureReviewTaskUpdate();
+        assertEquals(CodeReviewTask.STATUS_FAILED, updated.getStatus());
+        assertNotNull(updated.getErrorMsg(), "失败任务应落错误原因");
+        assertNotNull(updated.getFinishTime());
+        verify(siteMessageService, timeout(2000)).send(eq(7L), eq("AI 代码审查失败"), anyString(),
+            eq("CODE_REVIEW"), eq("99"), contains("reviewTask=99"));
+    }
+
+    // ===== 审查任务轮询 (归属校验) =====
+
+    @Test
+    void getReviewTask_shouldThrowNotFound_whenTaskMissing() {
+        when(reviewTaskMapper.selectById(1L)).thenReturn(null);
+
+        BizException ex = assertThrows(BizException.class, () -> service.getReviewTask(1L, 7L));
+        assertEquals(ResultCode.RESOURCE_NOT_FOUND, ex.getResultCode());
+    }
+
+    @Test
+    void getReviewTask_shouldThrowForbidden_whenNotOwner() {
+        CodeReviewTask task = new CodeReviewTask();
+        task.setId(1L);
+        task.setUserId(999L);
+        task.setStatus(CodeReviewTask.STATUS_RUNNING);
+        when(reviewTaskMapper.selectById(1L)).thenReturn(task);
+
+        BizException ex = assertThrows(BizException.class, () -> service.getReviewTask(1L, 7L));
+        assertEquals(ResultCode.FORBIDDEN, ex.getResultCode());
+    }
+
+    @Test
+    void getReviewTask_shouldReturnResult_whenSuccessAndOwned() {
+        CodeReviewTask task = new CodeReviewTask();
+        task.setId(1L);
+        task.setUserId(7L);
+        task.setStatus(CodeReviewTask.STATUS_SUCCESS);
+        task.setResultJson("{\"issues\":[],\"summary\":\"looks good\"}");
+        when(reviewTaskMapper.selectById(1L)).thenReturn(task);
+
+        ReviewTaskVO vo = service.getReviewTask(1L, 7L);
+
+        assertEquals(CodeReviewTask.STATUS_SUCCESS, vo.status());
+        assertNotNull(vo.result());
+        assertEquals("looks good", vo.result().summary());
+    }
+
+    @Test
+    void getReviewTask_shouldReturnNullResult_whenStillRunning() {
+        CodeReviewTask task = new CodeReviewTask();
+        task.setId(1L);
+        task.setUserId(7L);
+        task.setStatus(CodeReviewTask.STATUS_RUNNING);
+        when(reviewTaskMapper.selectById(1L)).thenReturn(task);
+
+        ReviewTaskVO vo = service.getReviewTask(1L, 7L);
+
+        assertEquals(CodeReviewTask.STATUS_RUNNING, vo.status());
+        assertTrue(vo.result() == null, "RUNNING 阶段无结果");
     }
 }

--- a/customer-admin-web/src/api/message.ts
+++ b/customer-admin-web/src/api/message.ts
@@ -1,0 +1,24 @@
+import { request } from './request'
+import type { PageResult, SiteMessagePageQuery, SiteMessageVO } from '@/types/api'
+
+const BASE_URL = '/message'
+
+/** 站内消息分页（顶栏铃铛弹层用）。readFlag 省略时查全部（已读+未读）。 */
+export function pageSiteMessages(query: SiteMessagePageQuery) {
+  return request<PageResult<SiteMessageVO>>({ url: `${BASE_URL}/page`, method: 'get', params: query })
+}
+
+/** 未读消息数，供铃铛徽标与轮询使用。 */
+export function getUnreadMessageCount() {
+  return request<number>({ url: `${BASE_URL}/unread-count`, method: 'get' })
+}
+
+/** 标记单条消息已读。 */
+export function markMessageRead(id: number) {
+  return request<void>({ url: `${BASE_URL}/${id}/read`, method: 'post' })
+}
+
+/** 全部标记已读。 */
+export function markAllMessagesRead() {
+  return request<void>({ url: `${BASE_URL}/read-all`, method: 'post' })
+}

--- a/customer-admin-web/src/api/vibecoding.ts
+++ b/customer-admin-web/src/api/vibecoding.ts
@@ -7,7 +7,7 @@ import type {
   GitDiffSummary,
   PlanConfirmRequest,
   PrDescriptionResponse,
-  ReviewResult,
+  ReviewTaskVO,
   RollbackResult,
   SandboxModeResponse,
   SaveFileContentRequest,
@@ -120,13 +120,24 @@ export function rollbackVibeCoding(agentCode: string, sessionId: string) {
   })
 }
 
-/** AI 代码审查：对本轮 diff 输出结构化审查意见（CRITICAL/WARNING/SUGGESTION）。 */
+/**
+ * AI 代码审查（异步化）：提交本轮 diff 审查任务，立即返回 taskId，不再同步等待模型产出结果。
+ * 提交本身是快操作（只是入队），不需要 LLM_TIMEOUT_MS 长超时，用默认 30s 即可；
+ * 真正耗时的模型调用在后端异步执行，前端通过 getReviewTask 轮询或站内信通知拿到终态。
+ */
 export function reviewVibeCoding(agentCode: string, sessionId: string) {
-  return request<ReviewResult>({
+  return request<number>({
     url: `/workspace/${agentCode}/vibecoding/review`,
     method: 'post',
     data: { sessionId },
-    timeout: LLM_TIMEOUT_MS,
+  })
+}
+
+/** 查询 AI 代码审查任务状态/结果（轮询接口，默认超时即可）。 */
+export function getReviewTask(agentCode: string, taskId: number) {
+  return request<ReviewTaskVO>({
+    url: `/workspace/${agentCode}/vibecoding/review-task/${taskId}`,
+    method: 'get',
   })
 }
 

--- a/customer-admin-web/src/components/NotificationBell.vue
+++ b/customer-admin-web/src/components/NotificationBell.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { getUnreadMessageCount, markAllMessagesRead, markMessageRead, pageSiteMessages } from '@/api/message'
+import type { SiteMessageVO } from '@/types/api'
+
+// 未读数轮询间隔；弹层里只展示最近 N 条（分页第一页），不做"加载更多"——铃铛只是速览入口，
+// 完整列表另有站内信管理页（不在本组件职责内）。
+const UNREAD_POLL_INTERVAL_MS = 30000
+const RECENT_MESSAGE_PAGE_SIZE = 10
+
+const router = useRouter()
+const unreadCount = ref(0)
+const messages = ref<SiteMessageVO[]>([])
+const loading = ref(false)
+const popoverVisible = ref(false)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+/** 拉取未读数刷新徽标；轮询场景静默失败即可，不打扰用户，下一轮会自然重试。 */
+async function refreshUnreadCount() {
+  try {
+    unreadCount.value = await getUnreadMessageCount()
+  } catch {
+    // 静默忽略：见上方注释
+  }
+}
+
+/** 弹层展开时加载最近消息（含已读+未读，不筛 readFlag）。 */
+async function loadRecentMessages() {
+  loading.value = true
+  try {
+    const page = await pageSiteMessages({ page: 1, size: RECENT_MESSAGE_PAGE_SIZE })
+    messages.value = page.list
+  } catch (error) {
+    ElMessage.error('站内消息加载失败：' + (error instanceof Error ? error.message : String(error)))
+  } finally {
+    loading.value = false
+  }
+}
+
+function handlePopoverShow() {
+  loadRecentMessages()
+}
+
+/** 点击某条消息：未读则先标记已读并刷新未读数；有跳转链接的再关闭弹层并导航。 */
+async function handleMessageClick(msg: SiteMessageVO) {
+  if (msg.readFlag === 0) {
+    try {
+      await markMessageRead(msg.id)
+      msg.readFlag = 1
+      await refreshUnreadCount()
+    } catch (error) {
+      ElMessage.error('标记已读失败：' + (error instanceof Error ? error.message : String(error)))
+      return
+    }
+  }
+  if (msg.link) {
+    popoverVisible.value = false
+    router.push(msg.link)
+  }
+}
+
+async function handleMarkAllRead() {
+  try {
+    await markAllMessagesRead()
+    messages.value.forEach((m) => { m.readFlag = 1 })
+    await refreshUnreadCount()
+    ElMessage.success('已全部标记已读')
+  } catch (error) {
+    ElMessage.error('操作失败：' + (error instanceof Error ? error.message : String(error)))
+  }
+}
+
+/**
+ * 相对时间展示（刚刚/n 分钟前/n 小时前/n 天前，超过 7 天直接显示日期）。
+ * 兼容后端可能返回的 "yyyy-MM-dd HH:mm:ss" 与 ISO "yyyy-MM-ddTHH:mm:ss" 两种时间字符串——
+ * 前者在部分浏览器里 `new Date()` 无法正确解析，统一补 T 再解析；解析失败原样兜底返回。
+ */
+function formatRelativeTime(createTime: string): string {
+  const normalized = createTime.includes('T') ? createTime : createTime.replace(' ', 'T')
+  const parsed = new Date(normalized)
+  if (Number.isNaN(parsed.getTime())) {
+    return createTime
+  }
+  const diffMinutes = Math.floor((Date.now() - parsed.getTime()) / 60000)
+  if (diffMinutes < 1) return '刚刚'
+  if (diffMinutes < 60) return `${diffMinutes} 分钟前`
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) return `${diffHours} 小时前`
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 7) return `${diffDays} 天前`
+  return parsed.toLocaleDateString()
+}
+
+onMounted(() => {
+  refreshUnreadCount()
+  pollTimer = setInterval(refreshUnreadCount, UNREAD_POLL_INTERVAL_MS)
+})
+
+onUnmounted(() => {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+})
+</script>
+
+<template>
+  <el-popover
+    v-model:visible="popoverVisible"
+    trigger="click"
+    width="360"
+    placement="bottom-end"
+    popper-class="notification-popover"
+    @show="handlePopoverShow"
+  >
+    <template #reference>
+      <el-badge :value="unreadCount" :max="99" :hidden="unreadCount === 0" class="notification-badge">
+        <el-button class="bell-btn" text title="站内消息">
+          <el-icon :size="18"><Bell /></el-icon>
+        </el-button>
+      </el-badge>
+    </template>
+    <div class="notification-panel" v-loading="loading">
+      <div class="notification-header">
+        <span class="notification-title">站内消息</span>
+        <el-button link type="primary" size="small" :disabled="unreadCount === 0" @click="handleMarkAllRead">
+          全部已读
+        </el-button>
+      </div>
+      <el-empty v-if="!loading && messages.length === 0" description="暂无消息" :image-size="50" />
+      <el-scrollbar v-else max-height="360px">
+        <div
+          v-for="msg in messages"
+          :key="msg.id"
+          class="notification-item"
+          @click="handleMessageClick(msg)"
+        >
+          <span class="unread-dot" :class="{ 'is-visible': msg.readFlag === 0 }" />
+          <div class="notification-item-body">
+            <div class="notification-item-title" :class="{ 'is-unread': msg.readFlag === 0 }">{{ msg.title }}</div>
+            <div class="notification-item-content">{{ msg.content }}</div>
+            <div class="notification-item-time">{{ formatRelativeTime(msg.createTime) }}</div>
+          </div>
+        </div>
+      </el-scrollbar>
+    </div>
+  </el-popover>
+</template>
+
+<style scoped>
+.notification-badge {
+  display: inline-flex;
+  align-items: center;
+}
+
+.bell-btn {
+  font-size: 18px;
+  color: var(--el-text-color-regular);
+  padding: 8px;
+}
+
+.bell-btn:hover {
+  color: var(--el-color-primary);
+  background: var(--el-fill-color-light);
+}
+
+.notification-panel {
+  min-height: 80px;
+}
+
+.notification-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.notification-title {
+  font-size: 14px;
+  color: var(--el-text-color-primary);
+}
+
+.notification-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+  cursor: pointer;
+}
+
+.notification-item:last-child {
+  border-bottom: none;
+}
+
+.notification-item:hover {
+  background: var(--el-fill-color-light);
+}
+
+.unread-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: var(--el-color-danger);
+  visibility: hidden;
+}
+
+.unread-dot.is-visible {
+  visibility: visible;
+}
+
+.notification-item-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-item-title {
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notification-item-title.is-unread {
+  font-weight: 600;
+}
+
+.notification-item-content {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notification-item-time {
+  font-size: 12px;
+  color: var(--el-text-color-placeholder);
+  margin-top: 2px;
+}
+</style>

--- a/customer-admin-web/src/components/ReviewReport.vue
+++ b/customer-admin-web/src/components/ReviewReport.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import type { ReviewIssue, ReviewResult } from '@/types/api'
+
+/**
+ * AI 代码审查报告渲染（从 VibeCodingPanel 的 Git 助手抽屉抽出，供该处与 WorkspaceView
+ * 站内信跳转弹窗共用，保证两处渲染一致）。
+ *
+ * interactive=false（如站内信跳转弹窗）：只读展示，文件名不可点、不出"一键生成修复"按钮——
+ * 那两个交互都要落到具体会话（打开文件预览/把修复意见发回对话），弹窗打开时不一定处于
+ * 该会话的 VibeCoding 面板上下文里，强行接线路径过长，只读展示反而是更贴合场景的最小实现。
+ */
+const props = withDefaults(
+  defineProps<{
+    result: ReviewResult
+    interactive?: boolean
+    /** "一键生成修复"按钮禁用态（如会话正在流式对话中），仅 interactive=true 时有意义。 */
+    fixDisabled?: boolean
+  }>(),
+  { interactive: true, fixDisabled: false },
+)
+
+const emit = defineEmits<{
+  (e: 'open-file', issue: ReviewIssue): void
+  (e: 'generate-fix'): void
+}>()
+
+/** 严重级别 → Element Plus tag 类型（着色）。 */
+function severityTagType(severity: ReviewIssue['severity']): 'danger' | 'warning' | 'info' {
+  if (severity === 'CRITICAL') return 'danger'
+  if (severity === 'WARNING') return 'warning'
+  return 'info'
+}
+
+/** 按严重级别分组审查意见（CRITICAL → WARNING → SUGGESTION 顺序）。 */
+function groupedIssues(issues: ReviewIssue[]): Array<{ severity: ReviewIssue['severity']; items: ReviewIssue[] }> {
+  const order: ReviewIssue['severity'][] = ['CRITICAL', 'WARNING', 'SUGGESTION']
+  return order
+    .map((severity) => ({ severity, items: issues.filter((i) => i.severity === severity) }))
+    .filter((g) => g.items.length > 0)
+}
+
+function handleOpenFile(issue: ReviewIssue) {
+  if (!props.interactive || !issue.file) return
+  emit('open-file', issue)
+}
+</script>
+
+<template>
+  <div class="review-report">
+    <p v-if="result.summary" class="review-summary">{{ result.summary }}</p>
+    <el-empty
+      v-if="result.issues.length === 0"
+      description="未发现结构化问题"
+      :image-size="40"
+    />
+    <div v-else class="review-issues">
+      <div v-for="group in groupedIssues(result.issues)" :key="group.severity" class="review-group">
+        <div class="review-group-header">
+          <el-tag :type="severityTagType(group.severity)" size="small" effect="dark">
+            {{ group.severity }}
+          </el-tag>
+          <span class="review-group-count">{{ group.items.length }} 项</span>
+        </div>
+        <div
+          v-for="(issue, ii) in group.items"
+          :key="ii"
+          class="review-issue"
+          :class="`review-issue--${group.severity.toLowerCase()}`"
+        >
+          <div class="review-issue-loc">
+            <el-tag size="small" class="review-issue-category">{{ issue.category }}</el-tag>
+            <el-link
+              v-if="interactive"
+              type="primary"
+              :underline="false"
+              @click="handleOpenFile(issue)"
+            >
+              {{ issue.file }}<template v-if="issue.line">:{{ issue.line }}</template>
+            </el-link>
+            <span v-else class="review-issue-file-text">
+              {{ issue.file }}<template v-if="issue.line">:{{ issue.line }}</template>
+            </span>
+          </div>
+          <div class="review-issue-message">{{ issue.message }}</div>
+          <div v-if="issue.suggestion" class="review-issue-suggestion">建议：{{ issue.suggestion }}</div>
+        </div>
+      </div>
+    </div>
+    <el-button
+      v-if="interactive && result.issues.some((i) => i.severity === 'CRITICAL' || i.severity === 'WARNING')"
+      type="warning"
+      size="small"
+      class="review-fix-btn"
+      :disabled="fixDisabled"
+      @click="emit('generate-fix')"
+    >
+      一键生成修复
+    </el-button>
+  </div>
+</template>
+
+<style scoped>
+.review-summary {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--el-text-color-primary);
+  margin: 0 0 8px;
+}
+
+.review-group {
+  margin-bottom: 10px;
+}
+
+.review-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.review-group-count {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+.review-issue {
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  border-left: 3px solid var(--el-border-color);
+  background: var(--el-fill-color-light);
+  border-radius: 4px;
+}
+
+.review-issue--critical {
+  border-left-color: var(--el-color-danger);
+}
+
+.review-issue--warning {
+  border-left-color: var(--el-color-warning);
+}
+
+.review-issue--suggestion {
+  border-left-color: var(--el-color-info);
+}
+
+.review-issue-loc {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
+.review-issue-category {
+  flex-shrink: 0;
+}
+
+.review-issue-file-text {
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+}
+
+.review-issue-message {
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+  line-height: 1.5;
+}
+
+.review-issue-suggestion {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-top: 2px;
+}
+
+.review-fix-btn {
+  margin-top: 8px;
+}
+</style>

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -9,6 +9,7 @@ import MenuTree from './MenuTree.vue'
 import TabsBar from './TabsBar.vue'
 import AppBreadcrumb from './AppBreadcrumb.vue'
 import FooterCopyright from '@/components/FooterCopyright.vue'
+import NotificationBell from '@/components/NotificationBell.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -72,6 +73,7 @@ async function handleLogout() {
             :title="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
             @click="themeStore.toggleDark()"
           />
+          <NotificationBell />
           <el-dropdown>
             <span class="user-info">{{ auth.nickname }}<el-icon><ArrowDown /></el-icon></span>
           <template #dropdown>

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -515,6 +515,20 @@ export interface ReviewResult {
   summary: string
 }
 
+/**
+ * AI 代码审查任务（异步化）：review 接口提交后不再同步返回结果，而是返回 taskId，
+ * 由前端轮询本类型或站内信跳转回查任务终态。status=SUCCESS 时 result 才有值，
+ * FAILED 时 errorMsg 有值，RUNNING 时两者都为 null。
+ */
+export interface ReviewTaskVO {
+  id: number
+  status: 'RUNNING' | 'SUCCESS' | 'FAILED'
+  result: ReviewResult | null
+  errorMsg: string | null
+  createTime: string
+  finishTime: string | null
+}
+
 /** plan SSE 事件里的单条高风险操作项（P1-1 HITL）。 */
 export interface PlanAction {
   /** DELETE（删除文件）｜RUN_COMMAND（非只读/破坏性命令）｜MODIFY_DEPENDENCY（改依赖）｜BATCH_MODIFY（批量修改超阈值） */
@@ -813,4 +827,24 @@ export interface KnowledgeSearchHit {
 export interface KnowledgeAskResponse {
   answer: string
   citations: KnowledgeSearchHit[]
+}
+
+// ---------- 站内消息 ----------
+/** 站内消息（顶栏铃铛）：bizType/bizId 标识来源业务（如 AI 代码审查任务），link 非空时点击可跳转。 */
+export interface SiteMessageVO {
+  id: number
+  title: string
+  content: string
+  bizType: string
+  bizId: string | null
+  link: string | null
+  readFlag: 0 | 1
+  createTime: string
+}
+
+/** 站内消息分页查询：page/size 与后端 /message/page 契约一致，与 MpPageQuery 的 current/size 命名不同，单独定义。 */
+export interface SiteMessagePageQuery {
+  page: number
+  size: number
+  readFlag?: 0 | 1
 }

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, nextTick, onActivated, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onActivated, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { UploadRequestOptions } from 'element-plus'
 import {
   confirmVibeCodingPlan,
   generateCommitMessage,
   generatePrDescription,
   getGitDiffSummary,
+  getReviewTask,
   readWorkspaceFileContent,
   reviewVibeCoding,
   rollbackVibeCoding,
@@ -15,6 +16,7 @@ import { parseChatAttachment } from '@/api/chat'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import TraceTimeline from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
+import ReviewReport from '@/components/ReviewReport.vue'
 import { useThemeStore } from '@/store/theme'
 import {
   useVibeConversationsStore,
@@ -34,6 +36,11 @@ import type {
 } from '@/types/api'
 import hljs from 'highlight.js'
 import 'highlight.js/styles/github.css'
+
+// AI 代码审查异步化（提交后轮询任务终态）：5 秒一次，最多轮询 40 次（约 200 秒）后停止，
+// 提示用户可等站内信通知——避免无限轮询在模型响应异常慢/任务卡住时占着定时器不放。
+const REVIEW_POLL_INTERVAL_MS = 5000
+const MAX_REVIEW_POLL_COUNT = 40
 
 const props = defineProps<{ agentCode: string }>()
 
@@ -73,9 +80,14 @@ const commitLoading = ref(false)
 const commitMessageText = ref('')
 const prLoading = ref(false)
 const prDescriptionText = ref('')
-// AI 代码审查（P0-2）
+// AI 代码审查（P0-2，异步化）：reviewLoading 覆盖"提交中 + 轮询中"两个阶段。
+// reviewPollTimer/reviewPollSessionId/reviewPollCount 是纯轮询控制状态，不需要响应式（不驱动模板），
+// 用普通变量即可；reviewPollSessionId 用来在轮询回调触发时判断会话是否已切换，切换了就丢弃本次结果。
 const reviewLoading = ref(false)
 const reviewResult = ref<ReviewResult | null>(null)
+let reviewPollTimer: ReturnType<typeof setTimeout> | null = null
+let reviewPollSessionId: string | null = null
+let reviewPollCount = 0
 
 // 文件预览抽屉
 const previewVisible = ref(false)
@@ -314,6 +326,8 @@ async function openGitAssistant() {
   commitMessageText.value = ''
   prDescriptionText.value = ''
   reviewResult.value = null
+  stopReviewPolling()
+  reviewLoading.value = false
   await loadGitDiff()
 }
 
@@ -358,33 +372,80 @@ async function handleGeneratePrDescription() {
   }
 }
 
-/** 触发 AI 代码审查：对本轮 diff 输出结构化审查意见。 */
+/**
+ * 触发 AI 代码审查（异步化）：提交后拿到 taskId 立即返回，不再同步等待模型产出结果——
+ * 提交成功只代表任务已入队，真正的审查结果通过下方轮询（或稍后到达的站内信）拿到。
+ */
 async function handleReview() {
   const conv = active.value
   if (!conv) return
+  stopReviewPolling()
+  reviewResult.value = null
   reviewLoading.value = true
   try {
-    reviewResult.value = await reviewVibeCoding(props.agentCode, conv.sessionId)
+    const taskId = await reviewVibeCoding(props.agentCode, conv.sessionId)
+    ElMessage.success('审查已提交，完成后会通过站内信提醒')
+    startReviewPolling(conv.sessionId, taskId)
   } catch (error) {
-    ElMessage.error('代码审查失败：' + (error instanceof Error ? error.message : String(error)))
-  } finally {
     reviewLoading.value = false
+    ElMessage.error('代码审查提交失败：' + (error instanceof Error ? error.message : String(error)))
   }
 }
 
-/** 严重级别 → Element Plus tag 类型（着色）。 */
-function severityTagType(severity: ReviewIssue['severity']): 'danger' | 'warning' | 'info' {
-  if (severity === 'CRITICAL') return 'danger'
-  if (severity === 'WARNING') return 'warning'
-  return 'info'
+/** 开始轮询审查任务终态：5 秒一次，最多 40 次，会话切走则丢弃结果并停止。 */
+function startReviewPolling(sessionId: string, taskId: number) {
+  reviewPollSessionId = sessionId
+  reviewPollCount = 0
+  const poll = async () => {
+    // 轮询期间用户切到了别的会话/新建了会话：本次审查结果不再对应当前视图，结果留给站内信承接
+    if (active.value?.sessionId !== reviewPollSessionId) {
+      stopReviewPolling()
+      return
+    }
+    reviewPollCount += 1
+    try {
+      const task = await getReviewTask(props.agentCode, taskId)
+      if (task.status === 'SUCCESS') {
+        reviewResult.value = task.result
+        reviewLoading.value = false
+        stopReviewPolling()
+        return
+      }
+      if (task.status === 'FAILED') {
+        ElMessage.error(task.errorMsg || '代码审查失败')
+        reviewLoading.value = false
+        stopReviewPolling()
+        return
+      }
+    } catch (error) {
+      // 轮询请求本身失败（网络抖动等）不等于审查失败，按剩余次数继续重试，次数耗尽再提示
+      if (reviewPollCount >= MAX_REVIEW_POLL_COUNT) {
+        reviewLoading.value = false
+        stopReviewPolling()
+        ElMessage.error('代码审查结果查询失败：' + (error instanceof Error ? error.message : String(error)))
+        return
+      }
+      reviewPollTimer = setTimeout(poll, REVIEW_POLL_INTERVAL_MS)
+      return
+    }
+    // 仍在 RUNNING：达到最大轮询次数则停止，剩余交给站内信兜底
+    if (reviewPollCount >= MAX_REVIEW_POLL_COUNT) {
+      reviewLoading.value = false
+      stopReviewPolling()
+      ElMessage.info('审查仍在进行，可稍后在站内信查看结果')
+      return
+    }
+    reviewPollTimer = setTimeout(poll, REVIEW_POLL_INTERVAL_MS)
+  }
+  reviewPollTimer = setTimeout(poll, REVIEW_POLL_INTERVAL_MS)
 }
 
-/** 按严重级别分组审查意见（CRITICAL → WARNING → SUGGESTION 顺序）。 */
-function groupedIssues(issues: ReviewIssue[]): Array<{ severity: ReviewIssue['severity']; items: ReviewIssue[] }> {
-  const order: ReviewIssue['severity'][] = ['CRITICAL', 'WARNING', 'SUGGESTION']
-  return order
-    .map((severity) => ({ severity, items: issues.filter((i) => i.severity === severity) }))
-    .filter((g) => g.items.length > 0)
+function stopReviewPolling() {
+  if (reviewPollTimer !== null) {
+    clearTimeout(reviewPollTimer)
+    reviewPollTimer = null
+  }
+  reviewPollSessionId = null
 }
 
 /** 点击审查意见里的文件，定位到工作区文件查看器（复用现有文件读取/预览抽屉）。 */
@@ -509,8 +570,12 @@ onActivated(() => {
   scrollToBottom()
 })
 
-// 注意：刻意没有 onUnmounted abort/清定时器——会话、SSE 流、plan 倒计时都属于全局 store，
-// 组件销毁（切智能体/关标签）不应终止后台会话。
+// 注意：刻意没有 onUnmounted abort/清 SSE/plan 倒计时定时器——那些都属于全局 store，
+// 组件销毁（切智能体/关标签）不应终止后台会话。但 AI 代码审查轮询定时器是本组件的纯 UI 局部状态
+// （审查任务本身在后端异步跑，不受前端轮询影响），组件销毁时必须清掉，否则定时器泄漏到已卸载组件。
+onUnmounted(() => {
+  stopReviewPolling()
+})
 
 // newSession 供 WorkspaceView 上提后的工具栏"新建会话"按钮按激活 Tab 分发调用
 defineExpose({ newSession })
@@ -899,50 +964,16 @@ defineExpose({ newSession })
           <div class="git-section-header">
             <span>Review 本次变更</span>
           </div>
-          <el-button type="primary" size="small" :loading="reviewLoading" @click="handleReview">审查</el-button>
-          <template v-if="reviewResult">
-            <p v-if="reviewResult.summary" class="git-summary-text review-summary">{{ reviewResult.summary }}</p>
-            <el-empty
-              v-if="reviewResult.issues.length === 0"
-              description="未发现结构化问题"
-              :image-size="40"
-            />
-            <div v-else class="review-issues">
-              <div v-for="group in groupedIssues(reviewResult.issues)" :key="group.severity" class="review-group">
-                <div class="review-group-header">
-                  <el-tag :type="severityTagType(group.severity)" size="small" effect="dark">
-                    {{ group.severity }}
-                  </el-tag>
-                  <span class="review-group-count">{{ group.items.length }} 项</span>
-                </div>
-                <div
-                  v-for="(issue, ii) in group.items"
-                  :key="ii"
-                  class="review-issue"
-                  :class="`review-issue--${group.severity.toLowerCase()}`"
-                >
-                  <div class="review-issue-loc">
-                    <el-tag size="small" class="review-issue-category">{{ issue.category }}</el-tag>
-                    <el-link type="primary" :underline="false" @click="openIssueFile(issue)">
-                      {{ issue.file }}<template v-if="issue.line">:{{ issue.line }}</template>
-                    </el-link>
-                  </div>
-                  <div class="review-issue-message">{{ issue.message }}</div>
-                  <div v-if="issue.suggestion" class="review-issue-suggestion">建议：{{ issue.suggestion }}</div>
-                </div>
-              </div>
-            </div>
-            <el-button
-              v-if="reviewResult.issues.some((i) => i.severity === 'CRITICAL' || i.severity === 'WARNING')"
-              type="warning"
-              size="small"
-              class="review-fix-btn"
-              :disabled="active?.streaming"
-              @click="generateFixFromReview"
-            >
-              一键生成修复
-            </el-button>
-          </template>
+          <el-button type="primary" size="small" :loading="reviewLoading" @click="handleReview">
+            {{ reviewLoading ? '审查中…' : '审查' }}
+          </el-button>
+          <ReviewReport
+            v-if="reviewResult"
+            :result="reviewResult"
+            :fix-disabled="active?.streaming"
+            @open-file="openIssueFile"
+            @generate-fix="generateFixFromReview"
+          />
         </div>
       </div>
     </el-drawer>
@@ -1354,73 +1385,7 @@ defineExpose({ newSession })
   gap: 8px;
 }
 
-/* AI 代码审查 */
-.review-summary {
-  margin-top: 8px;
-}
-
-.review-group {
-  margin-bottom: 10px;
-}
-
-.review-group-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 4px;
-}
-
-.review-group-count {
-  font-size: 12px;
-  color: var(--el-text-color-secondary);
-}
-
-.review-issue {
-  margin-bottom: 6px;
-  padding: 6px 8px;
-  border-left: 3px solid var(--el-border-color);
-  background: var(--el-fill-color-light);
-  border-radius: 4px;
-}
-
-.review-issue--critical {
-  border-left-color: var(--el-color-danger);
-}
-
-.review-issue--warning {
-  border-left-color: var(--el-color-warning);
-}
-
-.review-issue--suggestion {
-  border-left-color: var(--el-color-info);
-}
-
-.review-issue-loc {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 2px;
-}
-
-.review-issue-category {
-  flex-shrink: 0;
-}
-
-.review-issue-message {
-  font-size: 13px;
-  color: var(--el-text-color-primary);
-  line-height: 1.5;
-}
-
-.review-issue-suggestion {
-  font-size: 12px;
-  color: var(--el-text-color-secondary);
-  margin-top: 2px;
-}
-
-.review-fix-btn {
-  margin-top: 8px;
-}
+/* AI 代码审查区块本身（分组列表等）的样式已随渲染逻辑一并抽到 ReviewReport.vue，此处不再重复定义。 */
 
 .tree-node {
   display: flex;

--- a/customer-admin-web/src/views/workspace/WorkspaceView.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useMenuStore } from '@/store/menu'
-import type { MenuNode } from '@/types/api'
+import { getReviewTask } from '@/api/vibecoding'
+import type { MenuNode, ReviewResult } from '@/types/api'
 import ChatPanel from './ChatPanel.vue'
 import VibeCodingPanel from './VibeCodingPanel.vue'
 import KnowledgeDrawer from './KnowledgeDrawer.vue'
 import ThemeToolbar from '@/components/ThemeToolbar.vue'
+import ReviewReport from '@/components/ReviewReport.vue'
 
 // 供 MainLayout 的 <keep-alive :include> 按组件名精确命中——离开本页（切到其它菜单）时不销毁，
 // 只是 deactivated；SSE 流不会被 onUnmounted 打断，切回来消息能接着看，见 ChatPanel/VibeCodingPanel
@@ -16,6 +18,7 @@ defineOptions({ name: 'WorkspaceView' })
 const props = defineProps<{ agentCode: string }>()
 const menuStore = useMenuStore()
 const route = useRoute()
+const router = useRouter()
 // 从 Project 详情页"点会话跳回工作区"带过来的目标会话 id（?sessionId=xxx），只在首次挂载时读一次，
 // ChatPanel 内部 openSession 打开后由它自己的会话状态接管，不需要响应式跟随路由变化。
 const initialSessionId = computed(() => (route.query.sessionId as string) || undefined)
@@ -61,6 +64,53 @@ function newSession() {
 
 // 代码知识库抽屉（P3-2）
 const knowledgeVisible = ref(false)
+
+// 站内信跳转承接（AI 代码审查异步化）：link 形如 /workspace/{agentCode}?reviewTask={taskId}，
+// 挂载时读一次并回查任务终态，用完整报告弹窗展示，与 VibeCodingPanel 内的 Git 助手抽屉共用
+// ReviewReport 渲染，保证两处样式一致。
+const reviewDialogVisible = ref(false)
+const reviewDialogResult = ref<ReviewResult | null>(null)
+
+/**
+ * 处理 ?reviewTask= 查询参数：无论查询成功与否都立即从 query 里摘掉，避免用户刷新页面/
+ * 前进后退时重复弹出同一份报告。
+ *
+ * 用 watch(immediate) 而不是 onMounted：WorkspaceView 是 keep-alive 精确缓存的路由组件
+ * （见 MainLayout 里的 include: ['WorkspaceView'] 注释），/workspace/:agentCode 换参数时
+ * Vue Router 默认复用同一实例、不重新 mount——站内信链接从当前已打开的工作区页跳到
+ * 另一个 reviewTask 查询参数时，onMounted 不会再触发，只有响应式的 route.query 变化能感知到。
+ */
+async function handleReviewTaskQuery(taskIdRaw: string | null) {
+  if (!taskIdRaw) return
+  const taskId = Number(taskIdRaw)
+  const restQuery = { ...route.query }
+  delete restQuery.reviewTask
+  await router.replace({ query: restQuery })
+  if (!Number.isFinite(taskId)) return
+  try {
+    const task = await getReviewTask(props.agentCode, taskId)
+    if (task.status === 'SUCCESS' && task.result) {
+      reviewDialogResult.value = task.result
+      reviewDialogVisible.value = true
+    } else if (task.status === 'RUNNING') {
+      ElMessage.info('AI 代码审查仍在进行中，请稍后再查看')
+    } else if (task.status === 'FAILED') {
+      ElMessage.error(task.errorMsg || 'AI 代码审查失败')
+    }
+  } catch (error) {
+    ElMessage.error('审查任务查询失败：' + (error instanceof Error ? error.message : String(error)))
+  }
+}
+
+watch(
+  () => route.query.reviewTask,
+  (taskIdRaw) => {
+    if (typeof taskIdRaw === 'string') {
+      handleReviewTaskQuery(taskIdRaw)
+    }
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -74,6 +124,11 @@ const knowledgeVisible = ref(false)
       </div>
     </div>
     <KnowledgeDrawer v-model="knowledgeVisible" />
+    <!-- 站内信跳转承接：AI 代码审查任务完成后的完整报告，只读展示（不出"打开文件"/"一键生成修复"，
+         弹窗打开时不一定处于该会话的 VibeCoding 面板上下文，见 ReviewReport 组件注释） -->
+    <el-dialog v-model="reviewDialogVisible" title="AI 代码审查报告" width="640px" destroy-on-close>
+      <ReviewReport v-if="reviewDialogResult" :result="reviewDialogResult" :interactive="false" />
+    </el-dialog>
     <el-tabs v-model="activeTab" type="border-card" class="workspace-tabs">
       <el-tab-pane label="对话" name="chat">
         <!-- workspace/:agentCode 是同一条路由，只换参数，Vue Router 默认复用组件实例——


### PR DESCRIPTION
## 变更说明 / What

重开自 #46（原 PR base 误指 fix/llm-sync-timeout，合并后功能未进 main；本分支已拉取最新 main，diff 即站内信 + 审查异步化全部内容）。功能说明、自查与审阅提示见 #46 描述，此处不重复。

- 通用站内消息中心（message 模块 + ai_site_message + /api/message 四接口 + 顶栏铃铛）
- AI 代码审查异步化（提交-轮询 + ai_code_review_task + 成功/失败站内信 + 跳转承接弹窗）
- Flyway V28 建两表

## 类型 / Type
- [x] feat 新功能

## 自查 / Checklist
- [x] mvn test 全绿（admin-server 459/459 隔离 worktree 验证；前端 build 零错误；本机端到端实测通过；见 #46）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循约定（不适用）
- [x] 必要时更新了 README / 配置项说明（不适用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)