### PR TITLE
feat(admin): Skill zip 上传支持完整技能包（附属文件解析/存储/运行时加载）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/controller/SkillController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/controller/SkillController.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.aiconfig.skill.controller;
 import cn.dev33.satoken.annotation.SaCheckPermission;
 import cn.dev33.satoken.annotation.SaMode;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadParseResult;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillVO;
 import com.richard.fyoung.customeradmin.aiconfig.skill.service.SkillService;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
@@ -71,10 +72,10 @@ public class SkillController {
         return Result.success();
     }
 
-    /** 解析上传的 .md/.zip 文件为 SKILL.md 正文，不落库——前端拿到内容回填表单，仍走 create/update 保存。 */
+    /** 解析上传的 .md/.zip 文件为技能包（SKILL.md 正文 + 附属文件），不落库——前端回填表单后仍走 create/update 保存。 */
     @SaCheckPermission(value = {"skill:add", "skill:edit"}, mode = SaMode.OR)
     @PostMapping("/parse-upload")
-    public Result<String> parseUpload(@RequestParam("file") MultipartFile file) {
+    public Result<SkillUploadParseResult> parseUpload(@RequestParam("file") MultipartFile file) {
         return Result.success(skillService.parseUploadContent(file));
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillFileVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillFileVO.java
@@ -1,0 +1,10 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.dto;
+
+/**
+ * Skill 附属文件展示项（列表/详情用，不带文件内容）。
+ * @author owlzhangfq@gmail.com
+ */
+public record SkillFileVO(
+    String filePath,
+    Long fileSize) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillSaveRequest.java
@@ -15,5 +15,10 @@ public record SkillSaveRequest(
     String description,
     Integer status,
     /** 存储目标：local/nacos/sftp 多选，空/null 时默认 ["local"]。 */
-    List<String> storageTargets) {
+    List<String> storageTargets,
+    /**
+     * 附属文件（zip 上传解析所得，见 {@link SkillUploadParseResult}）：
+     * null = 保持现有文件不变（编辑但未重新上传）；非 null（含空列表）= 全量替换。
+     */
+    List<SkillUploadFile> files) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillUploadFile.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillUploadFile.java
@@ -1,0 +1,14 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.dto;
+
+/**
+ * Skill 附属文件传输载体（parse-upload 响应与保存请求共用）。
+ *
+ * <p>文本/二进制统一走 base64，避免 JSON 传输破坏字节；{@code filePath} 是相对 SKILL.md
+ * 所在目录的路径（如 {@code references/api.md}），路径合法性在 {@code SkillService} 统一校验。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record SkillUploadFile(
+    String filePath,
+    Long fileSize,
+    String contentBase64) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillUploadParseResult.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillUploadParseResult.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.dto;
+
+import java.util.List;
+
+/**
+ * parse-upload 解析结果：SKILL.md 正文 + zip 内全部附属文件。
+ *
+ * <p>不落库——前端拿到后回填表单并暂存 files，仍走 create/update 一并保存；
+ * {@code .md} 直传时 files 为空列表。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record SkillUploadParseResult(
+    String content,
+    List<SkillUploadFile> files) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillVO.java
@@ -19,5 +19,7 @@ public class SkillVO {
     private Integer status;
     /** 存储目标：local/nacos/sftp。 */
     private List<String> storageTargets;
+    /** 附属文件清单（不含内容），zip 上传的 references/scripts 等。 */
+    private List<SkillFileVO> files;
     private LocalDateTime createTime;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/entity/AiSkillFile.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/entity/AiSkillFile.java
@@ -1,0 +1,39 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Skill 附属文件（zip 上传的 references/scripts/examples 等，SKILL.md 本体仍存 {@code ai_skill.content}）。
+ *
+ * <p>随 Skill 保存全量替换、物理删除（不用逻辑删除，避免 LONGBLOB 死数据堆积），
+ * 构建智能体实例时与 SKILL.md 一起落盘供 FileSystemSkillRepository 加载。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_skill_file")
+public class AiSkillFile {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 所属 Skill（ai_skill.id）。 */
+    private Long skillId;
+    /** 相对 SKILL.md 所在目录的路径，如 {@code references/api.md}。 */
+    private String filePath;
+    /** 文件字节数。 */
+    private Long fileSize;
+    /** 文件内容（文本/二进制统一按字节存）。 */
+    private byte[] content;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/mapper/AiSkillFileMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/mapper/AiSkillFileMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkillFile;
+
+/**
+ * Skill 附属文件 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiSkillFileMapper extends BaseMapper<AiSkillFile> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillService.java
@@ -7,11 +7,17 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgentSkill;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillFileVO;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadParseResult;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillVO;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
+import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkillFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillFileMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.storage.SkillContentPublisher;
+import com.richard.fyoung.customeradmin.aiconfig.skill.storage.SkillFileContent;
 import com.richard.fyoung.customeradmin.aiconfig.skill.storage.SkillStorageTarget;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
@@ -27,10 +33,13 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +52,12 @@ import java.util.zip.ZipInputStream;
 /**
  * Skill 管理。
  *
- * <p>新建/编辑时除入库外，把 SKILL.md 正文发布到用户勾选的存储目标（local/nacos/sftp）。
+ * <p>zip 上传的技能包 = SKILL.md 本体 + references/scripts 等附属文件：SKILL.md 存
+ * {@code ai_skill.content}，附属文件全量存 {@code ai_skill_file}（文本/二进制统一按字节），
+ * 保存时随事务落库并发布到勾选的存储目标；运行时由 AdminAgentInstanceFactory 把两者一起
+ * 落盘交给 FileSystemSkillRepository 加载，技能里引用的脚本/文档才真正生效。</p>
+ *
+ * <p>新建/编辑时除入库外，把 SKILL.md 正文与附属文件发布到用户勾选的存储目标（local/nacos/sftp）。
  * 发布走 {@link SkillContentPublisher} SPI，发布失败让事务回滚，保证"保存成功=目标已上传"；
  * 取消勾选/删除时对相应目标做尽力而为的清理。智能体运行时消费仍从数据库读，不经这些目标。</p>
  * @author owlzhangfq@gmail.com
@@ -61,15 +75,18 @@ public class SkillService {
     private static final String TARGET_DELIMITER = ",";
 
     private final AiSkillMapper skillMapper;
+    private final AiSkillFileMapper skillFileMapper;
     private final AiAgentSkillMapper agentSkillMapper;
     private final AiAgentMapper agentMapper;
     private final AgentInstanceCache agentInstanceCache;
     /** 按目标索引的发布器；未启用的目标（nacos/sftp）在容器中无对应 Bean，故此处无键。 */
     private final Map<SkillStorageTarget, SkillContentPublisher> publishers;
 
-    public SkillService(AiSkillMapper skillMapper, AiAgentSkillMapper agentSkillMapper, AiAgentMapper agentMapper,
+    public SkillService(AiSkillMapper skillMapper, AiSkillFileMapper skillFileMapper,
+                         AiAgentSkillMapper agentSkillMapper, AiAgentMapper agentMapper,
                          AgentInstanceCache agentInstanceCache, List<SkillContentPublisher> contentPublishers) {
         this.skillMapper = skillMapper;
+        this.skillFileMapper = skillFileMapper;
         this.agentSkillMapper = agentSkillMapper;
         this.agentMapper = agentMapper;
         this.agentInstanceCache = agentInstanceCache;
@@ -90,11 +107,16 @@ public class SkillService {
         wrapper.orderBy(true, "asc".equalsIgnoreCase(query.getSortOrder()), AiSkill::getCreateTime);
 
         IPage<AiSkill> page = skillMapper.selectPage(new Page<>(query.getPageNum(), query.getPageSize()), wrapper);
-        return PageResult.of(page.convert(this::toVo));
+        // 附属文件清单一次批查（只取路径/大小，不捞 LONGBLOB），避免逐行 N+1
+        Map<Long, List<SkillFileVO>> filesBySkill = fileMetasBySkillIds(
+            page.getRecords().stream().map(AiSkill::getId).collect(Collectors.toList()));
+        return PageResult.of(page.convert(skill ->
+            toVo(skill, filesBySkill.getOrDefault(skill.getId(), List.of()))));
     }
 
     public SkillVO get(Long id) {
-        return toVo(requireSkill(id));
+        AiSkill skill = requireSkill(id);
+        return toVo(skill, fileMetasBySkillIds(List.of(id)).getOrDefault(id, List.of()));
     }
 
     @Transactional(rollbackFor = Exception.class)
@@ -106,8 +128,9 @@ public class SkillService {
         AiSkill skill = new AiSkill();
         fillFromRequest(skill, request, targets);
         skillMapper.insert(skill);
+        replaceFiles(skill.getId(), request.files() == null ? List.of() : request.files());
         // 入库成功后发布，发布失败抛业务异常回滚事务，保证"保存成功=目标已上传"
-        publishToTargets(skill.getSkillCode(), skill.getContent(), targets);
+        publishToTargets(skill.getSkillCode(), skill.getContent(), loadFileContents(skill.getId()), targets);
     }
 
     @Transactional(rollbackFor = Exception.class)
@@ -122,8 +145,12 @@ public class SkillService {
         List<SkillStorageTarget> targets = resolveTargets(request.storageTargets());
         fillFromRequest(skill, request, targets);
         skillMapper.updateById(skill);
-        // 覆盖发布到本次勾选的目标（失败回滚）
-        publishToTargets(skill.getSkillCode(), skill.getContent(), targets);
+        // files == null 表示本次未重新上传，保持现有附属文件；非 null（含空列表）全量替换
+        if (request.files() != null) {
+            replaceFiles(id, request.files());
+        }
+        // 覆盖发布到本次勾选的目标（失败回滚）；附属文件从库里读当前全量（未重传时即原有文件）
+        publishToTargets(skill.getSkillCode(), skill.getContent(), loadFileContents(id), targets);
         evictAgentsReferencingSkill(id);
         // 本次取消勾选的目标：尽力清理旧产物，失败仅记日志不阻断
         List<SkillStorageTarget> cancelled = new ArrayList<>(oldTargets);
@@ -131,7 +158,7 @@ public class SkillService {
         removeFromTargetsQuietly(oldSkillCode, cancelled);
     }
 
-    /** Skill 内容变更（content 等）会让引用它的智能体运行时用上旧 SKILL.md，需一并失效。 */
+    /** Skill 内容变更（content/附属文件等）会让引用它的智能体运行时用上旧技能包，需一并失效。 */
     private void evictAgentsReferencingSkill(Long skillId) {
         List<Long> agentIds = agentSkillMapper.selectList(new LambdaQueryWrapper<AiAgentSkill>().eq(AiAgentSkill::getSkillId, skillId))
             .stream().map(AiAgentSkill::getAgentId).collect(Collectors.toList());
@@ -150,8 +177,66 @@ public class SkillService {
             throw new BizException(ResultCode.RESOURCE_IN_USE, "该 Skill 正被智能体引用，无法删除");
         }
         skillMapper.deleteById(id);
+        skillFileMapper.delete(new LambdaQueryWrapper<AiSkillFile>().eq(AiSkillFile::getSkillId, id));
         // 落库的所有目标逐个尽力清理，失败仅记日志不阻断删除
         removeFromTargetsQuietly(skill.getSkillCode(), parseStoredTargets(skill.getStorageTargets()));
+    }
+
+    // ---- 附属文件落库/读取 ----
+
+    /** 全量替换附属文件：路径合法性/总大小在此统一校验（保存链路唯一防御点），base64 解码后按字节落库。 */
+    private void replaceFiles(Long skillId, List<SkillUploadFile> files) {
+        skillFileMapper.delete(new LambdaQueryWrapper<AiSkillFile>().eq(AiSkillFile::getSkillId, skillId));
+        long totalBytes = 0;
+        Set<String> seenPaths = new LinkedHashSet<>();
+        for (SkillUploadFile file : files) {
+            String path = requireSafeRelativePath(file.filePath());
+            if (!seenPaths.add(path)) {
+                throw new BizException(ResultCode.PARAM_INVALID, "附属文件路径重复: " + path);
+            }
+            byte[] bytes = decodeBase64(path, file.contentBase64());
+            totalBytes += bytes.length;
+            if (totalBytes > MAX_UNZIPPED_BYTES) {
+                throw new BizException(ResultCode.PARAM_INVALID,
+                    "附属文件总大小超过 " + (MAX_UNZIPPED_BYTES / BYTES_PER_MB) + "MB 限制");
+            }
+            AiSkillFile row = new AiSkillFile();
+            row.setSkillId(skillId);
+            row.setFilePath(path);
+            row.setFileSize((long) bytes.length);
+            row.setContent(bytes);
+            skillFileMapper.insert(row);
+        }
+    }
+
+    /** 读取某 skill 的全部附属文件（含内容），供发布到存储目标。 */
+    private List<SkillFileContent> loadFileContents(Long skillId) {
+        return skillFileMapper.selectList(new LambdaQueryWrapper<AiSkillFile>().eq(AiSkillFile::getSkillId, skillId))
+            .stream().map(f -> new SkillFileContent(f.getFilePath(), f.getContent()))
+            .collect(Collectors.toList());
+    }
+
+    /** 批查附属文件清单（只取 skill_id/file_path/file_size，不捞 LONGBLOB），按 skillId 分组。 */
+    private Map<Long, List<SkillFileVO>> fileMetasBySkillIds(List<Long> skillIds) {
+        if (CollectionUtils.isEmpty(skillIds)) {
+            return Map.of();
+        }
+        return skillFileMapper.selectList(new LambdaQueryWrapper<AiSkillFile>()
+                .select(AiSkillFile::getSkillId, AiSkillFile::getFilePath, AiSkillFile::getFileSize)
+                .in(AiSkillFile::getSkillId, skillIds))
+            .stream().collect(Collectors.groupingBy(AiSkillFile::getSkillId,
+                Collectors.mapping(f -> new SkillFileVO(f.getFilePath(), f.getFileSize()), Collectors.toList())));
+    }
+
+    private byte[] decodeBase64(String path, String contentBase64) {
+        if (contentBase64 == null) {
+            throw new BizException(ResultCode.PARAM_MISSING, "附属文件缺少内容: " + path);
+        }
+        try {
+            return Base64.getDecoder().decode(contentBase64);
+        } catch (IllegalArgumentException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "附属文件内容不是合法 base64: " + path);
+        }
     }
 
     // ---- 存储目标发布/清理 ----
@@ -171,8 +256,9 @@ public class SkillService {
         return new ArrayList<>(targets);
     }
 
-    /** 发布到指定目标；目标未启用或发布失败均抛业务异常（回滚事务）。 */
-    private void publishToTargets(String skillCode, String content, List<SkillStorageTarget> targets) {
+    /** 发布到指定目标（SKILL.md + 附属文件）；目标未启用或发布失败均抛业务异常（回滚事务）。 */
+    private void publishToTargets(String skillCode, String content, List<SkillFileContent> files,
+                                  List<SkillStorageTarget> targets) {
         for (SkillStorageTarget target : targets) {
             SkillContentPublisher publisher = publishers.get(target);
             if (publisher == null) {
@@ -183,6 +269,7 @@ public class SkillService {
             }
             try {
                 publisher.publish(skillCode, content);
+                publisher.publishFiles(skillCode, files);
             } catch (Exception e) {
                 log.error("skill storage publish failed, code={}, target={}, skillCode={}",
                     ERR_PUBLISH_FAIL, target.getCode(), skillCode, e);
@@ -220,29 +307,39 @@ public class SkillService {
         return targets;
     }
 
+    // ---- 上传解析 ----
+
     private static final String SKILL_FILE_NAME = "SKILL.md";
-    private static final long MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+    private static final long MAX_UPLOAD_BYTES = 5 * BYTES_PER_MB;
+    /** zip 解压后（以及保存请求里附属文件解码后）的总字节上限，防 zip bomb。 */
+    private static final long MAX_UNZIPPED_BYTES = 20 * BYTES_PER_MB;
+    /** zip 条目数上限，防恶意海量小文件。 */
+    private static final int MAX_ZIP_ENTRIES = 500;
+    /** 解析时跳过的打包工具垃圾条目：macOS 的 __MACOSX/ 与 .DS_Store。 */
+    private static final String MACOS_JUNK_DIR = "__macosx/";
+    private static final String MACOS_JUNK_FILE = ".ds_store";
 
     /**
-     * 解析上传文件为 SKILL.md 正文：{@code .md} 直接整篇当正文；{@code .zip} 在包内（任意目录层级）
-     * 查找文件名为 {@code SKILL.md}（大小写不敏感）的条目取其内容——按需求约定，zip 只是 SKILL.md 的
-     * 另一种上传方式，不落盘、不解压其余 references/examples/scripts 等附属文件，解析结果直接回填
-     * 前端表单的 content 字段，仍走既有的 create/update 接口保存，不新增数据库结构。
+     * 解析上传文件为技能包：{@code .md} 直接整篇当 SKILL.md 正文（无附属文件）；{@code .zip} 以
+     * 最浅层 SKILL.md（大小写不敏感）所在目录为技能根，正文取该 SKILL.md，根目录下其余全部文件
+     * （含子目录、二进制）按相对路径收进附属文件列表。不落库——解析结果回填前端表单，
+     * 仍走既有的 create/update 接口随事务保存。
      */
-    public String parseUploadContent(MultipartFile file) {
+    public SkillUploadParseResult parseUploadContent(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new BizException(ResultCode.PARAM_MISSING, "请选择要上传的文件");
         }
         if (file.getSize() > MAX_UPLOAD_BYTES) {
-            throw new BizException(ResultCode.PARAM_INVALID, "文件大小超过 5MB 限制");
+            throw new BizException(ResultCode.PARAM_INVALID, "文件大小超过 " + (MAX_UPLOAD_BYTES / BYTES_PER_MB) + "MB 限制");
         }
         String filename = file.getOriginalFilename() == null ? "" : file.getOriginalFilename().toLowerCase(Locale.ROOT);
         try {
             if (filename.endsWith(".md")) {
-                return new String(file.getBytes(), StandardCharsets.UTF_8);
+                return new SkillUploadParseResult(new String(file.getBytes(), StandardCharsets.UTF_8), List.of());
             }
             if (filename.endsWith(".zip")) {
-                return extractSkillMdFromZip(file);
+                return parseSkillZip(file);
             }
         } catch (IOException e) {
             throw new BizException(ResultCode.PARAM_INVALID, "文件读取失败: " + e.getMessage());
@@ -250,17 +347,112 @@ public class SkillService {
         throw new BizException(ResultCode.PARAM_INVALID, "仅支持上传 .md 或 .zip 文件");
     }
 
-    private String extractSkillMdFromZip(MultipartFile file) throws IOException {
+    private SkillUploadParseResult parseSkillZip(MultipartFile file) throws IOException {
+        Map<String, byte[]> entries = readZipEntries(file);
+        String skillMdName = findShallowestSkillMd(entries.keySet());
+        String rootPrefix = skillMdName.substring(0, skillMdName.lastIndexOf('/') + 1);
+        String content = new String(entries.get(skillMdName), StandardCharsets.UTF_8);
+
+        List<SkillUploadFile> files = new ArrayList<>();
+        int skippedOutsideRoot = 0;
+        for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+            if (entry.getKey().equals(skillMdName)) {
+                continue;
+            }
+            if (!entry.getKey().startsWith(rootPrefix)) {
+                skippedOutsideRoot++;
+                continue;
+            }
+            String relativePath = requireSafeRelativePath(entry.getKey().substring(rootPrefix.length()));
+            files.add(new SkillUploadFile(relativePath, (long) entry.getValue().length,
+                Base64.getEncoder().encodeToString(entry.getValue())));
+        }
+        if (skippedOutsideRoot > 0) {
+            log.info("skill zip entries outside skill root skipped, skillMd={}, skipped={}",
+                skillMdName, skippedOutsideRoot);
+        }
+        return new SkillUploadParseResult(content, files);
+    }
+
+    /** 顺序读出 zip 全部文件条目（路径→字节），跳过目录与打包垃圾，超条目数/解压总量上限 fast fail。 */
+    private Map<String, byte[]> readZipEntries(MultipartFile file) throws IOException {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        long totalBytes = 0;
         try (ZipInputStream zipIn = new ZipInputStream(new ByteArrayInputStream(file.getBytes()), StandardCharsets.UTF_8)) {
             ZipEntry entry;
             while ((entry = zipIn.getNextEntry()) != null) {
-                String entryFileName = entry.getName().substring(entry.getName().lastIndexOf('/') + 1);
-                if (SKILL_FILE_NAME.equalsIgnoreCase(entryFileName)) {
-                    return new String(zipIn.readAllBytes(), StandardCharsets.UTF_8);
+                if (entry.isDirectory() || isJunkEntry(entry.getName())) {
+                    continue;
                 }
+                if (entries.size() >= MAX_ZIP_ENTRIES) {
+                    throw new BizException(ResultCode.PARAM_INVALID, "zip 条目数超过 " + MAX_ZIP_ENTRIES + " 上限");
+                }
+                byte[] bytes = readEntryCapped(zipIn, totalBytes);
+                totalBytes += bytes.length;
+                entries.put(entry.getName(), bytes);
             }
         }
-        throw new BizException(ResultCode.PARAM_INVALID, "zip 压缩包中未找到 SKILL.md");
+        return entries;
+    }
+
+    /** 按声明大小不可信的前提读条目，累计超过解压总量上限即 fast fail（防 zip bomb）。 */
+    private byte[] readEntryCapped(ZipInputStream zipIn, long alreadyRead) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int len;
+        while ((len = zipIn.read(buffer)) > 0) {
+            if (alreadyRead + bos.size() + len > MAX_UNZIPPED_BYTES) {
+                throw new BizException(ResultCode.PARAM_INVALID,
+                    "zip 解压后总大小超过 " + (MAX_UNZIPPED_BYTES / BYTES_PER_MB) + "MB 限制");
+            }
+            bos.write(buffer, 0, len);
+        }
+        return bos.toByteArray();
+    }
+
+    private boolean isJunkEntry(String name) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        return lower.startsWith(MACOS_JUNK_DIR) || lower.endsWith(MACOS_JUNK_FILE);
+    }
+
+    /** 找最浅层（路径分隔符最少）的 SKILL.md 条目名；找不到报业务错误。 */
+    private String findShallowestSkillMd(Set<String> entryNames) {
+        String found = null;
+        int foundDepth = Integer.MAX_VALUE;
+        for (String name : entryNames) {
+            String fileName = name.substring(name.lastIndexOf('/') + 1);
+            if (!SKILL_FILE_NAME.equalsIgnoreCase(fileName)) {
+                continue;
+            }
+            int depth = (int) name.chars().filter(c -> c == '/').count();
+            if (depth < foundDepth) {
+                found = name;
+                foundDepth = depth;
+            }
+        }
+        if (found == null) {
+            throw new BizException(ResultCode.PARAM_INVALID, "zip 压缩包中未找到 SKILL.md");
+        }
+        return found;
+    }
+
+    /**
+     * 附属文件相对路径防御（zip-slip/路径穿越）：拒绝空路径、绝对路径、反斜杠、{@code ..} 上跳与空段；
+     * 解析与保存两个入口共用此唯一防御点，运行时落盘与发布器不再重复校验。
+     */
+    private String requireSafeRelativePath(String path) {
+        if (!StringUtils.hasText(path)) {
+            throw new BizException(ResultCode.PARAM_INVALID, "附属文件路径不能为空");
+        }
+        if (path.startsWith("/") || path.contains("\\")) {
+            throw new BizException(ResultCode.PARAM_INVALID, "附属文件路径非法: " + path);
+        }
+        for (String segment : path.split("/")) {
+            if (segment.isEmpty() || "..".equals(segment) || ".".equals(segment)) {
+                throw new BizException(ResultCode.PARAM_INVALID, "附属文件路径非法: " + path);
+            }
+        }
+        return path;
     }
 
     private void fillFromRequest(AiSkill skill, SkillSaveRequest request, List<SkillStorageTarget> targets) {
@@ -273,7 +465,7 @@ public class SkillService {
             .collect(Collectors.joining(TARGET_DELIMITER)));
     }
 
-    private SkillVO toVo(AiSkill skill) {
+    private SkillVO toVo(AiSkill skill, List<SkillFileVO> files) {
         SkillVO vo = new SkillVO();
         vo.setId(skill.getId());
         vo.setSkillName(skill.getSkillName());
@@ -283,6 +475,7 @@ public class SkillService {
         vo.setStatus(skill.getStatus());
         vo.setStorageTargets(parseStoredTargets(skill.getStorageTargets()).stream()
             .map(SkillStorageTarget::getCode).collect(Collectors.toList()));
+        vo.setFiles(files);
         vo.setCreateTime(skill.getCreateTime());
         return vo;
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/LocalWorkspaceSkillPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/LocalWorkspaceSkillPublisher.java
@@ -9,10 +9,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * 本地 workspace 存储：把 SKILL.md 写到 {base-dir}/{skillCode}/SKILL.md。
+ * 本地 workspace 存储：把 SKILL.md 写到 {base-dir}/{skillCode}/SKILL.md，
+ * 附属文件写到 {base-dir}/{skillCode}/{filePath}（自动建父目录）。
  *
  * <p>默认且始终启用的目标，无外部依赖；remove 递归删除该 skill 目录。</p>
  * @author owlzhangfq@gmail.com
@@ -43,6 +45,23 @@ public class LocalWorkspaceSkillPublisher implements SkillContentPublisher {
             log.info("local skill published, skillCode={}, path={}", skillCode, skillFile);
         } catch (IOException e) {
             throw new UncheckedIOException("write local SKILL.md failed: " + skillFile, e);
+        }
+    }
+
+    @Override
+    public void publishFiles(String skillCode, List<SkillFileContent> files) {
+        Path skillDir = baseDir.resolve(skillCode);
+        try {
+            for (SkillFileContent file : files) {
+                Path target = skillDir.resolve(file.filePath());
+                Files.createDirectories(target.getParent());
+                Files.write(target, file.content());
+            }
+            if (!files.isEmpty()) {
+                log.info("local skill files published, skillCode={}, count={}", skillCode, files.size());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("write local skill files failed: " + skillDir, e);
         }
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SftpSkillPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SftpSkillPublisher.java
@@ -13,7 +13,8 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * SFTP 存储：把 SKILL.md 上传到 {remote-dir}/{skillCode}/SKILL.md，远端目录逐级创建。
+ * SFTP 存储：把 SKILL.md 上传到 {remote-dir}/{skillCode}/SKILL.md，附属文件上传到
+ * {remote-dir}/{skillCode}/{filePath}，远端目录逐级创建；remove 递归删除整个 skill 目录。
  *
  * <p>JSch（mwiede 维护版）密码认证；低频操作，每次建连用完即断，不做连接池。
  * 仅 {@code admin.skill.storage.sftp.enabled=true} 时注册。</p>
@@ -57,6 +58,30 @@ public class SftpSkillPublisher implements SkillContentPublisher {
     }
 
     @Override
+    public void publishFiles(String skillCode, List<SkillFileContent> files) {
+        if (files.isEmpty()) {
+            return;
+        }
+        Session session = null;
+        ChannelSftp channel = null;
+        try {
+            session = openSession();
+            channel = openChannel(session);
+            String skillDir = remoteSkillDir(config.getRemoteDir(), skillCode);
+            for (SkillFileContent file : files) {
+                String remotePath = skillDir + PATH_SEPARATOR + file.filePath();
+                ensureRemoteDir(channel, parentDir(remotePath));
+                channel.put(new ByteArrayInputStream(file.content()), remotePath);
+            }
+            log.info("sftp skill files published, skillCode={}, count={}", skillCode, files.size());
+        } catch (Exception e) {
+            throw new IllegalStateException("publish files to sftp failed: " + e.getMessage(), e);
+        } finally {
+            disconnect(session, channel);
+        }
+    }
+
+    @Override
     public void remove(String skillCode) {
         Session session = null;
         ChannelSftp channel = null;
@@ -64,8 +89,8 @@ public class SftpSkillPublisher implements SkillContentPublisher {
             session = openSession();
             channel = openChannel(session);
             String dir = remoteSkillDir(config.getRemoteDir(), skillCode);
-            silentRm(channel, remoteSkillFile(config.getRemoteDir(), skillCode));
-            silentRmDir(channel, dir);
+            // 附属文件带子目录，需递归清理（历史上只 rm SKILL.md + rmdir，目录非空即残留）
+            silentRmRecursively(channel, dir);
             log.info("sftp skill removed, skillCode={}, dir={}", skillCode, dir);
         } catch (Exception e) {
             throw new IllegalStateException("remove from sftp failed: " + e.getMessage(), e);
@@ -104,19 +129,24 @@ public class SftpSkillPublisher implements SkillContentPublisher {
         }
     }
 
-    private void silentRm(ChannelSftp channel, String remoteFile) {
+    /** 递归删除远端目录（先删文件再删子目录最后删自身）；目录不存在等异常吞掉，删除是尽力而为。 */
+    private void silentRmRecursively(ChannelSftp channel, String remoteDir) {
         try {
-            channel.rm(remoteFile);
-        } catch (Exception ignore) {
-            // 文件可能本就不存在，删除是尽力而为
-        }
-    }
-
-    private void silentRmDir(ChannelSftp channel, String remoteDir) {
-        try {
+            for (ChannelSftp.LsEntry entry : channel.ls(remoteDir)) {
+                String name = entry.getFilename();
+                if (".".equals(name) || "..".equals(name)) {
+                    continue;
+                }
+                String childPath = remoteDir + PATH_SEPARATOR + name;
+                if (entry.getAttrs().isDir()) {
+                    silentRmRecursively(channel, childPath);
+                } else {
+                    channel.rm(childPath);
+                }
+            }
             channel.rmdir(remoteDir);
         } catch (Exception ignore) {
-            // 目录可能非空或不存在，尽力而为
+            // 目录可能本就不存在，删除是尽力而为
         }
     }
 
@@ -139,6 +169,11 @@ public class SftpSkillPublisher implements SkillContentPublisher {
     /** {remote-dir}/{skillCode}/SKILL.md。 */
     static String remoteSkillFile(String remoteDir, String skillCode) {
         return remoteSkillDir(remoteDir, skillCode) + PATH_SEPARATOR + SKILL_FILE_NAME;
+    }
+
+    /** 远端文件路径的父目录（附属文件路径必含 skillCode 层级，必有 {@code /}）。 */
+    static String parentDir(String remotePath) {
+        return remotePath.substring(0, remotePath.lastIndexOf(PATH_SEPARATOR));
     }
 
     /** 把目录路径拆成逐级累加的路径列表，用于逐级创建；保留绝对路径前导 {@code /}。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SkillContentPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SkillContentPublisher.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customeradmin.aiconfig.skill.storage;
 
+import java.util.List;
+
 /**
  * Skill 内容发布 SPI：把 SKILL.md 正文发布到某个存储目标，供 Skill 保存/删除时调用。
  *
@@ -19,6 +21,16 @@ public interface SkillContentPublisher {
      * @param content   SKILL.md 正文
      */
     void publish(String skillCode, String content);
+
+    /**
+     * 发布该 skill 的附属文件（zip 里除 SKILL.md 外的 references/scripts 等）；失败抛异常，
+     * 由上层转业务异常并回滚事务。默认空实现——不适合承载任意文件的目标（如 Nacos 配置中心
+     * 面向文本配置）保持只发 SKILL.md 的行为即可。
+     * @param skillCode 技能编码
+     * @param files     附属文件列表（可能为空）
+     */
+    default void publishFiles(String skillCode, List<SkillFileContent> files) {
+    }
 
     /**
      * 移除指定 skill 在本目标上的产物（删除 / 取消勾选时调用）。尽力而为，失败由调用方按场景处理。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SkillFileContent.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SkillFileContent.java
@@ -1,0 +1,13 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.storage;
+
+/**
+ * 发布到存储目标的附属文件（路径 + 原始字节），供 {@link SkillContentPublisher#publishFiles} 使用。
+ *
+ * <p>{@code filePath} 是相对 skill 目录的路径（如 {@code references/api.md}），
+ * 合法性由 {@code SkillService} 在入库前统一校验，发布器只管写出。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record SkillFileContent(
+    String filePath,
+    byte[] content) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -20,6 +20,8 @@ import com.richard.fyoung.customeradmin.aiconfig.model.runtime.AdminModelFactory
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover.FailoverModel;
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover.ModelCircuitBreakerRegistry;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
+import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkillFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillFileMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
@@ -60,12 +62,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +77,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * 动态智能体运行时工厂：按 {@code ai_agent} 任意一行现场组装 {@link Agent}
@@ -137,6 +142,7 @@ public class AdminAgentInstanceFactory {
     private final AiModelConfigMapper modelConfigMapper;
     private final AiMcpMapper mcpMapper;
     private final AiSkillMapper skillMapper;
+    private final AiSkillFileMapper skillFileMapper;
     private final AiAgentSystemToolMapper agentSystemToolMapper;
     private final AiSystemToolMapper systemToolMapper;
     private final ApplicationContext applicationContext;
@@ -161,7 +167,7 @@ public class AdminAgentInstanceFactory {
                                       AiAgentSkillMapper agentSkillMapper, AiAgentBackupModelMapper agentBackupModelMapper,
                                       AiAgentSubAgentMapper agentSubAgentMapper,
                                       AiModelConfigMapper modelConfigMapper,
-                                      AiMcpMapper mcpMapper, AiSkillMapper skillMapper,
+                                      AiMcpMapper mcpMapper, AiSkillMapper skillMapper, AiSkillFileMapper skillFileMapper,
                                       AiAgentSystemToolMapper agentSystemToolMapper, AiSystemToolMapper systemToolMapper,
                                       ApplicationContext applicationContext,
                                       AdminModelFactory modelFactory, AesGcmCryptoUtil cryptoUtil,
@@ -179,6 +185,7 @@ public class AdminAgentInstanceFactory {
         this.modelConfigMapper = modelConfigMapper;
         this.mcpMapper = mcpMapper;
         this.skillMapper = skillMapper;
+        this.skillFileMapper = skillFileMapper;
         this.agentSystemToolMapper = agentSystemToolMapper;
         this.systemToolMapper = systemToolMapper;
         this.applicationContext = applicationContext;
@@ -725,7 +732,9 @@ public class AdminAgentInstanceFactory {
     }
 
     /**
-     * 读 {@code ai_agent_skill} 关联行，把 content（SKILL.md 正文）落盘后复用 FileSystemSkillRepository 加载。
+     * 读 {@code ai_agent_skill} 关联行，把完整技能包（SKILL.md 正文 + ai_skill_file 附属文件）落盘后
+     * 复用 FileSystemSkillRepository 加载——附属文件不落盘的话，SKILL.md 里引用的 references/scripts
+     * 在运行时不存在，技能功能不完整。落盘前先清空该 skill 目录，避免上一版残留文件混入。
      * {@code skillToolNames} 收集本次注册进来的工具名，同 {@link #buildToolkit} 的差集手法。
      */
     private SkillBox buildSkillBox(AiAgent agent, Toolkit toolkit, Set<String> skillToolNames) {
@@ -740,8 +749,16 @@ public class AdminAgentInstanceFactory {
             Files.createDirectories(skillDir);
             for (AiSkill skill : skillMapper.selectBatchIds(skillIds)) {
                 Path skillSubDir = skillDir.resolve(skill.getSkillCode());
+                deleteRecursively(skillSubDir);
                 Files.createDirectories(skillSubDir);
                 Files.writeString(skillSubDir.resolve("SKILL.md"), skill.getContent());
+                // 附属文件路径合法性在 SkillService 保存时已统一校验，此处直接落盘
+                for (AiSkillFile skillFile : skillFileMapper.selectList(
+                        new LambdaQueryWrapper<AiSkillFile>().eq(AiSkillFile::getSkillId, skill.getId()))) {
+                    Path target = skillSubDir.resolve(skillFile.getFilePath());
+                    Files.createDirectories(target.getParent());
+                    Files.write(target, skillFile.getContent());
+                }
             }
             List<AgentSkill> skills = new FileSystemSkillRepository(skillDir, false).getAllSkills();
             SkillBox skillBox = new SkillBox(toolkit);
@@ -758,6 +775,19 @@ public class AdminAgentInstanceFactory {
             log.error("[workspace] skill loading failed (skip skill wiring), code={}, agentCode={}",
                 "SKILL_LOAD_ERROR", agent.getAgentCode(), e);
             return null;
+        }
+    }
+
+    /** 递归删除目录（不存在则跳过），用于技能落盘前清理旧产物。 */
+    private void deleteRecursively(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(dir)) {
+            List<Path> ordered = paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+            for (Path p : ordered) {
+                Files.delete(p);
+            }
         }
     }
 

--- a/customer-admin-server/src/main/resources/db/migration/V33__skill_files.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V33__skill_files.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- Skill 附属文件（Flyway V33，仅本地/测试 profile 自动执行）
+-- =============================================================================
+-- zip 上传的技能包除 SKILL.md 外还有 references/scripts/examples 等附属文件，此前被直接丢弃，
+-- 运行时落盘只有 SKILL.md，技能里引用的脚本/参考文档全部失效。本表按 skill 存全部附属文件
+-- （文本/二进制统一按字节存），构建智能体实例时与 SKILL.md 一起落盘供 FileSystemSkillRepository 加载。
+-- 文件随保存全量替换，行走物理删除（不用逻辑删除，避免 LONGBLOB 死数据堆积）。
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_skill_file` (
+    `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `skill_id`    BIGINT NOT NULL COMMENT '所属 Skill（ai_skill.id）',
+    `file_path`   VARCHAR(512) NOT NULL COMMENT '相对 SKILL.md 所在目录的路径，如 references/api.md',
+    `file_size`   BIGINT NOT NULL DEFAULT 0 COMMENT '文件字节数',
+    `content`     LONGBLOB COMMENT '文件内容（文本/二进制统一按字节存）',
+    `create_by`   BIGINT COMMENT '创建人ID',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    INDEX `idx_ai_skill_file_skill` (`skill_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Skill 附属文件（zip 上传的 references/scripts 等）';

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillServiceTest.java
@@ -3,7 +3,11 @@ package com.richard.fyoung.customeradmin.aiconfig.skill.service;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadParseResult;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
+import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkillFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillFileMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.skill.storage.SkillContentPublisher;
 import com.richard.fyoung.customeradmin.aiconfig.skill.storage.SkillStorageTarget;
@@ -11,18 +15,27 @@ import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -32,15 +45,18 @@ import static org.mockito.Mockito.when;
 /**
  * {@link SkillService} 单测：
  * <ul>
- *   <li>{@code parseUploadContent}：.md 直接读正文，.zip 找 SKILL.md（任意目录层级、大小写不敏感），
- *       找不到/文件类型不支持时报业务错误；</li>
- *   <li>存储目标编排：默认 local、目标未启用报错、发布失败回滚、取消勾选触发 remove、delete 尽力清理。</li>
+ *   <li>{@code parseUploadContent}：.md 直接读正文（无附属文件）；.zip 以最浅层 SKILL.md 所在目录
+ *       为技能根，收集根下全部附属文件（含子目录、二进制），找不到/类型不支持/路径穿越时报业务错误；</li>
+ *   <li>附属文件落库：create/update 全量替换 ai_skill_file，update 未传 files 保持不变，delete 清理；</li>
+ *   <li>存储目标编排：默认 local、目标未启用报错、发布失败回滚、取消勾选触发 remove、delete 尽力清理，
+ *       附属文件随 publishFiles 一起发布。</li>
  * </ul>
  * @author owlzhangfq@gmail.com
  */
 class SkillServiceTest {
 
     private AiSkillMapper skillMapper;
+    private AiSkillFileMapper skillFileMapper;
     private AiAgentSkillMapper agentSkillMapper;
     private AiAgentMapper agentMapper;
     private AgentInstanceCache agentInstanceCache;
@@ -48,6 +64,7 @@ class SkillServiceTest {
     @BeforeEach
     void setUp() {
         skillMapper = mock(AiSkillMapper.class);
+        skillFileMapper = mock(AiSkillFileMapper.class);
         agentSkillMapper = mock(AiAgentSkillMapper.class);
         agentMapper = mock(AiAgentMapper.class);
         agentInstanceCache = mock(AgentInstanceCache.class);
@@ -55,7 +72,8 @@ class SkillServiceTest {
 
     /** 用给定发布器组装 Service。 */
     private SkillService serviceWith(SkillContentPublisher... publishers) {
-        return new SkillService(skillMapper, agentSkillMapper, agentMapper, agentInstanceCache, List.of(publishers));
+        return new SkillService(skillMapper, skillFileMapper, agentSkillMapper, agentMapper,
+            agentInstanceCache, List.of(publishers));
     }
 
     private SkillContentPublisher publisher(SkillStorageTarget target) {
@@ -64,45 +82,91 @@ class SkillServiceTest {
         return p;
     }
 
+    private SkillSaveRequest saveRequest(String name, String code, String content, List<String> targets,
+                                         List<SkillUploadFile> files) {
+        return new SkillSaveRequest(name, code, content, "desc", 1, targets, files);
+    }
+
     // ---- parseUploadContent ----
 
     @Test
-    void parseUploadContent_shouldReadMdFileDirectly() {
+    void parseUploadContent_shouldReadMdFileDirectly_withoutFiles() {
         String markdown = "---\nname: test-skill\n---\n\n技能正文";
         MockMultipartFile file = new MockMultipartFile("file", "SKILL.md", "text/markdown",
             markdown.getBytes(StandardCharsets.UTF_8));
 
-        String result = serviceWith().parseUploadContent(file);
+        SkillUploadParseResult result = serviceWith().parseUploadContent(file);
 
-        assertEquals(markdown, result);
+        assertEquals(markdown, result.content());
+        assertTrue(result.files().isEmpty());
     }
 
     @Test
-    void parseUploadContent_shouldExtractSkillMdFromZip_atNestedPath() throws IOException {
+    void parseUploadContent_shouldCollectAllFilesUnderSkillRoot() throws IOException {
         String markdown = "---\nname: zipped-skill\n---\n\n压缩包里的技能正文";
-        byte[] zipBytes = buildZip("my-skill/SKILL.md", markdown, "my-skill/references/doc.txt", "参考资料");
-        MockMultipartFile file = new MockMultipartFile("file", "my-skill.zip", "application/zip", zipBytes);
+        byte[] binary = {0x00, 0x01, (byte) 0xFF, 0x7F};
+        Map<String, byte[]> zipContent = new LinkedHashMap<>();
+        zipContent.put("my-skill/SKILL.md", markdown.getBytes(StandardCharsets.UTF_8));
+        zipContent.put("my-skill/references/doc.md", "参考资料".getBytes(StandardCharsets.UTF_8));
+        zipContent.put("my-skill/scripts/run.py", "print('hi')".getBytes(StandardCharsets.UTF_8));
+        zipContent.put("my-skill/assets/logo.bin", binary);
+        MockMultipartFile file = new MockMultipartFile("file", "my-skill.zip", "application/zip", buildZip(zipContent));
 
-        String result = serviceWith().parseUploadContent(file);
+        SkillUploadParseResult result = serviceWith().parseUploadContent(file);
 
-        assertEquals(markdown, result);
+        assertEquals(markdown, result.content());
+        assertEquals(3, result.files().size());
+        Map<String, SkillUploadFile> byPath = result.files().stream()
+            .collect(Collectors.toMap(SkillUploadFile::filePath, f -> f));
+        assertTrue(byPath.containsKey("references/doc.md"));
+        assertTrue(byPath.containsKey("scripts/run.py"));
+        // 二进制文件字节精确往返（base64 编解码无损）
+        assertArrayEquals(binary, Base64.getDecoder().decode(byPath.get("assets/logo.bin").contentBase64()));
+        assertEquals(4L, byPath.get("assets/logo.bin").fileSize());
+    }
+
+    @Test
+    void parseUploadContent_shouldUseShallowestSkillMdAsRoot_andSkipEntriesOutsideRoot() throws IOException {
+        // 根目录 SKILL.md 与更深层的另一个 SKILL.md 并存时取最浅层；根外条目跳过
+        Map<String, byte[]> zipContent = new LinkedHashMap<>();
+        zipContent.put("pack/SKILL.md", "根技能".getBytes(StandardCharsets.UTF_8));
+        zipContent.put("pack/nested/SKILL.md", "嵌套技能".getBytes(StandardCharsets.UTF_8));
+        zipContent.put("other/readme.md", "根外文件".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile file = new MockMultipartFile("file", "a.zip", "application/zip", buildZip(zipContent));
+
+        SkillUploadParseResult result = serviceWith().parseUploadContent(file);
+
+        assertEquals("根技能", result.content());
+        assertEquals(1, result.files().size());
+        assertEquals("nested/SKILL.md", result.files().get(0).filePath());
+    }
+
+    @Test
+    void parseUploadContent_shouldSkipMacosJunkEntries() throws IOException {
+        Map<String, byte[]> zipContent = new LinkedHashMap<>();
+        zipContent.put("SKILL.md", "正文".getBytes(StandardCharsets.UTF_8));
+        zipContent.put("__MACOSX/._SKILL.md", "junk".getBytes(StandardCharsets.UTF_8));
+        zipContent.put(".DS_Store", "junk".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile file = new MockMultipartFile("file", "a.zip", "application/zip", buildZip(zipContent));
+
+        SkillUploadParseResult result = serviceWith().parseUploadContent(file);
+
+        assertEquals("正文", result.content());
+        assertTrue(result.files().isEmpty());
     }
 
     @Test
     void parseUploadContent_shouldMatchSkillMdCaseInsensitively() throws IOException {
-        String markdown = "内容";
-        byte[] zipBytes = buildZip("skill.md", markdown);
-        MockMultipartFile file = new MockMultipartFile("file", "a.zip", "application/zip", zipBytes);
+        MockMultipartFile file = new MockMultipartFile("file", "a.zip", "application/zip",
+            buildZip(Map.of("skill.md", "内容".getBytes(StandardCharsets.UTF_8))));
 
-        String result = serviceWith().parseUploadContent(file);
-
-        assertEquals(markdown, result);
+        assertEquals("内容", serviceWith().parseUploadContent(file).content());
     }
 
     @Test
     void parseUploadContent_shouldRejectZipWithoutSkillMd() throws IOException {
-        byte[] zipBytes = buildZip("readme.txt", "无关内容");
-        MockMultipartFile file = new MockMultipartFile("file", "a.zip", "application/zip", zipBytes);
+        MockMultipartFile file = new MockMultipartFile("file", "a.zip", "application/zip",
+            buildZip(Map.of("readme.txt", "无关内容".getBytes(StandardCharsets.UTF_8))));
 
         assertThrows(BizException.class, () -> serviceWith().parseUploadContent(file));
     }
@@ -121,6 +185,101 @@ class SkillServiceTest {
         assertThrows(BizException.class, () -> serviceWith().parseUploadContent(file));
     }
 
+    // ---- 附属文件落库 ----
+
+    @Test
+    void create_shouldPersistFiles_andPublishThem() {
+        SkillContentPublisher local = publisher(SkillStorageTarget.LOCAL);
+        SkillService service = serviceWith(local);
+        SkillUploadFile refDoc = new SkillUploadFile("references/doc.md", 6L,
+            Base64.getEncoder().encodeToString("参考".getBytes(StandardCharsets.UTF_8)));
+        // 发布前从库里读当前全量文件
+        AiSkillFile stored = new AiSkillFile();
+        stored.setFilePath("references/doc.md");
+        stored.setContent("参考".getBytes(StandardCharsets.UTF_8));
+        when(skillFileMapper.selectList(any())).thenReturn(List.of(stored));
+
+        service.create(saveRequest("s1", "code-1", "正文", List.of("local"), List.of(refDoc)));
+
+        ArgumentCaptor<AiSkillFile> captor = ArgumentCaptor.forClass(AiSkillFile.class);
+        verify(skillFileMapper).insert(captor.capture());
+        assertEquals("references/doc.md", captor.getValue().getFilePath());
+        assertArrayEquals("参考".getBytes(StandardCharsets.UTF_8), captor.getValue().getContent());
+        verify(local).publish("code-1", "正文");
+        verify(local).publishFiles(any(), anyList());
+    }
+
+    @Test
+    void create_shouldRejectTraversalFilePath() {
+        SkillService service = serviceWith(publisher(SkillStorageTarget.LOCAL));
+        SkillUploadFile evil = new SkillUploadFile("../../etc/passwd", 1L,
+            Base64.getEncoder().encodeToString("x".getBytes(StandardCharsets.UTF_8)));
+
+        assertThrows(BizException.class, () ->
+            service.create(saveRequest("s1", "code-1", "正文", List.of("local"), List.of(evil))));
+    }
+
+    @Test
+    void create_shouldRejectInvalidBase64() {
+        SkillService service = serviceWith(publisher(SkillStorageTarget.LOCAL));
+        SkillUploadFile bad = new SkillUploadFile("references/doc.md", 1L, "!!not-base64!!");
+
+        assertThrows(BizException.class, () ->
+            service.create(saveRequest("s1", "code-1", "正文", List.of("local"), List.of(bad))));
+    }
+
+    @Test
+    void update_shouldKeepExistingFiles_whenFilesNull() {
+        AiSkill existing = new AiSkill();
+        existing.setId(9L);
+        existing.setSkillCode("code-9");
+        existing.setStorageTargets("local");
+        when(skillMapper.selectById(9L)).thenReturn(existing);
+        SkillContentPublisher local = publisher(SkillStorageTarget.LOCAL);
+        SkillService service = serviceWith(local);
+
+        service.update(9L, saveRequest("s9", "code-9", "新正文", List.of("local"), null));
+
+        // files == null：不触发 ai_skill_file 删除/重建，但仍从库里读出现有文件发布
+        verify(skillFileMapper, never()).delete(any());
+        verify(skillFileMapper, never()).insert(any(AiSkillFile.class));
+        verify(skillFileMapper, atLeastOnce()).selectList(any());
+        verify(local).publishFiles(any(), anyList());
+    }
+
+    @Test
+    void update_shouldReplaceFiles_whenFilesProvided() {
+        AiSkill existing = new AiSkill();
+        existing.setId(9L);
+        existing.setSkillCode("code-9");
+        existing.setStorageTargets("local");
+        when(skillMapper.selectById(9L)).thenReturn(existing);
+        SkillService service = serviceWith(publisher(SkillStorageTarget.LOCAL));
+        SkillUploadFile newFile = new SkillUploadFile("scripts/run.sh", 2L,
+            Base64.getEncoder().encodeToString("ls".getBytes(StandardCharsets.UTF_8)));
+
+        service.update(9L, saveRequest("s9", "code-9", "新正文", List.of("local"), List.of(newFile)));
+
+        verify(skillFileMapper).delete(any());
+        verify(skillFileMapper).insert(any(AiSkillFile.class));
+    }
+
+    @Test
+    void delete_shouldRemoveFileRows() {
+        AiSkill existing = new AiSkill();
+        existing.setId(5L);
+        existing.setSkillCode("code-5");
+        existing.setStorageTargets("local");
+        when(skillMapper.selectById(5L)).thenReturn(existing);
+        when(agentSkillMapper.exists(any())).thenReturn(false);
+        SkillService service = serviceWith(publisher(SkillStorageTarget.LOCAL));
+
+        service.delete(5L);
+
+        verify(skillMapper).deleteById(5L);
+        verify(skillFileMapper).delete(any());
+    }
+
     // ---- 存储目标编排 ----
 
     @Test
@@ -128,7 +287,7 @@ class SkillServiceTest {
         SkillContentPublisher local = publisher(SkillStorageTarget.LOCAL);
         SkillService service = serviceWith(local);
 
-        service.create(new SkillSaveRequest("s1", "code-1", "正文", "desc", 1, null));
+        service.create(saveRequest("s1", "code-1", "正文", null, null));
 
         verify(local).publish("code-1", "正文");
     }
@@ -138,7 +297,7 @@ class SkillServiceTest {
         SkillService service = serviceWith(publisher(SkillStorageTarget.LOCAL));
 
         assertThrows(BizException.class, () ->
-            service.create(new SkillSaveRequest("s1", "code-1", "正文", "desc", 1, List.of("ftp"))));
+            service.create(saveRequest("s1", "code-1", "正文", List.of("ftp"), null)));
     }
 
     @Test
@@ -147,7 +306,7 @@ class SkillServiceTest {
         SkillService service = serviceWith(publisher(SkillStorageTarget.LOCAL));
 
         assertThrows(BizException.class, () ->
-            service.create(new SkillSaveRequest("s1", "code-1", "正文", "desc", 1, List.of("local", "nacos"))));
+            service.create(saveRequest("s1", "code-1", "正文", List.of("local", "nacos"), null)));
     }
 
     @Test
@@ -158,7 +317,7 @@ class SkillServiceTest {
 
         // 发布失败抛业务异常（触发事务回滚）
         assertThrows(BizException.class, () ->
-            service.create(new SkillSaveRequest("s1", "code-1", "正文", "desc", 1, List.of("local"))));
+            service.create(saveRequest("s1", "code-1", "正文", List.of("local"), null)));
     }
 
     @Test
@@ -174,7 +333,7 @@ class SkillServiceTest {
         SkillContentPublisher nacos = publisher(SkillStorageTarget.NACOS);
         SkillService service = serviceWith(local, nacos);
 
-        service.update(9L, new SkillSaveRequest("s9", "code-9", "新正文", "desc", 1, List.of("local")));
+        service.update(9L, saveRequest("s9", "code-9", "新正文", List.of("local"), null));
 
         verify(local).publish("code-9", "新正文");
         verify(nacos, never()).publish(any(), any());
@@ -195,7 +354,7 @@ class SkillServiceTest {
         SkillService service = serviceWith(local, nacos);
 
         // remove 失败仅记日志，不影响 update 成功
-        service.update(9L, new SkillSaveRequest("s9", "code-9", "新正文", "desc", 1, List.of("local")));
+        service.update(9L, saveRequest("s9", "code-9", "新正文", List.of("local"), null));
 
         verify(local).publish("code-9", "新正文");
         verify(nacos).remove("code-9");
@@ -221,12 +380,12 @@ class SkillServiceTest {
         verify(local).remove("code-5");
     }
 
-    private byte[] buildZip(String... nameContentPairs) throws IOException {
+    private byte[] buildZip(Map<String, byte[]> entries) throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(bos, StandardCharsets.UTF_8)) {
-            for (int i = 0; i < nameContentPairs.length; i += 2) {
-                zos.putNextEntry(new ZipEntry(nameContentPairs[i]));
-                zos.write(nameContentPairs[i + 1].getBytes(StandardCharsets.UTF_8));
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zos.putNextEntry(new ZipEntry(entry.getKey()));
+                zos.write(entry.getValue());
                 zos.closeEntry();
             }
         }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/LocalWorkspaceSkillPublisherTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/LocalWorkspaceSkillPublisherTest.java
@@ -46,9 +46,26 @@ class LocalWorkspaceSkillPublisherTest {
     }
 
     @Test
-    void remove_shouldDeleteSkillDir() {
+    void publishFiles_shouldWriteFilesWithSubDirs() throws IOException {
         LocalWorkspaceSkillPublisher publisher = newPublisher();
         publisher.publish("demo-skill", "content");
+        byte[] binary = {0x00, (byte) 0xFF, 0x10};
+
+        publisher.publishFiles("demo-skill", java.util.List.of(
+            new SkillFileContent("references/doc.md", "参考".getBytes(StandardCharsets.UTF_8)),
+            new SkillFileContent("assets/logo.bin", binary)));
+
+        assertEquals("参考", Files.readString(baseDir.resolve("demo-skill/references/doc.md"), StandardCharsets.UTF_8));
+        org.junit.jupiter.api.Assertions.assertArrayEquals(binary,
+            Files.readAllBytes(baseDir.resolve("demo-skill/assets/logo.bin")));
+    }
+
+    @Test
+    void remove_shouldDeleteSkillDir_includingNestedFiles() {
+        LocalWorkspaceSkillPublisher publisher = newPublisher();
+        publisher.publish("demo-skill", "content");
+        publisher.publishFiles("demo-skill", java.util.List.of(
+            new SkillFileContent("references/doc.md", "参考".getBytes(StandardCharsets.UTF_8))));
 
         publisher.remove("demo-skill");
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SftpSkillPublisherTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/storage/SftpSkillPublisherTest.java
@@ -48,4 +48,10 @@ class SftpSkillPublisherTest {
     void cumulativePaths_shouldSkipEmptySegments() {
         assertEquals(List.of("/a", "/a/b"), SftpSkillPublisher.cumulativePaths("/a//b/"));
     }
+
+    @Test
+    void parentDir_shouldStripLastSegment() {
+        assertEquals("/data/skills/code-1/references",
+            SftpSkillPublisher.parentDir("/data/skills/code-1/references/doc.md"));
+    }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
@@ -26,7 +26,7 @@ class AdminAgentInstanceFactoryTest {
 
     /** 构造器纯字段赋值，路径解析只依赖常量，传 null 依赖即可单测 resolveSessionWorkspace 的防御逻辑。 */
     private AdminAgentInstanceFactory newFactoryForPathTest() {
-        return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null,
+        return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null);
     }
 

--- a/customer-admin-web/src/api/skill.ts
+++ b/customer-admin-web/src/api/skill.ts
@@ -1,5 +1,5 @@
 import { request } from './request'
-import type { PageQuery, PageResult, SkillSaveRequest, SkillVO } from '@/types/api'
+import type { PageQuery, PageResult, SkillSaveRequest, SkillUploadParseResult, SkillVO } from '@/types/api'
 
 export function pageSkills(query: PageQuery) {
   return request<PageResult<SkillVO>>({ url: '/aiconfig/skill', method: 'get', params: query })
@@ -21,9 +21,9 @@ export function deleteSkill(id: number) {
   return request<void>({ url: `/aiconfig/skill/${id}`, method: 'delete' })
 }
 
-/** 解析上传的 .md/.zip 文件，返回 SKILL.md 正文；不落库，由调用方回填表单后仍走 create/update 保存。 */
+/** 解析上传的 .md/.zip 文件为技能包（SKILL.md 正文 + 附属文件）；不落库，由调用方回填表单后仍走 create/update 保存。 */
 export function parseSkillUpload(file: File) {
   const formData = new FormData()
   formData.append('file', file)
-  return request<string>({ url: '/aiconfig/skill/parse-upload', method: 'post', data: formData })
+  return request<SkillUploadParseResult>({ url: '/aiconfig/skill/parse-upload', method: 'post', data: formData })
 }

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -271,6 +271,25 @@ export interface McpDebugCallResult {
 }
 
 // ---------- aiconfig.skill ----------
+/** Skill 附属文件展示项（不含内容）。 */
+export interface SkillFileVO {
+  filePath: string
+  fileSize: number
+}
+
+/** Skill 附属文件传输载体（parse-upload 响应与保存请求共用，内容 base64）。 */
+export interface SkillUploadFile {
+  filePath: string
+  fileSize: number
+  contentBase64: string
+}
+
+/** parse-upload 解析结果：SKILL.md 正文 + zip 内全部附属文件（.md 直传时 files 为空）。 */
+export interface SkillUploadParseResult {
+  content: string
+  files: SkillUploadFile[]
+}
+
 export interface SkillVO {
   id: number
   skillName: string
@@ -281,6 +300,8 @@ export interface SkillVO {
   createTime: string
   /** 上传目标：local(本地Workspace) / nacos / sftp，见 SkillStorageTarget。 */
   storageTargets: string[]
+  /** 附属文件清单（zip 上传的 references/scripts 等，不含内容）。 */
+  files: SkillFileVO[]
 }
 
 export interface SkillSaveRequest {
@@ -290,6 +311,8 @@ export interface SkillSaveRequest {
   description?: string | null
   status?: number | null
   storageTargets: string[]
+  /** 附属文件：null/undefined = 保持现有不变（编辑未重新上传）；数组（含空）= 全量替换。 */
+  files?: SkillUploadFile[] | null
 }
 
 // ---------- aiconfig.system-tool ----------

--- a/customer-admin-web/src/views/aiconfig/SkillManage.vue
+++ b/customer-admin-web/src/views/aiconfig/SkillManage.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import type { FormInstance, UploadRequestOptions } from 'element-plus'
 import { createSkill, deleteSkill, pageSkills, parseSkillUpload, updateSkill } from '@/api/skill'
 import { useCrudPage } from '@/composables/useCrudPage'
 import type { PageQuery, SkillSaveRequest, SkillVO } from '@/types/api'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
+
+/** 文件大小人性化展示（附属文件清单用）。 */
+function formatSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
 
 const formRef = ref<FormInstance>()
 
@@ -26,10 +33,11 @@ const {
   update: updateSkill,
   remove: (row) => deleteSkill(row.id),
   initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
-  initForm: () => ({ skillName: '', skillCode: '', content: '', description: '', status: 1, storageTargets: ['local'] }),
+  // files: null = 保持后端现有附属文件不变；上传 zip 解析成功后被替换为解析出的完整文件列表
+  initForm: () => ({ skillName: '', skillCode: '', content: '', description: '', status: 1, storageTargets: ['local'], files: null }),
   toForm: (row) => ({
     skillName: row.skillName, skillCode: row.skillCode, content: row.content, description: row.description, status: row.status,
-    storageTargets: [...(row.storageTargets ?? [])],
+    storageTargets: [...(row.storageTargets ?? [])], files: null,
   }),
   deleteConfirm: (row) => `确认删除 Skill「${row.skillName}」？`,
 })
@@ -42,14 +50,36 @@ function openPreview(row: SkillVO) {
   previewVisible.value = true
 }
 
+/** 编辑弹窗里正在编辑的行（展示后端现有附属文件清单用）。 */
+const editingRow = ref<SkillVO | null>(null)
+
 const uploading = ref(false)
+
+/** 表单当前生效的附属文件清单：本次上传解析出的优先，否则显示后端现有的。 */
+const formFileList = computed(() => {
+  if (form.files != null) return form.files.map((f) => ({ filePath: f.filePath, fileSize: f.fileSize }))
+  return editingRow.value?.files ?? []
+})
+
+function openCreateWithReset() {
+  editingRow.value = null
+  openCreate()
+}
+
+function openEditWithRow(row: SkillVO) {
+  editingRow.value = row
+  openEdit(row)
+}
 
 async function handleUpload(options: UploadRequestOptions) {
   uploading.value = true
   try {
-    const content = await parseSkillUpload(options.file as File)
-    form.content = content
-    ElMessage.success('解析成功，已回填 SKILL.md 正文，确认无误后点“确定”保存')
+    const result = await parseSkillUpload(options.file as File)
+    form.content = result.content
+    // zip 解析出的附属文件随保存全量替换；.md 直传 files 为空数组，同样按"清空附属文件"处理
+    form.files = result.files
+    const fileTip = result.files.length > 0 ? `，含 ${result.files.length} 个附属文件` : ''
+    ElMessage.success(`解析成功，已回填 SKILL.md 正文${fileTip}，确认无误后点“确定”保存`)
   } finally {
     uploading.value = false
   }
@@ -64,7 +94,7 @@ onMounted(loadList)
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'skill:add'" type="primary" @click="openCreate">新建 Skill</el-button>
+        <el-button v-permission="'skill:add'" type="primary" @click="openCreateWithReset">新建 Skill</el-button>
       </div>
 
       <el-table v-loading="loading" :data="list" style="width: 100%">
@@ -77,6 +107,11 @@ onMounted(loadList)
             </el-tag>
           </template>
         </el-table-column>
+        <el-table-column label="附属文件" width="100">
+          <template #default="{ row }">
+            <span>{{ row.files?.length ?? 0 }} 个</span>
+          </template>
+        </el-table-column>
         <el-table-column prop="description" label="描述" show-overflow-tooltip />
         <el-table-column label="状态" width="90">
           <template #default="{ row }">
@@ -87,7 +122,7 @@ onMounted(loadList)
         <el-table-column label="操作" width="220" fixed="right">
           <template #default="{ row }">
             <el-button link type="primary" @click="openPreview(row)">查看</el-button>
-            <el-button v-permission="'skill:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
+            <el-button v-permission="'skill:edit'" link type="primary" @click="openEditWithRow(row)">编辑</el-button>
             <el-button v-permission="'skill:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
@@ -120,10 +155,20 @@ onMounted(loadList)
               style="margin-bottom: 8px"
             >
               <el-button :loading="uploading" size="small">
-                上传 .md 或 .zip 文件回填正文
+                上传 .md 或 .zip 技能包
               </el-button>
             </el-upload>
-            <el-input v-model="form.content" type="textarea" :rows="10" placeholder="含 YAML frontmatter 的 SKILL.md 正文，可直接编辑或用上方按钮上传文件回填" />
+            <el-input v-model="form.content" type="textarea" :rows="10" placeholder="含 YAML frontmatter 的 SKILL.md 正文，可直接编辑或用上方按钮上传文件回填；zip 包内 references/scripts 等附属文件将一并保存" />
+          </div>
+        </el-form-item>
+        <el-form-item v-if="formFileList.length > 0" label="附属文件">
+          <div class="file-list">
+            <el-tag v-for="f in formFileList" :key="f.filePath" type="info" class="file-tag">
+              {{ f.filePath }}（{{ formatSize(f.fileSize) }}）
+            </el-tag>
+            <div class="file-tip">
+              {{ form.files != null ? '本次上传解析出的文件，保存后将全量替换原有附属文件' : '当前已保存的附属文件，重新上传 zip 可整体替换' }}
+            </div>
           </div>
         </el-form-item>
         <el-form-item
@@ -149,18 +194,26 @@ onMounted(loadList)
     </el-dialog>
 
     <el-dialog v-model="previewVisible" :title="previewSkill ? `查看 · ${previewSkill.skillName}` : '查看'" width="1000px" top="5vh">
-      <div v-if="previewSkill" class="preview-split">
-        <div class="preview-pane">
-          <div class="preview-pane-title">SKILL.md 原文</div>
-          <el-scrollbar class="preview-pane-body">
-            <pre class="preview-raw">{{ previewSkill.content }}</pre>
-          </el-scrollbar>
+      <div v-if="previewSkill">
+        <div class="preview-split">
+          <div class="preview-pane">
+            <div class="preview-pane-title">SKILL.md 原文</div>
+            <el-scrollbar class="preview-pane-body">
+              <pre class="preview-raw">{{ previewSkill.content }}</pre>
+            </el-scrollbar>
+          </div>
+          <div class="preview-pane">
+            <div class="preview-pane-title">预览</div>
+            <el-scrollbar class="preview-pane-body">
+              <MarkdownRenderer :text="previewSkill.content" />
+            </el-scrollbar>
+          </div>
         </div>
-        <div class="preview-pane">
-          <div class="preview-pane-title">预览</div>
-          <el-scrollbar class="preview-pane-body">
-            <MarkdownRenderer :text="previewSkill.content" />
-          </el-scrollbar>
+        <div v-if="(previewSkill.files?.length ?? 0) > 0" class="preview-files">
+          <div class="preview-pane-title">附属文件（{{ previewSkill.files.length }} 个）</div>
+          <el-tag v-for="f in previewSkill.files" :key="f.filePath" type="info" class="file-tag">
+            {{ f.filePath }}（{{ formatSize(f.fileSize) }}）
+          </el-tag>
         </div>
       </div>
       <template #footer>
@@ -180,7 +233,37 @@ onMounted(loadList)
 .preview-split {
   display: flex;
   gap: 16px;
-  height: 65vh;
+  height: 60vh;
+}
+
+.file-list {
+  width: 100%;
+}
+
+.file-tag {
+  margin: 0 6px 6px 0;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+}
+
+.file-tip {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.5;
+}
+
+.preview-files {
+  margin-top: 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.preview-files .preview-pane-title {
+  margin-bottom: 8px;
+}
+
+.preview-files .file-tag {
+  margin: 0 6px 8px 12px;
 }
 
 .preview-pane {

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -800,9 +800,14 @@ evict 后重建）、`VibeCodingServiceTest`（能力校验/流式对话委托/w
   JSON 解析/transport 分支逻辑收敛到这里），`McpService#testConnectivity` 复用批次二模型连通性测试
   同一套异步 `CompletableFuture` + 独立线程池 + 硬超时模式，落库到新增的 `test_status`/`test_time`
   字段。
-- **Skill 支持上传 SKILL.md / zip**：`SkillService#parseUploadContent` 按扩展名分流——`.md` 直接读取
-  文本，`.zip` 用 `ZipInputStream` 按 basename 大小写不敏感匹配 `SKILL.md` 条目解出正文；zip 明确只是
-  `content` 字段的另一种录入方式，不支持多文件技能包（references/scripts 子目录），不做数据库改动。
+- **Skill 支持上传 SKILL.md / zip（后升级为完整技能包）**：`SkillService#parseUploadContent` 按扩展名
+  分流——`.md` 直接读取文本；`.zip` 以最浅层 `SKILL.md`（大小写不敏感）所在目录为技能根，解出正文并
+  收集根下全部附属文件（references/scripts 等，含子目录与二进制，防 zip-slip/zip bomb）。附属文件全量
+  存新表 `ai_skill_file`（`V33__skill_files.sql`，LONGBLOB，随保存全量替换、物理删除），运行时
+  `AdminAgentInstanceFactory#buildSkillBox` 把 SKILL.md + 附属文件一起落盘交给
+  `FileSystemSkillRepository` 加载，SKILL.md 里引用的脚本/文档真正生效；存储目标发布走
+  `SkillContentPublisher#publishFiles`（local/sftp 全量发布，nacos 面向文本配置仍只发 SKILL.md）。
+  历史说明：批次六首版 zip 只是 `content` 字段的另一种录入方式、丢弃附属文件，2026-07 已按完整技能包补齐。
 - **智能体图标库选择 + 新建 session + 工作区空状态**：`IconPicker.vue`（新组件）复用全局注册的
   Element Plus 图标集做弹出选择器；`ChatPanel.vue`/`VibeCodingPanel.vue` 新增"新建会话"按钮
   （`crypto.randomUUID()` 换 sessionId、清空消息列表）；`workspace` 路由新增静态空状态页

--- a/mysql/02-customer-admin/33-V33__skill_files.sql
+++ b/mysql/02-customer-admin/33-V33__skill_files.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- Skill 附属文件（Flyway V33，仅本地/测试 profile 自动执行）
+-- =============================================================================
+-- zip 上传的技能包除 SKILL.md 外还有 references/scripts/examples 等附属文件，此前被直接丢弃，
+-- 运行时落盘只有 SKILL.md，技能里引用的脚本/参考文档全部失效。本表按 skill 存全部附属文件
+-- （文本/二进制统一按字节存），构建智能体实例时与 SKILL.md 一起落盘供 FileSystemSkillRepository 加载。
+-- 文件随保存全量替换，行走物理删除（不用逻辑删除，避免 LONGBLOB 死数据堆积）。
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_skill_file` (
+    `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `skill_id`    BIGINT NOT NULL COMMENT '所属 Skill（ai_skill.id）',
+    `file_path`   VARCHAR(512) NOT NULL COMMENT '相对 SKILL.md 所在目录的路径，如 references/api.md',
+    `file_size`   BIGINT NOT NULL DEFAULT 0 COMMENT '文件字节数',
+    `content`     LONGBLOB COMMENT '文件内容（文本/二进制统一按字节存）',
+    `create_by`   BIGINT COMMENT '创建人ID',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    INDEX `idx_ai_skill_file_skill` (`skill_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Skill 附属文件（zip 上传的 references/scripts 等）';


### PR DESCRIPTION
## 背景

Skill 上传 zip 此前只抽取 SKILL.md 正文入库，包内 references/scripts/examples 等附属文件被直接丢弃；运行时 `buildSkillBox` 也只落盘 SKILL.md，SKILL.md 里引用的脚本/参考文档在磁盘上不存在，技能功能不完整。

## 方案（全链路补齐）

**解析**（`SkillService#parseUploadContent`）
- 以最浅层 SKILL.md（大小写不敏感）所在目录为技能根，收集根下全部文件（含子目录与二进制），根外条目跳过并记数
- 安全加固：zip-slip 路径穿越 fast fail（保存与解析共用唯一防御点 `requireSafeRelativePath`）、条目数上限 500、解压总量上限 20MB（防 zip bomb，不信任条目声明大小）、跳过 `__MACOSX`/`.DS_Store`
- `parse-upload` 返回结构化结果 `SkillUploadParseResult`（正文 + base64 附属文件列表），无状态、不需要暂存区

**存储**
- 新表 `ai_skill_file`（V33 迁移，LONGBLOB 按字节存，文本/二进制统一），`mysql/02-customer-admin/` 已同步
- `SkillSaveRequest` 增加 `files` 字段：null=保持现有不变（编辑未重传），非 null（含空）=全量替换；随既有 create/update 事务落库
- 文件行走物理删除（不用逻辑删除，避免大字段死数据堆积）

**运行时加载**
- `AdminAgentInstanceFactory#buildSkillBox` 先清空该 skill 落盘目录再写 SKILL.md + 全部附属文件，交给 `FileSystemSkillRepository` 加载，技能引用的脚本/文档真正生效
- 附属文件变更同样触发引用智能体实例缓存失效（复用既有 evict 链路）

**存储目标发布**（`SkillContentPublisher` SPI）
- 新增 `publishFiles` default 方法（空实现）：local/sftp 全量发布附属文件；nacos 是文本配置中心，保持只发 SKILL.md（javadoc 说明）
- sftp `remove` 由「rm SKILL.md + rmdir」改为递归删除（附属文件带子目录时旧实现删不干净）

**前端**（SkillManage.vue）
- 上传 zip 后展示附属文件清单（路径+大小）并随保存提交；编辑时展示已保存清单，重新上传整体替换
- 列表新增「附属文件 N 个」列，查看弹窗附文件清单

## 测试

- `SkillServiceTest` 全量重写：21 个（zip 全量收集/最浅根/根外跳过/垃圾条目/zip-slip 拒绝/非法 base64/files null 语义/发布编排回归）
- `LocalWorkspaceSkillPublisherTest` 补 publishFiles 子目录+二进制写出、嵌套删除；`SftpSkillPublisherTest` 补 parentDir
- admin-server 全量 **545 个测试全绿**（含 `AdminAgentInstanceFactoryTest` 构造器同步）；前端 `vite build` 通过
- 本机 `customer_admin` 库已按手工同步惯例 apply V33（utf8mb4 单行 -e，中文注释字节已验证完好）

🤖 Generated with [Claude Code](https://claude.com/claude-code)