### PR TITLE
feat(admin): 对话/VibeCoding 输入框支持粘贴上传附件，纯附件与空白输入自动处理

### DIFF
--- a/customer-admin-web/src/composables/useChatAttachments.ts
+++ b/customer-admin-web/src/composables/useChatAttachments.ts
@@ -1,0 +1,127 @@
+import { ElMessage } from 'element-plus'
+import type { UploadRequestOptions } from 'element-plus'
+import { parseChatAttachment } from '@/api/chat'
+import { generateUuid } from '@/utils/uuid'
+
+// 与 starter AttachmentParseService 的白名单/大小限制保持一致（后端 customer-work.attachment.max-file-size-mb=10）
+export const ATTACHMENT_ACCEPT =
+  '.md,.txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.proto,.properties,.ini,.conf,.cfg,.log,.env,.sql,.sh,.bash,.zsh,.bat,.ps1,.java,.kt,.kts,.groovy,.gradle,.scala,.py,.js,.ts,.jsx,.tsx,.vue,.css,.scss,.less,.c,.h,.cpp,.hpp,.cs,.go,.rs,.rb,.php,.swift,.lua,.r,.dart,.html,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.bmp,.webp'
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
+const ACCEPT_EXTENSIONS = new Set(ATTACHMENT_ACCEPT.split(','))
+
+/** Chat/VibeCoding 两个 store 的附件项结构相同，组合式函数按结构类型约束，不依赖具体 store。 */
+export interface AttachmentItem {
+  localId: string
+  id?: string
+  name: string
+  content: string
+  status: 'uploading' | 'success' | 'failed'
+  errorMessage?: string
+}
+
+interface AttachmentConversation {
+  attachments: AttachmentItem[]
+}
+
+/**
+ * 附件上传组合式函数：把"回形针按钮选文件"和"输入框 ⌘/Ctrl+V 粘贴文件（截图/CSV 等）"
+ * 收敛到同一条 parseChatAttachment 上传链路，Chat 与 VibeCoding 两个面板共用。
+ *
+ * getConversation 取"发起上传时刻"的会话：上传是异步的，期间用户可能切走会话，
+ * 结果必须回填到原会话而不是当前激活会话（在 uploadFile 入口一次性捕获 conv 引用）。
+ */
+export function useChatAttachments(options: {
+  agentCode: () => string
+  channel: string
+  getConversation: () => AttachmentConversation | undefined
+}) {
+  /** 前端先拦超限文件，与后端 max-file-size-mb 对齐，减少无谓上传请求。 */
+  function beforeAttachmentUpload(file: File) {
+    if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+      ElMessage.error(`附件 ${file.name} 超过 10MB，已跳过上传`)
+      return false
+    }
+    return true
+  }
+
+  /** 粘贴路径没有 el-upload 的 accept 过滤，按同一份白名单校验扩展名。 */
+  function isAcceptedFile(file: File): boolean {
+    const dot = file.name.lastIndexOf('.')
+    if (dot < 0) {
+      return false
+    }
+    return ACCEPT_EXTENSIONS.has(file.name.slice(dot).toLowerCase())
+  }
+
+  async function uploadFile(file: File) {
+    const conv = options.getConversation()
+    if (!conv) return
+    const attachment: AttachmentItem = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
+    conv.attachments.push(attachment)
+    try {
+      const result = await parseChatAttachment(options.agentCode(), file, options.channel)
+      const target = conv.attachments.find((a) => a.localId === attachment.localId)
+      if (!target) {
+        return // 结果返回前用户已手动移除该附件，迟到的结果直接丢弃
+      }
+      if (result.parseStatus === 'FAILED') {
+        target.status = 'failed'
+        target.errorMessage = result.errorMessage || '解析失败'
+        ElMessage.error(`附件解析失败：${file.name}${result.errorMessage ? '，' + result.errorMessage : ''}`)
+      } else {
+        target.id = result.id
+        target.content = result.content
+        target.status = 'success'
+      }
+    } catch (error) {
+      const target = conv.attachments.find((a) => a.localId === attachment.localId)
+      const message = error instanceof Error ? error.message : String(error)
+      if (target) {
+        target.status = 'failed'
+        target.errorMessage = message
+      }
+      ElMessage.error('附件解析失败：' + message)
+    }
+  }
+
+  /** el-upload 的 http-request 回调（回形针按钮路径）。 */
+  function handleAttachmentUpload(uploadOptions: UploadRequestOptions) {
+    return uploadFile(uploadOptions.file as File)
+  }
+
+  /**
+   * 输入框粘贴事件：剪贴板里带文件（截图、Finder 里复制的 CSV 等）就走附件上传；
+   * 纯文本粘贴不拦截，保持原生输入行为。
+   */
+  function handleAttachmentPaste(event: ClipboardEvent) {
+    const files = Array.from(event.clipboardData?.files ?? [])
+    if (files.length === 0) {
+      return
+    }
+    // 阻止浏览器把文件名等降级文本插进输入框
+    event.preventDefault()
+    for (const file of files) {
+      if (!isAcceptedFile(file)) {
+        ElMessage.error(`不支持的附件类型：${file.name}`)
+        continue
+      }
+      if (!beforeAttachmentUpload(file)) {
+        continue
+      }
+      uploadFile(file)
+    }
+  }
+
+  function removeAttachment(localId: string) {
+    const conv = options.getConversation()
+    if (!conv) return
+    conv.attachments = conv.attachments.filter((a) => a.localId !== localId)
+  }
+
+  return {
+    beforeAttachmentUpload,
+    handleAttachmentUpload,
+    handleAttachmentPaste,
+    removeAttachment,
+  }
+}

