### PR TITLE
feat(admin): 开发者工具箱新增 HTTP 请求工具（后端代理发送，支持常用请求方式）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/controller/DevToolHttpController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/controller/DevToolHttpController.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customeradmin.system.devtool.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolHttpSendRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolHttpSendResponse;
+import com.richard.fyoung.customeradmin.system.devtool.service.DevToolHttpService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 开发者工具箱 · HTTP 请求工具后端代理。权限复用工具箱菜单的 {@code devtools:view}
+ * （能进工具箱页面的人即可使用其中的工具，与其余工具的授权粒度保持一致）。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/devtools/http")
+public class DevToolHttpController {
+
+    private final DevToolHttpService devToolHttpService;
+
+    public DevToolHttpController(DevToolHttpService devToolHttpService) {
+        this.devToolHttpService = devToolHttpService;
+    }
+
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/send")
+    public Result<DevToolHttpSendResponse> send(@Valid @RequestBody DevToolHttpSendRequest request) {
+        return Result.success(devToolHttpService.send(request));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolHttpSendRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolHttpSendRequest.java
@@ -1,0 +1,52 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 开发者工具箱 HTTP 请求工具的发送入参：一次任意目标地址的 HTTP(S) 调用描述。
+ *
+ * <p>headers 用键值对列表而非 Map：请求头允许同名重复（如多个 Cookie），且与前端行编辑器的
+ * 数据形态天然一致。body 为原始文本，Content-Type 由前端按 Body 类型放进 headers 一并传入，
+ * 后端不单独建模。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolHttpSendRequest {
+
+    /** 请求方法，仅支持常用七种（大写）。 */
+    @NotBlank(message = "请求方法不能为空")
+    @Pattern(regexp = "GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS", message = "不支持的请求方法")
+    private String method;
+
+    /** 目标地址，仅支持 http/https。 */
+    @NotBlank(message = "URL 不能为空")
+    @Size(max = 4096, message = "URL 过长")
+    private String url;
+
+    /** 请求头列表，允许同名重复。 */
+    @Valid
+    private List<HeaderItem> headers = new ArrayList<>();
+
+    /** 请求体原始文本；GET/HEAD/OPTIONS 请求忽略该字段。 */
+    @Size(max = 1_048_576, message = "请求体不能超过 1MB")
+    private String body;
+
+    /** 单个请求头键值对。 */
+    @Data
+    public static class HeaderItem {
+
+        @NotBlank(message = "请求头名称不能为空")
+        @Size(max = 256, message = "请求头名称过长")
+        private String name;
+
+        @Size(max = 8192, message = "请求头值过长")
+        private String value;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolHttpSendResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolHttpSendResponse.java
@@ -1,0 +1,44 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 开发者工具箱 HTTP 请求工具的执行结果。
+ *
+ * <p>"目标服务连不上/超时/证书错误"对调试工具而言是要展示给用户的正常结果而非系统异常，
+ * 所以统一收敛进 {@link #error} 字段随 200 返回；只有 SSRF 拦截、参数非法这类"请求根本不该发出"
+ * 的场景才走业务异常。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@Builder
+public class DevToolHttpSendResponse {
+
+    /** HTTP 状态码；请求未发出/未收到响应时为 null。 */
+    private Integer statusCode;
+
+    /** 响应头（同名头合并为值列表）。 */
+    private Map<String, List<String>> headers;
+
+    /** 响应体文本（按 UTF-8 解码，超限截断）。 */
+    private String body;
+
+    /** 响应体原始字节数（截断前的真实大小）。 */
+    private Long bodyBytes;
+
+    /** 响应体是否因超过大小上限被截断。 */
+    private boolean bodyTruncated;
+
+    /** 本次请求耗时（毫秒）。 */
+    private long durationMs;
+
+    /** 3xx 响应的 Location 头（工具不自动跟随重定向，由用户决定是否跟进下一跳）。 */
+    private String redirectLocation;
+
+    /** 失败原因；成功时为 null。 */
+    private String error;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolHttpService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolHttpService.java
@@ -1,0 +1,169 @@
+package com.richard.fyoung.customeradmin.system.devtool.service;
+
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.tool.SystemToolHttpGuard;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolHttpSendRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolHttpSendResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 开发者工具箱 HTTP 请求工具：代理前端发起真实 HTTP(S) 调用（浏览器直连会被目标站 CORS 拦截，
+ * 故由后端出网）。
+ *
+ * <p>用 JDK 内建 {@link HttpClient} 而非 RestTemplate：智能体侧 httpclient 工具用的
+ * {@code SimpleClientHttpRequestFactory} 基于 HttpURLConnection，不支持 PATCH 方法，
+ * 而本工具要求覆盖常用七种方法。</p>
+ *
+ * <p>安全说明（与智能体 httpclient 工具同一套收口）：SSRF 面复用唯一防御点
+ * {@link SystemToolHttpGuard}（默认拒内网/环回、放公网，配 {@code admin.system-tool.http.allowed-hosts}
+ * 白名单后仅放行白名单内 host）；配套**禁止自动跟随重定向**（{@link HttpClient.Redirect#NEVER}），
+ * 3xx 作为终态结果返回并带回 Location——否则"合规公网域名 302 指向内网地址"即可绕过校验。
+ * TLS 走 JDK 默认信任链校验，不做 trust-all。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class DevToolHttpService {
+
+    private static final Logger log = LoggerFactory.getLogger(DevToolHttpService.class);
+
+    private static final String ERROR_CODE_SEND_FAIL = "DEVTOOL-HTTP-SEND-FAIL";
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    /** 单次请求（含读取完整响应）总时限。 */
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+    /** 响应体展示上限，超出部分截断（调试工具按文本展示，不承载大文件下载）。 */
+    private static final int MAX_RESPONSE_BODY_BYTES = 1_048_576;
+
+    /** 不允许发送请求体的方法（语义上无 body，且部分服务端会拒绝）。 */
+    private static final Set<String> NO_BODY_METHODS = Set.of("GET", "HEAD", "OPTIONS");
+
+    /**
+     * JDK HttpClient 禁止业务设置的请求头（由客户端自动生成，设置会抛 IllegalArgumentException），
+     * 组装时静默跳过，与主流调试工具（Postman 等对 auto header）的行为一致。
+     */
+    private static final Set<String> RESTRICTED_HEADERS =
+        Set.of("connection", "content-length", "expect", "host", "upgrade");
+
+    private final SystemToolHttpGuard httpGuard;
+    private final HttpClient httpClient;
+
+    public DevToolHttpService(SystemToolHttpGuard httpGuard) {
+        this.httpGuard = httpGuard;
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+    }
+
+    /**
+     * 发起一次 HTTP(S) 调用并返回执行结果；目标服务不可达/超时等收敛进 error 字段，
+     * SSRF 拦截与参数非法则 fast fail 抛业务异常。
+     */
+    public DevToolHttpSendResponse send(DevToolHttpSendRequest request) {
+        String url = request.getUrl().trim();
+        checkScheme(url);
+        // SSRF 收口：发起请求前统一校验目标地址（复用系统工具链路的唯一防御点），命中安全策略 fast fail
+        httpGuard.checkAllowed(url);
+
+        HttpRequest httpRequest = buildRequest(request, url);
+        long start = System.currentTimeMillis();
+        try {
+            HttpResponse<byte[]> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
+            return buildResponse(response, System.currentTimeMillis() - start);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("devtool http send interrupted, code={}, method={}, url={}",
+                ERROR_CODE_SEND_FAIL, request.getMethod(), url, e);
+            return failure("请求被中断", System.currentTimeMillis() - start);
+        } catch (Exception e) {
+            log.error("devtool http send failed, code={}, method={}, url={}",
+                ERROR_CODE_SEND_FAIL, request.getMethod(), url, e);
+            return failure(describeFailure(e), System.currentTimeMillis() - start);
+        }
+    }
+
+    /** 仅放行 http/https：file/ftp 等协议既无调试意义，JDK HttpClient 也不支持。 */
+    private void checkScheme(String url) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+            throw new BizException(ResultCode.PARAM_INVALID, "仅支持 http/https 协议的 URL");
+        }
+    }
+
+    private HttpRequest buildRequest(DevToolHttpSendRequest request, String url) {
+        HttpRequest.Builder builder;
+        try {
+            builder = HttpRequest.newBuilder(URI.create(url)).timeout(REQUEST_TIMEOUT);
+        } catch (IllegalArgumentException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "URL 格式非法: " + e.getMessage());
+        }
+
+        if (!CollectionUtils.isEmpty(request.getHeaders())) {
+            for (DevToolHttpSendRequest.HeaderItem item : request.getHeaders()) {
+                String name = item.getName().trim();
+                if (RESTRICTED_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
+                    continue;
+                }
+                try {
+                    builder.header(name, item.getValue() == null ? "" : item.getValue());
+                } catch (IllegalArgumentException e) {
+                    throw new BizException(ResultCode.PARAM_INVALID, "请求头不合法: " + name);
+                }
+            }
+        }
+
+        String method = request.getMethod();
+        HttpRequest.BodyPublisher bodyPublisher =
+            !NO_BODY_METHODS.contains(method) && StringUtils.hasText(request.getBody())
+                ? HttpRequest.BodyPublishers.ofString(request.getBody(), StandardCharsets.UTF_8)
+                : HttpRequest.BodyPublishers.noBody();
+        return builder.method(method, bodyPublisher).build();
+    }
+
+    private DevToolHttpSendResponse buildResponse(HttpResponse<byte[]> response, long durationMs) {
+        byte[] bytes = response.body() == null ? new byte[0] : response.body();
+        boolean truncated = bytes.length > MAX_RESPONSE_BODY_BYTES;
+        String bodyText = new String(bytes, 0, Math.min(bytes.length, MAX_RESPONSE_BODY_BYTES), StandardCharsets.UTF_8);
+        return DevToolHttpSendResponse.builder()
+            .statusCode(response.statusCode())
+            .headers(response.headers().map())
+            .body(bodyText)
+            .bodyBytes((long) bytes.length)
+            .bodyTruncated(truncated)
+            .durationMs(durationMs)
+            .redirectLocation(response.headers().firstValue("location").orElse(null))
+            .build();
+    }
+
+    private DevToolHttpSendResponse failure(String error, long durationMs) {
+        return DevToolHttpSendResponse.builder().error(error).durationMs(durationMs).build();
+    }
+
+    /** 把常见网络异常翻译成用户可读的失败原因（异常类型名对非开发者不友好）。 */
+    private String describeFailure(Exception e) {
+        if (e instanceof java.net.http.HttpTimeoutException) {
+            return "请求超时（超过 " + REQUEST_TIMEOUT.getSeconds() + " 秒未完成）";
+        }
+        if (e instanceof java.net.ConnectException) {
+            return "连接目标服务失败: " + e.getMessage();
+        }
+        if (e instanceof javax.net.ssl.SSLException) {
+            return "TLS 握手失败（证书校验不通过或协议不匹配）: " + e.getMessage();
+        }
+        return e.getClass().getSimpleName() + ": " + e.getMessage();
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolHttpServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolHttpServiceTest.java
@@ -1,0 +1,214 @@
+package com.richard.fyoung.customeradmin.system.devtool.service;
+
+import com.richard.fyoung.customeradmin.aiconfig.systemtool.tool.SystemToolHttpGuard;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.config.AdminSystemToolProperties;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolHttpSendRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolHttpSendResponse;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DevToolHttpService} 单测：起本地临时 {@link HttpServer}（JDK 内置，不引入 WireMock）验证
+ * 常用方法的请求组装、响应解析、大响应截断、重定向不跟随，以及目标不可达返回 error 字段而非抛异常；
+ * 另验证 SSRF 收口（默认拒环回）与协议校验的 fast fail 行为。
+ * @author owlzhangfq@gmail.com
+ */
+class DevToolHttpServiceTest {
+
+    // 本地临时 server 监听 127.0.0.1（环回），默认模式会被 SSRF 收口拦截；
+    // 用白名单模式显式放行 127.0.0.1，让请求组装/响应解析用例照常验证。
+    private final DevToolHttpService service = new DevToolHttpService(loopbackAllowedGuard());
+
+    private static SystemToolHttpGuard loopbackAllowedGuard() {
+        AdminSystemToolProperties properties = new AdminSystemToolProperties();
+        properties.getHttp().setAllowedHosts(List.of("127.0.0.1"));
+        return new SystemToolHttpGuard(properties);
+    }
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        // 回显 handler：把"收到的方法 + 指定请求头 + 请求体"写回响应体，供断言核对请求组装是否正确。
+        server.createContext("/echo", exchange -> {
+            String method = exchange.getRequestMethod();
+            String customHeader = exchange.getRequestHeaders().getFirst("X-Devtool-Test");
+            byte[] reqBody = exchange.getRequestBody().readAllBytes();
+            String text = "method=" + method + ";header=" + customHeader
+                + ";body=" + new String(reqBody, StandardCharsets.UTF_8);
+            byte[] resp = text.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("X-Echo-Resp", "yes");
+            exchange.sendResponseHeaders(200, resp.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(resp);
+            }
+        });
+        // 大响应 handler：回 1MB + 1 字节，验证截断
+        server.createContext("/large", exchange -> {
+            byte[] resp = new byte[1_048_577];
+            exchange.sendResponseHeaders(200, resp.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(resp);
+            }
+        });
+        // 重定向 handler：302 指向 /echo，验证不自动跟随
+        server.createContext("/redirect", exchange -> {
+            exchange.getResponseHeaders().add("Location", "/echo");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    private DevToolHttpSendRequest request(String method, String url) {
+        DevToolHttpSendRequest req = new DevToolHttpSendRequest();
+        req.setMethod(method);
+        req.setUrl(url);
+        return req;
+    }
+
+    private static DevToolHttpSendRequest.HeaderItem header(String name, String value) {
+        DevToolHttpSendRequest.HeaderItem item = new DevToolHttpSendRequest.HeaderItem();
+        item.setName(name);
+        item.setValue(value);
+        return item;
+    }
+
+    @Test
+    void get_shouldReturn200WithBodyAndHeaders() {
+        DevToolHttpSendResponse resp = service.send(request("GET", baseUrl + "/echo"));
+
+        assertEquals(200, resp.getStatusCode());
+        assertTrue(resp.getBody().contains("method=GET"));
+        assertNotNull(resp.getHeaders());
+        assertEquals(List.of("yes"), resp.getHeaders().get("x-echo-resp"));
+        assertTrue(resp.getDurationMs() >= 0);
+        assertNull(resp.getError());
+        assertFalse(resp.isBodyTruncated());
+    }
+
+    @Test
+    void post_shouldSendBodyAndCustomHeader() {
+        DevToolHttpSendRequest req = request("POST", baseUrl + "/echo");
+        req.setHeaders(List.of(header("X-Devtool-Test", "hello"), header("Content-Type", "application/json")));
+        req.setBody("{\"a\":1}");
+
+        DevToolHttpSendResponse resp = service.send(req);
+
+        assertEquals(200, resp.getStatusCode());
+        assertTrue(resp.getBody().contains("method=POST"));
+        assertTrue(resp.getBody().contains("header=hello"));
+        assertTrue(resp.getBody().contains("body={\"a\":1}"));
+    }
+
+    @Test
+    void patch_shouldBeSupported() {
+        DevToolHttpSendRequest req = request("PATCH", baseUrl + "/echo");
+        req.setBody("patched");
+
+        DevToolHttpSendResponse resp = service.send(req);
+
+        assertEquals(200, resp.getStatusCode());
+        assertTrue(resp.getBody().contains("method=PATCH"));
+        assertTrue(resp.getBody().contains("body=patched"));
+    }
+
+    @Test
+    void get_shouldIgnoreBodyEvenIfProvided() {
+        DevToolHttpSendRequest req = request("GET", baseUrl + "/echo");
+        req.setBody("should-not-send");
+
+        DevToolHttpSendResponse resp = service.send(req);
+
+        assertTrue(resp.getBody().contains("body=;") || resp.getBody().endsWith("body="));
+    }
+
+    @Test
+    void head_shouldReturnStatusWithoutBody() {
+        DevToolHttpSendResponse resp = service.send(request("HEAD", baseUrl + "/echo"));
+
+        assertEquals(200, resp.getStatusCode());
+        assertEquals("", resp.getBody());
+        assertNull(resp.getError());
+    }
+
+    @Test
+    void largeResponse_shouldBeTruncatedWithRealSizeReported() {
+        DevToolHttpSendResponse resp = service.send(request("GET", baseUrl + "/large"));
+
+        assertEquals(200, resp.getStatusCode());
+        assertTrue(resp.isBodyTruncated());
+        assertEquals(1_048_577L, resp.getBodyBytes());
+        assertEquals(1_048_576, resp.getBody().getBytes(StandardCharsets.UTF_8).length);
+    }
+
+    @Test
+    void redirect_shouldNotFollowAndReturnLocation() {
+        DevToolHttpSendResponse resp = service.send(request("GET", baseUrl + "/redirect"));
+
+        assertEquals(302, resp.getStatusCode());
+        assertEquals("/echo", resp.getRedirectLocation());
+    }
+
+    @Test
+    void restrictedHeader_shouldBeSkippedSilently() {
+        DevToolHttpSendRequest req = request("GET", baseUrl + "/echo");
+        req.setHeaders(List.of(header("Host", "evil.example.com"), header("X-Devtool-Test", "kept")));
+
+        DevToolHttpSendResponse resp = service.send(req);
+
+        assertEquals(200, resp.getStatusCode());
+        assertTrue(resp.getBody().contains("header=kept"));
+    }
+
+    @Test
+    void unreachableTarget_shouldReturnErrorFieldInsteadOfThrowing() throws Exception {
+        int freePort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            freePort = socket.getLocalPort();
+        }
+
+        DevToolHttpSendResponse resp = service.send(request("GET", "http://127.0.0.1:" + freePort + "/x"));
+
+        assertNull(resp.getStatusCode());
+        assertNotNull(resp.getError());
+    }
+
+    @Test
+    void loopbackTarget_shouldBeBlockedByDefaultGuard() {
+        // 默认模式（空白名单）：环回地址被 SSRF 收口拦截，fast fail 抛业务异常
+        DevToolHttpService defaultService =
+            new DevToolHttpService(new SystemToolHttpGuard(new AdminSystemToolProperties()));
+
+        assertThrows(BizException.class, () -> defaultService.send(request("GET", baseUrl + "/echo")));
+    }
+
+    @Test
+    void nonHttpScheme_shouldFastFail() {
+        assertThrows(BizException.class, () -> service.send(request("GET", "ftp://127.0.0.1/file")));
+    }
+}

--- a/customer-admin-web/src/api/devtools.ts
+++ b/customer-admin-web/src/api/devtools.ts
@@ -1,0 +1,33 @@
+import { request } from './request'
+
+/** 请求头/参数的键值对（允许同名重复，与后端 DTO 对齐） */
+export interface HttpKeyValueItem {
+  name: string
+  value: string
+}
+
+export interface HttpSendRequest {
+  method: string
+  url: string
+  headers: HttpKeyValueItem[]
+  body?: string
+}
+
+export interface HttpSendResponse {
+  statusCode: number | null
+  headers: Record<string, string[]> | null
+  body: string | null
+  bodyBytes: number | null
+  bodyTruncated: boolean
+  durationMs: number
+  redirectLocation: string | null
+  error: string | null
+}
+
+/** 后端单次请求总时限 30s（含读取完整响应），前端在其上留出网络与序列化余量。 */
+const HTTP_TOOL_TIMEOUT_MS = 45000
+
+/** 开发者工具箱 · HTTP 请求工具：由后端代理发起真实请求（浏览器直连会被目标站 CORS 拦截）。 */
+export function sendHttpRequest(data: HttpSendRequest) {
+  return request<HttpSendResponse>({ url: '/devtools/http/send', method: 'post', data, timeout: HTTP_TOOL_TIMEOUT_MS })
+}

--- a/customer-admin-web/src/views/system/DevToolboxView.vue
+++ b/customer-admin-web/src/views/system/DevToolboxView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-// 开发者工具箱：左侧工具导航（带搜索）+ 右侧当前工具面板。全部本地计算，不调任何后端接口。
+// 开发者工具箱：左侧工具导航（带搜索）+ 右侧当前工具面板。除 HTTP 请求工具经后端代理发送外，
+// 其余工具全部本地计算不调后端接口。
 // 当前工具用 route query ?tool= 同步，支持浏览器收藏直达/刷新保持；query 缺失或指向不存在的工具时
 // 兜底规整成默认工具（第一个），保持 URL 与实际展示始终一致。
 import { computed, defineAsyncComponent, ref, watch } from 'vue'

--- a/customer-admin-web/src/views/system/devtools/HttpRequestTool.vue
+++ b/customer-admin-web/src/views/system/devtools/HttpRequestTool.vue
@@ -1,0 +1,345 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import hljs from 'highlight.js/lib/core'
+import json from 'highlight.js/lib/languages/json'
+import { sendHttpRequest, type HttpKeyValueItem, type HttpSendResponse } from '@/api/devtools'
+import { usePersistedRef } from './composables/useToolStorage'
+import CopyButton from './CopyButton.vue'
+import KeyValueEditor from './KeyValueEditor.vue'
+
+hljs.registerLanguage('json', json)
+
+// 与后端 DevToolHttpSendRequest 的方法白名单保持一致
+const METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'] as const
+
+/** 语义上无请求体的方法（后端同样会忽略其 body），Body 页给出提示 */
+const NO_BODY_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+type BodyType = 'none' | 'json' | 'form' | 'raw'
+
+const method = usePersistedRef<string>('http:method', 'GET')
+const url = usePersistedRef('http:url', '')
+const params = usePersistedRef<HttpKeyValueItem[]>('http:params', [])
+const headers = usePersistedRef<HttpKeyValueItem[]>('http:headers', [])
+const bodyType = usePersistedRef<BodyType>('http:bodyType', 'none')
+const jsonBody = usePersistedRef('http:jsonBody', '')
+const formItems = usePersistedRef<HttpKeyValueItem[]>('http:formItems', [])
+const rawBody = usePersistedRef('http:rawBody', '')
+const rawContentType = usePersistedRef('http:rawContentType', 'text/plain')
+
+const activeRequestTab = ref('params')
+const activeResponseTab = ref('body')
+const sending = ref(false)
+const response = ref<HttpSendResponse | null>(null)
+
+const methodHasBody = computed(() => !NO_BODY_METHODS.has(method.value))
+
+/** 过滤掉名称为空的行（编辑器允许留空行，发送时忽略） */
+function effectiveItems(items: HttpKeyValueItem[]): HttpKeyValueItem[] {
+  return items.filter((item) => item.name.trim() !== '')
+}
+
+/** Params 合并进 URL：保留 URL 上已有的 query，追加编辑器里的参数并做 URL 编码 */
+function buildUrl(): string {
+  const base = url.value.trim()
+  const items = effectiveItems(params.value)
+  if (items.length === 0) return base
+  const search = items
+    .map((item) => `${encodeURIComponent(item.name.trim())}=${encodeURIComponent(item.value)}`)
+    .join('&')
+  return base + (base.includes('?') ? '&' : '?') + search
+}
+
+/** 按 Body 类型自动补 Content-Type（用户已显式填写同名头时不覆盖） */
+function buildHeaders(): HttpKeyValueItem[] {
+  const items = effectiveItems(headers.value).map((item) => ({ name: item.name.trim(), value: item.value }))
+  const hasContentType = items.some((item) => item.name.toLowerCase() === 'content-type')
+  if (!hasContentType && methodHasBody.value) {
+    if (bodyType.value === 'json') {
+      items.push({ name: 'Content-Type', value: 'application/json' })
+    } else if (bodyType.value === 'form') {
+      items.push({ name: 'Content-Type', value: 'application/x-www-form-urlencoded' })
+    } else if (bodyType.value === 'raw' && rawContentType.value.trim()) {
+      items.push({ name: 'Content-Type', value: rawContentType.value.trim() })
+    }
+  }
+  return items
+}
+
+function buildBody(): string | undefined {
+  if (!methodHasBody.value || bodyType.value === 'none') return undefined
+  if (bodyType.value === 'json') return jsonBody.value || undefined
+  if (bodyType.value === 'form') {
+    const items = effectiveItems(formItems.value)
+    if (items.length === 0) return undefined
+    return items
+      .map((item) => `${encodeURIComponent(item.name.trim())}=${encodeURIComponent(item.value)}`)
+      .join('&')
+  }
+  return rawBody.value || undefined
+}
+
+function formatJsonBody() {
+  try {
+    jsonBody.value = JSON.stringify(JSON.parse(jsonBody.value), null, 2)
+  } catch {
+    ElMessage.error('JSON 格式非法，无法格式化')
+  }
+}
+
+async function send() {
+  const target = url.value.trim()
+  if (!target) {
+    ElMessage.error('请输入请求 URL')
+    return
+  }
+  sending.value = true
+  response.value = null
+  try {
+    response.value = await sendHttpRequest({
+      method: method.value,
+      url: buildUrl(),
+      headers: buildHeaders(),
+      body: buildBody(),
+    })
+    activeResponseTab.value = 'body'
+  } catch {
+    // 业务失败（SSRF 拦截/参数非法等）request.ts 拦截器已统一弹出错误消息，这里无需重复处理
+  } finally {
+    sending.value = false
+  }
+}
+
+const statusTagType = computed(() => {
+  const code = response.value?.statusCode
+  if (!code) return 'danger'
+  if (code < 300) return 'success'
+  if (code < 400) return 'warning'
+  return 'danger'
+})
+
+/** 响应体展示：是合法 JSON 时自动美化 + 高亮，否则按纯文本原样展示 */
+const prettyBody = computed(() => {
+  const body = response.value?.body
+  if (!body) return { text: '', highlighted: '', isJson: false }
+  try {
+    const text = JSON.stringify(JSON.parse(body), null, 2)
+    return { text, highlighted: hljs.highlight(text, { language: 'json' }).value, isJson: true }
+  } catch {
+    return { text: body, highlighted: '', isJson: false }
+  }
+})
+
+const responseHeaderRows = computed(() => {
+  const map = response.value?.headers
+  if (!map) return []
+  return Object.entries(map)
+    .map(([name, values]) => ({ name, value: values.join(', ') }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}
+</script>
+
+<template>
+  <div class="http-tool">
+    <el-alert
+      type="info"
+      :closable="false"
+      show-icon
+      title="请求由后端服务代理发出（不受浏览器 CORS 限制）；出于安全策略默认拦截内网/环回地址，可通过 admin.system-tool.http.allowed-hosts 白名单放行。"
+      class="tool-tip"
+    />
+
+    <div class="request-line">
+      <el-select v-model="method" class="method-select">
+        <el-option v-for="m in METHODS" :key="m" :label="m" :value="m" />
+      </el-select>
+      <el-input
+        v-model="url"
+        placeholder="https://example.com/api/path"
+        class="url-input"
+        clearable
+        @keyup.enter="send"
+      />
+      <el-button type="primary" :loading="sending" @click="send">发送</el-button>
+    </div>
+
+    <el-tabs v-model="activeRequestTab" class="request-tabs">
+      <el-tab-pane :label="`Params (${params.filter((p) => p.name.trim()).length})`" name="params">
+        <div class="pane-hint">发送时自动 URL 编码后追加到地址栏 query，URL 上已有的参数保留。</div>
+        <KeyValueEditor v-model="params" name-placeholder="参数名" value-placeholder="参数值" />
+      </el-tab-pane>
+      <el-tab-pane :label="`Headers (${headers.filter((h) => h.name.trim()).length})`" name="headers">
+        <div class="pane-hint">
+          Host / Content-Length / Connection 等由客户端自动生成的请求头会被忽略；未显式填写 Content-Type 时按 Body
+          类型自动补齐。
+        </div>
+        <KeyValueEditor v-model="headers" name-placeholder="请求头名称" value-placeholder="请求头值" />
+      </el-tab-pane>
+      <el-tab-pane label="Body" name="body">
+        <el-alert
+          v-if="!methodHasBody"
+          type="info"
+          :closable="false"
+          :title="`${method} 请求不发送请求体`"
+          class="no-body-tip"
+        />
+        <template v-else>
+          <el-radio-group v-model="bodyType" class="body-type-group">
+            <el-radio-button value="none">none</el-radio-button>
+            <el-radio-button value="json">JSON</el-radio-button>
+            <el-radio-button value="form">form-urlencoded</el-radio-button>
+            <el-radio-button value="raw">raw</el-radio-button>
+          </el-radio-group>
+
+          <template v-if="bodyType === 'json'">
+            <div class="body-toolbar">
+              <el-button size="small" @click="formatJsonBody">格式化</el-button>
+            </div>
+            <el-input v-model="jsonBody" type="textarea" :rows="8" placeholder='{"key": "value"}' />
+          </template>
+          <KeyValueEditor
+            v-else-if="bodyType === 'form'"
+            v-model="formItems"
+            name-placeholder="字段名"
+            value-placeholder="字段值"
+          />
+          <template v-else-if="bodyType === 'raw'">
+            <div class="body-toolbar">
+              <span class="raw-ct-label">Content-Type</span>
+              <el-input v-model="rawContentType" placeholder="text/plain" class="raw-ct-input" />
+            </div>
+            <el-input v-model="rawBody" type="textarea" :rows="8" placeholder="请求体原始内容" />
+          </template>
+        </template>
+      </el-tab-pane>
+    </el-tabs>
+
+    <template v-if="response">
+      <el-divider content-position="left">响应</el-divider>
+
+      <el-alert v-if="response.error" type="error" :closable="false" show-icon :title="response.error" />
+      <template v-else>
+        <div class="response-meta">
+          <el-tag :type="statusTagType" size="large">{{ response.statusCode }}</el-tag>
+          <span class="meta-item">耗时 {{ response.durationMs }} ms</span>
+          <span class="meta-item">大小 {{ formatBytes(response.bodyBytes) }}</span>
+          <el-tag v-if="response.bodyTruncated" type="warning">响应体超过 1MB，已截断展示</el-tag>
+          <span v-if="response.redirectLocation" class="meta-item">
+            重定向至：{{ response.redirectLocation }}（工具不自动跟随，如需继续请手动更换 URL）
+          </span>
+        </div>
+
+        <el-tabs v-model="activeResponseTab">
+          <el-tab-pane label="响应体" name="body">
+            <div class="body-toolbar">
+              <CopyButton :text="prettyBody.text" label="响应体" />
+            </div>
+            <el-scrollbar max-height="420px" class="response-body">
+              <pre v-if="prettyBody.isJson" class="body-pre hljs" v-html="prettyBody.highlighted"></pre>
+              <pre v-else class="body-pre">{{ prettyBody.text || '(空响应体)' }}</pre>
+            </el-scrollbar>
+          </el-tab-pane>
+          <el-tab-pane :label="`响应头 (${responseHeaderRows.length})`" name="headers">
+            <el-table :data="responseHeaderRows" size="small" border>
+              <el-table-column prop="name" label="名称" width="280" />
+              <el-table-column prop="value" label="值" />
+            </el-table>
+          </el-tab-pane>
+        </el-tabs>
+      </template>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.http-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tool-tip :deep(.el-alert__title) {
+  line-height: 1.6;
+}
+
+.request-line {
+  display: flex;
+  gap: 8px;
+}
+
+.method-select {
+  width: 120px;
+  flex-shrink: 0;
+}
+
+.url-input {
+  flex: 1;
+}
+
+.pane-hint {
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+.no-body-tip {
+  margin-top: 4px;
+}
+
+.body-type-group {
+  margin-bottom: 10px;
+}
+
+.body-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.raw-ct-label {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  flex-shrink: 0;
+}
+
+.raw-ct-input {
+  width: 260px;
+}
+
+.response-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.meta-item {
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+}
+
+.response-body {
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-fill-color-lighter);
+}
+
+.body-pre {
+  margin: 0;
+  padding: 12px;
+  font-family: var(--el-font-family-mono, 'SFMono-Regular', Consolas, monospace);
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/KeyValueEditor.vue
+++ b/customer-admin-web/src/views/system/devtools/KeyValueEditor.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { HttpKeyValueItem } from '@/api/devtools'
+
+// Params/Headers/Form 三处共用的键值对行编辑器：行内删除 + 底部添加，空行在发送时由调用方过滤
+const props = withDefaults(
+  defineProps<{
+    modelValue: HttpKeyValueItem[]
+    namePlaceholder?: string
+    valuePlaceholder?: string
+  }>(),
+  {
+    namePlaceholder: '名称',
+    valuePlaceholder: '值',
+  },
+)
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: HttpKeyValueItem[]): void }>()
+
+function updateItem(index: number, patch: Partial<HttpKeyValueItem>) {
+  const next = props.modelValue.map((item, i) => (i === index ? { ...item, ...patch } : item))
+  emit('update:modelValue', next)
+}
+
+function removeItem(index: number) {
+  emit(
+    'update:modelValue',
+    props.modelValue.filter((_, i) => i !== index),
+  )
+}
+
+function addItem() {
+  emit('update:modelValue', [...props.modelValue, { name: '', value: '' }])
+}
+</script>
+
+<template>
+  <div class="kv-editor">
+    <div v-for="(item, index) in modelValue" :key="index" class="kv-row">
+      <el-input
+        :model-value="item.name"
+        :placeholder="namePlaceholder"
+        class="kv-name"
+        @update:model-value="(v: string) => updateItem(index, { name: v })"
+      />
+      <el-input
+        :model-value="item.value"
+        :placeholder="valuePlaceholder"
+        class="kv-value"
+        @update:model-value="(v: string) => updateItem(index, { value: v })"
+      />
+      <el-button link type="danger" @click="removeItem(index)">
+        <el-icon><Delete /></el-icon>
+      </el-button>
+    </div>
+    <el-button link type="primary" @click="addItem">
+      <el-icon><Plus /></el-icon>
+      添加一行
+    </el-button>
+  </div>
+</template>
+
+<style scoped>
+.kv-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kv-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.kv-name {
+  width: 260px;
+  flex-shrink: 0;
+}
+
+.kv-value {
+  flex: 1;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/toolRegistry.ts
+++ b/customer-admin-web/src/views/system/devtools/toolRegistry.ts
@@ -9,7 +9,8 @@ export interface DevTool {
 
 /**
  * 开发者工具箱的工具清单，供左侧导航渲染与搜索过滤，以及右侧按 key 动态加载对应组件。
- * 全部本地计算，不调任何后端接口。第一项是默认工具（route query 缺失/非法时兜底展示）。
+ * 除 HTTP 请求工具经后端代理发送外，其余工具全部本地计算不调后端接口。
+ * 第一项是默认工具（route query 缺失/非法时兜底展示）。
  */
 export const devTools: DevTool[] = [
   {
@@ -41,6 +42,12 @@ export const devTools: DevTool[] = [
     label: '正则测试',
     description: '匹配高亮、捕获组列表、替换预览',
     component: () => import('./RegexTool.vue'),
+  },
+  {
+    key: 'http',
+    label: 'HTTP 请求',
+    description: 'GET/POST/PUT/DELETE/PATCH 等，后端代理发送免 CORS',
+    component: () => import('./HttpRequestTool.vue'),
   },
 ]
 


### PR DESCRIPTION
## 变更说明 / What

开发者工具箱新增第 6 个工具「HTTP 请求」：类 Postman 的接口调试工具，支持 GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS 七种常用请求方式。

浏览器直连目标地址会被 CORS 拦截，故请求由 admin-server 后端代理发出：

**后端（customer-admin-server，新增 `system/devtool` 包）**
- `POST /api/devtools/http/send`，权限复用工具箱菜单已有的 `devtools:view`（无新增迁移）
- 用 JDK 17 内建 `java.net.http.HttpClient`：智能体侧 httpclient 工具的 `SimpleClientHttpRequestFactory`（HttpURLConnection）不支持 PATCH，本工具要求全方法覆盖
- SSRF 面复用现有唯一防御点 `SystemToolHttpGuard`（默认拒内网/环回放公网，`admin.system-tool.http.allowed-hosts` 白名单收紧；本地调试内网接口时配置白名单放行）；配套禁自动重定向（`Redirect.NEVER`），3xx 作为终态带回 Location，防"公网域名 302 指内网"绕过
- 响应体 1MB 截断（带 `bodyTruncated` 标志与真实字节数）；目标不可达/超时/TLS 失败收敛为 `error` 字段正常返回（对调试工具是结果不是异常），仅 SSRF 拦截与参数非法抛业务异常

**前端（customer-admin-web）**
- `HttpRequestTool.vue` 注册进 `toolRegistry`：方法/URL/Params/Headers/Body(none/JSON/form-urlencoded/raw) 编辑，Content-Type 按 Body 类型自动补齐（用户显式填写时不覆盖）
- 响应展示：状态码着色（2xx/3xx/4xx+）、耗时、大小、响应头表格；JSON 响应自动美化 + 高亮 + 一键复制；输入 localStorage 持久化
- `KeyValueEditor.vue` 供 Params/Headers/form 三处复用
- 工具箱"全部本地计算"的注释同步更新为"除 HTTP 请求工具经后端代理外"

## 类型 / Type
- [x] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（隔离 worktree 实测 admin-server 535 个测试 0 失败；新增 `DevToolHttpServiceTest` 11 例：方法组装/大响应截断/重定向不跟随/受限请求头跳过/目标不可达/SSRF 默认拦截/协议校验）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 无新增外部后端（SSRF 防护与配置项复用既有 `SystemToolHttpGuard` / `admin.system-tool.http.*`）
- [x] 无新增配置项，docs 无工具箱专章，无需文档更新

## 审阅提示 / Notes

- 前端 `vite build` 通过；工具页在登录墙后，UI 建议本地跑 5174 实测一次
- 权限粒度沿用"能进工具箱页面即可用其中所有工具"（`devtools:view`），如需为出网调试单独设权限码可后续加 V28 迁移

🤖 Generated with [Claude Code](https://claude.com/claude-code)