### PR TITLE
feat(admin): 登录页轮播图后台管理 + 登录页实时获取

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/SaTokenConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/SaTokenConfig.java
@@ -30,6 +30,10 @@ public class SaTokenConfig implements WebMvcConfigurer {
                 // Authorization 头，这类静态资源必须放行，鉴权收敛到"谁能上传"这一侧
                 // （见 MenuAdminController 的 @SaCheckPermission("menu:edit")）。
                 "/api/menu-icons/**",
+                // 登录页轮播图：登录页未登录即要实时拉取图片列表 + <img> 直接加载图片文件，
+                // 整个前缀放行（含 /list 读接口），鉴权收敛到"谁能上传/管理"一侧
+                // （见 LoginImageAdminController 的 @SaCheckPermission("login-image:*")）。
+                "/api/login-images/**",
                 "/actuator/**",
                 "/swagger-ui/**",
                 "/v3/api-docs/**",

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/StaticResourceConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/StaticResourceConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.config;
 
+import com.richard.fyoung.customeradmin.system.loginimage.service.LoginImageStorageService;
 import com.richard.fyoung.customeradmin.system.menu.service.MenuIconStorageService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -19,5 +20,8 @@ public class StaticResourceConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/api/menu-icons/**")
             .addResourceLocations("file:" + MenuIconStorageService.ICON_ROOT + "/");
+        // 登录页轮播图：同一套本地磁盘约定，/list 走 Controller（映射优先级高于静态资源），其余按文件名取图
+        registry.addResourceHandler("/api/login-images/**")
+            .addResourceLocations("file:" + LoginImageStorageService.IMAGE_ROOT + "/");
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/controller/LoginImageAdminController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/controller/LoginImageAdminController.java
@@ -1,0 +1,75 @@
+package com.richard.fyoung.customeradmin.system.loginimage.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginCarouselImageVO;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginImageEnabledRequest;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginImageReorderRequest;
+import com.richard.fyoung.customeradmin.system.loginimage.service.LoginCarouselImageService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 登录页轮播图管理（系统管理 › 登录页图片）：上传/列表/启停/排序/删除。
+ * 登录页读取侧走 {@link LoginImagePublicController} 免鉴权接口。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/system/login-image")
+public class LoginImageAdminController {
+
+    private final LoginCarouselImageService imageService;
+
+    public LoginImageAdminController(LoginCarouselImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    @SaCheckPermission("login-image:view")
+    @GetMapping
+    public Result<List<LoginCarouselImageVO>> list() {
+        return Result.success(imageService.list());
+    }
+
+    @SaCheckPermission("login-image:add")
+    @OperationLog(operation = "上传登录页轮播图", target = "login_carousel_image")
+    @PostMapping
+    public Result<LoginCarouselImageVO> upload(@RequestPart("file") MultipartFile file) {
+        return Result.success(imageService.upload(file));
+    }
+
+    @SaCheckPermission("login-image:edit")
+    @OperationLog(operation = "启停登录页轮播图", target = "login_carousel_image")
+    @PutMapping("/{id}/enabled")
+    public Result<Void> updateEnabled(@PathVariable Long id, @Valid @RequestBody LoginImageEnabledRequest request) {
+        imageService.updateEnabled(id, request.enabled());
+        return Result.success();
+    }
+
+    @SaCheckPermission("login-image:edit")
+    @OperationLog(operation = "调整登录页轮播图顺序", target = "login_carousel_image")
+    @PutMapping("/reorder")
+    public Result<Void> reorder(@Valid @RequestBody LoginImageReorderRequest request) {
+        imageService.reorder(request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("login-image:delete")
+    @OperationLog(operation = "删除登录页轮播图", target = "login_carousel_image")
+    @DeleteMapping("/{id}")
+    public Result<Void> delete(@PathVariable Long id) {
+        imageService.delete(id);
+        return Result.success();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/controller/LoginImagePublicController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/controller/LoginImagePublicController.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customeradmin.system.loginimage.controller;
+
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.loginimage.service.LoginCarouselImageService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 登录页轮播图公开读取接口：登录页在未登录状态下实时拉取启用图列表，路径挂在
+ * {@code /api/login-images/**} 下与静态图片共用同一条 Sa-Token 白名单
+ * （Controller 映射优先级高于静态资源映射，{@code /list} 不会被文件目录遮蔽；
+ * 图片文件名是 uuid 也不会反向撞上 {@code list}）。只暴露 URL 列表，无敏感信息。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/login-images")
+public class LoginImagePublicController {
+
+    private final LoginCarouselImageService imageService;
+
+    public LoginImagePublicController(LoginCarouselImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    @GetMapping("/list")
+    public Result<List<String>> list() {
+        return Result.success(imageService.listEnabledUrls());
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/dto/LoginCarouselImageVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/dto/LoginCarouselImageVO.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customeradmin.system.loginimage.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 登录页轮播图管理页回显 VO。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class LoginCarouselImageVO {
+
+    private Long id;
+    private String imageName;
+    private String imageUrl;
+    private Integer sortOrder;
+    private Boolean enabled;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/dto/LoginImageEnabledRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/dto/LoginImageEnabledRequest.java
@@ -1,0 +1,10 @@
+package com.richard.fyoung.customeradmin.system.loginimage.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 登录页轮播图启用/禁用请求。
+ * @author owlzhangfq@gmail.com
+ */
+public record LoginImageEnabledRequest(@NotNull(message = "enabled 不能为空") Boolean enabled) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/dto/LoginImageReorderRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/dto/LoginImageReorderRequest.java
@@ -1,0 +1,12 @@
+package com.richard.fyoung.customeradmin.system.loginimage.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * 登录页轮播图排序请求：前端传调整后的完整 id 顺序，后端按下标重写 sortOrder。
+ * @author owlzhangfq@gmail.com
+ */
+public record LoginImageReorderRequest(@NotEmpty(message = "排序 id 列表不能为空") List<Long> ids) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/entity/LoginCarouselImage.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/entity/LoginCarouselImage.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customeradmin.system.loginimage.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 登录页轮播背景图。原图落盘 {@code ./data/login-images}（沿用菜单图标同一套本地磁盘约定），
+ * {@code imageUrl} 存对外访问的相对 URL（{@code /api/login-images/xxx.jpg}），
+ * 登录页免鉴权实时拉取启用中的图片列表。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("login_carousel_image")
+public class LoginCarouselImage {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 上传时的原始文件名，仅用于管理页展示。 */
+    private String imageName;
+    /** 对外访问的相对 URL：/api/login-images/{uuid}.{ext}。 */
+    private String imageUrl;
+    /** 轮播顺序，小的在前。 */
+    private Integer sortOrder;
+    /** 0禁用 / 1启用，禁用的不出现在登录页。 */
+    private Integer enabled;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private Long updateBy;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    @TableLogic
+    private Integer deleted;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/mapper/LoginCarouselImageMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/mapper/LoginCarouselImageMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.system.loginimage.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.system.loginimage.entity.LoginCarouselImage;
+
+/**
+ * 登录页轮播图 Mapper，{@code @MapperScan("...**.mapper")} 自动扫描。
+ * @author owlzhangfq@gmail.com
+ */
+public interface LoginCarouselImageMapper extends BaseMapper<LoginCarouselImage> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginCarouselImageService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginCarouselImageService.java
@@ -1,0 +1,129 @@
+package com.richard.fyoung.customeradmin.system.loginimage.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginCarouselImageVO;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginImageReorderRequest;
+import com.richard.fyoung.customeradmin.system.loginimage.entity.LoginCarouselImage;
+import com.richard.fyoung.customeradmin.system.loginimage.mapper.LoginCarouselImageMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 登录页轮播图管理：上传/列表/启停/排序/删除，以及登录页免鉴权拉取的启用图列表。
+ *
+ * <p>格式/大小校验与落盘收敛在 {@link LoginImageStorageService}，本服务只管 DB 记录与业务规则
+ * （数量上限、排序重写、删除时联动清理磁盘文件）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class LoginCarouselImageService {
+
+    private static final int ENABLED = 1;
+    /** 轮播图数量上限：登录页轮播超过这个数没有展示价值，也防目录被无限制堆积。 */
+    private static final int MAX_IMAGE_COUNT = 10;
+
+    private final LoginCarouselImageMapper imageMapper;
+    private final LoginImageStorageService storageService;
+
+    public LoginCarouselImageService(LoginCarouselImageMapper imageMapper, LoginImageStorageService storageService) {
+        this.imageMapper = imageMapper;
+        this.storageService = storageService;
+    }
+
+    /** 管理页列表：全量按 sortOrder 升序（含禁用的，禁用状态由前端标识展示）。 */
+    public List<LoginCarouselImageVO> list() {
+        return listOrdered().stream().map(this::toVo).collect(Collectors.toList());
+    }
+
+    /** 登录页免鉴权实时拉取：仅启用图的访问 URL，按 sortOrder 升序。 */
+    public List<String> listEnabledUrls() {
+        return listOrdered().stream()
+            .filter(image -> image.getEnabled() != null && image.getEnabled() == ENABLED)
+            .map(LoginCarouselImage::getImageUrl)
+            .collect(Collectors.toList());
+    }
+
+    /** 上传新图：落盘后追加到当前排序末尾，默认启用。 */
+    public LoginCarouselImageVO upload(MultipartFile file) {
+        List<LoginCarouselImage> existing = listOrdered();
+        if (existing.size() >= MAX_IMAGE_COUNT) {
+            throw new BizException(ResultCode.PARAM_INVALID, "轮播图数量已达上限 " + MAX_IMAGE_COUNT + " 张，请先删除旧图");
+        }
+        String imageUrl = storageService.store(file);
+
+        LoginCarouselImage image = new LoginCarouselImage();
+        image.setImageName(file.getOriginalFilename());
+        image.setImageUrl(imageUrl);
+        image.setSortOrder(existing.isEmpty() ? 1 : existing.get(existing.size() - 1).getSortOrder() + 1);
+        image.setEnabled(ENABLED);
+        imageMapper.insert(image);
+        return toVo(image);
+    }
+
+    public void updateEnabled(Long id, boolean enabled) {
+        LoginCarouselImage image = requireImage(id);
+        image.setEnabled(enabled ? ENABLED : 0);
+        imageMapper.updateById(image);
+    }
+
+    /**
+     * 按前端传来的完整 id 顺序重写 sortOrder。要求 id 集合与库内完全一致，
+     * 防止并发编辑下按过期列表排序造成部分记录顺序丢失。
+     */
+    public void reorder(LoginImageReorderRequest request) {
+        List<LoginCarouselImage> existing = listOrdered();
+        Set<Long> existingIds = existing.stream().map(LoginCarouselImage::getId).collect(Collectors.toSet());
+        Set<Long> requestIds = request.ids().stream().filter(Objects::nonNull).collect(Collectors.toSet());
+        if (!existingIds.equals(requestIds)) {
+            throw new BizException(ResultCode.PARAM_INVALID, "排序列表与当前数据不一致，请刷新后重试");
+        }
+        for (int i = 0; i < request.ids().size(); i++) {
+            LoginCarouselImage image = new LoginCarouselImage();
+            image.setId(request.ids().get(i));
+            image.setSortOrder(i + 1);
+            imageMapper.updateById(image);
+        }
+    }
+
+    /** 删除记录（逻辑删除）并联动清理磁盘文件（清理失败不中断，见 storage 侧说明）。 */
+    public void delete(Long id) {
+        LoginCarouselImage image = requireImage(id);
+        imageMapper.deleteById(id);
+        storageService.delete(image.getImageUrl());
+    }
+
+    private List<LoginCarouselImage> listOrdered() {
+        List<LoginCarouselImage> images = imageMapper.selectList(
+            new LambdaQueryWrapper<LoginCarouselImage>().orderByAsc(LoginCarouselImage::getSortOrder));
+        return CollectionUtils.isEmpty(images) ? new ArrayList<>() : images;
+    }
+
+    private LoginCarouselImage requireImage(Long id) {
+        LoginCarouselImage image = imageMapper.selectById(id);
+        if (image == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "轮播图不存在: " + id);
+        }
+        return image;
+    }
+
+    private LoginCarouselImageVO toVo(LoginCarouselImage image) {
+        LoginCarouselImageVO vo = new LoginCarouselImageVO();
+        vo.setId(image.getId());
+        vo.setImageName(image.getImageName());
+        vo.setImageUrl(image.getImageUrl());
+        vo.setSortOrder(image.getSortOrder());
+        vo.setEnabled(image.getEnabled() != null && image.getEnabled() == ENABLED);
+        vo.setCreateTime(image.getCreateTime());
+        vo.setUpdateTime(image.getUpdateTime());
+        return vo;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginImageStorageService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginImageStorageService.java
@@ -1,0 +1,87 @@
+package com.richard.fyoung.customeradmin.system.loginimage.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 登录页轮播图文件存储：落盘到本地磁盘 {@code ./data/login-images}（沿用
+ * {@link com.richard.fyoung.customeradmin.system.menu.service.MenuIconStorageService}
+ * 同一套本地磁盘约定），通过 {@link com.richard.fyoung.customeradmin.config.StaticResourceConfig}
+ * 映射的 {@code /api/login-images/**} 对外提供访问 URL。
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class LoginImageStorageService {
+
+    /** 与 {@code StaticResourceConfig} 里的资源映射保持一致，改这里要同步改那边。 */
+    public static final String IMAGE_ROOT = "./data/login-images";
+    private static final String URL_PREFIX = "/api/login-images/";
+
+    /** 登录页背景是全屏大图，比菜单图标放宽到 5MB。 */
+    private static final long MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("png", "jpg", "jpeg", "webp");
+
+    /** @return 落盘后的可访问 URL（相对路径，前端拼自身 origin 即可直接展示）。 */
+    public String store(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BizException(ResultCode.PARAM_MISSING, "请选择要上传的图片");
+        }
+        if (file.getSize() > MAX_UPLOAD_BYTES) {
+            throw new BizException(ResultCode.PARAM_INVALID, "图片大小超过 5MB 限制");
+        }
+        String extension = extractExtension(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new BizException(ResultCode.PARAM_INVALID, "仅支持 png/jpg/jpeg/webp 格式图片");
+        }
+
+        String filename = UUID.randomUUID() + "." + extension;
+        try {
+            Path dir = Paths.get(IMAGE_ROOT);
+            Files.createDirectories(dir);
+            file.transferTo(dir.resolve(filename));
+        } catch (IOException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "图片保存失败: " + e.getMessage());
+        }
+        return URL_PREFIX + filename;
+    }
+
+    /**
+     * 按访问 URL 删除磁盘文件。删除记录的主链路在 DB 侧，文件清理失败只记 error 不中断
+     * （残留文件不影响功能，可运维期清理）。
+     */
+    public void delete(String imageUrl) {
+        if (!StringUtils.hasText(imageUrl) || !imageUrl.startsWith(URL_PREFIX)) {
+            return;
+        }
+        String filename = imageUrl.substring(URL_PREFIX.length());
+        // URL 由本服务生成（uuid.ext），这里防一手路径穿越，杜绝删到目录外的文件
+        if (filename.contains("/") || filename.contains("..")) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(Paths.get(IMAGE_ROOT).resolve(filename));
+        } catch (IOException e) {
+            log.error("delete login image file failed, code={}, url={}", "LOGIN-IMAGE-FILE-DELETE-FAIL", imageUrl, e);
+        }
+    }
+
+    private String extractExtension(String originalFilename) {
+        if (!StringUtils.hasText(originalFilename) || !originalFilename.contains(".")) {
+            throw new BizException(ResultCode.PARAM_INVALID, "文件名缺少扩展名");
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase(Locale.ROOT);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginImageStorageService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginImageStorageService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +36,13 @@ public class LoginImageStorageService {
     private static final long MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("png", "jpg", "jpeg", "webp");
 
+    /**
+     * 最低分辨率门槛：背景图以 cover 铺满整屏，低于主流视口（1280×720，高分屏还要再乘 DPR）
+     * 会被放大导致模糊，上传时直接 fast fail，比事后在登录页发虚好排查得多。
+     */
+    private static final int MIN_WIDTH = 1280;
+    private static final int MIN_HEIGHT = 720;
+
     /** @return 落盘后的可访问 URL（相对路径，前端拼自身 origin 即可直接展示）。 */
     public String store(MultipartFile file) {
         if (file == null || file.isEmpty()) {
@@ -46,6 +55,7 @@ public class LoginImageStorageService {
         if (!ALLOWED_EXTENSIONS.contains(extension)) {
             throw new BizException(ResultCode.PARAM_INVALID, "仅支持 png/jpg/jpeg/webp 格式图片");
         }
+        checkMinResolution(file);
 
         String filename = UUID.randomUUID() + "." + extension;
         try {
@@ -75,6 +85,28 @@ public class LoginImageStorageService {
             Files.deleteIfExists(Paths.get(IMAGE_ROOT).resolve(filename));
         } catch (IOException e) {
             log.error("delete login image file failed, code={}, url={}", "LOGIN-IMAGE-FILE-DELETE-FAIL", imageUrl, e);
+        }
+    }
+
+    /**
+     * 校验图片实际像素不低于 {@link #MIN_WIDTH}×{@link #MIN_HEIGHT}。JDK 自带 ImageIO
+     * 不认 webp（decode 返回 null），解不出来的按"无法校验"放行，不误杀合法 webp；
+     * 读流失败按无效图片 fast fail。
+     */
+    private void checkMinResolution(MultipartFile file) {
+        BufferedImage image;
+        try {
+            image = ImageIO.read(file.getInputStream());
+        } catch (IOException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "图片读取失败: " + e.getMessage());
+        }
+        if (image == null) {
+            return;
+        }
+        if (image.getWidth() < MIN_WIDTH || image.getHeight() < MIN_HEIGHT) {
+            throw new BizException(ResultCode.PARAM_INVALID,
+                "图片分辨率过低（" + image.getWidth() + "×" + image.getHeight() + "），"
+                    + "背景图会铺满整屏，低于 " + MIN_WIDTH + "×" + MIN_HEIGHT + " 会被拉伸模糊，请换高清图");
         }
     }
 

--- a/customer-admin-server/src/main/resources/db/migration/V35__login_carousel_image.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V35__login_carousel_image.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- 登录页轮播图管理（Flyway V35）
+-- =============================================================================
+-- 后台可上传多张登录页轮播背景图（原图落盘 ./data/login-images，表里存相对访问 URL
+-- /api/login-images/{uuid}.{ext}），支持排序/启停/删除；登录页未登录状态通过免鉴权接口
+-- GET /api/login-images/list 实时拉取启用图列表，拉不到或列表为空时前端回退内置默认图。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+--
+-- 菜单/权限种子：id 从 180 起——V31 显式 id 用到 166，但 V27 有一条不带显式 id 的插入吃掉了
+-- 自增号段（本机实测已分配到 170），170 段不安全，跳到 180 留足空间。超级管理员（super_admin）
+-- 无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接返回全部权限点
+-- （沿用 V29 同款做法，普通角色需在角色管理页手工授权）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `login_carousel_image` (
+    `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `image_name`  VARCHAR(255) COMMENT '上传时的原始文件名（管理页展示用）',
+    `image_url`   VARCHAR(255) NOT NULL COMMENT '对外访问相对URL：/api/login-images/{uuid}.{ext}',
+    `sort_order`  INT NOT NULL DEFAULT 0 COMMENT '轮播顺序，小的在前',
+    `enabled`     TINYINT NOT NULL DEFAULT 1 COMMENT '是否启用：0禁用 / 1启用',
+    `create_by`   BIGINT COMMENT '创建人ID',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`   BIGINT COMMENT '更新人ID',
+    `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`     TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    KEY `idx_login_carousel_sort` (`sort_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='登录页轮播背景图';
+
+-- 二级菜单：登录页图片（挂"系统管理" id=1 下，sort=7 排在开发者工具箱之后）。菜单可见性即 view 权限点。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (180, 1, '登录页图片', 'login-image:view', 1, '/system/login-image', 'Picture', 'library', 7);
+
+-- 三级：按钮/接口权限点（type=2，挂 180 下）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (181, 180, '上传登录页图片', 'login-image:add',    2, 1),
+    (182, 180, '编辑登录页图片', 'login-image:edit',   2, 2),
+    (183, 180, '删除登录页图片', 'login-image:delete', 2, 3);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginCarouselImageServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginCarouselImageServiceTest.java
@@ -1,0 +1,152 @@
+package com.richard.fyoung.customeradmin.system.loginimage.service;
+
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginCarouselImageVO;
+import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginImageReorderRequest;
+import com.richard.fyoung.customeradmin.system.loginimage.entity.LoginCarouselImage;
+import com.richard.fyoung.customeradmin.system.loginimage.mapper.LoginCarouselImageMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link LoginCarouselImageService} 单测：上传追加排序/数量上限、启用图 URL 过滤、
+ * 排序重写与 id 集合一致性校验、删除联动清理文件与不存在 fast fail。
+ * {@link LoginCarouselImageMapper} 与 {@link LoginImageStorageService} 均用 mock（不依赖真实库与磁盘）。
+ * @author owlzhangfq@gmail.com
+ */
+class LoginCarouselImageServiceTest {
+
+    private LoginCarouselImageMapper imageMapper;
+    private LoginImageStorageService storageService;
+    private LoginCarouselImageService service;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), LoginCarouselImage.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        imageMapper = mock(LoginCarouselImageMapper.class);
+        storageService = mock(LoginImageStorageService.class);
+        service = new LoginCarouselImageService(imageMapper, storageService);
+    }
+
+    private LoginCarouselImage image(long id, int sortOrder, int enabled) {
+        LoginCarouselImage image = new LoginCarouselImage();
+        image.setId(id);
+        image.setImageName("bg-" + id + ".jpg");
+        image.setImageUrl("/api/login-images/uuid-" + id + ".jpg");
+        image.setSortOrder(sortOrder);
+        image.setEnabled(enabled);
+        return image;
+    }
+
+    @Test
+    void upload_shouldAppendToTailWithEnabled() {
+        when(imageMapper.selectList(any())).thenReturn(new ArrayList<>(List.of(image(1L, 1, 1), image(2L, 2, 0))));
+        when(storageService.store(any())).thenReturn("/api/login-images/new-uuid.jpg");
+
+        LoginCarouselImageVO vo = service.upload(
+            new MockMultipartFile("file", "sunset.jpg", "image/jpeg", new byte[] {1}));
+
+        ArgumentCaptor<LoginCarouselImage> captor = ArgumentCaptor.forClass(LoginCarouselImage.class);
+        verify(imageMapper).insert(captor.capture());
+        assertEquals(3, captor.getValue().getSortOrder());
+        assertEquals(1, captor.getValue().getEnabled());
+        assertEquals("sunset.jpg", captor.getValue().getImageName());
+        assertEquals("/api/login-images/new-uuid.jpg", vo.getImageUrl());
+        assertTrue(vo.getEnabled());
+    }
+
+    @Test
+    void upload_shouldFailWhenReachMaxCount() {
+        List<LoginCarouselImage> full = IntStream.rangeClosed(1, 10)
+            .mapToObj(i -> image(i, i, 1))
+            .collect(Collectors.toList());
+        when(imageMapper.selectList(any())).thenReturn(full);
+
+        assertThrows(BizException.class, () -> service.upload(
+            new MockMultipartFile("file", "extra.jpg", "image/jpeg", new byte[] {1})));
+        verify(storageService, never()).store(any());
+        verify(imageMapper, never()).insert(any(LoginCarouselImage.class));
+    }
+
+    @Test
+    void listEnabledUrls_shouldFilterDisabledAndKeepOrder() {
+        when(imageMapper.selectList(any()))
+            .thenReturn(new ArrayList<>(List.of(image(1L, 1, 1), image(2L, 2, 0), image(3L, 3, 1))));
+
+        List<String> urls = service.listEnabledUrls();
+
+        assertEquals(List.of("/api/login-images/uuid-1.jpg", "/api/login-images/uuid-3.jpg"), urls);
+    }
+
+    @Test
+    void reorder_shouldRewriteSortOrderByIndex() {
+        when(imageMapper.selectList(any())).thenReturn(new ArrayList<>(List.of(image(1L, 1, 1), image(2L, 2, 1))));
+
+        service.reorder(new LoginImageReorderRequest(List.of(2L, 1L)));
+
+        ArgumentCaptor<LoginCarouselImage> captor = ArgumentCaptor.forClass(LoginCarouselImage.class);
+        verify(imageMapper, times(2)).updateById(captor.capture());
+        assertEquals(2L, captor.getAllValues().get(0).getId());
+        assertEquals(1, captor.getAllValues().get(0).getSortOrder());
+        assertEquals(1L, captor.getAllValues().get(1).getId());
+        assertEquals(2, captor.getAllValues().get(1).getSortOrder());
+    }
+
+    @Test
+    void reorder_shouldFailWhenIdsMismatch() {
+        when(imageMapper.selectList(any())).thenReturn(new ArrayList<>(List.of(image(1L, 1, 1), image(2L, 2, 1))));
+
+        assertThrows(BizException.class, () -> service.reorder(new LoginImageReorderRequest(List.of(2L, 3L))));
+        verify(imageMapper, never()).updateById(any(LoginCarouselImage.class));
+    }
+
+    @Test
+    void delete_shouldRemoveRecordAndFile() {
+        when(imageMapper.selectById(1L)).thenReturn(image(1L, 1, 1));
+
+        service.delete(1L);
+
+        verify(imageMapper).deleteById(1L);
+        verify(storageService).delete("/api/login-images/uuid-1.jpg");
+    }
+
+    @Test
+    void delete_shouldFailWhenNotFound() {
+        when(imageMapper.selectById(99L)).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.delete(99L));
+        verify(imageMapper, never()).deleteById(99L);
+    }
+
+    @Test
+    void updateEnabled_shouldFailWhenNotFound() {
+        when(imageMapper.selectById(99L)).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.updateEnabled(99L, false));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginImageStorageServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginImageStorageServiceTest.java
@@ -1,0 +1,60 @@
+package com.richard.fyoung.customeradmin.system.loginimage.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link LoginImageStorageService} 校验单测：空文件/超大/非法扩展名/低分辨率全部在落盘前
+ * fast fail（只测拒绝路径，不写磁盘）。低分辨率用例用内存生成的真实 PNG 验证 ImageIO 解码链路。
+ * @author owlzhangfq@gmail.com
+ */
+class LoginImageStorageServiceTest {
+
+    private LoginImageStorageService storageService;
+
+    @BeforeEach
+    void setUp() {
+        storageService = new LoginImageStorageService();
+    }
+
+    private byte[] pngBytes(int width, int height) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB), "png", out);
+        return out.toByteArray();
+    }
+
+    @Test
+    void store_shouldFailWhenFileEmpty() {
+        assertThrows(BizException.class, () -> storageService.store(
+            new MockMultipartFile("file", "bg.png", "image/png", new byte[0])));
+    }
+
+    @Test
+    void store_shouldFailWhenExtensionNotAllowed() {
+        assertThrows(BizException.class, () -> storageService.store(
+            new MockMultipartFile("file", "bg.svg", "image/svg+xml", new byte[] {1})));
+    }
+
+    @Test
+    void store_shouldFailWhenOverSizeLimit() {
+        assertThrows(BizException.class, () -> storageService.store(
+            new MockMultipartFile("file", "bg.jpg", "image/jpeg", new byte[5 * 1024 * 1024 + 1])));
+    }
+
+    @Test
+    void store_shouldFailWhenResolutionTooLow() throws IOException {
+        BizException exception = assertThrows(BizException.class, () -> storageService.store(
+            new MockMultipartFile("file", "small.png", "image/png", pngBytes(452, 300))));
+        assertTrue(exception.getMessage().contains("分辨率过低"));
+    }
+}

--- a/customer-admin-web/src/api/login-image.ts
+++ b/customer-admin-web/src/api/login-image.ts
@@ -1,0 +1,41 @@
+import { request } from './request'
+
+/** 登录页轮播图管理页回显 VO，对应后端 LoginCarouselImageVO */
+export interface LoginCarouselImageVO {
+  id: number
+  imageName: string
+  imageUrl: string
+  sortOrder: number
+  enabled: boolean
+  createTime: string
+  updateTime: string
+}
+
+export function fetchLoginImages() {
+  return request<LoginCarouselImageVO[]>({ url: '/system/login-image', method: 'get' })
+}
+
+/** 上传轮播图，返回新记录（含可直接展示的访问 URL） */
+export function uploadLoginImage(file: File) {
+  const formData = new FormData()
+  formData.append('file', file)
+  return request<LoginCarouselImageVO>({ url: '/system/login-image', method: 'post', data: formData })
+}
+
+export function updateLoginImageEnabled(id: number, enabled: boolean) {
+  return request<void>({ url: `/system/login-image/${id}/enabled`, method: 'put', data: { enabled } })
+}
+
+/** 传调整后的完整 id 顺序，后端按下标重写排序 */
+export function reorderLoginImages(ids: number[]) {
+  return request<void>({ url: '/system/login-image/reorder', method: 'put', data: { ids } })
+}
+
+export function deleteLoginImage(id: number) {
+  return request<void>({ url: `/system/login-image/${id}`, method: 'delete' })
+}
+
+/** 登录页免鉴权实时拉取启用图 URL 列表（后端 Sa-Token 白名单放行） */
+export function fetchLoginCarouselUrls() {
+  return request<string[]>({ url: '/login-images/list', method: 'get' })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -12,6 +12,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/ai-audit': () => import('@/views/system/AiCodingAudit.vue'),
   '/system/menu': () => import('@/views/system/MenuManage.vue'),
   '/system/devtools': () => import('@/views/system/DevToolboxView.vue'),
+  '/system/login-image': () => import('@/views/system/LoginImageManage.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -97,7 +97,7 @@ async function handleSubmit() {
 <template>
   <div class="login-page">
     <div class="bg-carousel">
-      <el-carousel type="fade" height="100%" :interval="5000" arrow="never" indicator-position="none">
+      <el-carousel type="fade" height="100%" :interval="1000" arrow="never" indicator-position="none">
         <el-carousel-item v-for="img in bgImages" :key="img">
           <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
         </el-carousel-item>

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -99,10 +99,7 @@ async function handleSubmit() {
     <div class="bg-carousel">
       <el-carousel type="fade" height="100%" :interval="2000" arrow="never" indicator-position="none">
         <el-carousel-item v-for="img in bgImages" :key="img">
-          <div class="bg-slide-wrap">
-            <div class="bg-slide-blur" :style="{ backgroundImage: `url(${img})` }" />
-            <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
-          </div>
+          <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
         </el-carousel-item>
       </el-carousel>
       <div class="bg-overlay" />
@@ -194,33 +191,13 @@ async function handleSubmit() {
   height: 100%;
 }
 
-.bg-slide-wrap {
-  position: relative;
+/* cover 铺满整屏不留空，与屏幕宽高比不一致的部分会被裁切（竖版图在横屏上会切掉上下）。
+   不做 Ken Burns 缩放动画：背景层是先光栅化再按 transform 拉伸，慢速放大必然发虚。 */
+.bg-slide {
   width: 100%;
   height: 100%;
-}
-
-/* 模糊填充层：主图用 contain 完整展示后，与屏幕宽高比不一致的那一维会留边，
-   用同一张图 cover 铺满并高斯模糊填补，比生硬留白自然。scale(1.1) 盖住 blur 边缘的羽化。 */
-.bg-slide-blur {
-  position: absolute;
-  inset: 0;
   background-size: cover;
   background-position: center;
-  filter: blur(28px) brightness(0.8);
-  transform: scale(1.1);
-}
-
-/* 主图层用 contain 完整展示，不裁切（cover 会按屏幕比例切掉图片边缘，导致内容看不全）。
-   不做 Ken Burns 缩放动画：背景层是先光栅化再按 transform 拉伸，慢速放大必然发虚。
-   必须 no-repeat——contain 留边处不收敛会平铺出重复图。 */
-.bg-slide {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
 }
 
 /* 深色渐变遮罩：保证登录卡片和页脚文字在任意风景图上都有足够对比度可读 */

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { FormInstance, FormRules } from 'element-plus'
 import { login, ssoLogin } from '@/api/auth'
+import { fetchLoginCarouselUrls } from '@/api/login-image'
 import { useAuthStore } from '@/store/auth'
 import { useMenuStore } from '@/store/menu'
 import FooterCopyright from '@/components/FooterCopyright.vue'
@@ -47,8 +48,22 @@ function switchMode(mode: 'local' | 'sso') {
 
 loadRememberedUsername(loginMode.value)
 
-// 登录页轮播背景图，RichardFyoung 提供，放在 public/ 根目录下
-const bgImages = ['/A1.jpg', '/A2.jpg', '/A3.jpg']
+// 登录页轮播背景图：先用 public/ 下的内置默认图兜底，挂载后实时拉取后台
+// "系统管理 › 登录页图片"上传的启用图（免鉴权接口，见后端 LoginImagePublicController）；
+// 拉取失败或列表为空时保持默认图，登录页永远有背景可展示。
+const DEFAULT_BG_IMAGES = ['/A1.jpg', '/A2.jpg', '/A3.jpg']
+const bgImages = ref<string[]>(DEFAULT_BG_IMAGES)
+
+onMounted(async () => {
+  try {
+    const urls = await fetchLoginCarouselUrls()
+    if (urls.length > 0) {
+      bgImages.value = urls
+    }
+  } catch {
+    // 后端不可用时静默保持默认图，不打扰登录
+  }
+})
 
 async function handleSubmit() {
   const valid = await formRef.value?.validate().catch(() => false)

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -191,21 +191,13 @@ async function handleSubmit() {
   height: 100%;
 }
 
+/* 不做 Ken Burns 缩放动画：浏览器对背景层是先光栅化再按 transform 拉伸，慢速放大过程中
+   图片必然发虚；保持 1:1 的 cover 展示才是最清晰的状态（图片清晰度要求见管理页提示）。 */
 .bg-slide {
   width: 100%;
   height: 100%;
   background-size: cover;
   background-position: center;
-  animation: kenburns 8s ease-in-out infinite alternate;
-}
-
-@keyframes kenburns {
-  from {
-    transform: scale(1);
-  }
-  to {
-    transform: scale(1.12);
-  }
 }
 
 /* 深色渐变遮罩：保证登录卡片和页脚文字在任意风景图上都有足够对比度可读 */

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -97,9 +97,12 @@ async function handleSubmit() {
 <template>
   <div class="login-page">
     <div class="bg-carousel">
-      <el-carousel type="fade" height="100%" :interval="1000" arrow="never" indicator-position="none">
+      <el-carousel type="fade" height="100%" :interval="2000" arrow="never" indicator-position="none">
         <el-carousel-item v-for="img in bgImages" :key="img">
-          <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
+          <div class="bg-slide-wrap">
+            <div class="bg-slide-blur" :style="{ backgroundImage: `url(${img})` }" />
+            <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
+          </div>
         </el-carousel-item>
       </el-carousel>
       <div class="bg-overlay" />
@@ -191,13 +194,33 @@ async function handleSubmit() {
   height: 100%;
 }
 
-/* 不做 Ken Burns 缩放动画：浏览器对背景层是先光栅化再按 transform 拉伸，慢速放大过程中
-   图片必然发虚；保持 1:1 的 cover 展示才是最清晰的状态（图片清晰度要求见管理页提示）。 */
-.bg-slide {
+.bg-slide-wrap {
+  position: relative;
   width: 100%;
   height: 100%;
+}
+
+/* 模糊填充层：主图用 contain 完整展示后，与屏幕宽高比不一致的那一维会留边，
+   用同一张图 cover 铺满并高斯模糊填补，比生硬留白自然。scale(1.1) 盖住 blur 边缘的羽化。 */
+.bg-slide-blur {
+  position: absolute;
+  inset: 0;
   background-size: cover;
   background-position: center;
+  filter: blur(28px) brightness(0.8);
+  transform: scale(1.1);
+}
+
+/* 主图层用 contain 完整展示，不裁切（cover 会按屏幕比例切掉图片边缘，导致内容看不全）。
+   不做 Ken Burns 缩放动画：背景层是先光栅化再按 transform 拉伸，慢速放大必然发虚。
+   必须 no-repeat——contain 留边处不收敛会平铺出重复图。 */
+.bg-slide {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 /* 深色渐变遮罩：保证登录卡片和页脚文字在任意风景图上都有足够对比度可读 */

--- a/customer-admin-web/src/views/system/LoginImageManage.vue
+++ b/customer-admin-web/src/views/system/LoginImageManage.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import type { UploadRequestOptions } from 'element-plus'
+import {
+  deleteLoginImage,
+  fetchLoginImages,
+  reorderLoginImages,
+  updateLoginImageEnabled,
+  uploadLoginImage,
+  type LoginCarouselImageVO,
+} from '@/api/login-image'
+
+const loading = ref(false)
+const images = ref<LoginCarouselImageVO[]>([])
+
+async function loadImages() {
+  loading.value = true
+  try {
+    images.value = await fetchLoginImages()
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadImages)
+
+async function handleUpload(options: UploadRequestOptions) {
+  try {
+    await uploadLoginImage(options.file as File)
+    ElMessage.success('上传成功，登录页已实时生效')
+    await loadImages()
+  } catch {
+    // 全局 axios 拦截器已经弹过错误提示，这里不用重复弹
+  }
+}
+
+async function handleToggleEnabled(row: LoginCarouselImageVO) {
+  try {
+    await updateLoginImageEnabled(row.id, row.enabled)
+    ElMessage.success(row.enabled ? '已启用' : '已禁用')
+  } catch {
+    row.enabled = !row.enabled
+  }
+}
+
+/** 上移/下移：本地交换后把完整 id 顺序提交后端重写 sortOrder */
+async function handleMove(index: number, offset: -1 | 1) {
+  const target = index + offset
+  if (target < 0 || target >= images.value.length) {
+    return
+  }
+  const list = [...images.value]
+  ;[list[index], list[target]] = [list[target], list[index]]
+  try {
+    await reorderLoginImages(list.map((item) => item.id))
+    images.value = list
+  } catch {
+    await loadImages()
+  }
+}
+
+async function handleDelete(row: LoginCarouselImageVO) {
+  await ElMessageBox.confirm(`确定删除「${row.imageName}」吗？删除后登录页立即不再展示该图。`, '删除确认', {
+    type: 'warning',
+  })
+  await deleteLoginImage(row.id)
+  ElMessage.success('删除成功')
+  await loadImages()
+}
+</script>
+
+<template>
+  <div class="login-image-page">
+    <el-card>
+      <template #header>
+        <div class="page-header">
+          <div>
+            <span class="page-title">登录页图片</span>
+            <span class="page-subtitle">上传多张图片作为登录页轮播背景，登录页实时获取；全部禁用或为空时回退内置默认图</span>
+          </div>
+          <el-upload
+            :show-file-list="false"
+            :http-request="handleUpload"
+            accept="image/png,image/jpeg,image/webp"
+          >
+            <el-button v-permission="'login-image:add'" type="primary">上传图片</el-button>
+          </el-upload>
+        </div>
+      </template>
+
+      <el-empty v-if="!loading && images.length === 0" description="暂无轮播图，登录页正在使用内置默认图" />
+
+      <div v-else v-loading="loading" class="image-grid">
+        <el-card v-for="(row, index) in images" :key="row.id" shadow="hover" class="image-card">
+          <el-image :src="row.imageUrl" fit="cover" class="image-preview" :preview-src-list="[row.imageUrl]" preview-teleported>
+            <template #error>
+              <div class="image-error">图片加载失败</div>
+            </template>
+          </el-image>
+          <div class="image-meta">
+            <span class="image-name" :title="row.imageName">{{ index + 1 }}. {{ row.imageName }}</span>
+            <el-tag v-if="!row.enabled" type="info" size="small">已禁用</el-tag>
+          </div>
+          <div class="image-actions">
+            <el-switch
+              v-model="row.enabled"
+              v-permission="'login-image:edit'"
+              inline-prompt
+              active-text="启用"
+              inactive-text="禁用"
+              @change="handleToggleEnabled(row)"
+            />
+            <span>
+              <el-button v-permission="'login-image:edit'" link :disabled="index === 0" @click="handleMove(index, -1)">
+                上移
+              </el-button>
+              <el-button
+                v-permission="'login-image:edit'"
+                link
+                :disabled="index === images.length - 1"
+                @click="handleMove(index, 1)"
+              >
+                下移
+              </el-button>
+              <el-button v-permission="'login-image:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            </span>
+          </div>
+        </el-card>
+      </div>
+
+      <div class="page-tip">支持 png/jpg/jpeg/webp，单张不超过 5MB，最多 10 张；轮播按序号顺序播放。</div>
+    </el-card>
+  </div>
+</template>
+
+<style scoped>
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.page-title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.page-subtitle {
+  margin-left: 12px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.image-preview {
+  width: 100%;
+  height: 160px;
+  border-radius: 4px;
+  display: block;
+}
+
+.image-error {
+  height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--el-text-color-secondary);
+  background: var(--el-fill-color-light);
+}
+
+.image-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+
+.image-name {
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+
+.page-tip {
+  margin-top: 16px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/customer-admin-web/src/views/system/LoginImageManage.vue
+++ b/customer-admin-web/src/views/system/LoginImageManage.vue
@@ -128,7 +128,10 @@ async function handleDelete(row: LoginCarouselImageVO) {
         </el-card>
       </div>
 
-      <div class="page-tip">支持 png/jpg/jpeg/webp，单张不超过 5MB，最多 10 张；轮播按序号顺序播放。</div>
+      <div class="page-tip">
+      支持 png/jpg/jpeg/webp，单张不超过 5MB，最多 10 张；轮播按序号顺序播放。
+      背景图会铺满整屏，建议上传不低于 1920×1080 的图片，分辨率过低会被拉伸放大导致模糊。
+    </div>
     </el-card>
   </div>
 </template>

--- a/customer-admin-web/src/views/system/LoginImageManage.vue
+++ b/customer-admin-web/src/views/system/LoginImageManage.vue
@@ -13,10 +13,40 @@ import {
 const loading = ref(false)
 const images = ref<LoginCarouselImageVO[]>([])
 
+/** 与后端 LoginImageStorageService 的最低分辨率门槛保持一致，改这里要同步改那边 */
+const MIN_WIDTH = 1280
+const MIN_HEIGHT = 720
+
+/** imageUrl -> "宽×高"，纯前端用 Image 对象读实际像素，不占后端接口 */
+const resolutions = ref<Record<string, { width: number; height: number }>>({})
+
+function isLowResolution(url: string) {
+  const size = resolutions.value[url]
+  return !!size && (size.width < MIN_WIDTH || size.height < MIN_HEIGHT)
+}
+
+/**
+ * 读取每张图的真实像素并缓存。校验门槛上线前存量的小图不会被拦，这里标出来方便识别替换；
+ * 单张读失败不影响其他图（不写入即不展示尺寸）。
+ */
+function loadResolutions(list: LoginCarouselImageVO[]) {
+  list.forEach((row) => {
+    const img = new Image()
+    img.onload = () => {
+      resolutions.value = {
+        ...resolutions.value,
+        [row.imageUrl]: { width: img.naturalWidth, height: img.naturalHeight },
+      }
+    }
+    img.src = row.imageUrl
+  })
+}
+
 async function loadImages() {
   loading.value = true
   try {
     images.value = await fetchLoginImages()
+    loadResolutions(images.value)
   } finally {
     loading.value = false
   }
@@ -100,6 +130,12 @@ async function handleDelete(row: LoginCarouselImageVO) {
           <div class="image-meta">
             <span class="image-name" :title="row.imageName">{{ index + 1 }}. {{ row.imageName }}</span>
             <el-tag v-if="!row.enabled" type="info" size="small">已禁用</el-tag>
+          </div>
+          <div v-if="resolutions[row.imageUrl]" class="image-resolution">
+            <span>{{ resolutions[row.imageUrl].width }} × {{ resolutions[row.imageUrl].height }}</span>
+            <el-tag v-if="isLowResolution(row.imageUrl)" type="danger" size="small">
+              分辨率偏低，登录页会拉伸模糊
+            </el-tag>
           </div>
           <div class="image-actions">
             <el-switch
@@ -188,6 +224,16 @@ async function handleDelete(row: LoginCarouselImageVO) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.image-resolution {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
 }
 
 .image-actions {

--- a/mysql/02-customer-admin/35-V35__login_carousel_image.sql
+++ b/mysql/02-customer-admin/35-V35__login_carousel_image.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- 登录页轮播图管理（Flyway V35）
+-- =============================================================================
+-- 后台可上传多张登录页轮播背景图（原图落盘 ./data/login-images，表里存相对访问 URL
+-- /api/login-images/{uuid}.{ext}），支持排序/启停/删除；登录页未登录状态通过免鉴权接口
+-- GET /api/login-images/list 实时拉取启用图列表，拉不到或列表为空时前端回退内置默认图。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+--
+-- 菜单/权限种子：id 从 180 起——V31 显式 id 用到 166，但 V27 有一条不带显式 id 的插入吃掉了
+-- 自增号段（本机实测已分配到 170），170 段不安全，跳到 180 留足空间。超级管理员（super_admin）
+-- 无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接返回全部权限点
+-- （沿用 V29 同款做法，普通角色需在角色管理页手工授权）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `login_carousel_image` (
+    `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `image_name`  VARCHAR(255) COMMENT '上传时的原始文件名（管理页展示用）',
+    `image_url`   VARCHAR(255) NOT NULL COMMENT '对外访问相对URL：/api/login-images/{uuid}.{ext}',
+    `sort_order`  INT NOT NULL DEFAULT 0 COMMENT '轮播顺序，小的在前',
+    `enabled`     TINYINT NOT NULL DEFAULT 1 COMMENT '是否启用：0禁用 / 1启用',
+    `create_by`   BIGINT COMMENT '创建人ID',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`   BIGINT COMMENT '更新人ID',
+    `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`     TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    KEY `idx_login_carousel_sort` (`sort_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='登录页轮播背景图';
+
+-- 二级菜单：登录页图片（挂"系统管理" id=1 下，sort=7 排在开发者工具箱之后）。菜单可见性即 view 权限点。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (180, 1, '登录页图片', 'login-image:view', 1, '/system/login-image', 'Picture', 'library', 7);
+
+-- 三级：按钮/接口权限点（type=2，挂 180 下）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (181, 180, '上传登录页图片', 'login-image:add',    2, 1),
+    (182, 180, '编辑登录页图片', 'login-image:edit',   2, 2),
+    (183, 180, '删除登录页图片', 'login-image:delete', 2, 3);


### PR DESCRIPTION
## 需求
后台可上传多张登录页轮播背景图并管理，登录页实时获取，替换此前前端写死的 `/A1.jpg~/A3.jpg`。

## 方案
沿用菜单图标"本地磁盘 + 静态映射 + 白名单"既有模式（唯一"上传返回可访问 URL"先例）：

**后端（customer-admin-server）**
- `login_carousel_image` 表（V35 迁移，含菜单/权限种子 id 180~183——170 段被 V27 一条无显式 id 的插入吃掉自增号，已跳开）
- `LoginImageStorageService`：落盘 `./data/login-images`，5MB/张，png/jpg/jpeg/webp
- `LoginCarouselImageService`：上传（追加排序、上限 10 张）/ 启停 / 整表排序重写（校验 id 集合一致防并发丢序）/ 删除联动清理文件
- `LoginImageAdminController`（`/api/system/login-image`，`login-image:view/add/edit/delete` 权限点）
- `LoginImagePublicController`（`GET /api/login-images/list` 免鉴权，与静态图片共用一条 Sa-Token 白名单；Controller 映射优先级高于静态资源映射，不冲突）
- `StaticResourceConfig` 增加 `/api/login-images/**` → `file:./data/login-images/`

**前端（customer-admin-web）**
- 新页面 `LoginImageManage.vue`（系统管理 › 登录页图片）：卡片网格预览、上传、启停 switch、上移/下移、删除
- `Login.vue`：挂载后免鉴权拉取启用图列表，拉取失败或为空回退内置默认图，登录页永远有背景
- `component-map.ts` 注册 `/system/login-image`

## 测试
- `LoginCarouselImageServiceTest` 8 例全过（mock mapper/storage）
- `vite build` 通过
- V35 已手工同步本机 `customer_admin` 库（`SET NAMES utf8mb4` 首行，中文 COMMENT 字节级验证无乱码），`mysql/02-customer-admin/` 副本已同步

## 待人工验证
- 重启本机 admin-server(8082) 后：管理页上传/排序/启停/删除 e2e；登录页（未登录）实时展示新图
- 普通角色需在角色管理页手工授权 `login-image:*`（超管自动全量）

🤖 Generated with [Claude Code](https://claude.com/claude-code)