--- a/customer-admin-web/src/store/chatConversations.ts
+++ b/customer-admin-web/src/store/chatConversations.ts
@@ -146,14 +146,17 @@ export const useChatConversationsStore = defineStore('chatConversations', {
       const conv = agent?.conversations[agent.activeId]
       if (!conv) return
       const text = conv.input.trim()
-      if (!text || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
+      // 输入框内容自动去首尾空白：纯空白输入被拦下时框里的空格也一并清掉，避免"有空格但发不出去"的困惑
+      conv.input = text
+      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
+      // 有解析成功的附件时允许"只发附件不写文字"（正文即附件内容，满足后端 message 非空要求）
+      if ((!text && attachedNames.length === 0) || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
       conv.interrupted = false
       const messageToSend = buildMessage(conv, text)
-      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
       // 用户气泡只展示原始输入 + 附件文件名提示，不把拼进正文的附件全文也显示出来（那部分只是发给模型看的）。
       conv.messages.push({
         role: 'user',
-        text: attachedNames.length > 0 ? `${text}\n📎 ${attachedNames.join('、')}` : text,
+        text: attachedNames.length > 0 ? `${text ? text + '\n' : ''}📎 ${attachedNames.join('、')}` : text,
         nodes: [],
       })
       conv.messages.push({ role: 'assistant', text: '', nodes: [] })

--- a/customer-admin-web/src/store/vibeConversations.ts
+++ b/customer-admin-web/src/store/vibeConversations.ts
@@ -218,13 +218,16 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
       const conv = agent?.conversations[agent.activeId]
       if (!conv) return
       const text = conv.input.trim()
-      if (!text || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
+      // 输入框内容自动去首尾空白：纯空白输入被拦下时框里的空格也一并清掉，避免"有空格但发不出去"的困惑
+      conv.input = text
+      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
+      // 有解析成功的附件时允许"只发附件不写文字"（正文即附件内容，满足后端 message 非空要求）
+      if ((!text && attachedNames.length === 0) || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
       conv.interrupted = false
       const messageToSend = buildMessage(conv, text)
-      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
       conv.messages.push({
         role: 'user',
-        text: attachedNames.length > 0 ? `${text}\n📎 ${attachedNames.join('、')}` : text,
+        text: attachedNames.length > 0 ? `${text ? text + '\n' : ''}📎 ${attachedNames.join('、')}` : text,
         nodes: [],
       })
       conv.messages.push({ role: 'assistant', text: '', nodes: [], testReports: [] })

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -1,23 +1,16 @@
 <script setup lang="ts">
 import { computed, nextTick, onActivated, onMounted, ref, watch } from 'vue'
-import type { UploadRequestOptions } from 'element-plus'
-import { parseChatAttachment } from '@/api/chat'
+import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import TraceTimeline from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import { useThemeStore } from '@/store/theme'
 import {
   useChatConversationsStore,
-  type ChatAttachmentItem,
   type ChatConversation,
 } from '@/store/chatConversations'
-import { generateUuid } from '@/utils/uuid'
 
 const props = defineProps<{ agentCode: string; initialSessionId?: string }>()
-
-// 与 starter AttachmentParseService 的白名单/大小限制保持一致（后端 customer-work.attachment.max-file-size-mb=10）
-const ATTACHMENT_ACCEPT = '.md,.txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.proto,.properties,.ini,.conf,.cfg,.log,.env,.sql,.sh,.bash,.zsh,.bat,.ps1,.java,.kt,.kts,.groovy,.gradle,.scala,.py,.js,.ts,.jsx,.tsx,.vue,.css,.scss,.less,.c,.h,.cpp,.hpp,.cs,.go,.rs,.rb,.php,.swift,.lua,.r,.dart,.html,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.bmp,.webp'
-const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
 /**
  * 会话状态全部在 Pinia store（chatConversations）里，本组件只是"当前正在看哪个会话"的视图：
@@ -41,53 +34,13 @@ function newSession() {
   store.newSession(props.agentCode)
 }
 
-/** 前端先拦超限文件，与后端 max-file-size-mb 对齐，减少无谓上传请求。 */
-function beforeAttachmentUpload(file: File) {
-  if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
-    ElMessage.error(`附件 ${file.name} 超过 10MB，已跳过上传`)
-    return false
-  }
-  return true
-}
-
-async function handleAttachmentUpload(options: UploadRequestOptions) {
-  // 绑定发起上传时所在的会话：上传是异步的，期间用户可能切走，结果要回填到原会话而不是当前激活会话。
-  const conv = active.value
-  if (!conv) return
-  const file = options.file as File
-  const attachment: ChatAttachmentItem = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
-  conv.attachments.push(attachment)
-  try {
-    const result = await parseChatAttachment(props.agentCode, file, 'admin_chat')
-    const target = conv.attachments.find((a) => a.localId === attachment.localId)
-    if (!target) {
-      return // 结果返回前用户已手动移除该附件，迟到的结果直接丢弃
-    }
-    if (result.parseStatus === 'FAILED') {
-      target.status = 'failed'
-      target.errorMessage = result.errorMessage || '解析失败'
-      ElMessage.error(`附件解析失败：${file.name}${result.errorMessage ? '，' + result.errorMessage : ''}`)
-    } else {
-      target.id = result.id
-      target.content = result.content
-      target.status = 'success'
-    }
-  } catch (error) {
-    const target = conv.attachments.find((a) => a.localId === attachment.localId)
-    const message = error instanceof Error ? error.message : String(error)
-    if (target) {
-      target.status = 'failed'
-      target.errorMessage = message
-    }
-    ElMessage.error('附件解析失败：' + message)
-  }
-}
-
-function removeAttachment(localId: string) {
-  const conv = active.value
-  if (!conv) return
-  conv.attachments = conv.attachments.filter((a) => a.localId !== localId)
-}
+// 附件上传（回形针按钮 + 输入框 ⌘/Ctrl+V 粘贴）统一走组合式函数，与 VibeCodingPanel 共用同一条链路
+const { beforeAttachmentUpload, handleAttachmentUpload, handleAttachmentPaste, removeAttachment } =
+  useChatAttachments({
+    agentCode: () => props.agentCode,
+    channel: 'admin_chat',
+    getConversation: () => active.value,
+  })
 
 /** 把附件内容拼进消息正文——用清晰的分隔符包起来，让模型分得清"附件材料"和"用户实际问题"。
  * 只拼成功解析的附件，上传中/失败的附件不参与（失败的已经在上传回调里提示过用户）。 */
@@ -99,7 +52,8 @@ function buildMessageWithAttachments(conv: ChatConversation, text: string): stri
   const attachmentText = successful
     .map((a) => `【附件：${a.name}】\n---\n${a.content}\n---`)
     .join('\n\n')
-  return `${attachmentText}\n\n${text}`
+  // 只发附件不写文字时正文就是附件内容本身
+  return text ? `${attachmentText}\n\n${text}` : attachmentText
 }
 
 async function openSession(targetSessionId: string) {
@@ -218,9 +172,10 @@ defineExpose({ newSession })
         <el-input
           v-if="active"
           v-model="active.input"
-          placeholder="输入消息，回车发送"
+          placeholder="输入消息，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件"
           :disabled="active.streaming"
           @keyup.enter="send"
+          @paste="handleAttachmentPaste"
         />
         <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
         <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onActivated, onMounted, onUnmounted, ref, watch } from 'vue'
-import type { UploadRequestOptions } from 'element-plus'
+import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import {
   confirmVibeCodingPlan,
   generateCommitMessage,
@@ -12,7 +12,6 @@ import {
   rollbackVibeCoding,
   saveWorkspaceFileContent,
 } from '@/api/vibecoding'
-import { parseChatAttachment } from '@/api/chat'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 import TraceTimeline from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
@@ -21,10 +20,8 @@ import { useThemeStore } from '@/store/theme'
 import {
   useVibeConversationsStore,
   type PlanCard,
-  type VibeAttachmentItem,
   type VibeConversation,
 } from '@/store/vibeConversations'
-import { generateUuid } from '@/utils/uuid'
 import type {
   GitDiffSummary,
   ReviewIssue,
@@ -43,10 +40,6 @@ const REVIEW_POLL_INTERVAL_MS = 5000
 const MAX_REVIEW_POLL_COUNT = 40
 
 const props = defineProps<{ agentCode: string }>()
-
-// 与 starter AttachmentParseService 的白名单/大小限制保持一致（后端 customer-work.attachment.max-file-size-mb=10）
-const ATTACHMENT_ACCEPT = '.md,.txt,.csv,.tsv,.json,.xml,.yaml,.yml,.toml,.proto,.properties,.ini,.conf,.cfg,.log,.env,.sql,.sh,.bash,.zsh,.bat,.ps1,.java,.kt,.kts,.groovy,.gradle,.scala,.py,.js,.ts,.jsx,.tsx,.vue,.css,.scss,.less,.c,.h,.cpp,.hpp,.cs,.go,.rs,.rb,.php,.swift,.lua,.r,.dart,.html,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.png,.jpg,.jpeg,.bmp,.webp'
-const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
 /**
  * 会话状态全部在 Pinia store（vibeConversations）里，本组件只是视图：切页面、切智能体、组件销毁
@@ -103,53 +96,13 @@ function newSession() {
   store.newSession(props.agentCode)
 }
 
-/** 前端先拦超限文件，与后端 max-file-size-mb 对齐，减少无谓上传请求。 */
-function beforeAttachmentUpload(file: File) {
-  if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
-    ElMessage.error(`附件 ${file.name} 超过 10MB，已跳过上传`)
-    return false
-  }
-  return true
-}
-
-async function handleAttachmentUpload(options: UploadRequestOptions) {
-  // 绑定发起上传时所在的会话：上传是异步的，期间用户可能切走，结果要回填到原会话而不是当前激活会话。
-  const conv = active.value
-  if (!conv) return
-  const file = options.file as File
-  const attachment: VibeAttachmentItem = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
-  conv.attachments.push(attachment)
-  try {
-    const result = await parseChatAttachment(props.agentCode, file, 'vibecoding')
-    const target = conv.attachments.find((a) => a.localId === attachment.localId)
-    if (!target) {
-      return // 结果返回前用户已手动移除该附件，迟到的结果直接丢弃
-    }
-    if (result.parseStatus === 'FAILED') {
-      target.status = 'failed'
-      target.errorMessage = result.errorMessage || '解析失败'
-      ElMessage.error(`附件解析失败：${file.name}${result.errorMessage ? '，' + result.errorMessage : ''}`)
-    } else {
-      target.id = result.id
-      target.content = result.content
-      target.status = 'success'
-    }
-  } catch (error) {
-    const target = conv.attachments.find((a) => a.localId === attachment.localId)
-    const message = error instanceof Error ? error.message : String(error)
-    if (target) {
-      target.status = 'failed'
-      target.errorMessage = message
-    }
-    ElMessage.error('附件解析失败：' + message)
-  }
-}
-
-function removeAttachment(localId: string) {
-  const conv = active.value
-  if (!conv) return
-  conv.attachments = conv.attachments.filter((a) => a.localId !== localId)
-}
+// 附件上传（回形针按钮 + 输入框 ⌘/Ctrl+V 粘贴）统一走组合式函数，与 ChatPanel 共用同一条链路
+const { beforeAttachmentUpload, handleAttachmentUpload, handleAttachmentPaste, removeAttachment } =
+  useChatAttachments({
+    agentCode: () => props.agentCode,
+    channel: 'vibecoding',
+    getConversation: () => active.value,
+  })
 
 /** 只拼成功解析的附件，上传中/失败的附件不参与（失败的已经在上传回调里提示过用户）。 */
 function buildMessageWithAttachments(conv: VibeConversation, text: string): string {
@@ -158,7 +111,8 @@ function buildMessageWithAttachments(conv: VibeConversation, text: string): stri
   const attachmentText = successful
     .map((a) => `【附件：${a.name}】\n---\n${a.content}\n---`)
     .join('\n\n')
-  return `${attachmentText}\n\n${text}`
+  // 只发附件不写文字时正文就是附件内容本身
+  return text ? `${attachmentText}\n\n${text}` : attachmentText
 }
 
 async function openSession(targetSessionId: string) {
@@ -739,7 +693,13 @@ defineExpose({ newSession })
             <el-icon><Paperclip /></el-icon>
           </el-button>
         </el-upload>
-        <el-input v-model="input" placeholder="描述需求，回车发送" :disabled="active?.streaming" @keyup.enter="send" />
+        <el-input
+          v-model="input"
+          placeholder="描述需求，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件"
+          :disabled="active?.streaming"
+          @keyup.enter="send"
+          @paste="handleAttachmentPaste"
+        />
         <el-tooltip
           placement="top"
           content="开启后按 需求分析→方案设计→编码实现→自测审查 多角色顺序协作"


### PR DESCRIPTION
## 变更说明 / What

后台工作台「对话」与「VibeCoding」两个面板的输入框支持 **⌘/Ctrl+V 粘贴上传附件**（截图、CSV、文档等），并顺带修复「输入框里只有空格时发不出去、空格残留」的问题。

- 新增 `useChatAttachments` 组合式函数：回形针按钮选文件与输入框粘贴收敛到同一条 `parseChatAttachment` 上传链路，Chat / VibeCoding 两面板共用，各删约 50 行重复代码
- 粘贴路径没有 `el-upload` 的 accept 过滤，按后端 `AttachmentParseService` 同一份扩展名白名单校验 + 10MB 前端拦截；纯文本粘贴不拦截，原生输入行为不变；支持一次粘贴多个文件
- `send` 时输入自动 trim 并回写输入框：纯空白输入被拦下时空格一并清掉，不再出现"有空格但发不出去"的困惑
- 有解析成功的附件时允许**只发附件不写文字**（正文即附件内容，天然满足后端 message 非空要求），用户气泡对纯附件消息只显示 📎 文件名

## 类型 / Type
- [x] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] 纯前端改动，`npm run build`（vue-tsc + vite build）通过；后端无变更，`mvn test` 不受影响
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 无新增外部后端（复用既有 `/workspace/{agentCode}/chat/attachment` 接口）
- [x] 无需更新 README / 配置项说明（无新增配置）

## 审阅提示 / Notes for reviewer

- 附件上传逻辑是从两个面板**原样平移**进组合式函数的（会话引用在发起上传时刻捕获、迟到结果丢弃等行为都保留），diff 里大段删除 + 新增实为搬移
- 流式进行中输入框 disabled，粘贴天然进不来，未额外加拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)