### PR TITLE
feat(admin): SQL 定义参数支持配置日期格式（DATETIME 参数）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/dto/SqlDefineParamSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/dto/SqlDefineParamSaveRequest.java
@@ -4,13 +4,15 @@ import jakarta.validation.constraints.NotBlank;
 
 /**
  * SQL 参数元数据新建/编辑请求。{@code paramType} 须为 ParamType 枚举之一，
- * {@code dropDown} 非空时须为合法 JSON 对象（Service 校验）。
+ * {@code dropDown} 非空时须为合法 JSON 对象，{@code dateFormat} 仅 DATETIME 类型可配且须为
+ * 合法日期格式串（Service 校验）。
  * @author owlzhangfq@gmail.com
  */
 public record SqlDefineParamSaveRequest(
     @NotBlank(message = "paramName 不能为空") String paramName,
     String paramDesc,
     @NotBlank(message = "paramType 不能为空") String paramType,
+    String dateFormat,
     Boolean required,
     String defaultValue,
     String dropDown,

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/dto/SqlDefineParamVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/dto/SqlDefineParamVO.java
@@ -13,6 +13,8 @@ public class SqlDefineParamVO {
     private String paramName;
     private String paramDesc;
     private String paramType;
+    /** 日期格式（仅 DATETIME 类型生效，空表示默认 yyyy-MM-dd HH:mm:ss）。 */
+    private String dateFormat;
     private Boolean required;
     private String defaultValue;
     private String dropDown;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/dto/SqlQueryParamMetaVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/dto/SqlQueryParamMetaVO.java
@@ -14,6 +14,8 @@ public class SqlQueryParamMetaVO {
     private String paramName;
     private String paramDesc;
     private String paramType;
+    /** 日期格式（仅 DATETIME 类型生效，空表示默认 yyyy-MM-dd HH:mm:ss），驱动前端日期控件粒度与提交格式。 */
+    private String dateFormat;
     private Boolean required;
     private String defaultValue;
     private Map<String, String> dropDown;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/DefaultValueResolver.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/DefaultValueResolver.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 /**
  * 参数默认值表达式解析：
  * <ul>
- *   <li>{@code ${now}} → 当前时间 {@code yyyy-MM-dd HH:mm:ss}</li>
+ *   <li>{@code ${now}} → 当前时间（默认 {@code yyyy-MM-dd HH:mm:ss}，可传自定义日期格式）</li>
  *   <li>{@code ${now-14d}} / {@code ${now+2h}} / {@code ${now-30m}} → 当前时间按 d/h/m 加减</li>
  *   <li>非 {@code ${...}} 表达式 → 原样返回（含 null）</li>
  * </ul>
@@ -25,12 +25,20 @@ public final class DefaultValueResolver {
     }
 
     public static String resolve(String expression) {
+        return resolve(expression, null);
+    }
+
+    /**
+     * 按指定日期格式解析时间表达式；{@code dateFormat} 为空时用默认 yyyy-MM-dd HH:mm:ss。
+     * 格式合法性在参数保存时已校验（fast fail 单点防御），此处不再兜底。
+     */
+    public static String resolve(String expression, String dateFormat) {
         if (expression == null) {
             return null;
         }
         String trimmed = expression.trim();
         if (NOW_PLAIN.matcher(trimmed).matches()) {
-            return LocalDateTime.now().format(FORMATTER);
+            return LocalDateTime.now().format(formatter(dateFormat));
         }
         Matcher matcher = NOW_EXPR.matcher(trimmed);
         if (matcher.matches()) {
@@ -43,8 +51,13 @@ public final class DefaultValueResolver {
                 case "m" -> base.plusMinutes(amount);
                 default -> base;
             };
-            return result.format(FORMATTER);
+            return result.format(formatter(dateFormat));
         }
         return expression;
+    }
+
+    private static DateTimeFormatter formatter(String dateFormat) {
+        return dateFormat == null || dateFormat.trim().isEmpty()
+            ? FORMATTER : DateTimeFormatter.ofPattern(dateFormat);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlQueryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlQueryService.java
@@ -259,7 +259,7 @@ public class SqlQueryService {
             String name = param.getParamName();
             String raw = rawValue(safeInput, name);
             if (isBlank(raw) && StringUtils.hasText(param.getDefaultValue())) {
-                raw = DefaultValueResolver.resolve(param.getDefaultValue());
+                raw = DefaultValueResolver.resolve(param.getDefaultValue(), param.getDateFormat());
             }
             if (isFlag(param.getIsPageNum())) {
                 long offset = export ? 0L : computeOffset(parsePageNum(raw), pageSize);
@@ -323,8 +323,10 @@ public class SqlQueryService {
         vo.setParamName(param.getParamName());
         vo.setParamDesc(param.getParamDesc());
         vo.setParamType(param.getParamType());
+        vo.setDateFormat(param.getDateFormat());
         vo.setRequired(isFlag(param.getRequired()));
-        vo.setDefaultValue(DefaultValueResolver.resolve(param.getDefaultValue()));
+        // 默认值时间表达式按参数配置的日期格式解析，保证预填值能被前端日期控件按同格式回显
+        vo.setDefaultValue(DefaultValueResolver.resolve(param.getDefaultValue(), param.getDateFormat()));
         vo.setDropDown(parseDropDown(param.getDropDown()));
         vo.setIsPageNum(isFlag(param.getIsPageNum()));
         vo.setIsPageSize(isFlag(param.getIsPageSize()));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/entity/SqlDefineParam.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/entity/SqlDefineParam.java
@@ -26,6 +26,8 @@ public class SqlDefineParam {
     private String paramDesc;
     /** STRING / INTEGER / DATETIME。 */
     private String paramType;
+    /** 日期格式（仅 DATETIME 类型生效，如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd；空默认 yyyy-MM-dd HH:mm:ss）。 */
+    private String dateFormat;
     /** 0否 / 1是。 */
     private Integer required;
     /** 默认值，支持 ${now}/${now-14d}/${now-2h} 时间表达式。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDefineService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDefineService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -130,6 +131,7 @@ public class SqlDefineService {
             paramCopy.setParamName(param.getParamName());
             paramCopy.setParamDesc(param.getParamDesc());
             paramCopy.setParamType(param.getParamType());
+            paramCopy.setDateFormat(param.getDateFormat());
             paramCopy.setRequired(param.getRequired());
             paramCopy.setDefaultValue(param.getDefaultValue());
             paramCopy.setDropDown(param.getDropDown());
@@ -217,6 +219,16 @@ public class SqlDefineService {
         if (!ParamType.isValid(request.paramType())) {
             throw new BizException(ResultCode.PARAM_INVALID, "paramType 非法（仅 STRING/INTEGER/DATETIME）: " + request.paramType());
         }
+        if (StringUtils.hasText(request.dateFormat())) {
+            if (!ParamType.DATETIME.name().equalsIgnoreCase(request.paramType())) {
+                throw new BizException(ResultCode.PARAM_INVALID, "dateFormat 仅 DATETIME 类型参数可配置");
+            }
+            try {
+                DateTimeFormatter.ofPattern(request.dateFormat());
+            } catch (IllegalArgumentException e) {
+                throw new BizException(ResultCode.PARAM_INVALID, "dateFormat 非法（如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd）: " + request.dateFormat());
+            }
+        }
         if (StringUtils.hasText(request.dropDown())) {
             requireJsonObject(request.dropDown(), "dropDown");
         }
@@ -287,6 +299,7 @@ public class SqlDefineService {
         param.setParamName(request.paramName());
         param.setParamDesc(request.paramDesc());
         param.setParamType(request.paramType().toUpperCase());
+        param.setDateFormat(request.dateFormat());
         param.setRequired(Boolean.TRUE.equals(request.required()) ? ENABLED : 0);
         param.setDefaultValue(request.defaultValue());
         param.setDropDown(request.dropDown());
@@ -337,6 +350,7 @@ public class SqlDefineService {
         vo.setParamName(param.getParamName());
         vo.setParamDesc(param.getParamDesc());
         vo.setParamType(param.getParamType());
+        vo.setDateFormat(param.getDateFormat());
         vo.setRequired(param.getRequired() != null && param.getRequired() == ENABLED);
         vo.setDefaultValue(param.getDefaultValue());
         vo.setDropDown(param.getDropDown());

--- a/customer-admin-server/src/main/resources/db/migration/V34__sql_param_date_format.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V34__sql_param_date_format.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- SQL 参数日期格式（Flyway V34，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- sql_define_param 新增 date_format 列：仅 DATETIME 类型参数生效，指定查询页日期
+-- 控件的选择粒度与提交格式（如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd）。空表示沿用
+-- 默认 yyyy-MM-dd HH:mm:ss，存量数据行为不变。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT
+-- 字节级写坏，故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `sql_define_param`
+    ADD COLUMN `date_format` VARCHAR(32) NULL COMMENT '日期格式（仅 DATETIME 类型生效，如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd；空默认 yyyy-MM-dd HH:mm:ss）' AFTER `param_type`;

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/sqlconfig/engine/DefaultValueResolverTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/sqlconfig/engine/DefaultValueResolverTest.java
@@ -48,4 +48,17 @@ class DefaultValueResolverTest {
         assertEquals("2026-01-01", DefaultValueResolver.resolve("2026-01-01"));
         assertNull(DefaultValueResolver.resolve(null));
     }
+
+    @Test
+    void shouldResolveWithCustomDateFormat() {
+        // 指定 yyyy-MM-dd 时表达式按该格式输出（10 位日期，可被同格式解析回来）
+        String resolved = DefaultValueResolver.resolve("${now-14d}", "yyyy-MM-dd");
+        assertEquals(10, resolved.length());
+        java.time.LocalDate value = java.time.LocalDate.parse(resolved, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        assertTrue(Math.abs(java.time.temporal.ChronoUnit.DAYS.between(value, LocalDateTime.now().minusDays(14).toLocalDate())) <= 1);
+
+        // 格式为空回落默认 yyyy-MM-dd HH:mm:ss；非表达式字面量不受格式影响
+        assertEquals(19, DefaultValueResolver.resolve("${now}", " ").length());
+        assertEquals("2026-01-01", DefaultValueResolver.resolve("2026-01-01", "yyyy/MM/dd"));
+    }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlQueryServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlQueryServiceTest.java
@@ -159,6 +159,35 @@ class SqlQueryServiceTest {
     }
 
     @Test
+    void meta_shouldResolveDefaultByConfiguredDateFormat_andExposeDateFormat() {
+        SqlDefine define = new SqlDefine();
+        define.setId(1L);
+        define.setDefineKey("user_list");
+        define.setEnabled(1);
+        when(defineMapper.selectOne(any())).thenReturn(define);
+
+        SqlDefineParam startDate = param("startDate", "DATETIME", false, "${now-7d}", false, false, 1);
+        startDate.setDateFormat("yyyy-MM-dd");
+        when(paramMapper.selectList(any())).thenReturn(List.of(startDate));
+
+        SqlQueryMetaVO meta = service.meta("user_list");
+
+        assertEquals("yyyy-MM-dd", meta.getParams().get(0).getDateFormat());
+        // 默认值表达式按参数配置格式输出（10 位日期），前端日期控件才能按同格式回显
+        assertEquals(10, meta.getParams().get(0).getDefaultValue().length());
+    }
+
+    @Test
+    void bindParams_shouldResolveDefaultExpressionByDateFormat() {
+        SqlDefineParam startDate = param("startDate", "DATETIME", false, "${now-7d}", false, false, 1);
+        startDate.setDateFormat("yyyy-MM-dd");
+
+        MapSqlParameterSource source = service.bindParams(List.of(startDate), Map.of(), false);
+
+        assertEquals(10, String.valueOf(source.getValue("startDate")).length());
+    }
+
+    @Test
     void executeAdhoc_shouldRejectNonReadOnly_beforeTouchingDatasource() {
         // 非只读 SQL 必须在建连接前就被 SqlValidator 拦下，绝不触达数据库
         BizException ex = assertThrows(BizException.class,

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDefineServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDefineServiceTest.java
@@ -132,7 +132,7 @@ class SqlDefineServiceTest {
     void createParam_shouldRejectInvalidParamType() {
         when(defineMapper.selectById(1L)).thenReturn(new SqlDefine());
         SqlDefineParamSaveRequest request = new SqlDefineParamSaveRequest(
-            "p", "desc", "BOOLEAN", false, null, null, false, false, 1);
+            "p", "desc", "BOOLEAN", null, false, null, null, false, false, 1);
         BizException ex = assertThrows(BizException.class, () -> service.createParam(1L, request));
         assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
     }
@@ -141,8 +141,39 @@ class SqlDefineServiceTest {
     void createParam_shouldRejectInvalidDropDownJson() {
         when(defineMapper.selectById(1L)).thenReturn(new SqlDefine());
         SqlDefineParamSaveRequest request = new SqlDefineParamSaveRequest(
-            "p", "desc", "STRING", false, null, "not-json", false, false, 1);
+            "p", "desc", "STRING", null, false, null, "not-json", false, false, 1);
         assertThrows(BizException.class, () -> service.createParam(1L, request));
+    }
+
+    @Test
+    void createParam_shouldRejectDateFormatOnNonDatetimeParam() {
+        when(defineMapper.selectById(1L)).thenReturn(new SqlDefine());
+        SqlDefineParamSaveRequest request = new SqlDefineParamSaveRequest(
+            "p", "desc", "STRING", "yyyy-MM-dd", false, null, null, false, false, 1);
+        BizException ex = assertThrows(BizException.class, () -> service.createParam(1L, request));
+        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
+    }
+
+    @Test
+    void createParam_shouldRejectIllegalDateFormatPattern() {
+        when(defineMapper.selectById(1L)).thenReturn(new SqlDefine());
+        SqlDefineParamSaveRequest request = new SqlDefineParamSaveRequest(
+            "p", "desc", "DATETIME", "yyyy-MM-dd bad{", false, null, null, false, false, 1);
+        BizException ex = assertThrows(BizException.class, () -> service.createParam(1L, request));
+        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
+    }
+
+    @Test
+    void createParam_shouldAcceptDateFormatOnDatetimeParam() {
+        when(defineMapper.selectById(1L)).thenReturn(new SqlDefine());
+        SqlDefineParamSaveRequest request = new SqlDefineParamSaveRequest(
+            "p", "desc", "DATETIME", "yyyy-MM-dd", false, null, null, false, false, 1);
+
+        service.createParam(1L, request);
+
+        ArgumentCaptor<SqlDefineParam> captor = ArgumentCaptor.forClass(SqlDefineParam.class);
+        verify(paramMapper).insert(captor.capture());
+        assertEquals("yyyy-MM-dd", captor.getValue().getDateFormat());
     }
 
     @Test

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -812,6 +812,8 @@ export interface SqlDefineParamVO {
   paramName: string
   paramDesc: string | null
   paramType: SqlParamType
+  /** 日期格式（仅 DATETIME 类型生效，如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd），空表示默认 yyyy-MM-dd HH:mm:ss。 */
+  dateFormat: string | null
   required: boolean
   defaultValue: string | null
   /** 下拉选项，后端存 JSON 字符串（如 {"1":"启用","0":"禁用"}），可空表示不是下拉参数。 */
@@ -825,6 +827,8 @@ export interface SqlDefineParamSaveRequest {
   paramName: string
   paramDesc?: string | null
   paramType: SqlParamType
+  /** 日期格式，仅 paramType 为 DATETIME 时可传（后端校验）。 */
+  dateFormat?: string | null
   required?: boolean | null
   defaultValue?: string | null
   dropDown?: string | null
@@ -854,6 +858,8 @@ export interface SqlQueryMetaParam {
   paramName: string
   paramDesc: string | null
   paramType: SqlParamType
+  /** 日期格式（仅 DATETIME 生效），驱动日期控件粒度与提交格式；空默认 yyyy-MM-dd HH:mm:ss。 */
+  dateFormat: string | null
   required: boolean
   /** 已解析为实际值的字符串（如 ${now-14d} 表达式已在后端算成具体日期），前端直接预填。 */
   defaultValue: string | null

--- a/customer-admin-web/src/views/sql/SqlDefineManage.vue
+++ b/customer-admin-web/src/views/sql/SqlDefineManage.vue
@@ -40,6 +40,8 @@ const TRANSFORM_TYPE_OPTIONS: { label: string; value: SqlTransformType }[] = [
   { label: '日期格式化', value: 'DATE_FORMAT' },
   { label: '值映射', value: 'VALUE_MAP' },
 ]
+/** DATETIME 参数常用日期格式预设（下拉可手输其他合法 Java 格式串）。 */
+const DATE_FORMAT_OPTIONS = ['yyyy-MM-dd HH:mm:ss', 'yyyy-MM-dd']
 
 const datasourceOptions = ref<SqlDatasourceVO[]>([])
 
@@ -107,13 +109,13 @@ const paramFormVisible = ref(false)
 const paramFormRef = ref<FormInstance>()
 const editingParamId = ref<number | null>(null)
 const paramForm = reactive<SqlDefineParamSaveRequest>({
-  paramName: '', paramDesc: '', paramType: 'STRING', required: false,
+  paramName: '', paramDesc: '', paramType: 'STRING', dateFormat: '', required: false,
   defaultValue: '', dropDown: '', isPageNum: false, isPageSize: false, sort: 0,
 })
 
 function resetParamForm() {
   Object.assign(paramForm, {
-    paramName: '', paramDesc: '', paramType: 'STRING', required: false,
+    paramName: '', paramDesc: '', paramType: 'STRING', dateFormat: '', required: false,
     defaultValue: '', dropDown: '', isPageNum: false, isPageSize: false, sort: 0,
   })
 }
@@ -127,7 +129,7 @@ function openParamCreate() {
 function openParamEdit(row: SqlDefineParamVO) {
   editingParamId.value = row.id
   Object.assign(paramForm, {
-    paramName: row.paramName, paramDesc: row.paramDesc, paramType: row.paramType, required: row.required,
+    paramName: row.paramName, paramDesc: row.paramDesc, paramType: row.paramType, dateFormat: row.dateFormat ?? '', required: row.required,
     defaultValue: row.defaultValue, dropDown: row.dropDown, isPageNum: row.isPageNum, isPageSize: row.isPageSize, sort: row.sort,
   })
   paramFormVisible.value = true
@@ -137,6 +139,10 @@ async function handleParamSubmit() {
   const valid = await paramFormRef.value?.validate().catch(() => false)
   if (!valid || !paramsDefineId.value) {
     return
+  }
+  // 日期格式仅 DATETIME 类型有意义，类型切走后清空，避免后端校验拒绝
+  if (paramForm.paramType !== 'DATETIME') {
+    paramForm.dateFormat = ''
   }
   if (editingParamId.value) {
     await updateSqlDefineParam(paramsDefineId.value, editingParamId.value, paramForm)
@@ -341,9 +347,10 @@ onMounted(() => {
       <el-table v-loading="paramsLoading" :data="paramsList" style="width: 100%" size="small">
         <el-table-column prop="paramName" label="参数名" width="130" />
         <el-table-column prop="paramDesc" label="描述" show-overflow-tooltip />
-        <el-table-column label="类型" width="90">
+        <el-table-column label="类型" width="150">
           <template #default="{ row }: { row: SqlDefineParamVO }">
             {{ PARAM_TYPE_OPTIONS.find((o) => o.value === row.paramType)?.label ?? row.paramType }}
+            <div v-if="row.dateFormat" class="param-date-format">{{ row.dateFormat }}</div>
           </template>
         </el-table-column>
         <el-table-column label="必填" width="70">
@@ -381,6 +388,19 @@ onMounted(() => {
         <el-form-item label="类型" prop="paramType" :rules="[{ required: true, message: '请选择类型' }]">
           <el-select v-model="paramForm.paramType" style="width: 100%">
             <el-option v-for="opt in PARAM_TYPE_OPTIONS" :key="opt.value" :label="opt.label" :value="opt.value" />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="paramForm.paramType === 'DATETIME'" label="日期格式">
+          <el-select
+            v-model="paramForm.dateFormat!"
+            filterable
+            allow-create
+            default-first-option
+            clearable
+            style="width: 100%"
+            placeholder="默认 yyyy-MM-dd HH:mm:ss，可手输其他格式"
+          >
+            <el-option v-for="fmt in DATE_FORMAT_OPTIONS" :key="fmt" :label="fmt" :value="fmt" />
           </el-select>
         </el-form-item>
         <el-form-item label="必填">
@@ -466,6 +486,12 @@ onMounted(() => {
   margin-left: 12px;
   font-size: 12px;
   color: var(--el-text-color-secondary);
+}
+
+.param-date-format {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.2;
 }
 
 .sql-textarea :deep(textarea) {

--- a/customer-admin-web/src/views/sql/SqlQueryView.vue
+++ b/customer-admin-web/src/views/sql/SqlQueryView.vue
@@ -34,6 +34,18 @@ function fieldKind(p: SqlQueryMetaParam): 'select' | 'date' | 'number' | 'input'
   return 'input'
 }
 
+const DEFAULT_DATE_FORMAT = 'yyyy-MM-dd HH:mm:ss'
+
+/** 控件粒度：格式串含时分秒（H/m/s，区分月份大写 M）用 datetime，纯日期用 date。 */
+function datePickerType(p: SqlQueryMetaParam): 'datetime' | 'date' {
+  return /[Hms]/.test(p.dateFormat || DEFAULT_DATE_FORMAT) ? 'datetime' : 'date'
+}
+
+/** Java 日期格式串转 dayjs 格式（el-date-picker 用）：yyyy→YYYY、dd→DD，M/H/m/s 两边一致。 */
+function datePickerFormat(p: SqlQueryMetaParam): string {
+  return (p.dateFormat || DEFAULT_DATE_FORMAT).replace(/y/g, 'Y').replace(/d/g, 'D')
+}
+
 function coerceDefault(p: SqlQueryMetaParam): unknown {
   if (p.defaultValue === null || p.defaultValue === '') {
     return p.paramType === 'INTEGER' ? undefined : ''
@@ -179,8 +191,9 @@ watch(() => route.query.defineKey, load, { immediate: true })
               <el-date-picker
                 v-else-if="fieldKind(p) === 'date'"
                 :model-value="paramValues[p.paramName] as string | undefined"
-                type="datetime"
-                value-format="YYYY-MM-DD HH:mm:ss"
+                :type="datePickerType(p)"
+                :format="datePickerFormat(p)"
+                :value-format="datePickerFormat(p)"
                 :placeholder="p.required ? '必填' : '不限'"
                 @update:model-value="(v: unknown) => (paramValues[p.paramName] = v)"
               />

--- a/mysql/02-customer-admin/34-V34__sql_param_date_format.sql
+++ b/mysql/02-customer-admin/34-V34__sql_param_date_format.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- SQL 参数日期格式（Flyway V34，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- sql_define_param 新增 date_format 列：仅 DATETIME 类型参数生效，指定查询页日期
+-- 控件的选择粒度与提交格式（如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd）。空表示沿用
+-- 默认 yyyy-MM-dd HH:mm:ss，存量数据行为不变。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT
+-- 字节级写坏，故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `sql_define_param`
+    ADD COLUMN `date_format` VARCHAR(32) NULL COMMENT '日期格式（仅 DATETIME 类型生效，如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd；空默认 yyyy-MM-dd HH:mm:ss）' AFTER `param_type`;


### PR DESCRIPTION
## 需求

SQL 配置管理 → SQL 定义 → 参数配置中，日期类型（DATETIME）参数可指定日期格式（如 `yyyy-MM-dd HH:mm:ss` 或 `yyyy-MM-dd`），新增参数与编辑参数弹窗均支持。

## 实现

**后端（customer-admin-server）**
- `sql_define_param` 新增 `date_format` 列：Flyway `V34__sql_param_date_format.sql` + 手工同步镜像 `mysql/02-customer-admin/34-...`；可空，空表示沿用默认 `yyyy-MM-dd HH:mm:ss`，存量数据行为不变
- 保存参数校验（fast fail 单点）：`dateFormat` 仅 DATETIME 类型可配，且须为合法 `DateTimeFormatter` 格式串
- `DefaultValueResolver` 新增按格式解析重载：`${now}/${now-14d}` 等默认值表达式按参数配置格式输出，meta 预填值与执行期默认值绑定（`bindParams`）保持同一格式
- 复制 SQL 定义时连带复制 `dateFormat`；管理端回显 VO 与查询页 meta VO 均透出该字段

**前端（customer-admin-web）**
- 参数弹窗（新增/编辑共用）：类型选「日期时间」时显示「日期格式」下拉，预设 `yyyy-MM-dd HH:mm:ss` / `yyyy-MM-dd`，支持手输其他合法格式；类型切走提交时自动清空
- 参数列表在类型列下方小字展示已配置格式
- 通用查询页（SqlQueryView）日期控件按配置格式渲染：含时分秒用 datetime picker，纯日期用 date picker，并按该格式回显默认值与提交参数（Java 格式串 → dayjs 格式转换）

## 测试

- sqlconfig 新增 5 个单测：非 DATETIME 配格式拒绝 / 非法格式串拒绝 / 合法保存落库、`DefaultValueResolver` 自定义格式解析、meta 按格式输出默认值 + `bindParams` 默认值按格式绑定
- customer-admin-server 全量 **582 个测试全绿**（BUILD SUCCESS）
- 前端 `vite build` 通过
- 本机 `customer_admin` 库已手工同步 V34（单行 -e 执行，避开 stdin 字符集坑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)