### PR TITLE
perf(workspace): 历史对话侧边栏 SQL 级分页 + 滚动加载

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.workspace.chat.controller;
 
 import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatAttachmentDTO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
@@ -59,11 +60,13 @@ public class ChatController {
             .concatWithValues(ServerSentEvent.<String>builder().event("done").data("[DONE]").build());
     }
 
-    /** 历史会话列表（按最后一条消息时间倒序），供前端侧边栏展示。 */
+    /** 历史会话列表（按最后更新时间倒序、分页），供前端侧边栏滚动加载。默认每页 20 条（见 {@code ChatHistoryService#DEFAULT_PAGE_SIZE}）。 */
     @SaCheckPermission("workspace")
     @GetMapping("/sessions")
-    public Result<List<ChatSessionSummary>> sessions(@PathVariable String agentCode) {
-        return Result.success(chatHistoryService.listSessions(agentCode));
+    public Result<PageResult<ChatSessionSummary>> sessions(@PathVariable String agentCode,
+                                                           @RequestParam(defaultValue = "1") long page,
+                                                           @RequestParam(defaultValue = "20") long size) {
+        return Result.success(chatHistoryService.listSessions(agentCode, page, size));
     }
 
     /** 重新打开某次历史会话的完整消息（含 vibecoding 的会话，两者共用同一套 session 状态）。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/mapper/ChatSessionStateQueryMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/mapper/ChatSessionStateQueryMapper.java
@@ -1,0 +1,36 @@
+package com.richard.fyoung.customeradmin.workspace.chat.mapper;
+
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 会话状态表 {@code ai_chat_session_state}（框架 {@code MysqlAgentStateStore} 自建、无 DO）的只读分页查询。
+ *
+ * <p>不迁移、不建表、不写 DO——仅对既有框架表做轻量只读查询：按 {@code session_id} 前缀
+ * （{@code {agentCode}:%}，命中主键最左前缀）分页取出本页会话 id，SQL 侧完成分页与排序，
+ * 上层只对本页 20 个会话逐个 resolve 整段 {@code AgentState}，避免把该智能体全部会话的 longtext
+ * blob 都拉进内存。SQL 写在 {@code resources/mapper/ChatSessionStateQueryMapper.xml}。
+ * 由 {@code CustomerAdminServerApplication} 的 {@code @MapperScan("...**.mapper")} 自动扫描。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface ChatSessionStateQueryMapper {
+
+    /**
+     * 分页取某智能体的会话 id（完整带 {@code {agentCode}:} 前缀），按最后更新时间倒序。
+     *
+     * <p>一个会话在表里对应多行（不同 {@code state_key}/{@code item_index}），故 {@code GROUP BY session_id}
+     * 后用 {@code MAX(updated_at)} 作为该会话的最后活跃时间排序——不硬编码框架内部的 {@code state_key} 取值，
+     * 对多行结构保持稳健。</p>
+     *
+     * @param agentCode 智能体编码（会话 id 前缀，SQL 内以 {@code CONCAT(#{agentCode}, ':%')} 拼 LIKE，防注入）
+     * @param offset    偏移量（{@code (page-1)*size}）
+     * @param limit     每页条数
+     */
+    List<String> pageSessionIds(@Param("agentCode") String agentCode,
+                                @Param("offset") long offset,
+                                @Param("limit") long limit);
+
+    /** 某智能体的去重会话总数（{@code COUNT(DISTINCT session_id)}），供分页总数。 */
+    long countSessions(@Param("agentCode") String agentCode);
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryCache.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryCache.java
@@ -3,7 +3,6 @@ package com.richard.fyoung.customeradmin.workspace.chat.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
-import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -14,15 +13,17 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * 历史对话列表的 Redis 读缓存：30 分钟内重复打开同一智能体的历史列表 / 重新打开同一次历史会话，
- * 直接命中缓存，不用每次都枚举 {@code AgentStateStore#listSessionIds} 再逐个反序列化整段
- * {@code AgentState}。权威数据源始终是 {@code MysqlAgentStateStore}——本类只是 {@link ChatHistoryService}
- * 前面的一层可丢弃缓存，任何 Redis 异常都在这里兜住退化为"未命中"，不允许缓存故障影响主流程
- * （{@code ChatHistoryService} 据此照常回源 MySQL）。
+ * 历史会话<b>消息内容</b>的 Redis 读缓存：30 分钟内重新打开同一次历史会话，直接命中缓存，
+ * 不用每次都反序列化整段 {@code AgentState} 再拆消息。权威数据源始终是 {@code MysqlAgentStateStore}——
+ * 本类只是 {@link ChatHistoryService} 前面的一层可丢弃缓存，任何 Redis 异常都在这里兜住退化为"未命中"，
+ * 不允许缓存故障影响主流程（{@code ChatHistoryService} 据此照常回源 MySQL）。
+ *
+ * <p>会话<b>列表</b>不再缓存（改成 SQL 级分页后每页仅 20 个会话，成本可控，不值得为它引入分页缓存复杂度）；
+ * 本类只保留单次历史会话的消息缓存。</p>
  *
  * <p>失效策略：写路径不变（仍是 {@code MysqlAgentStateStore} 每轮同步落库），{@link ChatService}
- * 在一轮对话流式完成后主动调用 {@link #evict} 清掉该智能体的会话列表缓存与这次会话的消息缓存，
- * 保证"新建会话"或结束一轮对话对页面来说立即可见，不必等 30 分钟 TTL 自然过期。</p>
+ * 在一轮对话流式完成后主动调用 {@link #evict} 清掉这次会话的消息缓存，保证结束一轮对话后重开该会话
+ * 立即可见最新消息，不必等 30 分钟 TTL 自然过期。</p>
  * @author owlzhangfq@gmail.com
  */
 @Component
@@ -39,15 +40,6 @@ public class ChatHistoryCache {
         this.jedisPool = jedisPool;
     }
 
-    public Optional<List<ChatSessionSummary>> getSessions(String agentCode) {
-        return read(sessionsKey(agentCode), new TypeReference<List<ChatSessionSummary>>() {
-        });
-    }
-
-    public void putSessions(String agentCode, List<ChatSessionSummary> sessions) {
-        write(sessionsKey(agentCode), sessions);
-    }
-
     public Optional<List<ChatMessageVO>> getMessages(String agentCode, String sessionId) {
         return read(messagesKey(agentCode, sessionId), new TypeReference<List<ChatMessageVO>>() {
         });
@@ -57,10 +49,10 @@ public class ChatHistoryCache {
         write(messagesKey(agentCode, sessionId), messages);
     }
 
-    /** 一轮对话完成后调用：该智能体的会话列表摘要（预览/消息数/时间）与这次会话的消息内容都已过期。 */
+    /** 一轮对话完成后调用：这次会话的消息内容已过期（会话列表不缓存，无需清理）。 */
     public void evict(String agentCode, String sessionId) {
         try (Jedis jedis = jedisPool.getResource()) {
-            jedis.del(sessionsKey(agentCode), messagesKey(agentCode, sessionId));
+            jedis.del(messagesKey(agentCode, sessionId));
         } catch (Exception e) {
             log.error("[workspace] chat history cache evict failed, code={}, agentCode={}",
                 "CHAT_HISTORY_CACHE_EVICT_ERROR", agentCode, e);
@@ -88,10 +80,6 @@ public class ChatHistoryCache {
             log.error("[workspace] chat history cache write failed, code={}, key={}",
                 "CHAT_HISTORY_CACHE_WRITE_ERROR", key, e);
         }
-    }
-
-    private String sessionsKey(String agentCode) {
-        return KEY_PREFIX + "sessions:" + agentCode;
     }
 
     private String messagesKey(String agentCode, String sessionId) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryService.java
@@ -1,7 +1,9 @@
 package com.richard.fyoung.customeradmin.workspace.chat.service;
 
+import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
+import com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentStateAccessor;
 import io.agentscope.core.agent.Agent;
@@ -10,63 +12,93 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.AgentStateStore;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * 历史会话查询：会话列表 + 重新打开某次历史会话的完整消息。
+ * 历史会话查询：会话列表（SQL 级分页）+ 重新打开某次历史会话的完整消息。
  *
- * <p>不新增数据库表——直接读 {@link AgentStateStore}（批次六起已换成
- * {@link io.agentscope.extensions.mysql.state.MysqlAgentStateStore}，重启不丢）：
- * {@link AgentStateStore#listSessionIds} 枚举某智能体下的全部 sessionId，
- * {@link AgentStateAccessor#resolve} 取每个 sessionId 的完整 {@link AgentState}，
- * {@link AgentState#getContext()} 即完整对话消息列表。chat 与 vibecoding 共用同一套 session 状态
+ * <p>不新增数据库表——直接读框架自建的会话状态表（批次六起已换成
+ * {@link io.agentscope.extensions.mysql.state.MysqlAgentStateStore}，重启不丢）。历史列表按
+ * {@link ChatSessionStateQueryMapper} 在 SQL 侧完成分页与排序（{@code session_id LIKE '{agentCode}:%'}
+ * 走主键最左前缀），每页只对本页会话逐个 {@link AgentStateAccessor#resolve} 取完整 {@link AgentState}
+ * 组装摘要——早期实现枚举该智能体全部 sessionId、逐个 resolve 整段 longtext blob 只为算预览/消息数，
+ * 会话数一多就把全部 blob 拉进内存，故改成分页。chat 与 vibecoding 共用同一套 session 状态
  * （只是 sessionId 不同），历史列表天然把两者混在一起，不做类型区分——如实符合"同一智能体下的历史
  * 对话"这个需求本身的粒度，不做额外的会话类型元数据设计。</p>
+ *
+ * <p>分页列表不走缓存（每页仅 20 个 blob，成本可控，不值得为它引入分页缓存复杂度）；
+ * {@link ChatHistoryCache} 只缓存单次历史会话的消息内容。</p>
  * @author owlzhangfq@gmail.com
  */
 @Service
 public class ChatHistoryService {
 
     private static final int PREVIEW_MAX_LENGTH = 60;
+    /** 默认每页条数（与 {@code ChatController#sessions} 的 {@code size} 默认值保持一致）。 */
+    public static final long DEFAULT_PAGE_SIZE = 20;
 
     private final AgentInstanceCache agentInstanceCache;
     private final AgentStateStore agentStateStore;
     private final AgentStateAccessor agentStateAccessor;
     private final ChatHistoryCache historyCache;
+    private final ChatSessionStateQueryMapper sessionStateQueryMapper;
 
     public ChatHistoryService(AgentInstanceCache agentInstanceCache, AgentStateStore agentStateStore,
-                               AgentStateAccessor agentStateAccessor, ChatHistoryCache historyCache) {
+                               AgentStateAccessor agentStateAccessor, ChatHistoryCache historyCache,
+                               ChatSessionStateQueryMapper sessionStateQueryMapper) {
         this.agentInstanceCache = agentInstanceCache;
         this.agentStateStore = agentStateStore;
         this.agentStateAccessor = agentStateAccessor;
         this.historyCache = historyCache;
+        this.sessionStateQueryMapper = sessionStateQueryMapper;
     }
 
-    /** 30 分钟读缓存命中直接返回；未命中回源 MySQL（{@link AgentStateStore}）后回填缓存。 */
-    public List<ChatSessionSummary> listSessions(String agentCode) {
-        Optional<List<ChatSessionSummary>> cached = historyCache.getSessions(agentCode);
-        if (cached.isPresent()) {
-            return cached.get();
+    /**
+     * 历史会话列表（按最后更新时间倒序、SQL 级分页）。mapper 只查出本页会话 id（带
+     * {@code {agentCode}:} 前缀），去前缀后逐个 resolve 完整上下文组装摘要——context 为空的会话跳过，
+     * 因此本页返回条数可能略少于 {@code size}（顺序仍以 SQL 的 updated_at 倒序为准）。
+     *
+     * @param page 页码（从 1 起）
+     * @param size 每页条数
+     */
+    public PageResult<ChatSessionSummary> listSessions(String agentCode, long page, long size) {
+        long total = sessionStateQueryMapper.countSessions(agentCode);
+        List<ChatSessionSummary> summaries = new ArrayList<>();
+
+        PageResult<ChatSessionSummary> result = new PageResult<>();
+        result.setPageNum(page);
+        result.setPageSize(size);
+        result.setTotal(total);
+        result.setList(summaries);
+        if (total == 0) {
+            return result;
+        }
+
+        long offset = (page - 1) * size;
+        List<String> prefixedSessionIds = sessionStateQueryMapper.pageSessionIds(agentCode, offset, size);
+        if (CollectionUtils.isEmpty(prefixedSessionIds)) {
+            return result;
         }
 
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
-        List<ChatSessionSummary> summaries = new ArrayList<>();
-        for (String sessionId : agentStateStore.listSessionIds(agentCode)) {
+        String prefix = agentCode + ":";
+        for (String prefixedSessionId : prefixedSessionIds) {
+            // mapper 查出的是完整带前缀 id，resolve 用的是去前缀的裸 sessionId（与写入侧 listSessionIds 语义对齐）
+            String sessionId = prefixedSessionId.startsWith(prefix)
+                ? prefixedSessionId.substring(prefix.length()) : prefixedSessionId;
             List<Msg> context = agentStateAccessor.resolve(agent, agentCode, sessionId).getContext();
             if (context.isEmpty()) {
                 continue;
             }
-            summaries.add(new ChatSessionSummary(sessionId, previewOf(context), context.get(context.size() - 1).getTimestamp(),
-                context.size()));
+            summaries.add(new ChatSessionSummary(sessionId, previewOf(context),
+                context.get(context.size() - 1).getTimestamp(), context.size()));
         }
-        summaries.sort(Comparator.comparing(ChatSessionSummary::lastMessageTime, Comparator.nullsLast(Comparator.reverseOrder())));
-        historyCache.putSessions(agentCode, summaries);
-        return summaries;
+        return result;
     }
 
     /** 30 分钟读缓存命中直接返回；未命中回源 MySQL（{@link AgentStateStore}）后回填缓存。 */

--- a/customer-admin-server/src/main/resources/mapper/ChatSessionStateQueryMapper.xml
+++ b/customer-admin-server/src/main/resources/mapper/ChatSessionStateQueryMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!--
+  会话状态表 ai_chat_session_state 的只读分页查询。
+  该表由框架 MysqlAgentStateStore 自建：主键 (session_id, state_key, item_index)，
+  session_id 存储格式为 "{agentCode}:{uuid}"，LIKE '{agentCode}:%' 走主键最左前缀。
+  前缀用 CONCAT(#{agentCode}, ':%') 参数化拼接，禁止 ${} 拼接防注入。
+-->
+<mapper namespace="com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper">
+
+    <select id="pageSessionIds" resultType="java.lang.String">
+        SELECT session_id
+        FROM ai_chat_session_state
+        WHERE session_id LIKE CONCAT(#{agentCode}, ':%')
+        GROUP BY session_id
+        ORDER BY MAX(updated_at) DESC
+        LIMIT #{offset}, #{limit}
+    </select>
+
+    <select id="countSessions" resultType="long">
+        SELECT COUNT(DISTINCT session_id)
+        FROM ai_chat_session_state
+        WHERE session_id LIKE CONCAT(#{agentCode}, ':%')
+    </select>
+
+</mapper>

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryCacheTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryCacheTest.java
@@ -1,14 +1,12 @@
 package com.richard.fyoung.customeradmin.workspace.chat.service;
 
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
-import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,8 +18,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link ChatHistoryCache} 单测：命中/未命中/写入/失效四种路径，以及 Redis 不可达时不抛异常
- * （缓存故障不能影响主流程，见类 Javadoc）。
+ * {@link ChatHistoryCache} 单测：会话消息缓存的命中/未命中/写入/失效四种路径，以及 Redis 不可达时不抛异常
+ * （缓存故障不能影响主流程，见类 Javadoc）。会话列表已改成 SQL 分页、不再走缓存。
  * @author owlzhangfq@gmail.com
  */
 class ChatHistoryCacheTest {
@@ -39,28 +37,10 @@ class ChatHistoryCacheTest {
     }
 
     @Test
-    void getSessions_shouldReturnEmpty_whenCacheMiss() {
-        when(jedis.get("admin:chat:sessions:agent-1")).thenReturn(null);
+    void getMessages_shouldReturnEmpty_whenCacheMiss() {
+        when(jedis.get("admin:chat:messages:agent-1:s1")).thenReturn(null);
 
-        assertTrue(cache.getSessions("agent-1").isEmpty());
-    }
-
-    @Test
-    void putSessions_thenGetSessions_shouldRoundTripThroughSerializedJson() {
-        List<ChatSessionSummary> sessions = List.of(new ChatSessionSummary("s1", "你好", "2026-07-08 12:00:00", 2));
-        String[] stored = new String[1];
-        when(jedis.setex(eq("admin:chat:sessions:agent-1"), anyLong(), anyString()))
-            .thenAnswer(invocation -> {
-                stored[0] = invocation.getArgument(2);
-                return "OK";
-            });
-
-        cache.putSessions("agent-1", sessions);
-        when(jedis.get("admin:chat:sessions:agent-1")).thenAnswer(invocation -> stored[0]);
-
-        Optional<List<ChatSessionSummary>> reloaded = cache.getSessions("agent-1");
-        assertTrue(reloaded.isPresent());
-        assertEquals(sessions, reloaded.get());
+        assertTrue(cache.getMessages("agent-1", "s1").isEmpty());
     }
 
     @Test
@@ -80,17 +60,17 @@ class ChatHistoryCacheTest {
     }
 
     @Test
-    void evict_shouldDeleteBothSessionsAndMessagesKeys() {
+    void evict_shouldDeleteMessagesKey() {
         cache.evict("agent-1", "s1");
 
-        verify(jedis).del("admin:chat:sessions:agent-1", "admin:chat:messages:agent-1:s1");
+        verify(jedis).del("admin:chat:messages:agent-1:s1");
     }
 
     @Test
-    void getSessions_shouldReturnEmpty_notThrow_whenRedisUnreachable() {
+    void getMessages_shouldReturnEmpty_notThrow_whenRedisUnreachable() {
         when(jedisPool.getResource()).thenThrow(new RuntimeException("connection refused"));
 
-        assertTrue(cache.getSessions("agent-1").isEmpty());
+        assertTrue(cache.getMessages("agent-1", "s1").isEmpty());
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryServiceTest.java
@@ -1,0 +1,140 @@
+package com.richard.fyoung.customeradmin.workspace.chat.service;
+
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
+import com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper;
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentStateAccessor;
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ChatHistoryService#listSessions(String, long, long)} 单测：验证 SQL 分页契约——
+ * ① 顺序以 mapper 返回的 updated_at 倒序为准、去掉 {@code {agentCode}:} 前缀后逐个组装；
+ * ② offset 按 {@code (page-1)*size} 计算；
+ * ③ context 为空的会话跳过（本页可能略少于 size）；
+ * ④ 总数为 0 时短路、不再查页数据。
+ * @author owlzhangfq@gmail.com
+ */
+class ChatHistoryServiceTest {
+
+    private static final String AGENT_CODE = "coder";
+
+    private AgentInstanceCache agentInstanceCache;
+    private AgentStateStore agentStateStore;
+    private AgentStateAccessor agentStateAccessor;
+    private ChatHistoryCache historyCache;
+    private ChatSessionStateQueryMapper sessionStateQueryMapper;
+    private ChatHistoryService service;
+    private ReActAgent agent;
+
+    @BeforeEach
+    void setUp() {
+        agentInstanceCache = mock(AgentInstanceCache.class);
+        agentStateStore = mock(AgentStateStore.class);
+        agentStateAccessor = mock(AgentStateAccessor.class);
+        historyCache = mock(ChatHistoryCache.class);
+        sessionStateQueryMapper = mock(ChatSessionStateQueryMapper.class);
+        service = new ChatHistoryService(agentInstanceCache, agentStateStore, agentStateAccessor,
+            historyCache, sessionStateQueryMapper);
+
+        agent = mock(ReActAgent.class);
+        when(agentInstanceCache.getOrBuild(AGENT_CODE)).thenReturn(agent);
+    }
+
+    /** 给某个裸 sessionId 备好一段上下文（首条为用户消息，供 preview 取值）。 */
+    private void stubContext(String sessionId, Msg... msgs) {
+        AgentState state = mock(AgentState.class);
+        when(state.getContext()).thenReturn(List.of(msgs));
+        when(agentStateAccessor.resolve(agent, AGENT_CODE, sessionId)).thenReturn(state);
+    }
+
+    private Msg userMsg(String text) {
+        return Msg.builder().role(MsgRole.USER).textContent(text).build();
+    }
+
+    private Msg assistantMsg(String text) {
+        return Msg.builder().role(MsgRole.ASSISTANT).textContent(text).build();
+    }
+
+    @Test
+    void listSessions_shouldPageInSqlOrder_stripPrefix_andBuildSummaries() {
+        when(sessionStateQueryMapper.countSessions(AGENT_CODE)).thenReturn(5L);
+        when(sessionStateQueryMapper.pageSessionIds(eq(AGENT_CODE), eq(0L), eq(20L)))
+            .thenReturn(List.of("coder:s1", "coder:s2"));
+        stubContext("s1", userMsg("你好"), assistantMsg("在的"));
+        stubContext("s2", userMsg("在吗"));
+
+        PageResult<ChatSessionSummary> result = service.listSessions(AGENT_CODE, 1, 20);
+
+        assertEquals(1, result.getPageNum());
+        assertEquals(20, result.getPageSize());
+        assertEquals(5, result.getTotal());
+        assertEquals(2, result.getList().size());
+        // 顺序以 SQL 返回为准，sessionId 已去前缀
+        assertEquals("s1", result.getList().get(0).sessionId());
+        assertEquals("你好", result.getList().get(0).preview());
+        assertEquals(2, result.getList().get(0).messageCount());
+        assertEquals("s2", result.getList().get(1).sessionId());
+        assertEquals(1, result.getList().get(1).messageCount());
+    }
+
+    @Test
+    void listSessions_shouldComputeOffset_fromPageAndSize() {
+        when(sessionStateQueryMapper.countSessions(AGENT_CODE)).thenReturn(50L);
+        when(sessionStateQueryMapper.pageSessionIds(eq(AGENT_CODE), eq(20L), eq(20L)))
+            .thenReturn(List.of("coder:s3"));
+        stubContext("s3", userMsg("第三页第一条"));
+
+        PageResult<ChatSessionSummary> result = service.listSessions(AGENT_CODE, 2, 20);
+
+        // offset = (2-1)*20 = 20
+        verify(sessionStateQueryMapper).pageSessionIds(eq(AGENT_CODE), eq(20L), eq(20L));
+        assertEquals(1, result.getList().size());
+        assertEquals("s3", result.getList().get(0).sessionId());
+    }
+
+    @Test
+    void listSessions_shouldSkipEmptyContextSessions_soPageMayBeShorterThanSize() {
+        when(sessionStateQueryMapper.countSessions(AGENT_CODE)).thenReturn(2L);
+        when(sessionStateQueryMapper.pageSessionIds(eq(AGENT_CODE), eq(0L), eq(20L)))
+            .thenReturn(List.of("coder:empty", "coder:s2"));
+        stubContext("empty"); // 空上下文
+        stubContext("s2", userMsg("在吗"));
+
+        PageResult<ChatSessionSummary> result = service.listSessions(AGENT_CODE, 1, 20);
+
+        // 空会话被跳过，本页只剩 1 条，但 total 仍是去重会话总数 2
+        assertEquals(2, result.getTotal());
+        assertEquals(1, result.getList().size());
+        assertEquals("s2", result.getList().get(0).sessionId());
+    }
+
+    @Test
+    void listSessions_shouldShortCircuit_whenTotalIsZero() {
+        when(sessionStateQueryMapper.countSessions(AGENT_CODE)).thenReturn(0L);
+
+        PageResult<ChatSessionSummary> result = service.listSessions(AGENT_CODE, 1, 20);
+
+        assertEquals(0, result.getTotal());
+        assertTrue(result.getList().isEmpty());
+        // 总数为 0 时不再查页数据
+        verify(sessionStateQueryMapper, never()).pageSessionIds(eq(AGENT_CODE), org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong());
+    }
+}

--- a/customer-admin-web/src/api/chat.ts
+++ b/customer-admin-web/src/api/chat.ts
@@ -1,13 +1,18 @@
 import { request as httpRequest } from './request'
 import { streamSse, type SseHandlers } from '@/utils/sse'
-import type { ChatAttachmentResult, ChatMessageVO, ChatRequest, ChatSessionSummary } from '@/types/api'
+import type { ChatAttachmentResult, ChatMessageVO, ChatRequest, ChatSessionSummary, PageResult } from '@/types/api'
 
 export function streamChat(agentCode: string, request: ChatRequest, handlers: SseHandlers) {
   return streamSse(`/workspace/${agentCode}/chat/stream`, request, handlers)
 }
 
-export function listChatSessions(agentCode: string) {
-  return httpRequest<ChatSessionSummary[]>({ url: `/workspace/${agentCode}/chat/sessions`, method: 'get' })
+/** 历史会话分页（按最后更新时间倒序），供侧边栏滚动加载。默认每页 20 条。 */
+export function listChatSessions(agentCode: string, page = 1, size = 20) {
+  return httpRequest<PageResult<ChatSessionSummary>>({
+    url: `/workspace/${agentCode}/chat/sessions`,
+    method: 'get',
+    params: { page, size },
+  })
 }
 
 export function getChatSessionMessages(agentCode: string, sessionId: string) {

--- a/customer-admin-web/src/components/ChatHistorySidebar.vue
+++ b/customer-admin-web/src/components/ChatHistorySidebar.vue
@@ -11,8 +11,17 @@ const props = withDefaults(
 )
 const emit = defineEmits<{ select: [sessionId: string] }>()
 
+/** 每页条数，与后端 ChatController#sessions 的 size 默认值保持一致。 */
+const PAGE_SIZE = 20
+
 const sessions = ref<ChatSessionSummary[]>([])
-const loading = ref(false)
+const page = ref(0)
+const total = ref(0)
+const loading = ref(false) // 首页加载
+const loadingMore = ref(false) // 滚动追加下一页
+
+// 以"已消费页数"判断到底，而非累积条数——空上下文会话在后端被跳过，累积条数可能永远够不到 total。
+const noMore = computed(() => page.value > 0 && page.value * PAGE_SIZE >= total.value)
 
 /** 侧边栏展示项：在后端已落库列表基础上叠加内存 streaming 标记。 */
 interface DisplaySession {
@@ -59,14 +68,47 @@ const displaySessions = computed<DisplaySession[]>(() => {
   return list.sort((a, b) => Number(b.streaming) - Number(a.streaming))
 })
 
+/** 拉取指定页并去重合并到累积列表（同 sessionId 以已有为准，防加载间隙新会话导致的页间重复）。 */
+async function loadPage(target: number) {
+  const result = await listChatSessions(props.agentCode, target, PAGE_SIZE)
+  total.value = result.total
+  page.value = target
+  const seen = new Set(sessions.value.map((s) => s.sessionId))
+  for (const s of result.list) {
+    if (!seen.has(s.sessionId)) {
+      sessions.value.push(s)
+      seen.add(s.sessionId)
+    }
+  }
+}
+
+/** 刷新：重置分页状态后重新拉第一页（「刷新」按钮与 defineExpose 的 refresh 同一语义）。 */
 async function refresh() {
   loading.value = true
   try {
-    sessions.value = await listChatSessions(props.agentCode)
+    sessions.value = []
+    page.value = 0
+    total.value = 0
+    await loadPage(1)
   } catch (error) {
     ElMessage.error('历史会话加载失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
     loading.value = false
+  }
+}
+
+/** 滚动到底触发：追加下一页（首页加载中 / 追加中 / 已到底时由 infinite-scroll-disabled 拦截，这里再兜一层）。 */
+async function loadMore() {
+  if (loading.value || loadingMore.value || noMore.value) {
+    return
+  }
+  loadingMore.value = true
+  try {
+    await loadPage(page.value + 1)
+  } catch (error) {
+    ElMessage.error('历史会话加载失败：' + (error instanceof Error ? error.message : String(error)))
+  } finally {
+    loadingMore.value = false
   }
 }
 
@@ -90,7 +132,14 @@ function openAddToProject(sessionId: string) {
       <el-button link type="primary" :loading="loading" @click="refresh">刷新</el-button>
     </div>
     <el-empty v-if="!loading && displaySessions.length === 0" description="暂无历史对话" :image-size="50" />
-    <el-scrollbar v-else height="100%">
+    <div
+      v-else
+      class="session-scroll"
+      v-infinite-scroll="loadMore"
+      :infinite-scroll-disabled="loading || loadingMore || noMore"
+      :infinite-scroll-immediate="false"
+      :infinite-scroll-distance="10"
+    >
       <ul class="session-list">
         <li
           v-for="session in displaySessions"
@@ -122,7 +171,9 @@ function openAddToProject(sessionId: string) {
           </div>
         </li>
       </ul>
-    </el-scrollbar>
+      <div v-if="loadingMore" class="load-status">加载中…</div>
+      <div v-else-if="noMore && displaySessions.length > 0" class="load-status">没有更多了</div>
+    </div>
 
     <AddToProjectDialog v-model="addToProjectVisible" :agent-code="agentCode" :session-id="addToProjectSessionId" />
   </div>
@@ -145,10 +196,34 @@ function openAddToProject(sessionId: string) {
   font-size: 13px;
 }
 
+/* 用普通 overflow 容器承接 v-infinite-scroll（指令监听宿主元素自身滚动，el-scrollbar 的内部滚动它监听不到） */
+.session-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.session-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.session-scroll::-webkit-scrollbar-thumb {
+  background: #dcdfe6;
+  border-radius: 3px;
+}
+
 .session-list {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.load-status {
+  text-align: center;
+  font-size: 12px;
+  color: #999;
+  padding: 8px 0;
 }
 
 .session-item {


### PR DESCRIPTION
## 变更说明 / What

历史对话侧边栏一次性加载慢的根因在后端：`ChatHistoryService.listSessions` 枚举智能体**全部**会话并逐个反序列化完整上下文 blob（现库 330 会话，每个几 KB~几十 KB）只为算预览与条数，再内存排序——会话越多越慢，纯前端分页治不了本。

### 后端
- 新增只读 mapper `ChatSessionStateQueryMapper`（XML SQL，admin-server 首个 XML mapper，走 MyBatis-Plus 默认 mapper-locations）：`LIKE CONCAT(#{agentCode}, ':%')` 参数化前缀命中主键最左索引（EXPLAIN 实测 `type: range, key: PRIMARY`，count 为覆盖索引），`GROUP BY session_id ORDER BY MAX(updated_at) DESC` 分页
- `listSessions(agentCode, page, size)` 返回 `PageResult`，**每页仅加载 20 个会话的 blob**；顺序以 SQL 为准，删除内存全量排序
- 会话列表**不再走 Redis 缓存**（每页成本可控，避免分页缓存复杂度；按用户决策）；`ChatHistoryCache` 移除 sessions 相关代码，**消息内容缓存与失效逻辑保留**
- `GET /sessions` 加 `page/size`（默认 1/20）

### 前端
- `ChatHistorySidebar` 滚动到底自动追加下一页（`v-infinite-scroll`，el-scrollbar 换普通滚动容器以使指令生效），底部「加载中…/没有更多了」状态；「刷新」重置回首页
- `noMore` 按已消费页数判断而非累积条数（后端跳过空上下文会话，累积条数可能凑不到 total）
- 「进行中」置顶与内存活跃会话合并逻辑不变

## 类型 / Type
- [x] perf 性能优化

## 自查 / Checklist
- [x] `mvn test` 全绿（admin-server 全量 **462/462**，隔离 worktree 验证；前端 vue-tsc + vite build 零错误；SQL 在本机真库 EXPLAIN 验证走索引）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循约定（不适用；只读查询框架自建表，不迁移不建表）
- [x] 必要时更新了 README / 配置项说明（不适用，无新增配置项）

## 审阅提示 / Reviewer notes
- `ai_chat_session_state` 是框架 `MysqlAgentStateStore` 自建表，mapper 为只读且不 `WHERE state_key='agent_state'` 硬编码框架内部键名（用 GROUP BY 稳健处理潜在多行）
- 分页查询带 `Using temporary; Using filesort`，但 range 已把扫描收敛到单智能体行集，量级可接受

🤖 Generated with [Claude Code](https://claude.com/claude-code)