### PR TITLE
feat(admin): 智能体跨会话长期记忆（memory 能力 + Store SPI 默认落库）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/controller/AgentController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/controller/AgentController.java
@@ -1,8 +1,10 @@
 package com.richard.fyoung.customeradmin.aiconfig.agent.controller;
 
 import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentMemoryVO;
 import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentSaveRequest;
 import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentVO;
+import com.richard.fyoung.customeradmin.aiconfig.agent.service.AgentMemoryService;
 import com.richard.fyoung.customeradmin.aiconfig.agent.service.AgentService;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
@@ -27,9 +29,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AgentController {
 
     private final AgentService agentService;
+    private final AgentMemoryService agentMemoryService;
 
-    public AgentController(AgentService agentService) {
+    public AgentController(AgentService agentService, AgentMemoryService agentMemoryService) {
         this.agentService = agentService;
+        this.agentMemoryService = agentMemoryService;
     }
 
     @SaCheckPermission("agent:view")
@@ -81,6 +85,20 @@ public class AgentController {
     @PutMapping("/{id}/disable")
     public Result<Void> disable(@PathVariable Long id) {
         agentService.updateStatus(id, 0);
+        return Result.success();
+    }
+
+    @SaCheckPermission("agent:view")
+    @GetMapping("/{id}/memory")
+    public Result<AgentMemoryVO> memory(@PathVariable Long id) {
+        return Result.success(agentMemoryService.getMemory(id));
+    }
+
+    @SaCheckPermission("agent:edit")
+    @OperationLog(operation = "清空智能体记忆", target = "ai_agent")
+    @DeleteMapping("/{id}/memory")
+    public Result<Void> clearMemory(@PathVariable Long id) {
+        agentMemoryService.clearMemory(id);
         return Result.success();
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentMemoryVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentMemoryVO.java
@@ -1,0 +1,13 @@
+package com.richard.fyoung.customeradmin.aiconfig.agent.dto;
+
+/**
+ * 智能体长期记忆查看结果。{@code exists=false} 表示 MEMORY.md 尚未生成（记忆能力刚开启或已被清空），
+ * 此时 {@code content} 为空串、{@code updateTime} 为 null。
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentMemoryVO(
+    boolean exists,
+    String content,
+    String updateTime
+) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryService.java
@@ -1,0 +1,105 @@
+package com.richard.fyoung.customeradmin.aiconfig.agent.service;
+
+import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentMemoryVO;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySnapshot;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryStore;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
+import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 智能体长期记忆运维：查看/清空。
+ *
+ * <p>读写对象是权威存储 {@link AgentMemoryStore}（默认库表 ai_agent_memory，配置 disk-root 后为磁盘）；
+ * 查看前先做一次 workspace → 权威存储的回写同步（拿到最近一轮对话刚 flush 的内容），清空时除权威存储外
+ * 一并删除 workspace 下的工作副本（MEMORY.md 与 memory/ 原料目录），避免运行副本把旧记忆同步回来。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class AgentMemoryService {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentMemoryService.class);
+
+    /** 框架分层记忆的工作副本文件名（workspace 根下，路径约定来自 Harness WorkspaceManager）。 */
+    private static final String MEMORY_FILE_NAME = "MEMORY.md";
+    /** 框架分层记忆的原料目录名（workspace 根下，存放按日/按会话沉淀的记忆文件）。 */
+    private static final String MEMORY_DIR_NAME = "memory";
+    private static final DateTimeFormatter UPDATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final AgentService agentService;
+    private final AdminAgentInstanceFactory instanceFactory;
+    private final AgentMemoryStore memoryStore;
+    private final AgentMemorySyncService memorySyncService;
+
+    public AgentMemoryService(AgentService agentService, AdminAgentInstanceFactory instanceFactory,
+                               AgentMemoryStore memoryStore, AgentMemorySyncService memorySyncService) {
+        this.agentService = agentService;
+        this.instanceFactory = instanceFactory;
+        this.memoryStore = memoryStore;
+        this.memorySyncService = memorySyncService;
+    }
+
+    /** 查看长期记忆：先同步 workspace 最新变更再读权威存储；从未沉淀过时返回 {@code exists=false}。 */
+    public AgentMemoryVO getMemory(Long id) {
+        AiAgent agent = agentService.requireAgent(id);
+        String agentCode = agent.getAgentCode();
+        memorySyncService.persistIfChanged(agentCode, instanceFactory.resolveWorkspace(agentCode));
+        try {
+            Optional<AgentMemorySnapshot> snapshot = memoryStore.load(agentCode);
+            if (snapshot.isEmpty()) {
+                return new AgentMemoryVO(false, "", null);
+            }
+            String updateTime = snapshot.get().updateTime() == null
+                ? null : UPDATE_TIME_FORMATTER.format(snapshot.get().updateTime());
+            return new AgentMemoryVO(true, snapshot.get().content(), updateTime);
+        } catch (Exception e) {
+            log.error("read agent memory failed, code={}, agentCode={}", "AGENT-MEMORY-READ-FAIL", agentCode, e);
+            throw new BizException(ResultCode.AGENT_MEMORY_OPERATION_FAILED, "读取记忆失败: " + e.getMessage());
+        }
+    }
+
+    /** 清空长期记忆：删除权威存储记录 + workspace 工作副本（MEMORY.md 与 memory/ 原料目录），幂等。 */
+    public void clearMemory(Long id) {
+        AiAgent agent = agentService.requireAgent(id);
+        String agentCode = agent.getAgentCode();
+        Path workspace = instanceFactory.resolveWorkspace(agentCode);
+        try {
+            memoryStore.delete(agentCode);
+            boolean removed = Files.deleteIfExists(workspace.resolve(MEMORY_FILE_NAME));
+            deleteRecursively(workspace.resolve(MEMORY_DIR_NAME));
+            log.info("agent memory cleared: agentCode={} workspaceCopyRemoved={}", agentCode, removed);
+        } catch (Exception e) {
+            log.error("clear agent memory failed, code={}, agentCode={}", "AGENT-MEMORY-CLEAR-FAIL", agentCode, e);
+            throw new BizException(ResultCode.AGENT_MEMORY_OPERATION_FAILED, "清空记忆失败: " + e.getMessage());
+        }
+    }
+
+    /** 递归删除目录（深度倒序保证先删文件再删目录），目录不存在时静默返回。 */
+    private void deleteRecursively(Path dir) throws IOException {
+        if (!Files.isDirectory(dir)) {
+            return;
+        }
+        List<Path> ordered;
+        try (Stream<Path> paths = Files.walk(dir)) {
+            ordered = paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+        }
+        for (Path path : ordered) {
+            Files.delete(path);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
@@ -60,7 +60,7 @@ public class AgentService {
 
     private static final Pattern AGENT_CODE_PATTERN = Pattern.compile("^[a-z0-9-]+$");
     private static final Set<String> VALID_CAPABILITIES =
-        Set.of("chat", "vibecoding", "subagent", "plan", "tasklist", "skill-learning", "dynamic-subagent");
+        Set.of("chat", "vibecoding", "subagent", "plan", "tasklist", "skill-learning", "dynamic-subagent", "memory");
     private static final String CAPABILITY_DELIMITER = ",";
     /** 保存门禁的连通性测试等待上限（秒）：给 ModelConfigService 内部 10s 硬超时留余量。 */
     private static final long MODEL_TEST_GATE_TIMEOUT_SECONDS = 12;
@@ -255,7 +255,7 @@ public class AgentService {
         if (!CollectionUtils.isEmpty(request.capabilities())
             && !VALID_CAPABILITIES.containsAll(request.capabilities())) {
             throw new BizException(ResultCode.PARAM_INVALID,
-                "capabilities 仅支持 chat/vibecoding/subagent/plan/tasklist/skill-learning/dynamic-subagent");
+                "capabilities 仅支持 chat/vibecoding/subagent/plan/tasklist/skill-learning/dynamic-subagent/memory");
         }
         validateAdvancedParams(request);
         validateSubAgentIds(request, selfId);
@@ -444,7 +444,8 @@ public class AgentService {
         vo.setBackupModelNames(backupIds.stream().map(nameById::get).collect(Collectors.toList()));
     }
 
-    private AiAgent requireAgent(Long id) {
+    /** 智能体存在性校验（全链路唯一防御点，包内 {@link AgentMemoryService} 复用）。 */
+    AiAgent requireAgent(Long id) {
         AiAgent agent = agentMapper.selectById(id);
         if (agent == null) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "智能体不存在: " + id);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -71,6 +71,7 @@ public enum ResultCode {
     KNOWLEDGE_PATH_NOT_ALLOWED(40030, "指定的源码路径不在允许的根目录范围内，已被安全策略拦截"),
     KNOWLEDGE_INDEX_BUILDING(40031, "该索引正在构建中，请等待构建完成后再操作"),
     MENU_REORDER_CONFLICT(40032, "菜单排序正在被其他管理员调整，请稍后重试"),
+    AGENT_MEMORY_OPERATION_FAILED(40033, "智能体记忆操作失败，请稍后重试"),
 
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.workspace.chat.service;
 
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.ToolSourceInfo;
@@ -62,12 +63,14 @@ public class ChatService {
     private final AgentInstanceCache agentInstanceCache;
     private final AdminAgentInstanceFactory agentInstanceFactory;
     private final ChatHistoryCache historyCache;
+    private final AgentMemorySyncService memorySyncService;
 
     public ChatService(AgentInstanceCache agentInstanceCache, AdminAgentInstanceFactory agentInstanceFactory,
-                        ChatHistoryCache historyCache) {
+                        ChatHistoryCache historyCache, AgentMemorySyncService memorySyncService) {
         this.agentInstanceCache = agentInstanceCache;
         this.agentInstanceFactory = agentInstanceFactory;
         this.historyCache = historyCache;
+        this.memorySyncService = memorySyncService;
     }
 
     /**
@@ -163,7 +166,13 @@ public class ChatService {
                     new ChatStreamChunk(ChatNodeKind.THINKING_END, "结束思考"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, FALLBACK_REPLY));
             })
-            .doOnComplete(() -> historyCache.evict(agentCode, sessionId))
+            .doOnComplete(() -> {
+                historyCache.evict(agentCode, sessionId);
+                // 长期记忆回写：框架的记忆 flush 只落 workspace/MEMORY.md 工作副本，这里把变更同步回
+                // 权威存储（默认库表）。非记忆智能体没有 MEMORY.md，方法内直接短路，无额外开销；
+                // 同步失败只记日志不打断流（见 AgentMemorySyncService 的兜底约定）
+                memorySyncService.persistIfChanged(agentCode, agentInstanceFactory.resolveWorkspace(agentCode));
+            })
             .doFinally(signal -> usageTotalObserver.accept(totalUsage(usageByMessage)));
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemoryProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemoryProperties.java
@@ -1,0 +1,19 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 长期记忆存储配置。默认落库（{@code ai_agent_memory} 表）；需要存磁盘时在配置里
+ * 显式指定 {@link #diskRoot}，指定后记忆权威副本改存 {@code {disk-root}/{agentCode}/MEMORY.md}。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "admin.agent-memory")
+public class AgentMemoryProperties {
+
+    /** 磁盘存储根目录：留空（默认）= 数据库存储；配置后 = 磁盘存储到该路径。 */
+    private String diskRoot = "";
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySnapshot.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySnapshot.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import java.time.LocalDateTime;
+
+/**
+ * 长期记忆快照：{@code content} 为 MEMORY.md 全文，{@code updateTime} 为权威存储侧的最后更新时间
+ * （JDBC 模式取 update_time 列，磁盘模式取文件 mtime）。
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentMemorySnapshot(String content, LocalDateTime updateTime) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemoryStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemoryStore.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import java.util.Optional;
+
+/**
+ * 智能体跨会话长期记忆的权威存储 SPI。
+ *
+ * <p>Harness 分层记忆的工作副本永远是 {@code {workspace}/MEMORY.md}（框架 WorkspaceManager
+ * 硬编码写磁盘，不可改）；本 SPI 负责它的持久化权威副本：构建实例时水合到 workspace、
+ * 对话轮次结束后回写（见 {@link AgentMemorySyncService}）。</p>
+ *
+ * <p>实现选择由 {@link AgentMemoryStoreConfig} 按配置决定：默认 JDBC 落库
+ * {@code ai_agent_memory}；配置 {@code admin.agent-memory.disk-root} 后改走磁盘。
+ * 实现内部不做异常兜底（统一抛出运行时异常），由调用侧按场景处理：同步链路吞掉记日志、
+ * 运维接口转业务异常。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface AgentMemoryStore {
+
+    /** 加载指定智能体的长期记忆；从未沉淀过（或已清空）时返回 empty。 */
+    Optional<AgentMemorySnapshot> load(String agentCode);
+
+    /** 保存（覆盖）指定智能体的长期记忆全文。 */
+    void save(String agentCode, String content);
+
+    /** 删除指定智能体的长期记忆（不存在视为成功，幂等）。 */
+    void delete(String agentCode);
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemoryStoreConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemoryStoreConfig.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import com.richard.fyoung.customeradmin.workspace.memory.mapper.AiAgentMemoryMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import java.nio.file.Path;
+
+/**
+ * 长期记忆权威存储装配：默认 JDBC 落库；配置 {@code admin.agent-memory.disk-root} 后切磁盘实现。
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class AgentMemoryStoreConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentMemoryStoreConfig.class);
+
+    @Bean
+    public AgentMemoryStore agentMemoryStore(AgentMemoryProperties properties, AiAgentMemoryMapper memoryMapper) {
+        if (StringUtils.hasText(properties.getDiskRoot())) {
+            log.info("agent memory store: disk, root={}", properties.getDiskRoot());
+            return new DiskAgentMemoryStore(Path.of(properties.getDiskRoot()));
+        }
+        log.info("agent memory store: jdbc (ai_agent_memory)");
+        return new JdbcAgentMemoryStore(memoryMapper);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySyncService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySyncService.java
@@ -1,0 +1,78 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * 长期记忆同步：权威存储（{@link AgentMemoryStore}）与框架工作副本（{@code {workspace}/MEMORY.md}）
+ * 之间的双向同步。
+ *
+ * <ul>
+ *   <li><b>水合</b>（{@link #hydrate}）：构建智能体实例时把权威副本写到 workspace，保证换机/重启/
+ *       清理 workspace 后框架仍能读到历史记忆；权威存储为空而 workspace 有存量文件时反向入库（存量迁移）。</li>
+ *   <li><b>回写</b>（{@link #persistIfChanged}）：对话轮次结束后把 workspace 文件的变更保存回权威存储；
+ *       内容未变化时跳过写入。</li>
+ * </ul>
+ *
+ * <p>两个方法都不抛异常（同步失败不应打断对话主链路，也不应阻断实例构建），失败只记 error 日志；
+ * 这是记忆同步链路的唯一异常兜底点，{@code AgentMemoryStore} 实现内部不再兜底。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class AgentMemorySyncService {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentMemorySyncService.class);
+
+    private static final String MEMORY_FILE_NAME = "MEMORY.md";
+
+    private final AgentMemoryStore memoryStore;
+
+    public AgentMemorySyncService(AgentMemoryStore memoryStore) {
+        this.memoryStore = memoryStore;
+    }
+
+    /** 水合：权威存储 → workspace/MEMORY.md（构建实例时调用）；权威侧为空且 workspace 有存量文件时反向入库。 */
+    public void hydrate(String agentCode, Path workspace) {
+        try {
+            Path memoryFile = workspace.resolve(MEMORY_FILE_NAME);
+            Optional<AgentMemorySnapshot> snapshot = memoryStore.load(agentCode);
+            if (snapshot.isPresent()) {
+                Files.writeString(memoryFile, snapshot.get().content(), StandardCharsets.UTF_8);
+                log.info("agent memory hydrated to workspace: agentCode={}", agentCode);
+                return;
+            }
+            if (Files.exists(memoryFile)) {
+                // 存量迁移：老版本记忆只落过 workspace 磁盘，第一次构建时收编进权威存储
+                memoryStore.save(agentCode, Files.readString(memoryFile, StandardCharsets.UTF_8));
+                log.info("legacy workspace memory imported into store: agentCode={}", agentCode);
+            }
+        } catch (Exception e) {
+            log.error("hydrate agent memory failed, code={}, agentCode={}", "AGENT-MEMORY-HYDRATE-FAIL", agentCode, e);
+        }
+    }
+
+    /** 回写：workspace/MEMORY.md → 权威存储（对话轮次结束后调用）；文件不存在或内容未变化时跳过。 */
+    public void persistIfChanged(String agentCode, Path workspace) {
+        try {
+            Path memoryFile = workspace.resolve(MEMORY_FILE_NAME);
+            if (!Files.exists(memoryFile)) {
+                return;
+            }
+            String content = Files.readString(memoryFile, StandardCharsets.UTF_8);
+            String stored = memoryStore.load(agentCode).map(AgentMemorySnapshot::content).orElse(null);
+            if (content.equals(stored)) {
+                return;
+            }
+            memoryStore.save(agentCode, content);
+            log.info("agent memory persisted to store: agentCode={} bytes={}", agentCode, content.length());
+        } catch (Exception e) {
+            log.error("persist agent memory failed, code={}, agentCode={}", "AGENT-MEMORY-PERSIST-FAIL", agentCode, e);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/DiskAgentMemoryStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/DiskAgentMemoryStore.java
@@ -1,0 +1,68 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+/**
+ * 长期记忆权威存储的磁盘实现：{@code {disk-root}/{agentCode}/MEMORY.md}。
+ * 仅在显式配置 {@code admin.agent-memory.disk-root} 时启用（见 {@link AgentMemoryStoreConfig}），
+ * 适用于不便新增数据表、或希望记忆随文件系统备份走的部署场景。
+ * @author owlzhangfq@gmail.com
+ */
+public class DiskAgentMemoryStore implements AgentMemoryStore {
+
+    private static final String MEMORY_FILE_NAME = "MEMORY.md";
+
+    private final Path root;
+
+    public DiskAgentMemoryStore(Path root) {
+        this.root = root;
+    }
+
+    @Override
+    public Optional<AgentMemorySnapshot> load(String agentCode) {
+        Path file = memoryFile(agentCode);
+        try {
+            if (!Files.exists(file)) {
+                return Optional.empty();
+            }
+            String content = Files.readString(file, StandardCharsets.UTF_8);
+            LocalDateTime updateTime = LocalDateTime.ofInstant(
+                Files.getLastModifiedTime(file).toInstant(), ZoneId.systemDefault());
+            return Optional.of(new AgentMemorySnapshot(content, updateTime));
+        } catch (IOException e) {
+            throw new UncheckedIOException("load agent memory from disk failed: " + file, e);
+        }
+    }
+
+    @Override
+    public void save(String agentCode, String content) {
+        Path file = memoryFile(agentCode);
+        try {
+            Files.createDirectories(file.getParent());
+            Files.writeString(file, content, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("save agent memory to disk failed: " + file, e);
+        }
+    }
+
+    @Override
+    public void delete(String agentCode) {
+        Path file = memoryFile(agentCode);
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException("delete agent memory on disk failed: " + file, e);
+        }
+    }
+
+    private Path memoryFile(String agentCode) {
+        return root.resolve(agentCode).resolve(MEMORY_FILE_NAME);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/JdbcAgentMemoryStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/JdbcAgentMemoryStore.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.workspace.memory.entity.AiAgentMemory;
+import com.richard.fyoung.customeradmin.workspace.memory.mapper.AiAgentMemoryMapper;
+
+import java.util.Optional;
+
+/**
+ * 长期记忆权威存储的 JDBC 实现（默认）：落库 {@code customer_admin.ai_agent_memory}，
+ * 每个智能体一行（agent_code 唯一键），update_time 由数据库维护。
+ * @author owlzhangfq@gmail.com
+ */
+public class JdbcAgentMemoryStore implements AgentMemoryStore {
+
+    private final AiAgentMemoryMapper memoryMapper;
+
+    public JdbcAgentMemoryStore(AiAgentMemoryMapper memoryMapper) {
+        this.memoryMapper = memoryMapper;
+    }
+
+    @Override
+    public Optional<AgentMemorySnapshot> load(String agentCode) {
+        AiAgentMemory row = selectByAgentCode(agentCode);
+        if (row == null || row.getContent() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new AgentMemorySnapshot(row.getContent(), row.getUpdateTime()));
+    }
+
+    @Override
+    public void save(String agentCode, String content) {
+        AiAgentMemory row = selectByAgentCode(agentCode);
+        if (row == null) {
+            AiAgentMemory insert = new AiAgentMemory();
+            insert.setAgentCode(agentCode);
+            insert.setContent(content);
+            memoryMapper.insert(insert);
+            return;
+        }
+        row.setContent(content);
+        memoryMapper.updateById(row);
+    }
+
+    @Override
+    public void delete(String agentCode) {
+        memoryMapper.delete(new LambdaQueryWrapper<AiAgentMemory>().eq(AiAgentMemory::getAgentCode, agentCode));
+    }
+
+    private AiAgentMemory selectByAgentCode(String agentCode) {
+        return memoryMapper.selectOne(new LambdaQueryWrapper<AiAgentMemory>().eq(AiAgentMemory::getAgentCode, agentCode));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/entity/AiAgentMemory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/entity/AiAgentMemory.java
@@ -1,0 +1,31 @@
+package com.richard.fyoung.customeradmin.workspace.memory.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 智能体跨会话长期记忆 DO（workspace/MEMORY.md 的权威存储）。
+ * 时间列由数据库 DEFAULT CURRENT_TIMESTAMP / ON UPDATE 维护，代码侧不做审计填充
+ * （写入方是运行时同步链路，不在登录上下文里，套 createBy/updateBy 填充器反而会拿到空值）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_agent_memory")
+public class AiAgentMemory {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 智能体编码（ai_agent.agent_code），唯一键。 */
+    private String agentCode;
+
+    /** 长期记忆内容（MEMORY.md 全文）。 */
+    private String content;
+
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/mapper/AiAgentMemoryMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/mapper/AiAgentMemoryMapper.java
@@ -1,0 +1,12 @@
+package com.richard.fyoung.customeradmin.workspace.memory.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.workspace.memory.entity.AiAgentMemory;
+
+/**
+ * 智能体长期记忆 Mapper。由 {@code CustomerAdminServerApplication} 的
+ * {@code @MapperScan("...**.mapper")} 自动扫描。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiAgentMemoryMapper extends BaseMapper<AiAgentMemory> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -29,6 +29,7 @@ import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminSandboxProperties;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
@@ -47,6 +48,7 @@ import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.spec.SandboxFilesystemSpec;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerFilesystemSpec;
@@ -100,6 +102,7 @@ public class AdminAgentInstanceFactory {
     private static final String CAPABILITY_TASKLIST = "tasklist";
     private static final String CAPABILITY_SKILL_LEARNING = "skill-learning";
     private static final String CAPABILITY_DYNAMIC_SUBAGENT = "dynamic-subagent";
+    private static final String CAPABILITY_MEMORY = "memory";
     private static final String CAPABILITY_DELIMITER = ",";
     private static final int STATUS_ENABLED = 1;
     private static final int DEFAULT_MAX_ITERS = 10;
@@ -146,6 +149,7 @@ public class AdminAgentInstanceFactory {
     private final SandboxGuardMiddleware sandboxGuardMiddleware;
     private final PlanConfirmationMiddleware planConfirmationMiddleware;
     private final ModelCircuitBreakerRegistry circuitBreakerRegistry;
+    private final AgentMemorySyncService memorySyncService;
 
     /**
      * {@code agentCode -> ToolSourceInfo}：{@link #build} 每次重建都会覆盖写入，天然跟着
@@ -165,7 +169,8 @@ public class AdminAgentInstanceFactory {
                                       AdminMcpFactory mcpFactory, AdminSandboxProperties sandboxProperties,
                                       SandboxGuardMiddleware sandboxGuardMiddleware,
                                       PlanConfirmationMiddleware planConfirmationMiddleware,
-                                      ModelCircuitBreakerRegistry circuitBreakerRegistry) {
+                                      ModelCircuitBreakerRegistry circuitBreakerRegistry,
+                                      AgentMemorySyncService memorySyncService) {
         this.agentMapper = agentMapper;
         this.agentMcpMapper = agentMcpMapper;
         this.agentSkillMapper = agentSkillMapper;
@@ -186,6 +191,7 @@ public class AdminAgentInstanceFactory {
         this.sandboxGuardMiddleware = sandboxGuardMiddleware;
         this.planConfirmationMiddleware = planConfirmationMiddleware;
         this.circuitBreakerRegistry = circuitBreakerRegistry;
+        this.memorySyncService = memorySyncService;
     }
 
     /** 查该智能体当前已装配的工具来源登记表；从未 {@link #build} 过（比如尚未触发过对话）时返回空表。 */
@@ -230,7 +236,7 @@ public class AdminAgentInstanceFactory {
 
     /**
      * 是否需要用 {@link HarnessAgent.Builder#fromAgent} 把内层 ReActAgent 升级为 HarnessAgent：
-     * capabilities 含 vibecoding/plan/subagent/skill-learning/dynamic-subagent 任一，或配置了上下文压缩触发阈值。
+     * capabilities 含 vibecoding/plan/subagent/skill-learning/dynamic-subagent/memory 任一，或配置了上下文压缩触发阈值。
      * tasklist 是 {@link ReActAgent.Builder#enableTaskList(boolean)} 的内层能力，单独勾选不触发升级。
      * 抽成纯函数便于单测（不依赖任何注入的协作对象）。
      */
@@ -240,6 +246,7 @@ public class AdminAgentInstanceFactory {
             || capabilities.contains(CAPABILITY_SUBAGENT)
             || capabilities.contains(CAPABILITY_SKILL_LEARNING)
             || capabilities.contains(CAPABILITY_DYNAMIC_SUBAGENT)
+            || capabilities.contains(CAPABILITY_MEMORY)
             || compressTriggerMsgs != null;
     }
 
@@ -353,6 +360,15 @@ public class AdminAgentInstanceFactory {
             // 互动学习新技能（Harness 半边）：技能管理工具 + SkillCurator 自动沉淀成功模式
             harnessBuilder.enableSkillManageTool(true)
                 .enableSkillCurator(SkillCuratorConfig.defaults());
+        }
+        if (capabilities.contains(CAPABILITY_MEMORY)) {
+            // 跨会话长期记忆（分层记忆）：对话事实自动 flush 到 workspace/MEMORY.md 并定期 consolidation，
+            // 按 agentCode 隔离（一个智能体一份记忆，全部会话共享）。workspace 文件只是框架的工作副本，
+            // 权威存储在 AgentMemoryStore（默认落库）：构建时水合到 workspace，对话轮次结束后由
+            // ChatService 回写（见 AgentMemorySyncService）
+            memorySyncService.hydrate(agentCode, workspace);
+            harnessBuilder.memory(MemoryConfig.builder().model(model).build());
+            log.info("[workspace] layered memory enabled: agentCode={}", agentCode);
         }
         if (agent.getCompressTriggerMsgs() != null) {
             int keepMsgs = agent.getCompressKeepMsgs() != null

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -58,6 +58,10 @@ admin:
   aes-secret-key: ${ADMIN_AES_SECRET_KEY:0123456789abcdef0123456789abcdef}
   # 登录“记住我”勾选后登录态有效期（秒），默认 7 天；不勾选时沿用 sa-token.timeout（2 小时）全局配置
   remember-me-timeout-seconds: ${ADMIN_REMEMBER_ME_TIMEOUT_SECONDS:604800}
+  agent-memory:
+    # 智能体长期记忆权威存储：留空（默认）= 落库 ai_agent_memory 表；
+    # 需要存磁盘时在此显式指定根目录，记忆改存 {disk-root}/{agentCode}/MEMORY.md（不再读写库表）
+    disk-root: ${ADMIN_AGENT_MEMORY_DISK_ROOT:}
   workbench:
     # 生成的 ScriptCat 登录脚本里内嵌的 admin-server 访问基址：脚本用 GM_xmlhttpRequest 回调此地址取凭证。
     # 必须是运行脚本的浏览器可达的地址（本地默认 8082，生产由运维改成内网可达域名）。

--- a/customer-admin-server/src/main/resources/db/migration/V32__agent_memory.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V32__agent_memory.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- 智能体跨会话长期记忆（默认存储后端）
+-- Harness 分层记忆的工作副本是 workspace/MEMORY.md（框架硬编码写磁盘），本表是它的权威存储：
+-- 构建智能体实例时从本表水合到 workspace，对话轮次结束后把变更同步回本表。
+-- 配置 admin.agent-memory.disk-root 后改走磁盘存储，本表不再读写（见 AgentMemoryStoreConfig）。
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_agent_memory` (
+    `id`          BIGINT NOT NULL AUTO_INCREMENT,
+    `agent_code`  VARCHAR(64) NOT NULL COMMENT '智能体编码（ai_agent.agent_code）',
+    `content`     LONGTEXT COMMENT '长期记忆内容（MEMORY.md 全文）',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_agent_code` (`agent_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体跨会话长期记忆（MEMORY.md 权威存储）';
+-- =============================================================================
+-- 智能体跨会话长期记忆（默认存储后端）
+-- Harness 分层记忆的工作副本是 workspace/MEMORY.md（框架硬编码写磁盘），本表是它的权威存储：
+-- 构建智能体实例时从本表水合到 workspace，对话轮次结束后把变更同步回本表。
+-- 配置 admin.agent-memory.disk-root 后改走磁盘存储，本表不再读写（见 AgentMemoryStoreConfig）。
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_agent_memory` (
+    `id`          BIGINT NOT NULL AUTO_INCREMENT,
+    `agent_code`  VARCHAR(64) NOT NULL COMMENT '智能体编码（ai_agent.agent_code）',
+    `content`     LONGTEXT COMMENT '长期记忆内容（MEMORY.md 全文）',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_agent_code` (`agent_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体跨会话长期记忆（MEMORY.md 权威存储）';

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryServiceTest.java
@@ -1,0 +1,111 @@
+package com.richard.fyoung.customeradmin.aiconfig.agent.service;
+
+import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentMemoryVO;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySnapshot;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryStore;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
+import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AgentMemoryService} 单测：查看走权威存储（查看前先回写同步）、清空同时删权威存储与
+ * workspace 工作副本（含 memory/ 原料目录、幂等）。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentMemoryServiceTest {
+
+    private static final Long AGENT_ID = 1L;
+    private static final String AGENT_CODE = "memo-agent";
+
+    @TempDir
+    Path workspace;
+
+    private AgentMemoryStore memoryStore;
+    private AgentMemorySyncService memorySyncService;
+    private AgentMemoryService service;
+
+    @BeforeEach
+    void setUp() {
+        AgentService agentService = mock(AgentService.class);
+        AiAgent agent = new AiAgent();
+        agent.setId(AGENT_ID);
+        agent.setAgentCode(AGENT_CODE);
+        when(agentService.requireAgent(AGENT_ID)).thenReturn(agent);
+
+        AdminAgentInstanceFactory instanceFactory = mock(AdminAgentInstanceFactory.class);
+        when(instanceFactory.resolveWorkspace(AGENT_CODE)).thenReturn(workspace);
+
+        memoryStore = mock(AgentMemoryStore.class);
+        memorySyncService = mock(AgentMemorySyncService.class);
+        service = new AgentMemoryService(agentService, instanceFactory, memoryStore, memorySyncService);
+    }
+
+    @Test
+    void getMemory_shouldReturnNotExists_whenStoreEmpty() {
+        when(memoryStore.load(AGENT_CODE)).thenReturn(Optional.empty());
+
+        AgentMemoryVO vo = service.getMemory(AGENT_ID);
+
+        assertFalse(vo.exists());
+        assertEquals("", vo.content());
+        assertNull(vo.updateTime());
+        // 查看前必须先做一次 workspace → 权威存储的回写同步，保证能看到最近一轮 flush 的内容
+        verify(memorySyncService).persistIfChanged(AGENT_CODE, workspace);
+    }
+
+    @Test
+    void getMemory_shouldReturnSnapshot_whenStoreHasContent() {
+        String content = "# MEMORY\n- 用户偏好 Java\n";
+        when(memoryStore.load(AGENT_CODE))
+            .thenReturn(Optional.of(new AgentMemorySnapshot(content, LocalDateTime.of(2026, 7, 22, 10, 30))));
+
+        AgentMemoryVO vo = service.getMemory(AGENT_ID);
+
+        assertTrue(vo.exists());
+        assertEquals(content, vo.content());
+        assertNotNull(vo.updateTime());
+        assertEquals("2026-07-22 10:30:00", vo.updateTime());
+    }
+
+    @Test
+    void clearMemory_shouldDeleteStoreAndWorkspaceCopy() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "profile", StandardCharsets.UTF_8);
+        Path memoryDir = workspace.resolve("memory");
+        Files.createDirectories(memoryDir.resolve("2026-07"));
+        Files.writeString(memoryDir.resolve("2026-07-22.md"), "daily", StandardCharsets.UTF_8);
+        Files.writeString(memoryDir.resolve("2026-07").resolve("nested.md"), "nested", StandardCharsets.UTF_8);
+
+        service.clearMemory(AGENT_ID);
+
+        verify(memoryStore).delete(AGENT_CODE);
+        assertFalse(Files.exists(workspace.resolve("MEMORY.md")));
+        assertFalse(Files.exists(memoryDir));
+    }
+
+    @Test
+    void clearMemory_shouldBeIdempotent_whenNothingExists() {
+        service.clearMemory(AGENT_ID);
+
+        verify(memoryStore).delete(AGENT_CODE);
+        assertFalse(Files.exists(workspace.resolve("MEMORY.md")));
+        assertFalse(Files.exists(workspace.resolve("memory")));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.workspace.chat.service;
 
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.ToolSourceInfo;
@@ -54,6 +55,7 @@ class ChatServiceTest {
     private AgentInstanceCache agentInstanceCache;
     private AdminAgentInstanceFactory agentInstanceFactory;
     private ChatHistoryCache historyCache;
+    private AgentMemorySyncService memorySyncService;
     private ChatService chatService;
     private ReActAgent agent;
 
@@ -62,7 +64,8 @@ class ChatServiceTest {
         agentInstanceCache = mock(AgentInstanceCache.class);
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
         historyCache = mock(ChatHistoryCache.class);
-        chatService = new ChatService(agentInstanceCache, agentInstanceFactory, historyCache);
+        memorySyncService = mock(AgentMemorySyncService.class);
+        chatService = new ChatService(agentInstanceCache, agentInstanceFactory, historyCache, memorySyncService);
 
         agent = mock(ReActAgent.class);
         when(agentInstanceCache.getOrBuild("coder")).thenReturn(agent);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySyncServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySyncServiceTest.java
@@ -1,0 +1,109 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AgentMemorySyncService} 单测：水合（正向/存量迁移）、回写（变更/未变更/文件缺失）与异常兜底。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentMemorySyncServiceTest {
+
+    private static final String AGENT_CODE = "memo-agent";
+
+    @TempDir
+    Path workspace;
+
+    private AgentMemoryStore store;
+    private AgentMemorySyncService service;
+
+    @BeforeEach
+    void setUp() {
+        store = mock(AgentMemoryStore.class);
+        service = new AgentMemorySyncService(store);
+    }
+
+    @Test
+    void hydrate_shouldWriteStoreContentToWorkspace() throws Exception {
+        when(store.load(AGENT_CODE))
+            .thenReturn(Optional.of(new AgentMemorySnapshot("from-store", LocalDateTime.now())));
+
+        service.hydrate(AGENT_CODE, workspace);
+
+        assertEquals("from-store", Files.readString(workspace.resolve("MEMORY.md"), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void hydrate_shouldImportLegacyWorkspaceFile_whenStoreEmpty() throws Exception {
+        when(store.load(AGENT_CODE)).thenReturn(Optional.empty());
+        Files.writeString(workspace.resolve("MEMORY.md"), "legacy", StandardCharsets.UTF_8);
+
+        service.hydrate(AGENT_CODE, workspace);
+
+        verify(store).save(AGENT_CODE, "legacy");
+    }
+
+    @Test
+    void hydrate_shouldDoNothing_whenBothSidesEmpty() {
+        when(store.load(AGENT_CODE)).thenReturn(Optional.empty());
+
+        service.hydrate(AGENT_CODE, workspace);
+
+        verify(store, never()).save(anyString(), anyString());
+    }
+
+    @Test
+    void persistIfChanged_shouldSave_whenContentDiffers() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "v2", StandardCharsets.UTF_8);
+        when(store.load(AGENT_CODE))
+            .thenReturn(Optional.of(new AgentMemorySnapshot("v1", LocalDateTime.now())));
+
+        service.persistIfChanged(AGENT_CODE, workspace);
+
+        verify(store).save(AGENT_CODE, "v2");
+    }
+
+    @Test
+    void persistIfChanged_shouldSkip_whenContentUnchanged() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "same", StandardCharsets.UTF_8);
+        when(store.load(AGENT_CODE))
+            .thenReturn(Optional.of(new AgentMemorySnapshot("same", LocalDateTime.now())));
+
+        service.persistIfChanged(AGENT_CODE, workspace);
+
+        verify(store, never()).save(anyString(), anyString());
+    }
+
+    @Test
+    void persistIfChanged_shouldSkip_whenWorkspaceFileAbsent() {
+        service.persistIfChanged(AGENT_CODE, workspace);
+
+        verify(store, never()).save(anyString(), anyString());
+    }
+
+    @Test
+    void bothMethods_shouldSwallowStoreExceptions() {
+        // 同步失败不允许打断对话主链路/实例构建（本服务是记忆同步链路的唯一异常兜底点）
+        when(store.load(anyString())).thenThrow(new IllegalStateException("db down"));
+
+        assertDoesNotThrow(() -> service.hydrate(AGENT_CODE, workspace));
+        assertDoesNotThrow(() -> service.persistIfChanged(AGENT_CODE, workspace));
+        verify(store, never()).save(any(), any());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/memory/DiskAgentMemoryStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/memory/DiskAgentMemoryStoreTest.java
@@ -1,0 +1,68 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DiskAgentMemoryStore} 单测：{@code {root}/{agentCode}/MEMORY.md} 的读写删与幂等。
+ * @author owlzhangfq@gmail.com
+ */
+class DiskAgentMemoryStoreTest {
+
+    private static final String AGENT_CODE = "memo-agent";
+
+    @TempDir
+    Path root;
+
+    private DiskAgentMemoryStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new DiskAgentMemoryStore(root);
+    }
+
+    @Test
+    void load_shouldReturnEmpty_whenFileAbsent() {
+        assertTrue(store.load(AGENT_CODE).isEmpty());
+    }
+
+    @Test
+    void saveThenLoad_shouldRoundTrip() throws Exception {
+        store.save(AGENT_CODE, "记忆内容");
+
+        Optional<AgentMemorySnapshot> snapshot = store.load(AGENT_CODE);
+        assertTrue(snapshot.isPresent());
+        assertEquals("记忆内容", snapshot.get().content());
+        assertNotNull(snapshot.get().updateTime());
+        assertEquals("记忆内容",
+            Files.readString(root.resolve(AGENT_CODE).resolve("MEMORY.md"), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void save_shouldOverwriteExisting() {
+        store.save(AGENT_CODE, "v1");
+        store.save(AGENT_CODE, "v2");
+
+        assertEquals("v2", store.load(AGENT_CODE).orElseThrow().content());
+    }
+
+    @Test
+    void delete_shouldRemoveFile_andBeIdempotent() {
+        store.save(AGENT_CODE, "content");
+
+        store.delete(AGENT_CODE);
+        assertTrue(store.load(AGENT_CODE).isEmpty());
+        assertDoesNotThrow(() -> store.delete(AGENT_CODE));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/memory/JdbcAgentMemoryStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/memory/JdbcAgentMemoryStoreTest.java
@@ -1,0 +1,104 @@
+package com.richard.fyoung.customeradmin.workspace.memory;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.richard.fyoung.customeradmin.workspace.memory.entity.AiAgentMemory;
+import com.richard.fyoung.customeradmin.workspace.memory.mapper.AiAgentMemoryMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link JdbcAgentMemoryStore} 单测：agent_code 单行 upsert（无行插入/有行更新）、load 空行语义、delete。
+ * @author owlzhangfq@gmail.com
+ */
+class JdbcAgentMemoryStoreTest {
+
+    private static final String AGENT_CODE = "memo-agent";
+
+    private AiAgentMemoryMapper mapper;
+    private JdbcAgentMemoryStore store;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(
+            new MapperBuilderAssistant(new MybatisConfiguration(), ""), AiAgentMemory.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        mapper = mock(AiAgentMemoryMapper.class);
+        store = new JdbcAgentMemoryStore(mapper);
+    }
+
+    @Test
+    void load_shouldReturnEmpty_whenRowAbsent() {
+        when(mapper.selectOne(any())).thenReturn(null);
+
+        assertTrue(store.load(AGENT_CODE).isEmpty());
+    }
+
+    @Test
+    void load_shouldReturnSnapshot_whenRowPresent() {
+        AiAgentMemory row = new AiAgentMemory();
+        row.setAgentCode(AGENT_CODE);
+        row.setContent("记忆内容");
+        row.setUpdateTime(LocalDateTime.of(2026, 7, 22, 10, 30));
+        when(mapper.selectOne(any())).thenReturn(row);
+
+        Optional<AgentMemorySnapshot> snapshot = store.load(AGENT_CODE);
+
+        assertTrue(snapshot.isPresent());
+        assertEquals("记忆内容", snapshot.get().content());
+        assertEquals(LocalDateTime.of(2026, 7, 22, 10, 30), snapshot.get().updateTime());
+    }
+
+    @Test
+    void save_shouldInsert_whenRowAbsent() {
+        when(mapper.selectOne(any())).thenReturn(null);
+
+        store.save(AGENT_CODE, "first");
+
+        ArgumentCaptor<AiAgentMemory> captor = ArgumentCaptor.forClass(AiAgentMemory.class);
+        verify(mapper).insert(captor.capture());
+        assertEquals(AGENT_CODE, captor.getValue().getAgentCode());
+        assertEquals("first", captor.getValue().getContent());
+        verify(mapper, never()).updateById(any(AiAgentMemory.class));
+    }
+
+    @Test
+    void save_shouldUpdate_whenRowPresent() {
+        AiAgentMemory row = new AiAgentMemory();
+        row.setId(9L);
+        row.setAgentCode(AGENT_CODE);
+        row.setContent("old");
+        when(mapper.selectOne(any())).thenReturn(row);
+
+        store.save(AGENT_CODE, "new");
+
+        ArgumentCaptor<AiAgentMemory> captor = ArgumentCaptor.forClass(AiAgentMemory.class);
+        verify(mapper).updateById(captor.capture());
+        assertEquals("new", captor.getValue().getContent());
+        verify(mapper, never()).insert(any(AiAgentMemory.class));
+    }
+
+    @Test
+    void delete_shouldDeleteByAgentCode() {
+        store.delete(AGENT_CODE);
+
+        verify(mapper).delete(any());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
@@ -27,7 +27,7 @@ class AdminAgentInstanceFactoryTest {
     /** 构造器纯字段赋值，路径解析只依赖常量，传 null 依赖即可单测 resolveSessionWorkspace 的防御逻辑。 */
     private AdminAgentInstanceFactory newFactoryForPathTest() {
         return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -49,6 +49,8 @@ class AdminAgentInstanceFactoryTest {
         assertTrue(AdminAgentInstanceFactory.requiresHarness(List.of("chat", "subagent"), null));
         assertTrue(AdminAgentInstanceFactory.requiresHarness(List.of("chat", "skill-learning"), null));
         assertTrue(AdminAgentInstanceFactory.requiresHarness(List.of("chat", "dynamic-subagent"), null));
+        // 长期记忆挂在 HarnessAgent 上（MemoryConfig），仅勾 memory 也需要升级
+        assertTrue(AdminAgentInstanceFactory.requiresHarness(List.of("chat", "memory"), null));
     }
 
     @Test

--- a/customer-admin-web/src/api/agent.ts
+++ b/customer-admin-web/src/api/agent.ts
@@ -1,5 +1,5 @@
 import { request } from './request'
-import type { AgentSaveRequest, AgentVO, PageQuery, PageResult } from '@/types/api'
+import type { AgentMemoryVO, AgentSaveRequest, AgentVO, PageQuery, PageResult } from '@/types/api'
 
 export function pageAgents(query: PageQuery) {
   return request<PageResult<AgentVO>>({ url: '/aiconfig/agent', method: 'get', params: query })
@@ -27,4 +27,12 @@ export function enableAgent(id: number) {
 
 export function disableAgent(id: number) {
   return request<void>({ url: `/aiconfig/agent/${id}/disable`, method: 'put' })
+}
+
+export function getAgentMemory(id: number) {
+  return request<AgentMemoryVO>({ url: `/aiconfig/agent/${id}/memory`, method: 'get' })
+}
+
+export function clearAgentMemory(id: number) {
+  return request<void>({ url: `/aiconfig/agent/${id}/memory`, method: 'delete' })
 }

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -344,6 +344,13 @@ export interface AgentVO {
   compressKeepMsgs?: number | null
 }
 
+/** 智能体长期记忆查看结果：exists=false 表示 MEMORY.md 尚未生成（刚开启记忆能力或已清空）。 */
+export interface AgentMemoryVO {
+  exists: boolean
+  content: string
+  updateTime: string | null
+}
+
 export interface AgentSaveRequest {
   agentName: string
   agentCode: string

--- a/customer-admin-web/src/views/aiconfig/AgentManage.vue
+++ b/customer-admin-web/src/views/aiconfig/AgentManage.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import type { FormInstance } from 'element-plus'
 import { Loading } from '@element-plus/icons-vue'
-import { createAgent, deleteAgent, disableAgent, enableAgent, pageAgents, updateAgent } from '@/api/agent'
+import { clearAgentMemory, createAgent, deleteAgent, disableAgent, enableAgent, getAgentMemory, pageAgents, updateAgent } from '@/api/agent'
 import { pageModels, testModelConnectivity } from '@/api/model'
 import { pageMcps } from '@/api/mcp'
 import { pageSkills } from '@/api/skill'
@@ -32,6 +32,7 @@ const agentOptions = ref<AgentVO[]>([])
 
 // 能力编码：value 与后端 capabilities 字段一一对应，tip 为勾选提示
 const CAPABILITY_SUBAGENT = 'subagent'
+const CAPABILITY_MEMORY = 'memory'
 const CAPABILITY_OPTIONS: { value: string; label: string; tip?: string }[] = [
   { value: 'chat', label: 'chat（对话）' },
   { value: 'vibecoding', label: 'vibecoding（代码生成）' },
@@ -40,6 +41,7 @@ const CAPABILITY_OPTIONS: { value: string; label: string; tip?: string }[] = [
   { value: 'tasklist', label: '任务列表', tip: '跟踪和维护任务列表' },
   { value: 'skill-learning', label: '学习新技能', tip: '与用户互动学习并沉淀新技能' },
   { value: 'dynamic-subagent', label: '动态子Agent', tip: '运行时按任务临时创建子 Agent，无需预先配置' },
+  { value: CAPABILITY_MEMORY, label: '长期记忆', tip: '跨会话记住对话中的关键事实，自动沉淀与归并' },
 ]
 
 function capabilityLabel(code: string) {
@@ -251,6 +253,44 @@ async function handleDelete(row: AgentVO) {
   await menuStore.refreshMenu()
 }
 
+// ---------- 长期记忆查看/清空 ----------
+const memoryDialogVisible = ref(false)
+const memoryLoading = ref(false)
+const memoryAgent = ref<AgentVO | null>(null)
+const memoryExists = ref(false)
+const memoryContent = ref('')
+const memoryUpdateTime = ref<string | null>(null)
+
+async function openMemory(row: AgentVO) {
+  memoryAgent.value = row
+  memoryDialogVisible.value = true
+  memoryLoading.value = true
+  try {
+    const result = await getAgentMemory(row.id)
+    memoryExists.value = result.exists
+    memoryContent.value = result.content
+    memoryUpdateTime.value = result.updateTime
+  } finally {
+    memoryLoading.value = false
+  }
+}
+
+async function handleClearMemory() {
+  if (!memoryAgent.value) {
+    return
+  }
+  await ElMessageBox.confirm(
+    `确认清空智能体「${memoryAgent.value.agentName}」的全部长期记忆？清空后不可恢复`,
+    '提示',
+    { type: 'warning' },
+  )
+  await clearAgentMemory(memoryAgent.value.id)
+  ElMessage.success('记忆已清空')
+  memoryExists.value = false
+  memoryContent.value = ''
+  memoryUpdateTime.value = null
+}
+
 async function handleToggleStatus(row: AgentVO) {
   if (row.status === 1) {
     await disableAgent(row.id)
@@ -307,12 +347,21 @@ onMounted(() => {
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '停用' }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="操作" width="260" fixed="right">
+        <el-table-column label="操作" width="300" fixed="right">
           <template #default="{ row }">
             <el-button v-permission="'agent:edit'" link type="primary" @click="handleToggleStatus(row)">
               {{ row.status === 1 ? '停用' : '启用' }}
             </el-button>
             <el-button v-permission="'agent:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
+            <el-button
+              v-if="row.capabilities?.includes(CAPABILITY_MEMORY)"
+              v-permission="'agent:view'"
+              link
+              type="primary"
+              @click="openMemory(row)"
+            >
+              记忆
+            </el-button>
             <el-button v-permission="'agent:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
@@ -474,6 +523,31 @@ onMounted(() => {
       </template>
     </el-dialog>
 
+    <el-dialog
+      v-model="memoryDialogVisible"
+      :title="`长期记忆 - ${memoryAgent?.agentName ?? ''}`"
+      width="640px"
+    >
+      <div v-loading="memoryLoading">
+        <template v-if="memoryExists">
+          <div class="memory-meta">最近更新：{{ memoryUpdateTime ?? '-' }}</div>
+          <pre class="memory-content">{{ memoryContent }}</pre>
+        </template>
+        <el-empty v-else description="暂无记忆，与该智能体对话后会自动沉淀" :image-size="80" />
+      </div>
+      <template #footer>
+        <el-button
+          v-permission="'agent:edit'"
+          type="danger"
+          :disabled="!memoryExists"
+          @click="handleClearMemory"
+        >
+          清空记忆
+        </el-button>
+        <el-button @click="memoryDialogVisible = false">关闭</el-button>
+      </template>
+    </el-dialog>
+
     <ChannelBindingDrawer v-model="channelBindingVisible" />
   </div>
 </template>
@@ -496,5 +570,24 @@ onMounted(() => {
   margin-top: 4px;
   font-size: 12px;
   color: #f56c6c;
+}
+
+.memory-meta {
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: #909399;
+}
+
+.memory-content {
+  max-height: 420px;
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--el-fill-color-light);
+  border-radius: 4px;
 }
 </style>

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -721,6 +721,7 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/aiconfig/mcp` / `/api/aiconfig/skill` | MCP / Skill 管理 CRUD（删除前校验是否被智能体引用，编辑后自动失效引用它的智能体运行时缓存） |
 | `/api/aiconfig/agent` | 智能体 CRUD（modelId 必填/mcpIds·skillIds 可选多选，关联表整体替换式维护） |
 | `PUT /api/aiconfig/agent/{id}/enable` / `disable` | 智能体启用/停用（联动动态菜单 + 运行时缓存失效） |
+| `GET /api/aiconfig/agent/{id}/memory` / `DELETE …/memory` | 智能体跨会话长期记忆查看/清空（`capabilities` 含 `memory` 时生效；权威存储默认落库 `ai_agent_memory`，配置 `admin.agent-memory.disk-root` 后改存磁盘） |
 | `GET /api/menu/routes` | 按当前用户权限点过滤的菜单树，`workspace` 节点下挂启用中的智能体动态节点 |
 | `GET /api/menu/version` | 菜单版本号（进程内自增），前端轻量轮询，仅版本变化才拉全量菜单 |
 | `POST /api/workspace/{agentCode}/chat/stream` | 智能体在线聊天（SSE，权限点复用 `workspace`，停用智能体报 `AGENT_DISABLED`） |
@@ -743,6 +744,13 @@ cd customer-admin-web && npm install && npm run dev
 智能体自身的 CRUD/启停、其引用的模型/MCP/Skill 编辑，都会驱动对应 agentCode 的缓存失效。
 `AgentStateStore`/`PermissionContextState` 用进程内简单实现（`AdminAgentRuntimeConfig`），刻意不复用
 `customer-work.session.*` 那套四后端可切换的持久化能力——admin 工作区是运营调试场景，过度设计不划算。
+
+**跨会话长期记忆**（`capabilities` 含 `memory`，V32 起）：Harness 分层记忆（`MemoryConfig`，对话事实自动
+flush 到 `workspace/MEMORY.md` 并定期 consolidation），按 agentCode 隔离、全部会话共享。workspace 文件只是
+框架工作副本，权威存储走 `AgentMemoryStore` SPI（`workspace.memory` 包）：默认 JDBC 落库 `ai_agent_memory`，
+配置 `admin.agent-memory.disk-root` 后改存 `{disk-root}/{agentCode}/MEMORY.md`。同步链路：构建实例时水合
+（store → workspace，权威侧为空时反向收编存量文件），`ChatService` 对话轮次结束后回写（workspace → store，
+内容未变跳过；失败只记日志不打断对话流）。运维入口在智能体管理页（查看/清空，清空同时删权威存储与工作副本）。
 
 测试：`AesGcmCryptoUtilTest`（加解密往返/掩码）、`SensitiveDataMaskerTest`（参数脱敏）、
 `SeedAdminPasswordTest`（种子哈希回归，防止手改种子脚本导致默认超管登录不了）、

--- a/mysql/02-customer-admin/32-V32__agent_memory.sql
+++ b/mysql/02-customer-admin/32-V32__agent_memory.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- 智能体跨会话长期记忆（默认存储后端）
+-- Harness 分层记忆的工作副本是 workspace/MEMORY.md（框架硬编码写磁盘），本表是它的权威存储：
+-- 构建智能体实例时从本表水合到 workspace，对话轮次结束后把变更同步回本表。
+-- 配置 admin.agent-memory.disk-root 后改走磁盘存储，本表不再读写（见 AgentMemoryStoreConfig）。
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_agent_memory` (
+    `id`          BIGINT NOT NULL AUTO_INCREMENT,
+    `agent_code`  VARCHAR(64) NOT NULL COMMENT '智能体编码（ai_agent.agent_code）',
+    `content`     LONGTEXT COMMENT '长期记忆内容（MEMORY.md 全文）',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_agent_code` (`agent_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体跨会话长期记忆（MEMORY.md 权威存储）';


### PR DESCRIPTION
## 变更说明 / What

后台智能体新增 **memory 能力（跨会话长期记忆）**：勾选后经 AgentScope Harness 分层记忆（`MemoryConfig`）在对话中自动沉淀关键事实并定期 consolidation，按 agentCode 隔离、全部会话共享——换会话、重启后智能体仍"记得"用户。

**核心设计（权威存储 + 工作副本）**：框架的分层记忆只写 `workspace/MEMORY.md`（`WorkspaceManager` 硬编码，不可改），因此新增 `AgentMemoryStore` SPI（`workspace.memory` 包）作为权威存储：

- **默认 JDBC 落库** `ai_agent_memory`（Flyway V32，已同步 `mysql/02-customer-admin/` 镜像副本）；配置 `admin.agent-memory.disk-root` 后改存 `{disk-root}/{agentCode}/MEMORY.md`
- **水合**：构建智能体实例时 store → workspace（权威侧为空且磁盘有存量文件时反向收编入库）
- **回写**：`ChatService` 对话轮次结束后 workspace → store，内容未变跳过；失败只记 error 日志不打断对话流（`AgentMemorySyncService` 是同步链路唯一异常兜底点）

**运维入口**：智能体管理页"记忆"按钮（查看 / 清空），`GET/DELETE /api/aiconfig/agent/{id}/memory`；清空同时删权威存储与 workspace 工作副本，防止旧记忆被回写还原。

**审阅要点**：
- 子智能体不叠加记忆（沿用"子智能体只构建内层 ReActAgent"的既有设计）
- `memory/` 原料目录（按日沉淀文件）不入权威存储，属 consolidation 中间产物，换机丢失可接受，已在 Javadoc 说明
- 非记忆智能体无 `MEMORY.md`，回写钩子直接短路，零开销

## 类型 / Type
- [x] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（admin-server 524 个测试通过，新增 20 个：SyncService 7 / Jdbc+Disk Store 9 / 运维 Service 4；前端 `vite build` + `vue-tsc` 通过）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循"接口 + 默认实现"约定（`AgentMemoryStore` + Jdbc 默认 / Disk 按配置切换，admin-server 无自动装配场景故用显式 `@Configuration` 选择实现）
- [x] 必要时更新了 README / 配置项说明（`docs/功能与配置全量参考.md` 接口表 + 运行时架构章节、`application.yml` 配置样例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)