### PR TITLE
feat(stats): 智能体调用分段耗时统计（MODEL/TOOL/MCP/SKILL）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsAppProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsAppProperties.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * APP 数据源（8080 客服端库 {@code agent_scope_customer_work}）连接参数：{@code admin.agent-call-stats.app.*}。
+ *
+ * <p>只用于"查询客服端调用日志"的第二只读数据源，默认指向本机 {@code localhost:3306} root/root。
+ * 全部可经环境变量覆盖（见各字段默认值）。该库不可达不影响 admin 启动——数据源惰性构建、查询时才连。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@ConfigurationProperties(prefix = "admin.agent-call-stats.app")
+public class AgentCallStatsAppProperties {
+
+    /** 数据库主机。 */
+    private String host = "localhost";
+
+    /** 数据库端口。 */
+    private int port = 3306;
+
+    /** 库名。 */
+    private String database = "agent_scope_customer_work";
+
+    /** 用户名。 */
+    private String username = "root";
+
+    /** 密码。 */
+    private String password = "root";
+
+    /** 拼装 JDBC URL（与 admin 主库同款连接参数）。 */
+    public String jdbcUrl() {
+        return "jdbc:mysql://" + host + ":" + port + "/" + database
+            + "?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true";
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsGatewayFactory.java
@@ -1,0 +1,81 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.config;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsExtMapper;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsGateway;
+import com.richard.fyoung.customerwork.calllog.AgentCallLogStore;
+import com.richard.fyoung.customerwork.calllog.MybatisAgentCallLogStore;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 为某个数据源装配一套独立的调用统计门面（{@link AgentCallStatsGateway}）。
+ *
+ * <p>关键点：用 MyBatis-Plus 的 {@link MybatisSqlSessionFactoryBean} 现场构建一个<b>专用</b>
+ * {@link SqlSessionFactory}（不作为 Spring Bean 暴露，避免让 MP 自动装配的主
+ * {@code SqlSessionFactory}/{@code SqlSessionTemplate} 因 {@code @ConditionalOnMissingBean} 退避而
+ * 破坏主 Mapper 扫描）。工厂加载 starter jar 内的两张 Mapper XML（{@code customerwork/mapper/*.xml}）
+ * 与 admin 自带的 ext XML（{@code callstats/*.xml}）——XML 的 namespace 绑定即完成 Mapper 接口注册与
+ * MP BaseMapper CRUD 注入，无需 {@code @MapperScan}。Mapper 代理由 {@link SqlSessionTemplate} 提供，
+ * 其在非 Spring 事务下每次操作自动提交（写入/查询均在本源独立提交，与主库事务完全隔离）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+final class AgentCallStatsGatewayFactory {
+
+    /** starter jar 内的调用日志主表 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
+    private static final String STARTER_LOG_XML = "classpath*:customerwork/mapper/AgentCallLogMapper.xml";
+    /** starter jar 内的调用分段 Mapper XML。 */
+    private static final String STARTER_SEGMENT_XML = "classpath*:customerwork/mapper/AgentCallSegmentMapper.xml";
+    /** admin 自带的读侧扩展 Mapper XML（放 /callstats 下，避开主 MP 默认的 /mapper 扫描）。 */
+    private static final String EXT_XML = "classpath*:callstats/AgentCallStatsExtMapper.xml";
+
+    private AgentCallStatsGatewayFactory() {
+    }
+
+    /** 按数据源装配一套门面。XML 解析/工厂构建阶段不连库，首次查询时才真正取连接。 */
+    static AgentCallStatsGateway build(DataSource dataSource) {
+        try {
+            SqlSessionFactory factory = buildSqlSessionFactory(dataSource);
+            SqlSessionTemplate template = new SqlSessionTemplate(factory);
+            AgentCallLogMapper logMapper = template.getMapper(AgentCallLogMapper.class);
+            AgentCallSegmentMapper segmentMapper = template.getMapper(AgentCallSegmentMapper.class);
+            AgentCallStatsExtMapper extMapper = template.getMapper(AgentCallStatsExtMapper.class);
+            AgentCallLogStore store = new MybatisAgentCallLogStore(logMapper, segmentMapper);
+            return new AgentCallStatsGateway(extMapper, logMapper, segmentMapper, store);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to build agent call stats gateway", e);
+        }
+    }
+
+    private static SqlSessionFactory buildSqlSessionFactory(DataSource dataSource) throws Exception {
+        MybatisConfiguration configuration = new MybatisConfiguration();
+        // starter/ext XML 均用列别名下划线命名（request_id 等），需开启驼峰映射到 DO 的驼峰字段
+        configuration.setMapUnderscoreToCamelCase(true);
+
+        MybatisSqlSessionFactoryBean factoryBean = new MybatisSqlSessionFactoryBean();
+        factoryBean.setDataSource(dataSource);
+        factoryBean.setConfiguration(configuration);
+        factoryBean.setMapperLocations(resolveMapperXml());
+        factoryBean.afterPropertiesSet();
+        return factoryBean.getObject();
+    }
+
+    private static Resource[] resolveMapperXml() throws Exception {
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        List<Resource> resources = new ArrayList<>();
+        resources.addAll(Arrays.asList(resolver.getResources(STARTER_LOG_XML)));
+        resources.addAll(Arrays.asList(resolver.getResources(STARTER_SEGMENT_XML)));
+        resources.addAll(Arrays.asList(resolver.getResources(EXT_XML)));
+        return resources.toArray(new Resource[0]);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsStoreConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsStoreConfig.java
@@ -1,0 +1,66 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.config;
+
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsGateway;
+import com.richard.fyoung.customerwork.calllog.AgentCallRecordSink;
+import com.richard.fyoung.customerwork.calllog.AgentCallTimingMiddleware;
+import com.richard.fyoung.customerwork.calllog.StoreAgentCallRecordSink;
+import com.richard.fyoung.customerwork.calllog.ToolKindRegistry;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * 智能体调用耗时统计的存储与采集装配（admin 排除了 starter 自动装配，故这里显式 new 全部 starter 组件）。
+ *
+ * <p>ADMIN 门面用 admin 主数据源现场装配（{@link AgentCallStatsGatewayFactory}，专用 SqlSessionFactory，
+ * 不污染主 MyBatis 环境）；采集侧把 {@link ToolKindRegistry} + {@link AgentCallTimingMiddleware} +
+ * {@link AgentCallRecordSink}（落 ADMIN 门面）三件套装成 Bean，供 {@code AdminAgentInstanceFactory} 挂到
+ * workspace 智能体链路上。APP 门面（客服端库只读）由 {@link AppAgentCallStatsGatewayProvider} 惰性提供，
+ * 不在此装配。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+@EnableConfigurationProperties(AgentCallStatsAppProperties.class)
+public class AgentCallStatsStoreConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentCallStatsStoreConfig.class);
+
+    /** ADMIN 数据源门面：用 admin 主数据源，启动期只解析 XML/建工厂，不连库。 */
+    @Bean
+    public AgentCallStatsGateway adminAgentCallStatsGateway(DataSource dataSource) {
+        log.info("agent call stats ADMIN gateway wired on primary datasource");
+        return AgentCallStatsGatewayFactory.build(dataSource);
+    }
+
+    /** 工具名→类别登记表：供 AdminAgentInstanceFactory 装配 MCP/Skill 时登记，采集时 onActing 归类。 */
+    @Bean
+    public ToolKindRegistry agentCallToolKindRegistry() {
+        return new ToolKindRegistry();
+    }
+
+    /** 采集落库 Sink（异步、单线程有界队列），指向 ADMIN 门面的 Store。DisposableBean，容器关闭优雅停池。 */
+    @Bean
+    public AgentCallRecordSink agentCallRecordSink(AgentCallStatsGateway adminAgentCallStatsGateway) {
+        return new StoreAgentCallRecordSink(adminAgentCallStatsGateway.store());
+    }
+
+    /**
+     * 分段耗时采集中间件：开关经 {@code customer-work.call-log.enabled}（默认开）绑定到配置，
+     * 运维可通过配置/环境变量关闭采集；storeMode 在 admin 侧无意义（Store 由本类显式装配），不绑定。
+     */
+    @Bean
+    public AgentCallTimingMiddleware agentCallTimingMiddleware(
+            @Value("${customer-work.call-log.enabled:true}") boolean callLogEnabled,
+            ToolKindRegistry agentCallToolKindRegistry,
+            AgentCallRecordSink agentCallRecordSink) {
+        CustomerWorkProperties properties = new CustomerWorkProperties();
+        properties.getCallLog().setEnabled(callLogEnabled);
+        return new AgentCallTimingMiddleware(properties, agentCallToolKindRegistry, agentCallRecordSink);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AppAgentCallStatsGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AppAgentCallStatsGatewayProvider.java
@@ -1,0 +1,111 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.config;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsGateway;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+
+/**
+ * APP 数据源（客服端库 {@code agent_scope_customer_work}）调用统计门面的惰性提供者。
+ *
+ * <p><b>惰性 + 容错</b>：连接池与门面在首次 {@link #get()} 时才构建并做一次连通性探测（open+close 一条连接），
+ * 库不可达则抛 {@link ResultCode#CUSTOMER_WORK_UNAVAILABLE} 业务异常并返回明确信息，绝不在 admin 启动期
+ * 触碰该库。构建成功后缓存复用（双重检查）；构建失败不缓存，下次 {@link #get()} 重试（覆盖库稍后恢复的场景）。
+ * 连接池只读、参数保守（参考 {@code SqlDatasourceConnectionManager}）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class AppAgentCallStatsGatewayProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(AppAgentCallStatsGatewayProvider.class);
+
+    private static final String POOL_NAME = "agent-call-stats-app-pool";
+    private static final int MAX_POOL_SIZE = 3;
+    private static final int MIN_IDLE = 0;
+    private static final long CONNECTION_TIMEOUT_MS = 5000L;
+    private static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+
+    private final AgentCallStatsAppProperties properties;
+
+    private volatile AgentCallStatsGateway cachedGateway;
+    private volatile HikariDataSource dataSource;
+
+    public AppAgentCallStatsGatewayProvider(AgentCallStatsAppProperties properties) {
+        this.properties = properties;
+    }
+
+    /** 取 APP 门面（惰性构建 + 探测 + 缓存）；库不可达抛明确业务异常。 */
+    public AgentCallStatsGateway get() {
+        AgentCallStatsGateway gateway = cachedGateway;
+        if (gateway != null) {
+            return gateway;
+        }
+        synchronized (this) {
+            if (cachedGateway != null) {
+                return cachedGateway;
+            }
+            HikariDataSource ds = buildAndProbeDataSource();
+            AgentCallStatsGateway built = AgentCallStatsGatewayFactory.build(ds);
+            this.dataSource = ds;
+            this.cachedGateway = built;
+            log.info("agent call stats APP datasource ready, url={}", properties.jdbcUrl());
+            return built;
+        }
+    }
+
+    /** 构建只读连接池并探测连通性；任何失败关闭半开池并抛 {@link ResultCode#CUSTOMER_WORK_UNAVAILABLE}。 */
+    private HikariDataSource buildAndProbeDataSource() {
+        HikariDataSource ds = null;
+        try {
+            HikariConfig config = new HikariConfig();
+            config.setPoolName(POOL_NAME);
+            config.setDriverClassName(DRIVER_CLASS);
+            config.setJdbcUrl(properties.jdbcUrl());
+            config.setUsername(properties.getUsername());
+            config.setPassword(properties.getPassword());
+            config.setMaximumPoolSize(MAX_POOL_SIZE);
+            config.setMinimumIdle(MIN_IDLE);
+            config.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
+            config.setReadOnly(true);
+            // 惰性：构造连接池本身不因不可达而抛（探测放在下方显式 getConnection，失败信息更明确可控）
+            config.setInitializationFailTimeout(-1L);
+            ds = new HikariDataSource(config);
+            try (Connection ignored = ds.getConnection()) {
+                // 探测一次：拿到连接即视为可达，随即归还
+                log.info("agent call stats APP datasource probe ok");
+            }
+            return ds;
+        } catch (Exception e) {
+            if (ds != null) {
+                ds.close();
+            }
+            log.error("agent call stats APP datasource unavailable, code={}, url={}",
+                "CALLSTATS-APP-DS-UNAVAILABLE", properties.jdbcUrl(), e);
+            throw new BizException(ResultCode.CUSTOMER_WORK_UNAVAILABLE,
+                "客服端调用日志库不可达：" + rootMessage(e));
+        }
+    }
+
+    private String rootMessage(Throwable e) {
+        Throwable cause = e;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+    }
+
+    @PreDestroy
+    public void close() {
+        if (dataSource != null) {
+            dataSource.close();
+            log.info("agent call stats APP datasource closed");
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/controller/AgentCallStatsController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/controller/AgentCallStatsController.java
@@ -1,0 +1,74 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsDetailVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsPageVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsQuery;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsSummaryVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallTrendVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.service.AgentCallStatsService;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 智能体调用分段耗时统计查询（只读为主 + 删除）。数据由 {@code AgentCallTimingMiddleware} 采集落库，
+ * {@code source=ADMIN}（默认，本库）/{@code APP}（客服端库 agent_scope_customer_work）双源可查。
+ * 鉴权：查询点 {@code agent-call-stats:view}、删除点 {@code agent-call-stats:delete}（与 V38 种子一致）。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/agent-call-stats")
+public class AgentCallStatsController {
+
+    private static final String DEFAULT_SOURCE = "ADMIN";
+
+    private final AgentCallStatsService callStatsService;
+
+    public AgentCallStatsController(AgentCallStatsService callStatsService) {
+        this.callStatsService = callStatsService;
+    }
+
+    /** 分页查询（{total, rows}），支持 source/username/agentCode/sessionType/requestId/sessionId/时间范围过滤。 */
+    @SaCheckPermission("agent-call-stats:view")
+    @GetMapping("/page")
+    public Result<AgentCallStatsPageVO> page(AgentCallStatsQuery query) {
+        return Result.success(callStatsService.page(query));
+    }
+
+    /** 调用汇总（总数/平均总耗时/最大总耗时/各段平均），筛选条件同 page。 */
+    @SaCheckPermission("agent-call-stats:view")
+    @GetMapping("/summary")
+    public Result<AgentCallStatsSummaryVO> summary(AgentCallStatsQuery query) {
+        return Result.success(callStatsService.summary(query));
+    }
+
+    /** 调用趋势（granularity=day|hour，含各段平均耗时），筛选条件同 page。 */
+    @SaCheckPermission("agent-call-stats:view")
+    @GetMapping("/trend")
+    public Result<List<AgentCallTrendVO>> trend(AgentCallStatsQuery query) {
+        return Result.success(callStatsService.trend(query));
+    }
+
+    /** 调用明细（全量字段 + 回答全文 + 分段列表）。 */
+    @SaCheckPermission("agent-call-stats:view")
+    @GetMapping("/{id}")
+    public Result<AgentCallStatsDetailVO> detail(@PathVariable long id,
+                                                 @RequestParam(defaultValue = DEFAULT_SOURCE) String source) {
+        return Result.success(callStatsService.detail(id, source));
+    }
+
+    /** 删除一条调用（主记录 + 分段级联）。 */
+    @SaCheckPermission("agent-call-stats:delete")
+    @DeleteMapping("/{id}")
+    public Result<Boolean> delete(@PathVariable long id,
+                                  @RequestParam(defaultValue = DEFAULT_SOURCE) String source) {
+        return Result.success(callStatsService.delete(id, source));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallSegmentVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallSegmentVO.java
@@ -14,6 +14,9 @@ public class AgentCallSegmentVO {
     private String name;
     private String startTime;
     private Long durationMs;
+    /** token 消耗（仅 MODEL 段有值，缺失为 null）。 */
+    private Long inputTokens;
+    private Long outputTokens;
     private Boolean success;
     private String errorMsg;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallSegmentVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallSegmentVO.java
@@ -1,0 +1,19 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+/**
+ * 调用明细中的一段耗时（MODEL/TOOL/MCP/SKILL）。{@code startTime} 输出 {@code yyyy-MM-dd HH:mm:ss}。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallSegmentVO {
+
+    private Integer seq;
+    private String kind;
+    private String name;
+    private String startTime;
+    private Long durationMs;
+    private Boolean success;
+    private String errorMsg;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsDetailVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsDetailVO.java
@@ -29,5 +29,9 @@ public class AgentCallStatsDetailVO {
     private Long toolMs;
     private Long mcpMs;
     private Long skillMs;
+    /** 请求级 token 消耗（缺失为 null）。 */
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long totalTokens;
     private List<AgentCallSegmentVO> segments;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsDetailVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsDetailVO.java
@@ -1,0 +1,33 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 调用耗时统计明细（详情视图）：主记录全量字段（含回答全文）+ 分段明细列表（seq 升序）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsDetailVO {
+
+    private Long id;
+    private String requestId;
+    private String userId;
+    private String username;
+    private String agentCode;
+    private String agentName;
+    private String sessionId;
+    private String sessionType;
+    private String question;
+    /** 智能体回答全文（不截断）。 */
+    private String answer;
+    private String startTime;
+    private String endTime;
+    private Long durationMs;
+    private Long modelMs;
+    private Long toolMs;
+    private Long mcpMs;
+    private Long skillMs;
+    private List<AgentCallSegmentVO> segments;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsPageVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsPageVO.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 分页返回体：{@code {total, rows}}（与前端契约一致，不用通用 PageResult 的 {pageNum,pageSize,list} 形状）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsPageVO {
+
+    private long total;
+    private List<AgentCallStatsRowVO> rows;
+
+    public AgentCallStatsPageVO(long total, List<AgentCallStatsRowVO> rows) {
+        this.total = total;
+        this.rows = rows;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsQuery.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsQuery.java
@@ -1,0 +1,48 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+/**
+ * 智能体调用耗时统计查询条件（page / summary / trend 共用）。全部过滤项可空，空即不约束该维度。
+ *
+ * <p>{@code startTime}/{@code endTime} 为 {@code "yyyy-MM-dd HH:mm:ss"} 文本，服务层转毫秒时间戳按
+ * 主表 {@code start_time} 过滤；{@code source} 决定路由到 ADMIN 本库还是 APP 客服端库；
+ * {@code granularity} 仅 trend 用（day/hour）。Spring MVC 按同名请求参数绑定。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsQuery {
+
+    /** 数据源：ADMIN（默认）/ APP。 */
+    private String source;
+
+    /** 用户名（精确匹配）。 */
+    private String username;
+
+    /** 智能体编码（精确匹配）。 */
+    private String agentCode;
+
+    /** 会话类型 CHAT / VIBE_CODING（精确匹配）。 */
+    private String sessionType;
+
+    /** 请求ID（精确匹配）。 */
+    private String requestId;
+
+    /** 会话ID（精确匹配）。 */
+    private String sessionId;
+
+    /** 起始时间下界（含），格式 {@code yyyy-MM-dd HH:mm:ss}。 */
+    private String startTime;
+
+    /** 起始时间上界（含），格式 {@code yyyy-MM-dd HH:mm:ss}。 */
+    private String endTime;
+
+    /** 趋势聚合粒度：day（默认）/ hour，仅 trend 接口使用。 */
+    private String granularity;
+
+    /** 页码（从 1 起），仅 page 接口使用。 */
+    private Integer pageNum = 1;
+
+    /** 每页条数，仅 page 接口使用。 */
+    private Integer pageSize = 10;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsRowVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsRowVO.java
@@ -1,0 +1,31 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+/**
+ * 调用耗时统计分页行（列表视图，问题/回答按预览截断）。时间字段输出 {@code yyyy-MM-dd HH:mm:ss}。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsRowVO {
+
+    private Long id;
+    private String requestId;
+    private String userId;
+    private String username;
+    private String agentCode;
+    private String agentName;
+    private String sessionId;
+    private String sessionType;
+    /** 用户问题（截断至预览长度）。 */
+    private String question;
+    /** 智能体回答预览（截断至预览长度）。 */
+    private String answerPreview;
+    private String startTime;
+    private String endTime;
+    private Long durationMs;
+    private Long modelMs;
+    private Long toolMs;
+    private Long mcpMs;
+    private Long skillMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsRowVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsRowVO.java
@@ -28,4 +28,8 @@ public class AgentCallStatsRowVO {
     private Long toolMs;
     private Long mcpMs;
     private Long skillMs;
+    /** 请求级 token 消耗（缺失为 null）。 */
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long totalTokens;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSource.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSource.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+/**
+ * 调用日志数据源：ADMIN=后台库（customer_admin，本模块埋点写入的库）；
+ * APP=客服端库（agent_scope_customer_work，8080 客服链路写入的库，本模块只读查询）。
+ * @author owlzhangfq@gmail.com
+ */
+public enum AgentCallStatsSource {
+
+    ADMIN, APP;
+
+    /** 宽松解析：空/非法一律回落 {@link #ADMIN}（契约默认值）。 */
+    public static AgentCallStatsSource parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return ADMIN;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ADMIN;
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSummaryVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSummaryVO.java
@@ -1,0 +1,19 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+/**
+ * 调用耗时汇总（符合筛选条件的整体口径）。平均值单位毫秒。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsSummaryVO {
+
+    private Long totalCalls;
+    private Double avgDurationMs;
+    private Long maxDurationMs;
+    private Double avgModelMs;
+    private Double avgToolMs;
+    private Double avgMcpMs;
+    private Double avgSkillMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSummaryVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSummaryVO.java
@@ -16,4 +16,8 @@ public class AgentCallStatsSummaryVO {
     private Double avgToolMs;
     private Double avgMcpMs;
     private Double avgSkillMs;
+    /** 总 token 消耗（符合条件记录 total_tokens 求和）。 */
+    private Long totalTokens;
+    /** 平均每次 token 消耗。 */
+    private Double avgTotalTokens;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallTrendVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallTrendVO.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import lombok.Data;
+
+/**
+ * 调用耗时趋势的一个时间桶（按天 {@code yyyy-MM-dd} 或按小时 {@code yyyy-MM-dd HH}）。
+ * 各段平均耗时随桶给出，供前端画分段耗时趋势。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallTrendVO {
+
+    private String bucket;
+    private Long count;
+    private Double avgDurationMs;
+    private Double avgModelMs;
+    private Double avgToolMs;
+    private Double avgMcpMs;
+    private Double avgSkillMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallTrendVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallTrendVO.java
@@ -17,4 +17,6 @@ public class AgentCallTrendVO {
     private Double avgToolMs;
     private Double avgMcpMs;
     private Double avgSkillMs;
+    /** 该桶内 token 消耗合计。 */
+    private Long totalTokens;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsExtMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsExtMapper.java
@@ -1,0 +1,38 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.jdbc;
+
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * admin 侧智能体调用统计扩展 Mapper（纯手写 XML，非 MyBatis-Plus BaseMapper）。
+ *
+ * <p><b>为何 admin 自带一套读侧 Mapper</b>：starter 的 {@code AgentCallLogMapper} 读侧不支持
+ * {@code session_type} 过滤，且 trend 只出 avgDurationMs；而前端契约要求 page/summary/trend 能按
+ * CHAT/VIBE_CODING 筛、trend 还要各段平均耗时。故此处对同两张表（{@code cw_agent_call_log} /
+ * {@code cw_agent_call_segment}）另写一套读 SQL 补齐差异，starter 的 Mapper 仍复用于写入（insert）、
+ * 按 id 取主记录（selectById）、明细段与删除，不重复造持久层。</p>
+ *
+ * <p>刻意放在 {@code .jdbc} 包（而非 {@code .mapper}）：admin 主 {@code @MapperScan("...**.mapper")}
+ * 不扫到本接口，本接口只由 callstats 专用 {@code SqlSessionFactory} 注册，避免污染主 MyBatis 环境。
+ * XML 在 {@code classpath:/callstats/AgentCallStatsExtMapper.xml}（避开主 MP 默认的
+ * {@code classpath*:/mapper/**} 扫描）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface AgentCallStatsExtMapper {
+
+    /** 分页条件查询主记录（id 倒序，最新在前），复用 starter 的 {@link AgentCallLogDO} 承载列。 */
+    List<AgentCallLogDO> findPage(@Param("q") AgentCallStatsQueryParam query);
+
+    /** 符合条件的主记录总数。 */
+    long countBy(@Param("q") AgentCallStatsQueryParam query);
+
+    /** 汇总统计（总数/平均总耗时/最大总耗时/各段平均），复用 starter 的 {@link AgentCallSummaryDO}。 */
+    AgentCallSummaryDO summary(@Param("q") AgentCallStatsQueryParam query);
+
+    /** 趋势聚合：{@code dateFormat} 为 MySQL DATE_FORMAT 格式串（按天/小时），含各段平均耗时。 */
+    List<AgentCallStatsTrendRow> trend(@Param("q") AgentCallStatsQueryParam query,
+                                       @Param("dateFormat") String dateFormat);
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsGateway.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsGateway.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.jdbc;
+
+import com.richard.fyoung.customerwork.calllog.AgentCallLogStore;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
+
+/**
+ * 单个数据源（ADMIN 本库 / APP 客服端库）的调用统计读写门面：把该源的一套 Mapper 与 Store 收拢在一起。
+ *
+ * <p>{@code extMapper} 承接 page/summary/trend（含 sessionType 过滤 + 各段趋势）；starter 的
+ * {@code logMapper} 提供按 id 取主记录（BaseMapper#selectById，供详情），{@code segmentMapper} 提供
+ * 明细段查询；{@code store} 复用 starter 的删除（主记录 + 分段级联）与写入（save，仅 ADMIN 侧 Sink 用到）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class AgentCallStatsGateway {
+
+    private final AgentCallStatsExtMapper extMapper;
+    private final AgentCallLogMapper logMapper;
+    private final AgentCallSegmentMapper segmentMapper;
+    private final AgentCallLogStore store;
+
+    public AgentCallStatsGateway(AgentCallStatsExtMapper extMapper, AgentCallLogMapper logMapper,
+                                 AgentCallSegmentMapper segmentMapper, AgentCallLogStore store) {
+        this.extMapper = extMapper;
+        this.logMapper = logMapper;
+        this.segmentMapper = segmentMapper;
+        this.store = store;
+    }
+
+    public AgentCallStatsExtMapper extMapper() {
+        return extMapper;
+    }
+
+    public AgentCallLogMapper logMapper() {
+        return logMapper;
+    }
+
+    public AgentCallSegmentMapper segmentMapper() {
+        return segmentMapper;
+    }
+
+    public AgentCallLogStore store() {
+        return store;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsQueryParam.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsQueryParam.java
@@ -1,0 +1,25 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.jdbc;
+
+import lombok.Data;
+
+/**
+ * 调用统计查询的 XML 传参对象（page / count / summary / trend 共用）。
+ *
+ * <p>相比 starter 的 {@code AgentCallLogQueryParam} 多出 {@code sessionType} 过滤维度——starter 的读侧
+ * 契约不含会话类型过滤，而前端契约需要按 CHAT/VIBE_CODING 筛，故 admin 侧自带一套 ext Mapper 覆盖
+ * page/summary/trend（trend 还额外聚合各段平均耗时），starter 的 Mapper 仅复用写入/明细/删除/按 id 取。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsQueryParam {
+
+    private String username;
+    private String agentCode;
+    private String sessionType;
+    private String requestId;
+    private String sessionId;
+    private Long startFromMs;
+    private Long startToMs;
+    private int offset;
+    private int limit;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsTrendRow.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsTrendRow.java
@@ -19,4 +19,6 @@ public class AgentCallStatsTrendRow {
     private BigDecimal avgToolMs;
     private BigDecimal avgMcpMs;
     private BigDecimal avgSkillMs;
+    /** 该桶内 token 消耗合计（SUM(total_tokens)，缺失记 0）。 */
+    private Long totalTokens;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsTrendRow.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/jdbc/AgentCallStatsTrendRow.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.jdbc;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 趋势聚合查询结果承载（一个时间桶）。相比 starter 的 {@code AgentCallTrendDO} 多出各段平均耗时列，
+ * 满足前端契约里 trend 需返回 avgModel/Tool/Mcp/Skill 的要求。{@code AVG} 返回 {@link BigDecimal}。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallStatsTrendRow {
+
+    private String bucket;
+    private Long cnt;
+    private BigDecimal avgDurationMs;
+    private BigDecimal avgModelMs;
+    private BigDecimal avgToolMs;
+    private BigDecimal avgMcpMs;
+    private BigDecimal avgSkillMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallMetaFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallMetaFactory.java
@@ -1,0 +1,68 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.service;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+/**
+ * 构建一次调用的 {@link AgentCallMeta}——必须在<b>请求线程的同步段</b>调用（用户名取自 Sa-Token 的
+ * ThreadLocal，SSE 的 reactor 回调线程里已拿不到登录上下文，与审计埋点同一约束）。
+ *
+ * <p>requestId 生成 UUID（admin 无全链路 requestId 机制）；username 取当前登录用户账号（未登录/无上下文
+ * 兜底 null，中间件会回落 ctx.userId）；agentName 取 {@code ai_agent.agent_name}（查不到回落 agentCode）；
+ * sessionType 由调用方按渠道传入（对话=CHAT，VibeCoding=VIBE_CODING）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class AgentCallMetaFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentCallMetaFactory.class);
+
+    private final AiAgentMapper agentMapper;
+
+    public AgentCallMetaFactory(AiAgentMapper agentMapper) {
+        this.agentMapper = agentMapper;
+    }
+
+    /** 构建调用元数据。{@code question} 为用户原始输入（VibeCoding 传原始需求而非注入路径指引后的富文本）。 */
+    public AgentCallMeta build(String agentCode, AgentCallSessionType sessionType, String question) {
+        return new AgentCallMeta(UUID.randomUUID().toString(), resolveUsername(), agentCode,
+            resolveAgentName(agentCode), sessionType, question);
+    }
+
+    /** 当前登录用户账号；未登录/无 Sa-Token 上下文（如单测/开放 API）时返回 null，不阻断对话。 */
+    private String resolveUsername() {
+        try {
+            if (StpUtil.isLogin()) {
+                return StpUtil.getTokenSession().getString("username");
+            }
+        } catch (Exception e) {
+            log.error("resolve call meta username failed, code={}", "CALLSTATS-META-USER-FAIL", e);
+        }
+        return null;
+    }
+
+    /** 智能体展示名（ai_agent.agent_name）；查不到或异常回落 agentCode。 */
+    private String resolveAgentName(String agentCode) {
+        try {
+            AiAgent agent = agentMapper.selectOne(
+                new LambdaQueryWrapper<AiAgent>().eq(AiAgent::getAgentCode, agentCode));
+            if (agent != null && StringUtils.hasText(agent.getAgentName())) {
+                return agent.getAgentName();
+            }
+        } catch (Exception e) {
+            log.error("resolve call meta agent name failed, code={}, agentCode={}",
+                "CALLSTATS-META-AGENT-FAIL", agentCode, e);
+        }
+        return agentCode;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
@@ -1,0 +1,279 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.callstats.config.AppAgentCallStatsGatewayProvider;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallSegmentVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsDetailVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsPageVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsQuery;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsRowVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsSource;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsSummaryVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallTrendVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsGateway;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsQueryParam;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsTrendRow;
+import com.richard.fyoung.customerwork.calllog.TrendGranularity;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 智能体调用耗时统计查询服务：按 {@code source} 路由到 ADMIN 本库 / APP 客服端库门面，做分页/详情/汇总/
+ * 趋势/删除，并把持久层 DO 转成前端契约 VO（时间戳→{@code yyyy-MM-dd HH:mm:ss}、问题/回答预览截断）。
+ *
+ * <p>读侧 page/summary/trend 走 admin 的 ext Mapper（带 sessionType 过滤 + trend 各段平均）；详情按 id 取
+ * 主记录（starter BaseMapper#selectById）+ 明细段；删除复用 starter Store（主记录 + 分段级联）。APP 源不可
+ * 达时门面构建阶段即抛 {@link ResultCode#CUSTOMER_WORK_UNAVAILABLE}（见 {@link AppAgentCallStatsGatewayProvider}）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class AgentCallStatsService {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentCallStatsService.class);
+
+    /** 列表视图问题/回答预览截断长度。 */
+    private static final int PREVIEW_MAX_LENGTH = 200;
+    private static final int DEFAULT_PAGE_NUM = 1;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final String GRANULARITY_HOUR = "hour";
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final ZoneId ZONE = ZoneId.systemDefault();
+
+    private final AgentCallStatsGateway adminGateway;
+    private final AppAgentCallStatsGatewayProvider appGatewayProvider;
+
+    public AgentCallStatsService(AgentCallStatsGateway adminAgentCallStatsGateway,
+                                 AppAgentCallStatsGatewayProvider appGatewayProvider) {
+        this.adminGateway = adminAgentCallStatsGateway;
+        this.appGatewayProvider = appGatewayProvider;
+    }
+
+    /** 分页查询（{total, rows}）。 */
+    public AgentCallStatsPageVO page(AgentCallStatsQuery query) {
+        AgentCallStatsGateway gateway = gatewayOf(query.getSource());
+        AgentCallStatsQueryParam param = toParam(query, true);
+        long total = gateway.extMapper().countBy(param);
+        List<AgentCallStatsRowVO> rows = new ArrayList<>();
+        if (total > 0) {
+            for (AgentCallLogDO logDO : gateway.extMapper().findPage(param)) {
+                rows.add(toRow(logDO));
+            }
+        }
+        return new AgentCallStatsPageVO(total, rows);
+    }
+
+    /** 明细（全量字段 + 分段列表）。id 不存在抛 {@link ResultCode#RESOURCE_NOT_FOUND}。 */
+    public AgentCallStatsDetailVO detail(long id, String source) {
+        AgentCallStatsGateway gateway = gatewayOf(source);
+        AgentCallLogDO logDO = gateway.logMapper().selectById(id);
+        if (logDO == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "调用记录不存在: " + id);
+        }
+        List<AgentCallSegmentDO> segments = gateway.segmentMapper().findByCallLogId(id);
+        return toDetail(logDO, segments);
+    }
+
+    /** 汇总统计。 */
+    public AgentCallStatsSummaryVO summary(AgentCallStatsQuery query) {
+        AgentCallStatsGateway gateway = gatewayOf(query.getSource());
+        AgentCallSummaryDO summaryDO = gateway.extMapper().summary(toParam(query, false));
+        return toSummary(summaryDO);
+    }
+
+    /** 趋势聚合（按天/小时，含各段平均耗时）。 */
+    public List<AgentCallTrendVO> trend(AgentCallStatsQuery query) {
+        AgentCallStatsGateway gateway = gatewayOf(query.getSource());
+        TrendGranularity granularity = GRANULARITY_HOUR.equalsIgnoreCase(query.getGranularity())
+            ? TrendGranularity.HOUR : TrendGranularity.DAY;
+        List<AgentCallStatsTrendRow> rows = gateway.extMapper().trend(toParam(query, false), granularity.mysqlFormat());
+        List<AgentCallTrendVO> result = new ArrayList<>();
+        if (!CollectionUtils.isEmpty(rows)) {
+            for (AgentCallStatsTrendRow row : rows) {
+                result.add(toTrend(row));
+            }
+        }
+        return result;
+    }
+
+    /** 删除一条调用（主记录 + 分段级联，复用 starter Store）。 */
+    public boolean delete(long id, String source) {
+        AgentCallStatsGateway gateway = gatewayOf(source);
+        boolean deleted = gateway.store().delete(id);
+        log.info("agent call stats deleted, source={}, id={}, deleted={}",
+            AgentCallStatsSource.parse(source), id, deleted);
+        return deleted;
+    }
+
+    /** 按 source 路由门面：APP 走惰性只读门面（不可达抛明确业务异常），否则 ADMIN 本库门面。 */
+    private AgentCallStatsGateway gatewayOf(String source) {
+        return AgentCallStatsSource.parse(source) == AgentCallStatsSource.APP
+            ? appGatewayProvider.get() : adminGateway;
+    }
+
+    private AgentCallStatsQueryParam toParam(AgentCallStatsQuery query, boolean paged) {
+        AgentCallStatsQueryParam param = new AgentCallStatsQueryParam();
+        param.setUsername(trimToNull(query.getUsername()));
+        param.setAgentCode(trimToNull(query.getAgentCode()));
+        param.setSessionType(trimToNull(query.getSessionType()));
+        param.setRequestId(trimToNull(query.getRequestId()));
+        param.setSessionId(trimToNull(query.getSessionId()));
+        param.setStartFromMs(parseTime(query.getStartTime()));
+        param.setStartToMs(parseTime(query.getEndTime()));
+        if (paged) {
+            int pageNum = query.getPageNum() == null || query.getPageNum() < 1 ? DEFAULT_PAGE_NUM : query.getPageNum();
+            int pageSize = query.getPageSize() == null || query.getPageSize() < 1 ? DEFAULT_PAGE_SIZE : query.getPageSize();
+            param.setOffset((pageNum - 1) * pageSize);
+            param.setLimit(pageSize);
+        }
+        return param;
+    }
+
+    private AgentCallStatsRowVO toRow(AgentCallLogDO d) {
+        AgentCallStatsRowVO vo = new AgentCallStatsRowVO();
+        vo.setId(d.getId());
+        vo.setRequestId(d.getRequestId());
+        vo.setUserId(d.getUserId());
+        vo.setUsername(d.getUsername());
+        vo.setAgentCode(d.getAgentCode());
+        vo.setAgentName(d.getAgentName());
+        vo.setSessionId(d.getSessionId());
+        vo.setSessionType(d.getSessionType());
+        vo.setQuestion(truncate(d.getQuestion()));
+        vo.setAnswerPreview(truncate(d.getAnswer()));
+        vo.setStartTime(formatTime(d.getStartTime()));
+        vo.setEndTime(formatTime(d.getEndTime()));
+        vo.setDurationMs(d.getDurationMs());
+        vo.setModelMs(d.getModelMs());
+        vo.setToolMs(d.getToolMs());
+        vo.setMcpMs(d.getMcpMs());
+        vo.setSkillMs(d.getSkillMs());
+        return vo;
+    }
+
+    private AgentCallStatsDetailVO toDetail(AgentCallLogDO d, List<AgentCallSegmentDO> segments) {
+        AgentCallStatsDetailVO vo = new AgentCallStatsDetailVO();
+        vo.setId(d.getId());
+        vo.setRequestId(d.getRequestId());
+        vo.setUserId(d.getUserId());
+        vo.setUsername(d.getUsername());
+        vo.setAgentCode(d.getAgentCode());
+        vo.setAgentName(d.getAgentName());
+        vo.setSessionId(d.getSessionId());
+        vo.setSessionType(d.getSessionType());
+        vo.setQuestion(d.getQuestion());
+        vo.setAnswer(d.getAnswer());
+        vo.setStartTime(formatTime(d.getStartTime()));
+        vo.setEndTime(formatTime(d.getEndTime()));
+        vo.setDurationMs(d.getDurationMs());
+        vo.setModelMs(d.getModelMs());
+        vo.setToolMs(d.getToolMs());
+        vo.setMcpMs(d.getMcpMs());
+        vo.setSkillMs(d.getSkillMs());
+        List<AgentCallSegmentVO> segmentVOs = new ArrayList<>();
+        if (!CollectionUtils.isEmpty(segments)) {
+            for (AgentCallSegmentDO segment : segments) {
+                segmentVOs.add(toSegment(segment));
+            }
+        }
+        vo.setSegments(segmentVOs);
+        return vo;
+    }
+
+    private AgentCallSegmentVO toSegment(AgentCallSegmentDO d) {
+        AgentCallSegmentVO vo = new AgentCallSegmentVO();
+        vo.setSeq(d.getSeq());
+        vo.setKind(d.getKind());
+        vo.setName(d.getName());
+        vo.setStartTime(formatTime(d.getStartTime()));
+        vo.setDurationMs(d.getDurationMs());
+        vo.setSuccess(d.getSuccess());
+        vo.setErrorMsg(d.getErrorMsg());
+        return vo;
+    }
+
+    private AgentCallStatsSummaryVO toSummary(AgentCallSummaryDO d) {
+        AgentCallStatsSummaryVO vo = new AgentCallStatsSummaryVO();
+        if (d == null || d.getTotalCount() == null || d.getTotalCount() == 0L) {
+            vo.setTotalCalls(0L);
+            vo.setAvgDurationMs(0d);
+            vo.setMaxDurationMs(0L);
+            vo.setAvgModelMs(0d);
+            vo.setAvgToolMs(0d);
+            vo.setAvgMcpMs(0d);
+            vo.setAvgSkillMs(0d);
+            return vo;
+        }
+        vo.setTotalCalls(d.getTotalCount());
+        vo.setAvgDurationMs(toDouble(d.getAvgDurationMs()));
+        vo.setMaxDurationMs(d.getMaxDurationMs() == null ? 0L : d.getMaxDurationMs());
+        vo.setAvgModelMs(toDouble(d.getAvgModelMs()));
+        vo.setAvgToolMs(toDouble(d.getAvgToolMs()));
+        vo.setAvgMcpMs(toDouble(d.getAvgMcpMs()));
+        vo.setAvgSkillMs(toDouble(d.getAvgSkillMs()));
+        return vo;
+    }
+
+    private AgentCallTrendVO toTrend(AgentCallStatsTrendRow d) {
+        AgentCallTrendVO vo = new AgentCallTrendVO();
+        vo.setBucket(d.getBucket());
+        vo.setCount(d.getCnt() == null ? 0L : d.getCnt());
+        vo.setAvgDurationMs(toDouble(d.getAvgDurationMs()));
+        vo.setAvgModelMs(toDouble(d.getAvgModelMs()));
+        vo.setAvgToolMs(toDouble(d.getAvgToolMs()));
+        vo.setAvgMcpMs(toDouble(d.getAvgMcpMs()));
+        vo.setAvgSkillMs(toDouble(d.getAvgSkillMs()));
+        return vo;
+    }
+
+    /** {@code yyyy-MM-dd HH:mm:ss} 文本转毫秒时间戳；空白返回 null（不约束该边界）；非法格式记日志后忽略。 */
+    private Long parseTime(String text) {
+        if (!StringUtils.hasText(text)) {
+            return null;
+        }
+        try {
+            LocalDateTime dateTime = LocalDateTime.parse(text.trim(), TIME_FORMATTER);
+            return dateTime.atZone(ZONE).toInstant().toEpochMilli();
+        } catch (Exception e) {
+            log.error("parse call stats time failed, code={}, text={}", "CALLSTATS-TIME-PARSE-FAIL", text, e);
+            return null;
+        }
+    }
+
+    /** 毫秒时间戳转 {@code yyyy-MM-dd HH:mm:ss}；null/<=0 返回 null。 */
+    private String formatTime(Long millis) {
+        if (millis == null || millis <= 0L) {
+            return null;
+        }
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZONE).format(TIME_FORMATTER);
+    }
+
+    private String truncate(String text) {
+        if (text == null) {
+            return null;
+        }
+        return text.length() <= PREVIEW_MAX_LENGTH ? text : text.substring(0, PREVIEW_MAX_LENGTH);
+    }
+
+    private double toDouble(BigDecimal value) {
+        return value == null ? 0d : value.doubleValue();
+    }
+
+    private String trimToNull(String text) {
+        return StringUtils.hasText(text) ? text.trim() : null;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
@@ -162,6 +162,9 @@ public class AgentCallStatsService {
         vo.setToolMs(d.getToolMs());
         vo.setMcpMs(d.getMcpMs());
         vo.setSkillMs(d.getSkillMs());
+        vo.setInputTokens(d.getInputTokens());
+        vo.setOutputTokens(d.getOutputTokens());
+        vo.setTotalTokens(d.getTotalTokens());
         return vo;
     }
 
@@ -184,6 +187,9 @@ public class AgentCallStatsService {
         vo.setToolMs(d.getToolMs());
         vo.setMcpMs(d.getMcpMs());
         vo.setSkillMs(d.getSkillMs());
+        vo.setInputTokens(d.getInputTokens());
+        vo.setOutputTokens(d.getOutputTokens());
+        vo.setTotalTokens(d.getTotalTokens());
         List<AgentCallSegmentVO> segmentVOs = new ArrayList<>();
         if (!CollectionUtils.isEmpty(segments)) {
             for (AgentCallSegmentDO segment : segments) {
@@ -201,6 +207,8 @@ public class AgentCallStatsService {
         vo.setName(d.getName());
         vo.setStartTime(formatTime(d.getStartTime()));
         vo.setDurationMs(d.getDurationMs());
+        vo.setInputTokens(d.getInputTokens());
+        vo.setOutputTokens(d.getOutputTokens());
         vo.setSuccess(d.getSuccess());
         vo.setErrorMsg(d.getErrorMsg());
         return vo;
@@ -216,6 +224,8 @@ public class AgentCallStatsService {
             vo.setAvgToolMs(0d);
             vo.setAvgMcpMs(0d);
             vo.setAvgSkillMs(0d);
+            vo.setTotalTokens(0L);
+            vo.setAvgTotalTokens(0d);
             return vo;
         }
         vo.setTotalCalls(d.getTotalCount());
@@ -225,6 +235,8 @@ public class AgentCallStatsService {
         vo.setAvgToolMs(toDouble(d.getAvgToolMs()));
         vo.setAvgMcpMs(toDouble(d.getAvgMcpMs()));
         vo.setAvgSkillMs(toDouble(d.getAvgSkillMs()));
+        vo.setTotalTokens(d.getTotalTokens() == null ? 0L : d.getTotalTokens());
+        vo.setAvgTotalTokens(toDouble(d.getAvgTotalTokens()));
         return vo;
     }
 
@@ -237,6 +249,7 @@ public class AgentCallStatsService {
         vo.setAvgToolMs(toDouble(d.getAvgToolMs()));
         vo.setAvgMcpMs(toDouble(d.getAvgMcpMs()));
         vo.setAvgSkillMs(toDouble(d.getAvgSkillMs()));
+        vo.setTotalTokens(d.getTotalTokens() == null ? 0L : d.getTotalTokens());
         return vo;
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatController.java
@@ -10,7 +10,10 @@ import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatAttachmentService;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatHistoryService;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
+import com.richard.fyoung.customeradmin.workspace.callstats.service.AgentCallMetaFactory;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PlanConfirmRequest;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -44,18 +47,22 @@ public class ChatController {
     private final ChatService chatService;
     private final ChatHistoryService chatHistoryService;
     private final ChatAttachmentService chatAttachmentService;
+    private final AgentCallMetaFactory agentCallMetaFactory;
 
     public ChatController(ChatService chatService, ChatHistoryService chatHistoryService,
-                           ChatAttachmentService chatAttachmentService) {
+                           ChatAttachmentService chatAttachmentService, AgentCallMetaFactory agentCallMetaFactory) {
         this.chatService = chatService;
         this.chatHistoryService = chatHistoryService;
         this.chatAttachmentService = chatAttachmentService;
+        this.agentCallMetaFactory = agentCallMetaFactory;
     }
 
     @SaCheckPermission("workspace")
     @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> stream(@PathVariable String agentCode, @Valid @RequestBody ChatRequest request) {
-        return chatService.chatStream(agentCode, request.sessionId(), request.message(), request.mode())
+        // 采集元数据必须在请求线程同步段构建（用户名取自 Sa-Token 的 ThreadLocal）；渠道=admin_chat → CHAT
+        AgentCallMeta callMeta = agentCallMetaFactory.build(agentCode, AgentCallSessionType.CHAT, request.message());
+        return chatService.chatStream(agentCode, request.sessionId(), request.message(), request.mode(), callMeta)
             // data 编码见 ChatStreamChunk#sseData：父 Agent 纯文本，子 Agent 片段 JSON 包装携带来源标识
             .map(chunk -> ServerSentEvent.<String>builder().event(chunk.kind().sseEventName()).data(chunk.sseData()).build())
             .concatWithValues(ServerSentEvent.<String>builder().event("done").data("[DONE]").build());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -12,6 +12,7 @@ import com.richard.fyoung.customeradmin.workspace.runtime.mode.ExecutionMode;
 import com.richard.fyoung.customeradmin.workspace.runtime.mode.ExecutionModeRegistry;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.service.PlanConfirmationService;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.service.PlanConfirmationService.PlanChannel;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
@@ -139,18 +140,30 @@ public class ChatService {
      * 任何 SSE 头下发之前就能拿到结构化错误响应，而不是半开的失败流）。
      */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText) {
-        return chatStream(agentCode, sessionId, userText, null, usage -> { });
+        return chatStream(agentCode, sessionId, userText, null, null, usage -> { });
     }
 
-    /** 流式对话（带执行模式，无用量观察者）：供对话链路（ChatController）使用。 */
+    /** 流式对话（带执行模式，无用量观察者）：保留旧签名，供既有调用点/测试使用。 */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText, String mode) {
-        return chatStream(agentCode, sessionId, userText, mode, usage -> { });
+        return chatStream(agentCode, sessionId, userText, mode, null, usage -> { });
+    }
+
+    /** 流式对话（带执行模式 + 调用元数据，无用量观察者）：供对话链路（ChatController）使用，采集耗时统计。 */
+    public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText, String mode,
+                                             AgentCallMeta callMeta) {
+        return chatStream(agentCode, sessionId, userText, mode, callMeta, usage -> { });
     }
 
     /** 流式对话（带用量观察者，未指定执行模式）：保留旧签名，供既有调用点/测试使用。 */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
                                              Consumer<ChatUsage> usageTotalObserver) {
-        return chatStream(agentCode, sessionId, userText, null, usageTotalObserver);
+        return chatStream(agentCode, sessionId, userText, null, null, usageTotalObserver);
+    }
+
+    /** 流式对话（带执行模式 + 用量观察者，未带调用元数据）：保留旧签名，供既有调用点/测试使用。 */
+    public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
+                                             String mode, Consumer<ChatUsage> usageTotalObserver) {
+        return chatStream(agentCode, sessionId, userText, mode, null, usageTotalObserver);
     }
 
     /**
@@ -168,9 +181,15 @@ public class ChatService {
      * mode 未指定/非法（{@link ExecutionMode#parse} 返回 null）→ 不登记，中间件回落全局语义。</p>
      */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
-                                             String mode, Consumer<ChatUsage> usageTotalObserver) {
+                                             String mode, AgentCallMeta callMeta,
+                                             Consumer<ChatUsage> usageTotalObserver) {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
         RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
+        // 绑定调用元数据供 AgentCallTimingMiddleware 采集（requestId/username/agentName/sessionType/question）；
+        // 缺省（旧调用点/测试）不绑，中间件按 ctx.userId/MDC 降级，不影响主链路。
+        if (callMeta != null) {
+            ctx.put(AgentCallMeta.class, callMeta);
+        }
         ToolSourceInfo toolSource = agentInstanceFactory.toolSourceFor(agentCode);
 
         // 除了 REASONING/AGENT_RESULT，还订阅 TOOL_RESULT——不然模型调用 MCP 工具等待结果的这段时间

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -32,6 +32,8 @@ import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminSandboxProperties;
 import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
+import com.richard.fyoung.customerwork.calllog.AgentCallTimingMiddleware;
+import com.richard.fyoung.customerwork.calllog.ToolKindRegistry;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
@@ -156,6 +158,10 @@ public class AdminAgentInstanceFactory {
     private final ExecutionModeMiddleware executionModeMiddleware;
     private final ModelCircuitBreakerRegistry circuitBreakerRegistry;
     private final AgentMemorySyncService memorySyncService;
+    /** 分段耗时采集中间件（starter 提供，admin 显式装配），挂在内层 ReActAgent 上采集每次调用的分段耗时。 */
+    private final AgentCallTimingMiddleware agentCallTimingMiddleware;
+    /** 工具名→类别登记表：装配 MCP/Skill 时把工具名登记进来，采集时 onActing 据此归 MCP/SKILL（否则默认 TOOL）。 */
+    private final ToolKindRegistry agentCallToolKindRegistry;
 
     /**
      * {@code agentCode -> ToolSourceInfo}：{@link #build} 每次重建都会覆盖写入，天然跟着
@@ -176,7 +182,9 @@ public class AdminAgentInstanceFactory {
                                       SandboxGuardMiddleware sandboxGuardMiddleware,
                                       ExecutionModeMiddleware executionModeMiddleware,
                                       ModelCircuitBreakerRegistry circuitBreakerRegistry,
-                                      AgentMemorySyncService memorySyncService) {
+                                      AgentMemorySyncService memorySyncService,
+                                      AgentCallTimingMiddleware agentCallTimingMiddleware,
+                                      ToolKindRegistry agentCallToolKindRegistry) {
         this.agentMapper = agentMapper;
         this.agentMcpMapper = agentMcpMapper;
         this.agentSkillMapper = agentSkillMapper;
@@ -199,6 +207,8 @@ public class AdminAgentInstanceFactory {
         this.executionModeMiddleware = executionModeMiddleware;
         this.circuitBreakerRegistry = circuitBreakerRegistry;
         this.memorySyncService = memorySyncService;
+        this.agentCallTimingMiddleware = agentCallTimingMiddleware;
+        this.agentCallToolKindRegistry = agentCallToolKindRegistry;
     }
 
     /** 查该智能体当前已装配的工具来源登记表；从未 {@link #build} 过（比如尚未触发过对话）时返回空表。 */
@@ -279,6 +289,10 @@ public class AdminAgentInstanceFactory {
             // 中断后无缝续跑：会话被安全中断（见 ChatService#interrupt）后再次调用，先恢复被打断的
             // 挂起工具调用，再处理新消息，与 customer-work-starter 侧的默认行为保持一致。
             .enablePendingToolRecovery(true);
+        // 分段耗时采集中间件挂最外层（first = outermost）：onAgent 包裹整次调用统计总耗时，onModelCall/
+        // onActing 逐段计时，只读透传不改事件、不打断主链路（异常安全收敛在中间件内）。放在模式闸门之外，
+        // 统计口径覆盖完整链路。chat 与 vibecoding 走同一内层 ReActAgent，均被采集。
+        builder.middleware(agentCallTimingMiddleware);
         // 执行模式闸门对所有智能体挂载（chat 也生效）：运行时按会话选定的五档模式决策，未指定模式且全局
         // permission-mode=bypass 时纯透传，行为等价于挂载前。顺序关键（first = outermost）：模式闸门在最外层
         // 先看到原始命令挂起/拦改，护栏在内层作最后防线（下方仅 vibecoding 挂载）。
@@ -304,6 +318,9 @@ public class AdminAgentInstanceFactory {
             builder.skillBox(skillBox);
         }
         toolSourceCache.put(agentCode, new ToolSourceInfo(skillToolNames, mcpToolNames));
+        // 登记本智能体的 MCP/Skill 工具名，供采集中间件把 onActing 分段归为 MCP/SKILL（未登记者默认 TOOL）
+        agentCallToolKindRegistry.registerMcpTools(mcpToolNames);
+        agentCallToolKindRegistry.registerSkillTools(skillToolNames);
         return builder.build();
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
@@ -13,8 +13,11 @@ import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
 import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk;
+import com.richard.fyoung.customeradmin.workspace.callstats.service.AgentCallMetaFactory;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.FileChangeEvent;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.RollbackResult;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.TestReport;
@@ -86,6 +89,7 @@ public class VibeCodingService {
     private final AdminSandboxProperties sandboxProperties;
     private final AiCodingAuditService auditService;
     private final PlanConfirmationService planConfirmationService;
+    private final AgentCallMetaFactory agentCallMetaFactory;
 
     /** {@code agentCode:sessionId -> 对话开始前的目录快照}，进程内、重启丢失（v1 降级方案的一部分）。 */
     private final Map<String, Map<String, FileFingerprint>> beforeSnapshots = new ConcurrentHashMap<>();
@@ -94,7 +98,8 @@ public class VibeCodingService {
     public VibeCodingService(ChatService chatService, AdminAgentInstanceFactory agentInstanceFactory,
                               AiAgentMapper agentMapper, GitWorkspaceService gitWorkspaceService,
                               AdminSandboxProperties sandboxProperties, AiCodingAuditService auditService,
-                              PlanConfirmationService planConfirmationService) {
+                              PlanConfirmationService planConfirmationService,
+                              AgentCallMetaFactory agentCallMetaFactory) {
         this.chatService = chatService;
         this.agentInstanceFactory = agentInstanceFactory;
         this.agentMapper = agentMapper;
@@ -102,6 +107,7 @@ public class VibeCodingService {
         this.sandboxProperties = sandboxProperties;
         this.auditService = auditService;
         this.planConfirmationService = planConfirmationService;
+        this.agentCallMetaFactory = agentCallMetaFactory;
     }
 
     /** 当前 VibeCoding 沙箱模式（{@code admin.sandbox.mode} 全局配置，不随会话变化）："docker"｜"local"。 */
@@ -168,6 +174,9 @@ public class VibeCodingService {
         // 审计条目必须在请求线程的同步段创建（操作人取自 Sa-Token 的 ThreadLocal），
         // doFinally 跑在 reactor 线程，届时已拿不到登录上下文。
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.CHAT_STREAM, agentCode, safeSession);
+        // 采集元数据同样在请求线程同步段构建：渠道=vibecoding → VIBE_CODING，question 用用户原始输入
+        // （而非注入路径指引后的 enrichedText，报表展示的是用户真实提问）。
+        AgentCallMeta callMeta = agentCallMetaFactory.build(agentCode, AgentCallSessionType.VIBE_CODING, userText);
         AtomicReference<ChatUsage> usageTotal = new AtomicReference<>();
 
         AtomicReference<Map<String, FileFingerprint>> lastSnapshot = new AtomicReference<>(initialSnapshot);
@@ -178,7 +187,7 @@ public class VibeCodingService {
         // 执行模式随消息透传给 ChatService：模式登记 + Plan 确认通道（plan/plan_result 合并进流）均由
         // chatStream 统一承接（对话/VibeCoding/协作共用同一套闭环），本类只在其输出上叠加 file_change/
         // test_report 检测与审计，plan 事件作为普通 chunk 透传给前端。
-        Flux<ChatStreamChunk> chatFlux = chatService.chatStream(agentCode, sessionId, enrichedText, mode, usageTotal::set)
+        Flux<ChatStreamChunk> chatFlux = chatService.chatStream(agentCode, sessionId, enrichedText, mode, callMeta, usageTotal::set)
             .concatMap(chunk -> chunk.kind() == ChatNodeKind.TOOL_RESULT
                 // 顺序：原始工具结果 → 结构化 test_report（若可识别为编译/测试执行）→ 实时 file_change
                 ? Flux.concat(Flux.just(chunk),

--- a/customer-admin-server/src/main/resources/callstats/AgentCallStatsExtMapper.xml
+++ b/customer-admin-server/src/main/resources/callstats/AgentCallStatsExtMapper.xml
@@ -21,7 +21,7 @@
     <select id="findPage" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO">
         SELECT id, request_id, user_id, username, agent_code, agent_name, session_id, session_type,
                question, answer, start_time, end_time, duration_ms, model_ms, tool_ms, mcp_ms,
-               skill_ms, segment_count, success, error_msg
+               skill_ms, segment_count, input_tokens, output_tokens, total_tokens, success, error_msg
         FROM cw_agent_call_log
         <include refid="whereClause"/>
         ORDER BY id DESC
@@ -36,13 +36,15 @@
 
     <!-- 汇总统计：总数 / 平均总耗时 / 最大总耗时 / 各段平均耗时。复用 starter AgentCallSummaryDO。 -->
     <select id="summary" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO">
-        SELECT COUNT(*)          AS total_count,
-               AVG(duration_ms)  AS avg_duration_ms,
-               MAX(duration_ms)  AS max_duration_ms,
-               AVG(model_ms)     AS avg_model_ms,
-               AVG(tool_ms)      AS avg_tool_ms,
-               AVG(mcp_ms)       AS avg_mcp_ms,
-               AVG(skill_ms)     AS avg_skill_ms
+        SELECT COUNT(*)            AS total_count,
+               AVG(duration_ms)    AS avg_duration_ms,
+               MAX(duration_ms)    AS max_duration_ms,
+               AVG(model_ms)       AS avg_model_ms,
+               AVG(tool_ms)        AS avg_tool_ms,
+               AVG(mcp_ms)         AS avg_mcp_ms,
+               AVG(skill_ms)       AS avg_skill_ms,
+               COALESCE(SUM(total_tokens), 0) AS total_tokens,
+               AVG(total_tokens)   AS avg_total_tokens
         FROM cw_agent_call_log
         <include refid="whereClause"/>
     </select>
@@ -56,7 +58,8 @@
                AVG(model_ms)    AS avg_model_ms,
                AVG(tool_ms)     AS avg_tool_ms,
                AVG(mcp_ms)      AS avg_mcp_ms,
-               AVG(skill_ms)    AS avg_skill_ms
+               AVG(skill_ms)    AS avg_skill_ms,
+               COALESCE(SUM(total_tokens), 0) AS total_tokens
         FROM cw_agent_call_log
         <include refid="whereClause"/>
         GROUP BY bucket

--- a/customer-admin-server/src/main/resources/callstats/AgentCallStatsExtMapper.xml
+++ b/customer-admin-server/src/main/resources/callstats/AgentCallStatsExtMapper.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsExtMapper">
+
+    <!-- 公共动态过滤条件（用户 / agentCode / sessionType / requestId / sessionId / 时间范围）。
+         相比 starter 的 whereClause 多一个 session_type 维度。 -->
+    <sql id="whereClause">
+        <where>
+            <if test="q.username != null">AND username = #{q.username}</if>
+            <if test="q.agentCode != null">AND agent_code = #{q.agentCode}</if>
+            <if test="q.sessionType != null">AND session_type = #{q.sessionType}</if>
+            <if test="q.requestId != null">AND request_id = #{q.requestId}</if>
+            <if test="q.sessionId != null">AND session_id = #{q.sessionId}</if>
+            <if test="q.startFromMs != null">AND start_time &gt;= #{q.startFromMs}</if>
+            <if test="q.startToMs != null">AND start_time &lt;= #{q.startToMs}</if>
+        </where>
+    </sql>
+
+    <!-- 分页条件查询：id 倒序取一页（最新在前）。列与 starter AgentCallLogDO 完全一致。 -->
+    <select id="findPage" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO">
+        SELECT id, request_id, user_id, username, agent_code, agent_name, session_id, session_type,
+               question, answer, start_time, end_time, duration_ms, model_ms, tool_ms, mcp_ms,
+               skill_ms, segment_count, success, error_msg
+        FROM cw_agent_call_log
+        <include refid="whereClause"/>
+        ORDER BY id DESC
+        LIMIT #{q.limit} OFFSET #{q.offset}
+    </select>
+
+    <!-- 符合条件总数。 -->
+    <select id="countBy" resultType="long">
+        SELECT COUNT(*) FROM cw_agent_call_log
+        <include refid="whereClause"/>
+    </select>
+
+    <!-- 汇总统计：总数 / 平均总耗时 / 最大总耗时 / 各段平均耗时。复用 starter AgentCallSummaryDO。 -->
+    <select id="summary" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO">
+        SELECT COUNT(*)          AS total_count,
+               AVG(duration_ms)  AS avg_duration_ms,
+               MAX(duration_ms)  AS max_duration_ms,
+               AVG(model_ms)     AS avg_model_ms,
+               AVG(tool_ms)      AS avg_tool_ms,
+               AVG(mcp_ms)       AS avg_mcp_ms,
+               AVG(skill_ms)     AS avg_skill_ms
+        FROM cw_agent_call_log
+        <include refid="whereClause"/>
+    </select>
+
+    <!-- 趋势聚合：按 dateFormat（天/小时）分桶，每桶调用数 + 平均总耗时 + 各段平均耗时，桶标签升序。
+         start_time 为毫秒时间戳，FROM_UNIXTIME 除以 1000 转秒后按本地时区格式化。 -->
+    <select id="trend" resultType="com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsTrendRow">
+        SELECT DATE_FORMAT(FROM_UNIXTIME(start_time / 1000), #{dateFormat}) AS bucket,
+               COUNT(*)         AS cnt,
+               AVG(duration_ms) AS avg_duration_ms,
+               AVG(model_ms)    AS avg_model_ms,
+               AVG(tool_ms)     AS avg_tool_ms,
+               AVG(mcp_ms)      AS avg_mcp_ms,
+               AVG(skill_ms)    AS avg_skill_ms
+        FROM cw_agent_call_log
+        <include refid="whereClause"/>
+        GROUP BY bucket
+        ORDER BY bucket ASC
+    </select>
+
+</mapper>

--- a/customer-admin-server/src/main/resources/db/migration/V38__agent_call_stats.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V38__agent_call_stats.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- 智能体调用分段耗时统计（Flyway V38）
+-- =============================================================================
+-- 在后台库 customer_admin 落地"智能体调用分段耗时"统计的两张表：调用主记录 + 分段明细。
+-- 采集由 starter 的 AgentCallTimingMiddleware 完成，落库走 starter 的 MybatisAgentCallLogStore；
+-- 后台把中间件/存储显式装配进 workspace 智能体链路（AdminAgentInstanceFactory + ChatService），
+-- 并新增查询接口 /api/agent-call-stats/**（ADMIN 本库 + APP 客服端库 agent_scope_customer_work 双源）。
+--
+-- 【表名刻意带 cw_ 前缀，与 admin 的 ai_ 惯例不同】：DDL 从 starter 的 customer-work-schema.sql
+-- 原样拷贝、列完全一致，换取直接复用 starter jar 内的 AgentCallLogMapper.xml / AgentCallSegmentMapper.xml
+-- （namespace 绑定 starter 的 Mapper 接口，零改动）。若改名为 ai_agent_call_* 则 starter 的 XML 里
+-- 硬编码的表名对不上，必须另写一套 Mapper/XML，得不偿失。故此处保持 cw_ 前缀。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+--
+-- 菜单/权限种子：id 从 194 起（V36 显式 id 用到 193，194 起是既定约定，留足安全空间）。
+-- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接
+-- 返回全部权限点（沿用 V35/V36 同款做法，普通角色需在角色管理页手工授权）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+-- 智能体调用主记录表（MybatisAgentCallLogStore）：一次调用一行，四类分段耗时冗余存储。
+CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `request_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
+    `user_id`        VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
+    `username`       VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户名',
+    `agent_code`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '智能体编码',
+    `agent_name`     VARCHAR(255) NOT NULL DEFAULT '' COMMENT '智能体名称',
+    `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+    `session_type`   VARCHAR(32) NOT NULL DEFAULT 'CHAT' COMMENT '会话类型 CHAT/VIBE_CODING',
+    `question`       MEDIUMTEXT COMMENT '用户问题',
+    `answer`         MEDIUMTEXT COMMENT '智能体回答',
+    `start_time`     BIGINT NOT NULL COMMENT '调用开始时间戳（毫秒）',
+    `end_time`       BIGINT NOT NULL COMMENT '调用结束时间戳（毫秒）',
+    `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '总耗时（毫秒）',
+    `model_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'MODEL段耗时合计（毫秒）',
+    `tool_ms`        BIGINT NOT NULL DEFAULT 0 COMMENT 'TOOL段耗时合计（毫秒）',
+    `mcp_ms`         BIGINT NOT NULL DEFAULT 0 COMMENT 'MCP段耗时合计（毫秒）',
+    `skill_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'SKILL段耗时合计（毫秒）',
+    `segment_count`  INT NOT NULL DEFAULT 0 COMMENT '分段总数',
+    `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
+    `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
+    INDEX `idx_call_request` (`request_id`),
+    INDEX `idx_call_username` (`username`),
+    INDEX `idx_call_agent_code` (`agent_code`),
+    INDEX `idx_call_session` (`session_id`),
+    INDEX `idx_call_start` (`start_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用主记录（分段耗时统计）';
+
+-- 智能体调用分段明细表（MybatisAgentCallLogStore）：一次调用的每段耗时一行。
+CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `call_log_id`    BIGINT NOT NULL COMMENT '所属主记录ID',
+    `seq`            INT NOT NULL COMMENT '调用内分段序号（从1起）',
+    `kind`           VARCHAR(16) NOT NULL COMMENT '分段类别 MODEL/TOOL/MCP/SKILL',
+    `name`           VARCHAR(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
+    `start_time`     BIGINT NOT NULL COMMENT '分段开始时间戳（毫秒）',
+    `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
+    `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
+    `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用分段明细';
+
+-- 二级菜单：智能体耗时统计（挂"系统管理" id=1 下，参照 AI 编码审计 id=100 的父子结构）。
+-- 菜单可见性即 view 权限点（perm_code=agent-call-stats:view）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (194, 1, '智能体耗时统计', 'agent-call-stats:view', 1, '/system/agent-call-stats', 'Timer', 'library', 6);
+
+-- 三级：按钮/接口权限点（type=2，挂 194 下）。只读报表仅一个删除按钮权限。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (195, 194, '删除调用日志', 'agent-call-stats:delete', 2, 1);

--- a/customer-admin-server/src/main/resources/db/migration/V39__agent_call_stats_tokens.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V39__agent_call_stats_tokens.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- 智能体调用分段耗时统计——token 消耗采集（Flyway V39）
+-- =============================================================================
+-- 在 V38 建的两张表上补 token 列：主记录加请求级 input/output/total token，分段明细加 input/output token
+-- （仅 MODEL 段有值）。采集口径与 admin 审计模块一致，均取自框架 ModelCallEndEvent 携带的 ChatUsage。
+-- token 缺失（离线/框架未上报）时列值 NULL，区分"未采到"与"用了 0 token"。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+-- 本迁移无 DML 种子，仅 ALTER。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `cw_agent_call_log`
+    ADD COLUMN `input_tokens`  BIGINT DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）' AFTER `segment_count`,
+    ADD COLUMN `output_tokens` BIGINT DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）' AFTER `input_tokens`,
+    ADD COLUMN `total_tokens`  BIGINT DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）' AFTER `output_tokens`;
+
+ALTER TABLE `cw_agent_call_segment`
+    ADD COLUMN `input_tokens`  BIGINT DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）' AFTER `duration_ms`,
+    ADD COLUMN `output_tokens` BIGINT DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）' AFTER `input_tokens`;

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AppAgentCallStatsGatewayProviderTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AppAgentCallStatsGatewayProviderTest.java
@@ -1,0 +1,43 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.config;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link AppAgentCallStatsGatewayProvider} 容错单测：APP 客服端库不可达时 {@link #get()} 抛
+ * {@link ResultCode#CUSTOMER_WORK_UNAVAILABLE} 明确业务异常，且失败不缓存（下次可重试）——
+ * 保证该库不可达绝不在启动期触碰、也不污染后续恢复。指向必然关闭的端口，无需真实 DB，CI 可跑。
+ * @author owlzhangfq@gmail.com
+ */
+class AppAgentCallStatsGatewayProviderTest {
+
+    private AppAgentCallStatsGatewayProvider unreachableProvider() {
+        AgentCallStatsAppProperties props = new AgentCallStatsAppProperties();
+        props.setHost("127.0.0.1");
+        // 65534 端口默认无监听，连接立即被拒（不会长时间超时）
+        props.setPort(65534);
+        props.setDatabase("agent_scope_customer_work");
+        props.setUsername("root");
+        props.setPassword("root");
+        return new AppAgentCallStatsGatewayProvider(props);
+    }
+
+    @Test
+    void get_shouldThrowCustomerWorkUnavailable_whenAppDbUnreachable() {
+        AppAgentCallStatsGatewayProvider provider = unreachableProvider();
+        BizException e = assertThrows(BizException.class, provider::get);
+        assertEquals(ResultCode.CUSTOMER_WORK_UNAVAILABLE, e.getResultCode());
+    }
+
+    @Test
+    void get_shouldNotCacheFailure_andRetryEachTime() {
+        AppAgentCallStatsGatewayProvider provider = unreachableProvider();
+        assertThrows(BizException.class, provider::get);
+        // 第二次仍抛（失败不缓存，覆盖库稍后恢复的场景）
+        assertThrows(BizException.class, provider::get);
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/controller/AgentCallStatsControllerTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/controller/AgentCallStatsControllerTest.java
@@ -1,0 +1,83 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.controller;
+
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsDetailVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsPageVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsQuery;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsSummaryVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallTrendVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.service.AgentCallStatsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AgentCallStatsController} 单测：各端点薄委托 Service，并用统一 {@link Result} 包裹（code=0）。
+ * source 默认值/透传、路径参数 id 透传。鉴权注解由 Sa-Token 拦截，非单测范畴。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallStatsControllerTest {
+
+    private AgentCallStatsService service;
+    private AgentCallStatsController controller;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(AgentCallStatsService.class);
+        controller = new AgentCallStatsController(service);
+    }
+
+    @Test
+    void page_shouldWrapServiceResult() {
+        AgentCallStatsPageVO vo = new AgentCallStatsPageVO(0L, List.of());
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        when(service.page(query)).thenReturn(vo);
+
+        Result<AgentCallStatsPageVO> result = controller.page(query);
+        assertEquals(ResultCode.SUCCESS.getCode(), result.getCode());
+        assertSame(vo, result.getData());
+    }
+
+    @Test
+    void summary_shouldWrapServiceResult() {
+        AgentCallStatsSummaryVO vo = new AgentCallStatsSummaryVO();
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        when(service.summary(query)).thenReturn(vo);
+        assertSame(vo, controller.summary(query).getData());
+    }
+
+    @Test
+    void trend_shouldWrapServiceResult() {
+        List<AgentCallTrendVO> vos = List.of(new AgentCallTrendVO());
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        when(service.trend(query)).thenReturn(vos);
+        assertSame(vos, controller.trend(query).getData());
+    }
+
+    @Test
+    void detail_shouldPassIdAndSource() {
+        AgentCallStatsDetailVO vo = new AgentCallStatsDetailVO();
+        when(service.detail(5L, "APP")).thenReturn(vo);
+        assertSame(vo, controller.detail(5L, "APP").getData());
+        verify(service).detail(5L, "APP");
+    }
+
+    @Test
+    void delete_shouldPassIdAndSource() {
+        when(service.delete(eq(9L), any())).thenReturn(true);
+        Result<Boolean> result = controller.delete(9L, "ADMIN");
+        assertTrue(result.getData());
+        verify(service).delete(9L, "ADMIN");
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSourceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSourceTest.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link AgentCallStatsSource#parse} 宽松解析单测：空/非法回落 ADMIN，大小写不敏感。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallStatsSourceTest {
+
+    @Test
+    void parse_shouldFallbackToAdmin_forNullBlankOrInvalid() {
+        assertEquals(AgentCallStatsSource.ADMIN, AgentCallStatsSource.parse(null));
+        assertEquals(AgentCallStatsSource.ADMIN, AgentCallStatsSource.parse("  "));
+        assertEquals(AgentCallStatsSource.ADMIN, AgentCallStatsSource.parse("xyz"));
+    }
+
+    @Test
+    void parse_shouldBeCaseInsensitive() {
+        assertEquals(AgentCallStatsSource.APP, AgentCallStatsSource.parse("app"));
+        assertEquals(AgentCallStatsSource.APP, AgentCallStatsSource.parse(" APP "));
+        assertEquals(AgentCallStatsSource.ADMIN, AgentCallStatsSource.parse("Admin"));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallMetaFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallMetaFactoryTest.java
@@ -1,0 +1,72 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.service;
+
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AgentCallMetaFactory} 单测：无 Sa-Token 上下文时用户名防御兜底（留 null），agentName 取自
+ * ai_agent（查不到/异常回落 agentCode），requestId 生成、sessionType/question 原样透传。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallMetaFactoryTest {
+
+    private AiAgentMapper agentMapper;
+    private AgentCallMetaFactory factory;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgent.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        agentMapper = mock(AiAgentMapper.class);
+        factory = new AgentCallMetaFactory(agentMapper);
+    }
+
+    @Test
+    void build_shouldResolveAgentName_andLeaveUsernameNullWithoutLoginContext() {
+        AiAgent agent = new AiAgent();
+        agent.setAgentCode("coder");
+        agent.setAgentName("编码助手");
+        when(agentMapper.selectOne(any())).thenReturn(agent);
+
+        AgentCallMeta meta = factory.build("coder", AgentCallSessionType.VIBE_CODING, "写个脚本");
+
+        assertNotNull(meta.requestId(), "requestId 应生成");
+        assertNull(meta.username(), "无登录上下文用户名兜底为 null");
+        assertEquals("coder", meta.agentCode());
+        assertEquals("编码助手", meta.agentName());
+        assertEquals(AgentCallSessionType.VIBE_CODING, meta.sessionType());
+        assertEquals("写个脚本", meta.question());
+    }
+
+    @Test
+    void build_shouldFallbackAgentNameToCode_whenAgentMissing() {
+        when(agentMapper.selectOne(any())).thenReturn(null);
+        AgentCallMeta meta = factory.build("coder", AgentCallSessionType.CHAT, "你好");
+        assertEquals("coder", meta.agentName());
+    }
+
+    @Test
+    void build_shouldFallbackAgentNameToCode_whenMapperThrows() {
+        when(agentMapper.selectOne(any())).thenThrow(new RuntimeException("db down"));
+        AgentCallMeta meta = factory.build("coder", AgentCallSessionType.CHAT, "你好");
+        assertEquals("coder", meta.agentName(), "查询异常时 agentName 防御性回落 agentCode");
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsServiceTest.java
@@ -97,6 +97,9 @@ class AgentCallStatsServiceTest {
         d.setToolMs(200L);
         d.setMcpMs(30L);
         d.setSkillMs(4L);
+        d.setInputTokens(800L);
+        d.setOutputTokens(200L);
+        d.setTotalTokens(1000L);
 
         when(adminExtMapper.countBy(any())).thenReturn(1L);
         when(adminExtMapper.findPage(any())).thenReturn(List.of(d));
@@ -113,6 +116,9 @@ class AgentCallStatsServiceTest {
         assertEquals(expectFormat(start), vo.getRows().get(0).getStartTime());
         assertEquals(expectFormat(end), vo.getRows().get(0).getEndTime());
         assertEquals(1000L, vo.getRows().get(0).getModelMs());
+        assertEquals(800L, vo.getRows().get(0).getInputTokens(), "行透出输入 token");
+        assertEquals(200L, vo.getRows().get(0).getOutputTokens(), "行透出输出 token");
+        assertEquals(1000L, vo.getRows().get(0).getTotalTokens(), "行透出总 token");
 
         // 分页偏移：pageNum=2, pageSize=10 → offset=10, limit=10
         ArgumentCaptor<AgentCallStatsQueryParam> captor = ArgumentCaptor.forClass(AgentCallStatsQueryParam.class);
@@ -144,15 +150,23 @@ class AgentCallStatsServiceTest {
         seg.setName("qwen");
         seg.setStartTime(1_700_000_000_000L);
         seg.setDurationMs(800L);
+        seg.setInputTokens(640L);
+        seg.setOutputTokens(160L);
         seg.setSuccess(true);
         when(adminSegmentMapper.findByCallLogId(5L)).thenReturn(List.of(seg));
+        d.setInputTokens(640L);
+        d.setOutputTokens(160L);
+        d.setTotalTokens(800L);
 
         AgentCallStatsDetailVO vo = service.detail(5L, "ADMIN");
 
         assertEquals(250, vo.getAnswer().length(), "详情回答应为全文，不截断");
+        assertEquals(800L, vo.getTotalTokens(), "详情头部透出总 token");
         assertEquals(1, vo.getSegments().size());
         assertEquals("MODEL", vo.getSegments().get(0).getKind());
         assertEquals(800L, vo.getSegments().get(0).getDurationMs());
+        assertEquals(640L, vo.getSegments().get(0).getInputTokens(), "MODEL 段透出输入 token");
+        assertEquals(160L, vo.getSegments().get(0).getOutputTokens(), "MODEL 段透出输出 token");
     }
 
     @Test
@@ -183,6 +197,8 @@ class AgentCallStatsServiceTest {
         d.setAvgToolMs(new BigDecimal("150"));
         d.setAvgMcpMs(new BigDecimal("40"));
         d.setAvgSkillMs(new BigDecimal("10"));
+        d.setTotalTokens(3000L);
+        d.setAvgTotalTokens(new BigDecimal("1000"));
         when(adminExtMapper.summary(any())).thenReturn(d);
 
         AgentCallStatsSummaryVO vo = service.summary(new AgentCallStatsQuery());
@@ -190,6 +206,8 @@ class AgentCallStatsServiceTest {
         assertEquals(1200.5d, vo.getAvgDurationMs());
         assertEquals(3000L, vo.getMaxDurationMs());
         assertEquals(1000d, vo.getAvgModelMs());
+        assertEquals(3000L, vo.getTotalTokens(), "汇总总 token");
+        assertEquals(1000d, vo.getAvgTotalTokens(), "汇总平均 token");
     }
 
     // ===== 趋势 =====
@@ -204,6 +222,7 @@ class AgentCallStatsServiceTest {
         row.setAvgToolMs(new BigDecimal("80"));
         row.setAvgMcpMs(new BigDecimal("15"));
         row.setAvgSkillMs(new BigDecimal("5"));
+        row.setTotalTokens(2400L);
         when(adminExtMapper.trend(any(), eq("%Y-%m-%d %H"))).thenReturn(List.of(row));
 
         AgentCallStatsQuery query = new AgentCallStatsQuery();
@@ -214,6 +233,7 @@ class AgentCallStatsServiceTest {
         assertEquals("2026-07-24 10", vos.get(0).getBucket());
         assertEquals(2L, vos.get(0).getCount());
         assertEquals(400d, vos.get(0).getAvgModelMs());
+        assertEquals(2400L, vos.get(0).getTotalTokens(), "趋势桶 token 合计");
         verify(adminExtMapper).trend(any(), eq("%Y-%m-%d %H"));
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsServiceTest.java
@@ -1,0 +1,294 @@
+package com.richard.fyoung.customeradmin.workspace.callstats.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.workspace.callstats.config.AppAgentCallStatsGatewayProvider;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsDetailVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsPageVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsQuery;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallStatsSummaryVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.dto.AgentCallTrendVO;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsExtMapper;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsGateway;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsQueryParam;
+import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsTrendRow;
+import com.richard.fyoung.customerwork.calllog.AgentCallLogStore;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AgentCallStatsService} 单测：ADMIN/APP 双源路由、DO→VO 映射（时间格式化、预览截断）、
+ * 详情命中/未命中、汇总空结果兜底、趋势粒度选择、删除委托、APP 源不可达时的错误透传。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallStatsServiceTest {
+
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private AgentCallStatsExtMapper adminExtMapper;
+    private AgentCallLogMapper adminLogMapper;
+    private AgentCallSegmentMapper adminSegmentMapper;
+    private AgentCallLogStore adminStore;
+    private AgentCallStatsGateway adminGateway;
+
+    private AppAgentCallStatsGatewayProvider appProvider;
+    private AgentCallStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        adminExtMapper = mock(AgentCallStatsExtMapper.class);
+        adminLogMapper = mock(AgentCallLogMapper.class);
+        adminSegmentMapper = mock(AgentCallSegmentMapper.class);
+        adminStore = mock(AgentCallLogStore.class);
+        adminGateway = new AgentCallStatsGateway(adminExtMapper, adminLogMapper, adminSegmentMapper, adminStore);
+        appProvider = mock(AppAgentCallStatsGatewayProvider.class);
+        service = new AgentCallStatsService(adminGateway, appProvider);
+    }
+
+    private String expectFormat(long millis) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()).format(FMT);
+    }
+
+    // ===== 分页 + 映射 =====
+
+    @Test
+    void page_shouldMapRows_formatTime_andTruncatePreview() {
+        long start = 1_700_000_000_000L;
+        long end = start + 1234L;
+        AgentCallLogDO d = new AgentCallLogDO();
+        d.setId(9L);
+        d.setRequestId("req-1");
+        d.setUserId("coder");
+        d.setUsername("alice");
+        d.setAgentCode("coder");
+        d.setAgentName("编码助手");
+        d.setSessionId("s1");
+        d.setSessionType("CHAT");
+        d.setQuestion("Q".repeat(250));
+        d.setAnswer("A".repeat(250));
+        d.setStartTime(start);
+        d.setEndTime(end);
+        d.setDurationMs(1234L);
+        d.setModelMs(1000L);
+        d.setToolMs(200L);
+        d.setMcpMs(30L);
+        d.setSkillMs(4L);
+
+        when(adminExtMapper.countBy(any())).thenReturn(1L);
+        when(adminExtMapper.findPage(any())).thenReturn(List.of(d));
+
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        query.setPageNum(2);
+        query.setPageSize(10);
+        AgentCallStatsPageVO vo = service.page(query);
+
+        assertEquals(1L, vo.getTotal());
+        assertEquals(1, vo.getRows().size());
+        assertEquals(200, vo.getRows().get(0).getQuestion().length(), "问题应截断到 200");
+        assertEquals(200, vo.getRows().get(0).getAnswerPreview().length(), "回答预览应截断到 200");
+        assertEquals(expectFormat(start), vo.getRows().get(0).getStartTime());
+        assertEquals(expectFormat(end), vo.getRows().get(0).getEndTime());
+        assertEquals(1000L, vo.getRows().get(0).getModelMs());
+
+        // 分页偏移：pageNum=2, pageSize=10 → offset=10, limit=10
+        ArgumentCaptor<AgentCallStatsQueryParam> captor = ArgumentCaptor.forClass(AgentCallStatsQueryParam.class);
+        verify(adminExtMapper).findPage(captor.capture());
+        assertEquals(10, captor.getValue().getOffset());
+        assertEquals(10, captor.getValue().getLimit());
+    }
+
+    @Test
+    void page_shouldSkipQuery_whenTotalZero() {
+        when(adminExtMapper.countBy(any())).thenReturn(0L);
+        AgentCallStatsPageVO vo = service.page(new AgentCallStatsQuery());
+        assertEquals(0L, vo.getTotal());
+        assertTrue(vo.getRows().isEmpty());
+    }
+
+    // ===== 详情 =====
+
+    @Test
+    void detail_shouldReturnFullAnswerAndSegments() {
+        AgentCallLogDO d = new AgentCallLogDO();
+        d.setId(5L);
+        d.setAnswer("A".repeat(250));
+        d.setStartTime(1_700_000_000_000L);
+        when(adminLogMapper.selectById(5L)).thenReturn(d);
+        AgentCallSegmentDO seg = new AgentCallSegmentDO();
+        seg.setSeq(1);
+        seg.setKind("MODEL");
+        seg.setName("qwen");
+        seg.setStartTime(1_700_000_000_000L);
+        seg.setDurationMs(800L);
+        seg.setSuccess(true);
+        when(adminSegmentMapper.findByCallLogId(5L)).thenReturn(List.of(seg));
+
+        AgentCallStatsDetailVO vo = service.detail(5L, "ADMIN");
+
+        assertEquals(250, vo.getAnswer().length(), "详情回答应为全文，不截断");
+        assertEquals(1, vo.getSegments().size());
+        assertEquals("MODEL", vo.getSegments().get(0).getKind());
+        assertEquals(800L, vo.getSegments().get(0).getDurationMs());
+    }
+
+    @Test
+    void detail_shouldThrowNotFound_whenAbsent() {
+        when(adminLogMapper.selectById(404L)).thenReturn(null);
+        BizException e = assertThrows(BizException.class, () -> service.detail(404L, "ADMIN"));
+        assertEquals(ResultCode.RESOURCE_NOT_FOUND, e.getResultCode());
+    }
+
+    // ===== 汇总 =====
+
+    @Test
+    void summary_shouldReturnZeros_whenNoData() {
+        when(adminExtMapper.summary(any())).thenReturn(null);
+        AgentCallStatsSummaryVO vo = service.summary(new AgentCallStatsQuery());
+        assertEquals(0L, vo.getTotalCalls());
+        assertEquals(0d, vo.getAvgDurationMs());
+        assertEquals(0L, vo.getMaxDurationMs());
+    }
+
+    @Test
+    void summary_shouldMapAggregates() {
+        AgentCallSummaryDO d = new AgentCallSummaryDO();
+        d.setTotalCount(3L);
+        d.setAvgDurationMs(new BigDecimal("1200.5"));
+        d.setMaxDurationMs(3000L);
+        d.setAvgModelMs(new BigDecimal("1000"));
+        d.setAvgToolMs(new BigDecimal("150"));
+        d.setAvgMcpMs(new BigDecimal("40"));
+        d.setAvgSkillMs(new BigDecimal("10"));
+        when(adminExtMapper.summary(any())).thenReturn(d);
+
+        AgentCallStatsSummaryVO vo = service.summary(new AgentCallStatsQuery());
+        assertEquals(3L, vo.getTotalCalls());
+        assertEquals(1200.5d, vo.getAvgDurationMs());
+        assertEquals(3000L, vo.getMaxDurationMs());
+        assertEquals(1000d, vo.getAvgModelMs());
+    }
+
+    // ===== 趋势 =====
+
+    @Test
+    void trend_shouldUseHourFormat_andMapSegmentAverages() {
+        AgentCallStatsTrendRow row = new AgentCallStatsTrendRow();
+        row.setBucket("2026-07-24 10");
+        row.setCnt(2L);
+        row.setAvgDurationMs(new BigDecimal("500"));
+        row.setAvgModelMs(new BigDecimal("400"));
+        row.setAvgToolMs(new BigDecimal("80"));
+        row.setAvgMcpMs(new BigDecimal("15"));
+        row.setAvgSkillMs(new BigDecimal("5"));
+        when(adminExtMapper.trend(any(), eq("%Y-%m-%d %H"))).thenReturn(List.of(row));
+
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        query.setGranularity("hour");
+        List<AgentCallTrendVO> vos = service.trend(query);
+
+        assertEquals(1, vos.size());
+        assertEquals("2026-07-24 10", vos.get(0).getBucket());
+        assertEquals(2L, vos.get(0).getCount());
+        assertEquals(400d, vos.get(0).getAvgModelMs());
+        verify(adminExtMapper).trend(any(), eq("%Y-%m-%d %H"));
+    }
+
+    @Test
+    void trend_shouldDefaultToDayFormat() {
+        when(adminExtMapper.trend(any(), eq("%Y-%m-%d"))).thenReturn(List.of());
+        service.trend(new AgentCallStatsQuery());
+        verify(adminExtMapper).trend(any(), eq("%Y-%m-%d"));
+    }
+
+    // ===== 删除 =====
+
+    @Test
+    void delete_shouldDelegateToStore() {
+        when(adminStore.delete(7L)).thenReturn(true);
+        assertTrue(service.delete(7L, "ADMIN"));
+        verify(adminStore).delete(7L);
+    }
+
+    // ===== APP 源路由 =====
+
+    @Test
+    void page_shouldRouteToAppGateway_whenSourceApp() {
+        AgentCallStatsExtMapper appExt = mock(AgentCallStatsExtMapper.class);
+        AgentCallStatsGateway appGateway = new AgentCallStatsGateway(appExt,
+            mock(AgentCallLogMapper.class), mock(AgentCallSegmentMapper.class), mock(AgentCallLogStore.class));
+        when(appProvider.get()).thenReturn(appGateway);
+        when(appExt.countBy(any())).thenReturn(0L);
+
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        query.setSource("APP");
+        service.page(query);
+
+        verify(appProvider).get();
+        verify(appExt).countBy(any());
+    }
+
+    @Test
+    void page_shouldPropagateBizException_whenAppUnreachable() {
+        when(appProvider.get()).thenThrow(new BizException(ResultCode.CUSTOMER_WORK_UNAVAILABLE, "客服端调用日志库不可达：conn refused"));
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        query.setSource("APP");
+        BizException e = assertThrows(BizException.class, () -> service.page(query));
+        assertEquals(ResultCode.CUSTOMER_WORK_UNAVAILABLE, e.getResultCode());
+    }
+
+    // ===== sessionType 过滤透传 =====
+
+    @Test
+    void summary_shouldPassSessionTypeFilter() {
+        when(adminExtMapper.summary(any())).thenReturn(null);
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        query.setSessionType("VIBE_CODING");
+        service.summary(query);
+
+        ArgumentCaptor<AgentCallStatsQueryParam> captor = ArgumentCaptor.forClass(AgentCallStatsQueryParam.class);
+        verify(adminExtMapper).summary(captor.capture());
+        assertEquals("VIBE_CODING", captor.getValue().getSessionType());
+    }
+
+    @Test
+    void toParam_shouldConvertBlankFiltersToNull_andParseTime() {
+        long millis = 1_700_000_000_000L;
+        String startText = expectFormat(millis);
+        when(adminExtMapper.summary(any())).thenReturn(null);
+
+        AgentCallStatsQuery query = new AgentCallStatsQuery();
+        query.setUsername("  ");
+        query.setStartTime(startText);
+        service.summary(query);
+
+        ArgumentCaptor<AgentCallStatsQueryParam> captor = ArgumentCaptor.forClass(AgentCallStatsQueryParam.class);
+        verify(adminExtMapper).summary(captor.capture());
+        assertNull(captor.getValue().getUsername(), "空白用户名应转 null（不约束）");
+        assertEquals(millis, captor.getValue().getStartFromMs());
+        assertSame(adminExtMapper, adminGateway.extMapper());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
@@ -27,7 +27,7 @@ class AdminAgentInstanceFactoryTest {
     /** 构造器纯字段赋值，路径解析只依赖常量，传 null 依赖即可单测 resolveSessionWorkspace 的防御逻辑。 */
     private AdminAgentInstanceFactory newFactoryForPathTest() {
         return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
@@ -9,6 +9,7 @@ import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk;
 import com.richard.fyoung.customeradmin.workspace.audit.service.AiCodingAuditService;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
+import com.richard.fyoung.customeradmin.workspace.callstats.service.AgentCallMetaFactory;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.WorkspaceFileContent;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.WorkspaceFileNode;
@@ -65,7 +66,8 @@ class VibeCodingServiceTest {
         // 需真起容器，由门控式 DockerSandboxIntegrationTest 覆盖，本单测聚焦模式无关的流式/快照/审计逻辑。
         // 审计服务用 mock（旁路能力，埋点行为由 AiCodingAuditServiceTest 单独覆盖）
         service = new VibeCodingService(chatService, agentInstanceFactory, agentMapper, gitWorkspaceService,
-            new AdminSandboxProperties(), mock(AiCodingAuditService.class), new PlanConfirmationService());
+            new AdminSandboxProperties(), mock(AiCodingAuditService.class), new PlanConfirmationService(),
+            mock(AgentCallMetaFactory.class));
 
         // resolveWorkspace 返回 agentRoot（向后兼容，listChangedArtifacts 旧逻辑已不使用此方法）
         when(agentInstanceFactory.resolveWorkspace("coder")).thenReturn(agentRoot);
@@ -107,7 +109,7 @@ class VibeCodingServiceTest {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         // stream 会在用户消息头部注入路径指引，所以 chatService 收到的消息不是原始 "write 文件"
         // 而是含指引的 enrichedText，这里用 anyString() 匹配即可。
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any()))
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any()))
             .thenReturn(Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "好的")));
 
         List<ChatStreamChunk> emitted = service.stream("coder", "s1", "write 文件").collectList().block();
@@ -120,7 +122,7 @@ class VibeCodingServiceTest {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         // 捕获实际传给 chatService 的消息内容
         java.util.concurrent.atomic.AtomicReference<String> capturedText = new java.util.concurrent.atomic.AtomicReference<>();
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenAnswer(inv -> {
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenAnswer(inv -> {
             capturedText.set(inv.getArgument(2));
             return Flux.empty();
         });
@@ -138,7 +140,7 @@ class VibeCodingServiceTest {
     @Test
     void listChangedArtifacts_shouldDetectNewAndModifiedFiles_butNotUntouchedFiles() throws IOException {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(Flux.empty());
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(Flux.empty());
 
         // stream 开始前写两个文件（已存在于快照）
         Path sessionWs = agentRoot.resolve("sessions/s1");
@@ -162,7 +164,7 @@ class VibeCodingServiceTest {
     @Test
     void listChangedArtifacts_differentSessions_shouldBeIsolated() throws IOException {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(Flux.empty());
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(Flux.empty());
 
         // 会话 s1 产出文件
         service.stream("coder", "s1", "任务A").blockLast();
@@ -380,7 +382,7 @@ class VibeCodingServiceTest {
                 Mono.fromRunnable(() -> writeQuietly(sessionWs, "output.txt", "hello"))
                     .thenReturn(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok")),
                 Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-1", "写个文件").collectList().block();
 
@@ -400,7 +402,7 @@ class VibeCodingServiceTest {
             // 没有任何 TOOL_RESULT 节点，文件是在流结束前"悄悄"写入的（异步落盘边界场景）
             Flux<ChatStreamChunk> simulated = Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成"))
                 .doOnComplete(() -> writeQuietly(sessionWs, "late-file.txt", "late"));
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-2", "写个文件").collectList().block();
 
@@ -412,7 +414,7 @@ class VibeCodingServiceTest {
         @Test
         void shouldNotEmitFileChangeEvent_whenNoFileWritten() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「read_file」返回：内容"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
 
@@ -433,7 +435,7 @@ class VibeCodingServiceTest {
                 Mono.fromRunnable(() -> writeQuietly(sessionWs, ".git/hooks/pre-commit.sample", "#!/bin/sh"))
                     .thenReturn(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok")),
                 Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-4", "写个文件").collectList().block();
 
@@ -466,7 +468,7 @@ class VibeCodingServiceTest {
         void shouldEmitTestReport_afterMavenTestExecute() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
             String mvnOk = executeResult(0, "[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0\n[INFO] BUILD SUCCESS");
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, mvnOk),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "测试通过")));
 
@@ -487,7 +489,7 @@ class VibeCodingServiceTest {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
             String fail = executeResult(1, "[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0\n[INFO] BUILD FAILURE");
             // 同一轮对话里连续三次失败的 execute 结果（模拟 Agent 三轮修复仍失败）
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, fail),
                     new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, fail),
                     new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, fail)));
@@ -505,7 +507,7 @@ class VibeCodingServiceTest {
         @Test
         void shouldNotEmitTestReport_forNonExecuteToolResult() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "完成")));
 

--- a/customer-admin-web/package-lock.json
+++ b/customer-admin-web/package-lock.json
@@ -12,6 +12,7 @@
         "@types/crypto-js": "^4.2.2",
         "axios": "^1.18.1",
         "crypto-js": "^4.2.0",
+        "echarts": "^6.1.0",
         "element-plus": "^2.14.2",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.3.0",
@@ -1007,6 +1008,22 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/element-plus": {
       "version": "2.14.2",
@@ -2450,6 +2467,21 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/customer-admin-web/package.json
+++ b/customer-admin-web/package.json
@@ -13,6 +13,7 @@
     "@types/crypto-js": "^4.2.2",
     "axios": "^1.18.1",
     "crypto-js": "^4.2.0",
+    "echarts": "^6.1.0",
     "element-plus": "^2.14.2",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.3.0",

--- a/customer-admin-web/src/api/agentCallStats.ts
+++ b/customer-admin-web/src/api/agentCallStats.ts
@@ -1,0 +1,41 @@
+import { request } from './request'
+import type {
+  AgentCallSource,
+  AgentCallStatsDetail,
+  AgentCallStatsPageResult,
+  AgentCallStatsQuery,
+  AgentCallStatsSummary,
+  AgentCallStatsTrendPoint,
+  AgentCallTrendGranularity,
+} from '@/types/api'
+
+const BASE_URL = '/agent-call-stats'
+
+/** 智能体调用耗时统计分页查询。 */
+export function pageAgentCallStats(query: AgentCallStatsQuery) {
+  return request<AgentCallStatsPageResult>({ url: `${BASE_URL}/page`, method: 'get', params: query })
+}
+
+/** 单条调用全量详情（含回答全文 + 分段耗时明细）。 */
+export function getAgentCallStatsDetail(id: number, source: AgentCallSource) {
+  return request<AgentCallStatsDetail>({ url: `${BASE_URL}/${id}`, method: 'get', params: { source } })
+}
+
+/** 汇总卡片：与分页查询共用同一套筛选参数，不含 pageNum/pageSize。 */
+export function getAgentCallStatsSummary(query: AgentCallStatsQuery) {
+  return request<AgentCallStatsSummary>({ url: `${BASE_URL}/summary`, method: 'get', params: query })
+}
+
+/** 趋势图：筛选参数 + 统计粒度（按天/按小时）。 */
+export function getAgentCallStatsTrend(query: AgentCallStatsQuery, granularity: AgentCallTrendGranularity) {
+  return request<AgentCallStatsTrendPoint[]>({
+    url: `${BASE_URL}/trend`,
+    method: 'get',
+    params: { ...query, granularity },
+  })
+}
+
+/** 删除一条调用记录。 */
+export function deleteAgentCallStats(id: number, source: AgentCallSource) {
+  return request<void>({ url: `${BASE_URL}/${id}`, method: 'delete', params: { source } })
+}

--- a/customer-admin-web/src/components/AgentCallTrendChart.vue
+++ b/customer-admin-web/src/components/AgentCallTrendChart.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import * as echarts from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import { GridComponent, LegendComponent, TooltipComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
+import { useThemeStore } from '@/store/theme'
+import type { AgentCallStatsTrendPoint, AgentCallTrendGranularity } from '@/types/api'
+
+// 按需引入：只注册用到的折线图 + 网格/图例/tooltip + Canvas 渲染器，不拉全量 echarts 包体积。
+echarts.use([LineChart, GridComponent, LegendComponent, TooltipComponent, CanvasRenderer])
+
+const props = defineProps<{
+  points: AgentCallStatsTrendPoint[]
+  granularity: AgentCallTrendGranularity
+  loading?: boolean
+}>()
+
+const themeStore = useThemeStore()
+const chartEl = ref<HTMLDivElement>()
+let chart: echarts.ECharts | null = null
+
+/**
+ * 后端未强约束 bucket 的具体字符串格式（day 粒度大概率 yyyy-MM-dd，hour 粒度大概率
+ * yyyy-MM-dd HH:00 一类），这里只做保守裁剪去掉年份前缀，超长的（含时间部分）截到分钟位，
+ * 不对具体格式做强假设，hover tooltip 里始终展示 bucket 原文兜底。
+ */
+function shortenBucket(bucket: string): string {
+  const trimmed = bucket.length > 10 ? bucket.slice(5, 16) : bucket.slice(5)
+  return trimmed || bucket
+}
+
+function buildOption() {
+  const dark = themeStore.isDark
+  const textColor = dark ? '#c9cdd4' : '#606266'
+  const axisLineColor = dark ? '#3c3f45' : '#dcdfe6'
+  const categories = props.points.map((p) => p.bucket)
+  const rotate = categories.length > 12 ? 30 : 0
+
+  return {
+    textStyle: { color: textColor },
+    tooltip: { trigger: 'axis' },
+    legend: {
+      data: ['调用量', '平均总耗时', '大模型', '工具', 'MCP', 'Skill'],
+      top: 0,
+      textStyle: { color: textColor },
+    },
+    grid: { left: 56, right: 56, top: 44, bottom: rotate ? 56 : 30 },
+    xAxis: {
+      type: 'category',
+      data: categories,
+      axisLine: { lineStyle: { color: axisLineColor } },
+      axisLabel: { color: textColor, formatter: shortenBucket, rotate },
+    },
+    yAxis: [
+      { type: 'value', name: '调用量', position: 'left', axisLine: { lineStyle: { color: axisLineColor } }, axisLabel: { color: textColor }, splitLine: { lineStyle: { color: axisLineColor, opacity: 0.5 } } },
+      { type: 'value', name: '耗时(ms)', position: 'right', axisLine: { lineStyle: { color: axisLineColor } }, axisLabel: { color: textColor }, splitLine: { show: false } },
+    ],
+    series: [
+      { name: '调用量', type: 'line', yAxisIndex: 0, smooth: true, data: props.points.map((p) => p.count) },
+      { name: '平均总耗时', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgDurationMs) },
+      { name: '大模型', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgModelMs) },
+      { name: '工具', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgToolMs) },
+      { name: 'MCP', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgMcpMs) },
+      { name: 'Skill', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgSkillMs) },
+    ],
+  }
+}
+
+function render() {
+  if (!chart) return
+  chart.setOption(buildOption(), true)
+}
+
+function handleResize() {
+  chart?.resize()
+}
+
+onMounted(() => {
+  if (!chartEl.value) return
+  chart = echarts.init(chartEl.value)
+  render()
+  window.addEventListener('resize', handleResize)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', handleResize)
+  chart?.dispose()
+  chart = null
+})
+
+// points/granularity 变化（切筛选条件、切粒度）与深浅主题切换都要重绘
+watch(() => [props.points, props.granularity, themeStore.isDark], render, { deep: false })
+</script>
+
+<template>
+  <div v-loading="loading" class="trend-chart-wrap">
+    <div v-if="!loading && points.length === 0" class="empty-tip">暂无趋势数据</div>
+    <div ref="chartEl" class="trend-chart" />
+  </div>
+</template>
+
+<style scoped>
+.trend-chart-wrap {
+  position: relative;
+  width: 100%;
+  height: 320px;
+}
+
+.trend-chart {
+  width: 100%;
+  height: 100%;
+}
+
+.empty-tip {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--el-text-color-placeholder);
+  font-size: 13px;
+  z-index: 1;
+}
+</style>

--- a/customer-admin-web/src/components/AgentCallTrendChart.vue
+++ b/customer-admin-web/src/components/AgentCallTrendChart.vue
@@ -41,11 +41,14 @@ function buildOption() {
     textStyle: { color: textColor },
     tooltip: { trigger: 'axis' },
     legend: {
-      data: ['调用量', '平均总耗时', '大模型', '工具', 'MCP', 'Skill'],
+      // Token 量纲（可达数万）与耗时 ms 不同，单列一条曲线绑独立右侧 Y 轴，默认不选中避免首屏喧宾夺主，
+      // 用户按需点亮；调用量/耗时各占一条 Y 轴。
+      data: ['调用量', '平均总耗时', '大模型', '工具', 'MCP', 'Skill', 'Token'],
+      selected: { Token: false },
       top: 0,
       textStyle: { color: textColor },
     },
-    grid: { left: 56, right: 56, top: 44, bottom: rotate ? 56 : 30 },
+    grid: { left: 56, right: 88, top: 44, bottom: rotate ? 56 : 30 },
     xAxis: {
       type: 'category',
       data: categories,
@@ -55,6 +58,7 @@ function buildOption() {
     yAxis: [
       { type: 'value', name: '调用量', position: 'left', axisLine: { lineStyle: { color: axisLineColor } }, axisLabel: { color: textColor }, splitLine: { lineStyle: { color: axisLineColor, opacity: 0.5 } } },
       { type: 'value', name: '耗时(ms)', position: 'right', axisLine: { lineStyle: { color: axisLineColor } }, axisLabel: { color: textColor }, splitLine: { show: false } },
+      { type: 'value', name: 'Token', position: 'right', offset: 52, axisLine: { lineStyle: { color: axisLineColor } }, axisLabel: { color: textColor }, splitLine: { show: false } },
     ],
     series: [
       { name: '调用量', type: 'line', yAxisIndex: 0, smooth: true, data: props.points.map((p) => p.count) },
@@ -63,6 +67,7 @@ function buildOption() {
       { name: '工具', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgToolMs) },
       { name: 'MCP', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgMcpMs) },
       { name: 'Skill', type: 'line', yAxisIndex: 1, smooth: true, data: props.points.map((p) => p.avgSkillMs) },
+      { name: 'Token', type: 'line', yAxisIndex: 2, smooth: true, data: props.points.map((p) => p.totalTokens) },
     ],
   }
 }

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -10,6 +10,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/role': () => import('@/views/system/RoleManage.vue'),
   '/system/log': () => import('@/views/system/OperationLog.vue'),
   '/system/ai-audit': () => import('@/views/system/AiCodingAudit.vue'),
+  '/system/agent-call-stats': () => import('@/views/system/AgentCallStats.vue'),
   '/system/menu': () => import('@/views/system/MenuManage.vue'),
   '/system/devtools': () => import('@/views/system/DevToolboxView.vue'),
   '/system/login-image': () => import('@/views/system/LoginImageManage.vue'),

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -187,6 +187,99 @@ export interface AiCodingAuditQuery extends PageQuery {
   operation?: string
 }
 
+// ---------- system.agent-call-stats ----------
+// 契约由后端并行开发分支约定死（/api/agent-call-stats/*），字段命名与下方一一对应，不自行发明。
+
+/** 调用来源：ADMIN=后台工作台（客服坐席/内部使用），APP=客服端 H5（面向终端用户）。 */
+export type AgentCallSource = 'ADMIN' | 'APP'
+/** 会话类型：CHAT=普通对话，VIBE_CODING=编码协作。APP 来源恒为 CHAT。 */
+export type AgentCallSessionType = 'CHAT' | 'VIBE_CODING'
+/** 单次调用内的分段耗时类型：大模型/工具/MCP/技能。 */
+export type AgentCallSegmentKind = 'MODEL' | 'TOOL' | 'MCP' | 'SKILL'
+/** 趋势图统计粒度。 */
+export type AgentCallTrendGranularity = 'day' | 'hour'
+
+/** 智能体调用耗时统计查询条件：分页/汇总/趋势三个接口共用同一套筛选参数。 */
+export interface AgentCallStatsQuery extends PageQuery {
+  source?: AgentCallSource
+  username?: string
+  agentCode?: string
+  sessionType?: AgentCallSessionType
+  requestId?: string
+  sessionId?: string
+  /** 格式 yyyy-MM-dd HH:mm:ss，与后端 SQL 通用日期参数约定一致（见 SqlQueryView 同类用法）。 */
+  startTime?: string
+  endTime?: string
+}
+
+/** 分页明细行（不含 answer 全文与分段明细，详情走单条接口）。 */
+export interface AgentCallStatsRow {
+  id: number
+  requestId: string
+  /** 注意：后端此字段为字符串（admin 链路实际取 agentCode 作状态隔离键），非数字用户 id。 */
+  userId: string | null
+  username: string | null
+  agentCode: string
+  agentName: string | null
+  sessionId: string
+  sessionType: AgentCallSessionType
+  question: string
+  answerPreview: string
+  startTime: string
+  endTime: string
+  durationMs: number
+  modelMs: number
+  toolMs: number
+  mcpMs: number
+  skillMs: number
+}
+
+// 契约固定 { total, rows }，与通用 PageResult 的 pageNum/pageSize/list 命名不同（同 MpPageResult
+// 的先例：不同后端模块按各自契约透出，不强行套通用形状）。
+export interface AgentCallStatsPageResult {
+  total: number
+  rows: AgentCallStatsRow[]
+}
+
+/** 单次调用内的一段耗时（一次模型调用/一次工具调用/一次 MCP 调用/一次技能调用）。 */
+export interface AgentCallStatsSegment {
+  seq: number
+  kind: AgentCallSegmentKind
+  name: string
+  startTime: string
+  durationMs: number
+  success: boolean
+  errorMsg: string | null
+}
+
+/** 单条调用详情：分页行字段 + 回答全文 + 分段耗时明细。 */
+export interface AgentCallStatsDetail extends AgentCallStatsRow {
+  answer: string
+  segments: AgentCallStatsSegment[]
+}
+
+/** 汇总卡片：总调用数/耗时均值峰值/各分段耗时均值。 */
+export interface AgentCallStatsSummary {
+  totalCalls: number
+  avgDurationMs: number
+  maxDurationMs: number
+  avgModelMs: number
+  avgToolMs: number
+  avgMcpMs: number
+  avgSkillMs: number
+}
+
+/** 趋势图单个时间桶。 */
+export interface AgentCallStatsTrendPoint {
+  bucket: string
+  count: number
+  avgDurationMs: number
+  avgModelMs: number
+  avgToolMs: number
+  avgMcpMs: number
+  avgSkillMs: number
+}
+
 // ---------- aiconfig.model ----------
 export interface ModelVO {
   id: number

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -232,6 +232,10 @@ export interface AgentCallStatsRow {
   toolMs: number
   mcpMs: number
   skillMs: number
+  /** 请求级 token 消耗（缺失为 null）。 */
+  inputTokens: number | null
+  outputTokens: number | null
+  totalTokens: number | null
 }
 
 // 契约固定 { total, rows }，与通用 PageResult 的 pageNum/pageSize/list 命名不同（同 MpPageResult
@@ -248,6 +252,9 @@ export interface AgentCallStatsSegment {
   name: string
   startTime: string
   durationMs: number
+  /** token 消耗（仅 MODEL 段有值，缺失为 null）。 */
+  inputTokens: number | null
+  outputTokens: number | null
   success: boolean
   errorMsg: string | null
 }
@@ -267,6 +274,9 @@ export interface AgentCallStatsSummary {
   avgToolMs: number
   avgMcpMs: number
   avgSkillMs: number
+  /** 总 token 消耗 / 平均每次 token 消耗。 */
+  totalTokens: number
+  avgTotalTokens: number
 }
 
 /** 趋势图单个时间桶。 */
@@ -278,6 +288,8 @@ export interface AgentCallStatsTrendPoint {
   avgToolMs: number
   avgMcpMs: number
   avgSkillMs: number
+  /** 该桶内 token 消耗合计。 */
+  totalTokens: number
 }
 
 // ---------- aiconfig.model ----------

--- a/customer-admin-web/src/views/system/AgentCallStats.vue
+++ b/customer-admin-web/src/views/system/AgentCallStats.vue
@@ -146,6 +146,8 @@ async function loadSummary() {
 
 const SUMMARY_CARDS = [
   { key: 'totalCalls', label: '总调用数', unit: '次' },
+  { key: 'totalTokens', label: '总 Token 消耗', unit: 'token' },
+  { key: 'avgTotalTokens', label: '平均 Token/次', unit: 'token' },
   { key: 'avgDurationMs', label: '平均耗时', unit: 'ms' },
   { key: 'maxDurationMs', label: '最大耗时', unit: 'ms' },
   { key: 'avgModelMs', label: '大模型平均耗时', unit: 'ms' },
@@ -156,6 +158,14 @@ const SUMMARY_CARDS = [
 
 function summaryValue(key: (typeof SUMMARY_CARDS)[number]['key']): number {
   return summary.value?.[key] ?? 0
+}
+
+/** 卡片取值格式化：ms 走人性化耗时，token 走千分位（均值四舍五入取整），其余原样。 */
+function summaryDisplay(card: (typeof SUMMARY_CARDS)[number]): string {
+  const value = summaryValue(card.key)
+  if (card.unit === 'ms') return formatDuration(value)
+  if (card.unit === 'token') return formatTokens(Math.round(value))
+  return String(value)
 }
 
 // ---------- 趋势图 ----------
@@ -219,6 +229,12 @@ function formatDuration(ms: number | null | undefined): string {
   const minutes = Math.floor(totalSeconds / 60)
   const seconds = totalSeconds % 60
   return seconds === 0 ? `${minutes}分` : `${minutes}分${seconds}秒`
+}
+
+/** token 数千分位展示；null/undefined 显示 —（区分"未采集到用量"与 0）。 */
+function formatTokens(tokens: number | null | undefined): string {
+  if (tokens == null) return '—'
+  return tokens.toLocaleString('en-US')
 }
 
 function sessionTypeLabel(type: string): string {
@@ -331,9 +347,7 @@ onMounted(() => {
     <div class="summary-row">
       <div v-for="card in SUMMARY_CARDS" :key="card.key" class="stat-card" v-loading="summaryLoading">
         <div class="stat-label">{{ card.label }}</div>
-        <div class="stat-value">
-          {{ card.unit === 'ms' ? formatDuration(summaryValue(card.key)) : summaryValue(card.key) }}
-        </div>
+        <div class="stat-value">{{ summaryDisplay(card) }}</div>
       </div>
     </div>
 
@@ -375,6 +389,18 @@ onMounted(() => {
         </el-table-column>
         <el-table-column label="总耗时" width="100" align="right">
           <template #default="{ row }: { row: AgentCallStatsRow }">{{ formatDuration(row.durationMs) }}</template>
+        </el-table-column>
+        <el-table-column label="Token" width="110" align="right">
+          <template #default="{ row }: { row: AgentCallStatsRow }">
+            <el-tooltip v-if="row.totalTokens != null" placement="top">
+              <template #content>
+                <div>输入：{{ formatTokens(row.inputTokens) }}</div>
+                <div>输出：{{ formatTokens(row.outputTokens) }}</div>
+              </template>
+              <span>{{ formatTokens(row.totalTokens) }}</span>
+            </el-tooltip>
+            <span v-else class="muted">—</span>
+          </template>
         </el-table-column>
         <el-table-column label="分段耗时" width="140">
           <template #default="{ row }: { row: AgentCallStatsRow }">
@@ -430,6 +456,9 @@ onMounted(() => {
             <el-descriptions-item label="开始时间">{{ detail.startTime }}</el-descriptions-item>
             <el-descriptions-item label="结束时间">{{ detail.endTime }}</el-descriptions-item>
             <el-descriptions-item label="总耗时" :span="2">{{ formatDuration(detail.durationMs) }}</el-descriptions-item>
+            <el-descriptions-item label="输入 Token">{{ formatTokens(detail.inputTokens) }}</el-descriptions-item>
+            <el-descriptions-item label="输出 Token">{{ formatTokens(detail.outputTokens) }}</el-descriptions-item>
+            <el-descriptions-item label="总 Token" :span="2">{{ formatTokens(detail.totalTokens) }}</el-descriptions-item>
           </el-descriptions>
 
           <div class="detail-block">
@@ -477,6 +506,12 @@ onMounted(() => {
               <el-table-column prop="startTime" label="开始时间" width="150" />
               <el-table-column label="耗时" width="90" align="right">
                 <template #default="{ row }: { row: AgentCallStatsSegment }">{{ formatDuration(row.durationMs) }}</template>
+              </el-table-column>
+              <el-table-column label="输入Token" width="90" align="right">
+                <template #default="{ row }: { row: AgentCallStatsSegment }">{{ formatTokens(row.inputTokens) }}</template>
+              </el-table-column>
+              <el-table-column label="输出Token" width="90" align="right">
+                <template #default="{ row }: { row: AgentCallStatsSegment }">{{ formatTokens(row.outputTokens) }}</template>
               </el-table-column>
               <el-table-column label="成败" width="70">
                 <template #default="{ row }: { row: AgentCallStatsSegment }">

--- a/customer-admin-web/src/views/system/AgentCallStats.vue
+++ b/customer-admin-web/src/views/system/AgentCallStats.vue
@@ -1,0 +1,640 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  deleteAgentCallStats,
+  getAgentCallStatsDetail,
+  getAgentCallStatsSummary,
+  getAgentCallStatsTrend,
+  pageAgentCallStats,
+} from '@/api/agentCallStats'
+import { pageAgents } from '@/api/agent'
+import AgentCallTrendChart from '@/components/AgentCallTrendChart.vue'
+import type {
+  AgentCallSegmentKind,
+  AgentCallSource,
+  AgentCallStatsDetail,
+  AgentCallStatsQuery,
+  AgentCallStatsRow,
+  AgentCallStatsSegment,
+  AgentCallStatsSummary,
+  AgentCallStatsTrendPoint,
+  AgentCallTrendGranularity,
+  AgentVO,
+} from '@/types/api'
+
+const router = useRouter()
+
+const DEFAULT_PAGE_SIZE = 10
+// 智能体下拉复用「智能体管理」的分页接口，无独立全量接口时拉大页兜底（同 ChannelBindingDrawer 用法）。
+const AGENT_OPTION_PAGE_SIZE = 200
+
+const SOURCE_OPTIONS: Array<{ label: string; value: AgentCallSource }> = [
+  { label: '工作台（Admin）', value: 'ADMIN' },
+  { label: '客服端（App）', value: 'APP' },
+]
+const SESSION_TYPE_OPTIONS: Array<{ label: string; value: 'CHAT' | 'VIBE_CODING' }> = [
+  { label: '对话', value: 'CHAT' },
+  { label: 'VibeCoding', value: 'VIBE_CODING' },
+]
+
+/** 分段耗时类型元信息：展示名 + 统一配色，明细表迷你条形图与详情抽屉标签共用。 */
+const SEGMENT_KIND_META: Record<AgentCallSegmentKind, { label: string; color: string }> = {
+  MODEL: { label: '大模型', color: '#f59e0b' },
+  TOOL: { label: '工具', color: '#67c23a' },
+  MCP: { label: 'MCP', color: '#409eff' },
+  SKILL: { label: 'Skill', color: '#8b5cf6' },
+}
+
+interface FilterState {
+  source: AgentCallSource
+  username: string
+  agentCode: string
+  sessionType: 'CHAT' | 'VIBE_CODING' | ''
+  requestId: string
+  sessionId: string
+}
+
+const filters = reactive<FilterState>({
+  source: 'ADMIN',
+  username: '',
+  agentCode: '',
+  sessionType: '',
+  requestId: '',
+  sessionId: '',
+})
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function formatDateTime(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+/** 默认展示最近 7 天，避免首屏空筛选把全量历史记录一次性拉回来。 */
+function defaultTimeRange(): [string, string] {
+  const end = new Date()
+  const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000)
+  return [formatDateTime(start), formatDateTime(end)]
+}
+
+const timeRange = ref<[string, string] | null>(defaultTimeRange())
+const sourceIsApp = computed(() => filters.source === 'APP')
+
+// 客服端（App）恒为普通对话，没有 VibeCoding 概念：切到 APP 时清空并禁用会话类型筛选，
+// 与「打开会话」按钮仅 ADMIN 行可用是同一条业务约束（源头见需求 §2/§6）。
+watch(
+  () => filters.source,
+  (source) => {
+    if (source === 'APP') {
+      filters.sessionType = ''
+    }
+  },
+)
+
+/** 分页/汇总/趋势三个接口共用的筛选参数：空值一律不传，交给后端默认语义。 */
+function buildFilterParams(): AgentCallStatsQuery {
+  const q: AgentCallStatsQuery = { source: filters.source }
+  if (filters.username) q.username = filters.username
+  if (filters.agentCode) q.agentCode = filters.agentCode
+  const sessionType = sourceIsApp.value ? 'CHAT' : filters.sessionType
+  if (sessionType) q.sessionType = sessionType
+  if (filters.requestId) q.requestId = filters.requestId
+  if (filters.sessionId) q.sessionId = filters.sessionId
+  if (timeRange.value?.[0]) q.startTime = timeRange.value[0]
+  if (timeRange.value?.[1]) q.endTime = timeRange.value[1]
+  return q
+}
+
+// ---------- 智能体下拉选项 ----------
+const agentOptions = ref<AgentVO[]>([])
+async function loadAgentOptions() {
+  const result = await pageAgents({ pageNum: 1, pageSize: AGENT_OPTION_PAGE_SIZE })
+  agentOptions.value = result.list
+}
+
+// ---------- 明细分页列表 ----------
+const loading = ref(false)
+const list = ref<AgentCallStatsRow[]>([])
+const total = ref(0)
+const pageNum = ref(1)
+const pageSize = ref(DEFAULT_PAGE_SIZE)
+
+async function loadList() {
+  loading.value = true
+  try {
+    const res = await pageAgentCallStats({ ...buildFilterParams(), pageNum: pageNum.value, pageSize: pageSize.value })
+    list.value = res.rows
+    total.value = res.total
+  } finally {
+    loading.value = false
+  }
+}
+
+// ---------- 汇总卡片 ----------
+const summaryLoading = ref(false)
+const summary = ref<AgentCallStatsSummary | null>(null)
+async function loadSummary() {
+  summaryLoading.value = true
+  try {
+    summary.value = await getAgentCallStatsSummary(buildFilterParams())
+  } finally {
+    summaryLoading.value = false
+  }
+}
+
+const SUMMARY_CARDS = [
+  { key: 'totalCalls', label: '总调用数', unit: '次' },
+  { key: 'avgDurationMs', label: '平均耗时', unit: 'ms' },
+  { key: 'maxDurationMs', label: '最大耗时', unit: 'ms' },
+  { key: 'avgModelMs', label: '大模型平均耗时', unit: 'ms' },
+  { key: 'avgToolMs', label: '工具平均耗时', unit: 'ms' },
+  { key: 'avgMcpMs', label: 'MCP平均耗时', unit: 'ms' },
+  { key: 'avgSkillMs', label: 'Skill平均耗时', unit: 'ms' },
+] as const
+
+function summaryValue(key: (typeof SUMMARY_CARDS)[number]['key']): number {
+  return summary.value?.[key] ?? 0
+}
+
+// ---------- 趋势图 ----------
+const trendLoading = ref(false)
+const trendPoints = ref<AgentCallStatsTrendPoint[]>([])
+const trendGranularityMode = ref<'auto' | AgentCallTrendGranularity>('auto')
+
+/** auto 模式按当前时间跨度自动选粒度：跨度 <= 2 天用小时，否则按天，避免小跨度下按天只出一两个点。 */
+const effectiveGranularity = computed<AgentCallTrendGranularity>(() => {
+  if (trendGranularityMode.value !== 'auto') return trendGranularityMode.value
+  const start = timeRange.value?.[0]
+  const end = timeRange.value?.[1]
+  if (!start || !end) return 'day'
+  const spanMs = new Date(end).getTime() - new Date(start).getTime()
+  const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000
+  return spanMs > 0 && spanMs <= TWO_DAYS_MS ? 'hour' : 'day'
+})
+
+async function loadTrend() {
+  trendLoading.value = true
+  try {
+    trendPoints.value = await getAgentCallStatsTrend(buildFilterParams(), effectiveGranularity.value)
+  } finally {
+    trendLoading.value = false
+  }
+}
+
+// 用户切换粒度开关时立即重绘趋势图，不需要重新点搜索
+watch(trendGranularityMode, () => {
+  loadTrend()
+})
+
+async function refreshAll() {
+  await Promise.all([loadList(), loadSummary(), loadTrend()])
+}
+
+function handleSearch() {
+  pageNum.value = 1
+  refreshAll()
+}
+
+function handleReset() {
+  filters.source = 'ADMIN'
+  filters.username = ''
+  filters.agentCode = ''
+  filters.sessionType = ''
+  filters.requestId = ''
+  filters.sessionId = ''
+  timeRange.value = defaultTimeRange()
+  pageNum.value = 1
+  refreshAll()
+}
+
+// ---------- 耗时格式化 ----------
+/** 人性化耗时：<1s 展示毫秒；<60s 展示整秒；否则 分+秒（如 1分13秒）。 */
+function formatDuration(ms: number | null | undefined): string {
+  if (ms == null) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const totalSeconds = Math.round(ms / 1000)
+  if (totalSeconds < 60) return `${totalSeconds}秒`
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return seconds === 0 ? `${minutes}分` : `${minutes}分${seconds}秒`
+}
+
+function sessionTypeLabel(type: string): string {
+  return type === 'VIBE_CODING' ? 'VibeCoding' : '对话'
+}
+
+/** 明细行的分段耗时迷你条形展示：按各段耗时占比拉伸宽度，全零时不渲染任何条。 */
+function segmentBreakdown(row: AgentCallStatsRow): Array<{ kind: AgentCallSegmentKind; ms: number }> {
+  return (
+    [
+      { kind: 'MODEL', ms: row.modelMs },
+      { kind: 'TOOL', ms: row.toolMs },
+      { kind: 'MCP', ms: row.mcpMs },
+      { kind: 'SKILL', ms: row.skillMs },
+    ] as const
+  ).filter((s) => s.ms > 0)
+}
+
+// ---------- 行操作：耗时详情 ----------
+const detailVisible = ref(false)
+const detailLoading = ref(false)
+const detail = ref<AgentCallStatsDetail | null>(null)
+
+async function openDetail(row: AgentCallStatsRow) {
+  detailVisible.value = true
+  detailLoading.value = true
+  detail.value = null
+  try {
+    detail.value = await getAgentCallStatsDetail(row.id, filters.source)
+  } catch (error) {
+    ElMessage.error('详情加载失败：' + (error instanceof Error ? error.message : String(error)))
+    detailVisible.value = false
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+/** 分段时间轴的 CSS 条形定位：相对本次调用开始时间的偏移与占比，均以总耗时归一化。 */
+function segmentOffsetPercent(seg: AgentCallStatsSegment): number {
+  if (!detail.value || !detail.value.durationMs) return 0
+  const offset = new Date(seg.startTime).getTime() - new Date(detail.value.startTime).getTime()
+  return Math.min(Math.max((offset / detail.value.durationMs) * 100, 0), 100)
+}
+
+function segmentWidthPercent(seg: AgentCallStatsSegment): number {
+  if (!detail.value || !detail.value.durationMs) return 0
+  return Math.min(Math.max((seg.durationMs / detail.value.durationMs) * 100, 0.6), 100)
+}
+
+// ---------- 行操作：打开会话 ----------
+function openInWorkspace(row: AgentCallStatsRow) {
+  router.push({
+    name: 'Workspace',
+    params: { agentCode: row.agentCode },
+    query: { sessionId: row.sessionId, mode: row.sessionType === 'VIBE_CODING' ? 'vibecoding' : 'chat' },
+  })
+}
+
+// ---------- 行操作：删除 ----------
+async function handleDelete(row: AgentCallStatsRow) {
+  await ElMessageBox.confirm(`确认删除这条调用记录？（请求ID：${row.requestId}）`, '提示', { type: 'warning' })
+  await deleteAgentCallStats(row.id, filters.source)
+  ElMessage.success('删除成功')
+  await refreshAll()
+}
+
+onMounted(() => {
+  loadAgentOptions()
+  refreshAll()
+})
+</script>
+
+<template>
+  <div class="page">
+    <el-card class="filter-card">
+      <div class="toolbar">
+        <el-select v-model="filters.source" placeholder="来源" style="width: 160px">
+          <el-option v-for="opt in SOURCE_OPTIONS" :key="opt.value" :label="opt.label" :value="opt.value" />
+        </el-select>
+        <el-input v-model="filters.username" placeholder="用户名" style="width: 140px" clearable @keyup.enter="handleSearch" />
+        <el-select v-model="filters.agentCode" placeholder="智能体" style="width: 160px" clearable filterable>
+          <el-option v-for="a in agentOptions" :key="a.agentCode" :label="a.agentName" :value="a.agentCode" />
+        </el-select>
+        <el-select
+          v-model="filters.sessionType"
+          placeholder="会话类型"
+          style="width: 140px"
+          clearable
+          :disabled="sourceIsApp"
+        >
+          <el-option v-for="opt in SESSION_TYPE_OPTIONS" :key="opt.value" :label="opt.label" :value="opt.value" />
+        </el-select>
+        <el-date-picker
+          v-model="timeRange"
+          type="datetimerange"
+          range-separator="至"
+          start-placeholder="开始时间"
+          end-placeholder="结束时间"
+          value-format="YYYY-MM-DD HH:mm:ss"
+          style="width: 360px"
+        />
+        <el-input v-model="filters.requestId" placeholder="请求ID" style="width: 160px" clearable @keyup.enter="handleSearch" />
+        <el-input v-model="filters.sessionId" placeholder="会话ID" style="width: 160px" clearable @keyup.enter="handleSearch" />
+        <el-button type="primary" @click="handleSearch">搜索</el-button>
+        <el-button @click="handleReset">重置</el-button>
+      </div>
+      <div v-if="sourceIsApp" class="filter-tip">客服端来源恒为「对话」，无 VibeCoding 会话</div>
+    </el-card>
+
+    <div class="summary-row">
+      <div v-for="card in SUMMARY_CARDS" :key="card.key" class="stat-card" v-loading="summaryLoading">
+        <div class="stat-label">{{ card.label }}</div>
+        <div class="stat-value">
+          {{ card.unit === 'ms' ? formatDuration(summaryValue(card.key)) : summaryValue(card.key) }}
+        </div>
+      </div>
+    </div>
+
+    <el-card class="trend-card">
+      <div class="trend-header">
+        <span class="trend-title">调用趋势</span>
+        <el-radio-group v-model="trendGranularityMode" size="small">
+          <el-radio-button value="auto">自动</el-radio-button>
+          <el-radio-button value="day">按天</el-radio-button>
+          <el-radio-button value="hour">按小时</el-radio-button>
+        </el-radio-group>
+      </div>
+      <AgentCallTrendChart :points="trendPoints" :granularity="effectiveGranularity" :loading="trendLoading" />
+    </el-card>
+
+    <el-card>
+      <el-table v-loading="loading" :data="list" style="width: 100%">
+        <el-table-column prop="username" label="用户名" width="110">
+          <template #default="{ row }: { row: AgentCallStatsRow }">{{ row.username || '—' }}</template>
+        </el-table-column>
+        <el-table-column prop="agentName" label="智能体" width="130">
+          <template #default="{ row }: { row: AgentCallStatsRow }">{{ row.agentName || row.agentCode }}</template>
+        </el-table-column>
+        <el-table-column label="会话类型" width="100">
+          <template #default="{ row }: { row: AgentCallStatsRow }">
+            <el-tag :type="row.sessionType === 'VIBE_CODING' ? 'warning' : 'primary'" size="small">
+              {{ sessionTypeLabel(row.sessionType) }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="question" label="问题" min-width="180" show-overflow-tooltip />
+        <el-table-column prop="answerPreview" label="回答预览" min-width="180" show-overflow-tooltip />
+        <el-table-column prop="requestId" label="请求ID" width="160" show-overflow-tooltip />
+        <el-table-column label="开始时间" width="150">
+          <template #default="{ row }: { row: AgentCallStatsRow }">{{ row.startTime }}</template>
+        </el-table-column>
+        <el-table-column label="结束时间" width="150">
+          <template #default="{ row }: { row: AgentCallStatsRow }">{{ row.endTime }}</template>
+        </el-table-column>
+        <el-table-column label="总耗时" width="100" align="right">
+          <template #default="{ row }: { row: AgentCallStatsRow }">{{ formatDuration(row.durationMs) }}</template>
+        </el-table-column>
+        <el-table-column label="分段耗时" width="140">
+          <template #default="{ row }: { row: AgentCallStatsRow }">
+            <el-tooltip placement="top">
+              <template #content>
+                <div v-for="s in segmentBreakdown(row)" :key="s.kind">
+                  {{ SEGMENT_KIND_META[s.kind].label }}：{{ formatDuration(s.ms) }}
+                </div>
+                <div v-if="segmentBreakdown(row).length === 0">暂无分段耗时</div>
+              </template>
+              <div class="segment-bar">
+                <span
+                  v-for="s in segmentBreakdown(row)"
+                  :key="s.kind"
+                  class="segment-piece"
+                  :style="{ flexGrow: s.ms, backgroundColor: SEGMENT_KIND_META[s.kind].color }"
+                />
+                <span v-if="segmentBreakdown(row).length === 0" class="muted">—</span>
+              </div>
+            </el-tooltip>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="220" fixed="right">
+          <template #default="{ row }: { row: AgentCallStatsRow }">
+            <el-button link type="primary" @click="openDetail(row)">耗时详情</el-button>
+            <el-button v-if="filters.source === 'ADMIN'" link type="primary" @click="openInWorkspace(row)">打开会话</el-button>
+            <el-button link type="danger" @click="handleDelete(row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-model:current-page="pageNum"
+        v-model:page-size="pageSize"
+        :total="total"
+        :page-sizes="[10, 20, 50, 100]"
+        layout="total, sizes, prev, pager, next"
+        style="margin-top: 16px; justify-content: flex-end"
+        @current-change="loadList"
+        @size-change="loadList"
+      />
+    </el-card>
+
+    <el-drawer v-model="detailVisible" title="调用耗时详情" size="640px" destroy-on-close>
+      <div v-loading="detailLoading">
+        <template v-if="detail">
+          <el-descriptions :column="2" border size="small">
+            <el-descriptions-item label="请求ID" :span="2">{{ detail.requestId }}</el-descriptions-item>
+            <el-descriptions-item label="用户名">{{ detail.username || '—' }}</el-descriptions-item>
+            <el-descriptions-item label="智能体">{{ detail.agentName || detail.agentCode }}</el-descriptions-item>
+            <el-descriptions-item label="会话类型">{{ sessionTypeLabel(detail.sessionType) }}</el-descriptions-item>
+            <el-descriptions-item label="会话ID">{{ detail.sessionId }}</el-descriptions-item>
+            <el-descriptions-item label="开始时间">{{ detail.startTime }}</el-descriptions-item>
+            <el-descriptions-item label="结束时间">{{ detail.endTime }}</el-descriptions-item>
+            <el-descriptions-item label="总耗时" :span="2">{{ formatDuration(detail.durationMs) }}</el-descriptions-item>
+          </el-descriptions>
+
+          <div class="detail-block">
+            <div class="detail-block-title">问题</div>
+            <div class="detail-text">{{ detail.question }}</div>
+          </div>
+          <div class="detail-block">
+            <div class="detail-block-title">回答</div>
+            <div class="detail-text">{{ detail.answer }}</div>
+          </div>
+
+          <div class="detail-block">
+            <div class="detail-block-title">分段耗时时间轴</div>
+            <div class="segment-timeline">
+              <div v-for="seg in detail.segments" :key="seg.seq" class="timeline-row">
+                <span class="timeline-name" :title="seg.name">{{ seg.name }}</span>
+                <span class="timeline-track">
+                  <span
+                    class="timeline-bar"
+                    :style="{
+                      left: segmentOffsetPercent(seg) + '%',
+                      width: segmentWidthPercent(seg) + '%',
+                      backgroundColor: SEGMENT_KIND_META[seg.kind].color,
+                    }"
+                  />
+                </span>
+                <span class="timeline-ms">{{ formatDuration(seg.durationMs) }}</span>
+              </div>
+              <div v-if="detail.segments.length === 0" class="muted">暂无分段耗时记录</div>
+            </div>
+          </div>
+
+          <div class="detail-block">
+            <div class="detail-block-title">分段耗时明细</div>
+            <el-table :data="detail.segments" size="small" style="width: 100%">
+              <el-table-column prop="seq" label="序号" width="60" />
+              <el-table-column label="类型" width="90">
+                <template #default="{ row }: { row: AgentCallStatsSegment }">
+                  <el-tag :color="SEGMENT_KIND_META[row.kind].color" style="color: #fff; border: none">
+                    {{ SEGMENT_KIND_META[row.kind].label }}
+                  </el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column prop="name" label="名称" min-width="140" show-overflow-tooltip />
+              <el-table-column prop="startTime" label="开始时间" width="150" />
+              <el-table-column label="耗时" width="90" align="right">
+                <template #default="{ row }: { row: AgentCallStatsSegment }">{{ formatDuration(row.durationMs) }}</template>
+              </el-table-column>
+              <el-table-column label="成败" width="70">
+                <template #default="{ row }: { row: AgentCallStatsSegment }">
+                  <el-tag :type="row.success ? 'success' : 'danger'" size="small">{{ row.success ? '成功' : '失败' }}</el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column prop="errorMsg" label="错误信息" min-width="140" show-overflow-tooltip>
+                <template #default="{ row }: { row: AgentCallStatsSegment }">{{ row.errorMsg || '—' }}</template>
+              </el-table-column>
+            </el-table>
+          </div>
+        </template>
+      </div>
+    </el-drawer>
+  </div>
+</template>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.filter-tip {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--el-text-color-placeholder);
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.stat-card {
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+}
+
+.stat-value {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+}
+
+.trend-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.trend-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+}
+
+.segment-bar {
+  display: flex;
+  align-items: center;
+  height: 10px;
+  width: 100%;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--el-fill-color-light);
+}
+
+.segment-piece {
+  height: 100%;
+  min-width: 2px;
+}
+
+.muted {
+  color: var(--el-text-color-placeholder);
+  font-size: 12px;
+}
+
+.detail-block {
+  margin-top: 16px;
+}
+
+.detail-block-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+  margin-bottom: 8px;
+}
+
+.detail-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--el-fill-color-lighter);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.segment-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.timeline-name {
+  width: 96px;
+  flex-shrink: 0;
+  color: var(--el-text-color-regular);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline-track {
+  position: relative;
+  flex: 1;
+  height: 10px;
+  background: var(--el-fill-color-light);
+  border-radius: 3px;
+}
+
+.timeline-bar {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 3px;
+}
+
+.timeline-ms {
+  width: 64px;
+  flex-shrink: 0;
+  text-align: right;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -41,7 +41,7 @@ import 'highlight.js/styles/github.css'
 const REVIEW_POLL_INTERVAL_MS = 5000
 const MAX_REVIEW_POLL_COUNT = 40
 
-const props = defineProps<{ agentCode: string }>()
+const props = defineProps<{ agentCode: string; initialSessionId?: string }>()
 
 /**
  * 会话状态全部在 Pinia store（vibeConversations）里，本组件只是视图：切页面、切智能体、组件销毁
@@ -498,6 +498,19 @@ onMounted(() => {
 watch(
   () => store.historyVersion[props.agentCode],
   () => historySidebar.value?.refresh(),
+)
+
+// 从「智能体耗时统计」页「打开会话」跳转过来时带上目标会话 id，直接打开对应历史会话。
+// 用 watch 而非 onMounted 一次性读取：本页处于 keep-alive 下，二次带新 sessionId 跳进来不会重新
+// mount。immediate 保留首挂载即打开，逻辑镜像 ChatPanel 里同名 watch。
+watch(
+  () => props.initialSessionId,
+  (id) => {
+    if (id) {
+      openSession(id)
+    }
+  },
+  { immediate: true },
 )
 
 // 从 keep-alive 缓存里重新激活时滚到最新内容——离开期间进行中的会话仍在后台追加增量。

--- a/customer-admin-web/src/views/workspace/WorkspaceView.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceView.vue
@@ -19,9 +19,12 @@ const props = defineProps<{ agentCode: string }>()
 const menuStore = useMenuStore()
 const route = useRoute()
 const router = useRouter()
-// 从 Project 详情页"点会话跳回工作区"带过来的目标会话 id（?sessionId=xxx），只在首次挂载时读一次，
-// ChatPanel 内部 openSession 打开后由它自己的会话状态接管，不需要响应式跟随路由变化。
+// 从 Project 详情页"点会话跳回工作区"、或「智能体耗时统计」页"打开会话"带过来的目标会话 id
+// （?sessionId=xxx），ChatPanel/VibeCodingPanel 各自用 watch(immediate) 响应式跟随，
+// 支持同一实例二次带新 sessionId 跳入（keep-alive 下不会重新 mount，见两个面板内部注释）。
 const initialSessionId = computed(() => (route.query.sessionId as string) || undefined)
+// 与 sessionId 配套的目标 Tab：VibeCoding 会话跳 VibeCoding 面板，其余（含缺省）落对话面板。
+const initialMode = computed(() => (route.query.mode as string) || undefined)
 
 function findNode(nodes: MenuNode[], agentCode: string): MenuNode | null {
   for (const node of nodes) {
@@ -51,6 +54,21 @@ watch(supportsVibeCoding, (supported) => {
     activeTab.value = 'chat'
   }
 })
+
+// 带 ?mode= 跳入时按目标 Tab 切换（「智能体耗时统计」页"打开会话"的入口）。supportsVibeCoding
+// 依赖 menuStore 异步拉到的智能体能力树，跟 initialMode 一起 watch，防止菜单树晚到位时错过一次切换。
+watch(
+  [initialMode, supportsVibeCoding],
+  ([mode, supported]) => {
+    if (mode === 'vibecoding' && supported) {
+      activeTab.value = 'vibecoding'
+    } else if (mode === 'chat') {
+      activeTab.value = 'chat'
+    }
+  },
+  { immediate: true },
+)
+
 const chatPanelRef = ref<InstanceType<typeof ChatPanel>>()
 const vibeCodingPanelRef = ref<InstanceType<typeof VibeCodingPanel>>()
 
@@ -138,7 +156,7 @@ watch(
         <ChatPanel ref="chatPanelRef" :key="agentCode" :agent-code="agentCode" :initial-session-id="initialSessionId" />
       </el-tab-pane>
       <el-tab-pane v-if="supportsVibeCoding" label="VibeCoding" name="vibecoding">
-        <VibeCodingPanel ref="vibeCodingPanelRef" :key="agentCode" :agent-code="agentCode" />
+        <VibeCodingPanel ref="vibeCodingPanelRef" :key="agentCode" :agent-code="agentCode" :initial-session-id="initialSessionId" />
       </el-tab-pane>
     </el-tabs>
   </div>

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/CustomerWorkAppServerApplication.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/CustomerWorkAppServerApplication.java
@@ -18,9 +18,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @author owlzhangfq@gmail.com
  */
 @SpringBootApplication
-public class CustomerWorkApplication {
+public class CustomerWorkAppServerApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(CustomerWorkApplication.class, args);
+        SpringApplication.run(CustomerWorkAppServerApplication.class, args);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/agent/CustomerServiceAgentFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/agent/CustomerServiceAgentFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.agent;
 
+import com.richard.fyoung.customerwork.calllog.ToolKindRegistry;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.support.TenantResolver;
 import com.richard.fyoung.customerwork.config.NacosPromptService;
@@ -89,6 +90,8 @@ public class CustomerServiceAgentFactory implements DisposableBean {
     private final NacosPromptService nacosPromptService;
     /** 租户解析（单一职责，与质检/诊断链路共用同一实现）。 */
     private final TenantResolver tenantResolver;
+    /** 工具归类登记表：skill 工具在此登记名称，供分段耗时统计按类归段。 */
+    private final ToolKindRegistry toolKindRegistry;
     /** 可插拔 Middleware：本库内置（延迟/脱敏/审计/自我纠错/护栏/动态参数/租户）+ 下游自定义的所有 {@link MiddlewareBase} Bean。 */
     private final ObjectProvider<MiddlewareBase> pluggableMiddlewares;
 
@@ -106,6 +109,7 @@ public class CustomerServiceAgentFactory implements DisposableBean {
                                        PermissionContextState permissionContext,
                                        NacosPromptService nacosPromptService,
                                        TenantResolver tenantResolver,
+                                       ToolKindRegistry toolKindRegistry,
                                        ObjectProvider<MiddlewareBase> pluggableMiddlewares,
                                        ObjectProvider<MeterRegistry> meterRegistryProvider) {
         this.model = model;
@@ -119,6 +123,7 @@ public class CustomerServiceAgentFactory implements DisposableBean {
         this.permissionContext = permissionContext;
         this.nacosPromptService = nacosPromptService;
         this.tenantResolver = tenantResolver;
+        this.toolKindRegistry = toolKindRegistry;
         this.pluggableMiddlewares = pluggableMiddlewares;
         this.meterRegistry = meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable();
     }
@@ -270,10 +275,23 @@ public class CustomerServiceAgentFactory implements DisposableBean {
             } else {
                 skills = new ClasspathSkillRepository(cfg.getLocation()).getAllSkills();
             }
+            // 快照注册前工具名，注册 skill 后取增量即为 skill 贡献的工具，登记为 SKILL 类别
+            // （用 toolkit 实际工具名做键，与 onActing 的 ToolUseBlock.getName() 一致）
+            java.util.Set<String> beforeSkill = new java.util.HashSet<>(toolkit.getToolNames());
             SkillBox skillBox = new SkillBox(toolkit);
             for (AgentSkill skill : skills) {
                 skillBox.registerSkill(skill);
             }
+            java.util.Set<String> skillTools = new java.util.HashSet<>(toolkit.getToolNames());
+            skillTools.removeAll(beforeSkill);
+            // 兜底：skill 可能以懒激活形式尚未落 toolkit，同时登记 skillId / skillName，覆盖 onActing 可能出现的两种名
+            skillTools.addAll(skillBox.getAllSkillIds());
+            for (AgentSkill skill : skills) {
+                if (skill.getName() != null) {
+                    skillTools.add(skill.getName());
+                }
+            }
+            toolKindRegistry.registerSkillTools(skillTools);
             // 运行时加载技能工具：允许 Agent 按需自行加载技能（技能自进化）
             if (cfg.isRuntimeLoadToolEnabled()) {
                 skillBox.registerSkillLoadTool();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallCollector.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallCollector.java
@@ -33,12 +33,14 @@ public class AgentCallCollector {
      * @param segStartNano 分段开始的 {@code System.nanoTime()}（用于高精度算耗时）
      * @param success      是否成功
      * @param errorMsg     失败原因
+     * @param inputTokens  输入 token（仅 MODEL 段有值，缺失传 null）
+     * @param outputTokens 输出 token（仅 MODEL 段有值，缺失传 null）
      */
     public void addSegment(AgentCallKind kind, String name, long segStartMs, long segStartNano,
-                           boolean success, String errorMsg) {
+                           boolean success, String errorMsg, Long inputTokens, Long outputTokens) {
         long durationMs = Math.max(0L, (System.nanoTime() - segStartNano) / 1_000_000L);
         segments.add(new AgentCallSegment(seq.incrementAndGet(), kind, name, segStartMs, durationMs,
-            success, errorMsg));
+            success, errorMsg, inputTokens, outputTokens));
     }
 
     /** 设置最终回答（可被后续 AGENT_RESULT 覆盖为最新全文）。 */
@@ -75,6 +77,10 @@ public class AgentCallCollector {
         long toolMs = 0L;
         long mcpMs = 0L;
         long skillMs = 0L;
+        // 请求级 token 汇总：各段 usage 求和；一段都没采到（全 null）则整体置 null（区分"未采到"与"0 token"，
+        // 与 admin 审计模块 totalUsage 的空判语义一致）
+        Long inputTokens = null;
+        Long outputTokens = null;
         for (AgentCallSegment s : snapshot) {
             switch (s.kind()) {
                 case MODEL -> modelMs += s.durationMs();
@@ -82,10 +88,19 @@ public class AgentCallCollector {
                 case MCP -> mcpMs += s.durationMs();
                 case SKILL -> skillMs += s.durationMs();
             }
+            if (s.inputTokens() != null) {
+                inputTokens = (inputTokens == null ? 0L : inputTokens) + s.inputTokens();
+            }
+            if (s.outputTokens() != null) {
+                outputTokens = (outputTokens == null ? 0L : outputTokens) + s.outputTokens();
+            }
         }
+        Long totalTokens = (inputTokens == null && outputTokens == null) ? null
+            : (inputTokens == null ? 0L : inputTokens) + (outputTokens == null ? 0L : outputTokens);
         long durationMs = Math.max(0L, endTimeMs - startTimeMs);
         return new AgentCallRecord(0L, requestId, userId, username, agentCode, agentName, sessionId,
             sessionType, question, answer, startTimeMs, endTimeMs, durationMs,
-            modelMs, toolMs, mcpMs, skillMs, snapshot.size(), success, errorMsg, snapshot);
+            modelMs, toolMs, mcpMs, skillMs, snapshot.size(), inputTokens, outputTokens, totalTokens,
+            success, errorMsg, snapshot);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallCollector.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallCollector.java
@@ -1,0 +1,91 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 一次智能体调用的请求级采集器（可变，线程安全）。
+ *
+ * <p>由 {@code AgentCallTimingMiddleware#onAgent} 在调用开始时创建并放入
+ * {@link io.agentscope.core.agent.RuntimeContext}，同一次 call 全程共享——onModelCall / onActing
+ * 从 ctx 取到同一实例往里追加分段。工具批量执行时 hook 会有线程跳变，故分段列表用同步包装，
+ * {@code seq} 用 {@link AtomicInteger} 自增，保证并发追加安全。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class AgentCallCollector {
+
+    /** 调用开始墙上时钟（毫秒），组装记录时作为 startTime。 */
+    private final long startTimeMs = System.currentTimeMillis();
+    private final List<AgentCallSegment> segments = Collections.synchronizedList(new ArrayList<>());
+    private final AtomicInteger seq = new AtomicInteger(0);
+
+    /** 智能体最终回答（从 onAgent 事件流的 AgentResultEvent 采集，最后一个 AGENT_RESULT 为准）。 */
+    private volatile String answer;
+
+    /**
+     * 追加一段耗时明细。
+     *
+     * @param kind         分段类别
+     * @param name         分段名称（模型名 / 工具名）
+     * @param segStartMs   分段开始墙上时钟（毫秒）
+     * @param segStartNano 分段开始的 {@code System.nanoTime()}（用于高精度算耗时）
+     * @param success      是否成功
+     * @param errorMsg     失败原因
+     */
+    public void addSegment(AgentCallKind kind, String name, long segStartMs, long segStartNano,
+                           boolean success, String errorMsg) {
+        long durationMs = Math.max(0L, (System.nanoTime() - segStartNano) / 1_000_000L);
+        segments.add(new AgentCallSegment(seq.incrementAndGet(), kind, name, segStartMs, durationMs,
+            success, errorMsg));
+    }
+
+    /** 设置最终回答（可被后续 AGENT_RESULT 覆盖为最新全文）。 */
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public long startTimeMs() {
+        return startTimeMs;
+    }
+
+    /**
+     * 组装为不可变记录：按分段类别汇总四类耗时与分段数，填入调用方元数据与整体成败。
+     *
+     * @param requestId   请求 ID
+     * @param userId      用户 ID
+     * @param username    用户名
+     * @param agentCode   智能体编码
+     * @param agentName   智能体名称
+     * @param sessionId   会话 ID
+     * @param sessionType 会话类型
+     * @param question    用户问题
+     * @param endTimeMs   调用结束时间戳（毫秒）
+     * @param success     整次调用是否成功
+     * @param errorMsg    失败原因
+     */
+    public AgentCallRecord toRecord(String requestId, String userId, String username,
+                                    String agentCode, String agentName, String sessionId,
+                                    AgentCallSessionType sessionType, String question,
+                                    long endTimeMs, boolean success, String errorMsg) {
+        // 快照分段（同步列表，拷贝出来再统计，避免统计期间被并发修改）
+        List<AgentCallSegment> snapshot = new ArrayList<>(segments);
+        long modelMs = 0L;
+        long toolMs = 0L;
+        long mcpMs = 0L;
+        long skillMs = 0L;
+        for (AgentCallSegment s : snapshot) {
+            switch (s.kind()) {
+                case MODEL -> modelMs += s.durationMs();
+                case TOOL -> toolMs += s.durationMs();
+                case MCP -> mcpMs += s.durationMs();
+                case SKILL -> skillMs += s.durationMs();
+            }
+        }
+        long durationMs = Math.max(0L, endTimeMs - startTimeMs);
+        return new AgentCallRecord(0L, requestId, userId, username, agentCode, agentName, sessionId,
+            sessionType, question, answer, startTimeMs, endTimeMs, durationMs,
+            modelMs, toolMs, mcpMs, skillMs, snapshot.size(), success, errorMsg, snapshot);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallKind.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallKind.java
@@ -1,0 +1,19 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 智能体调用分段类别（分段耗时统计维度）。
+ *
+ * <ul>
+ *   <li>{@link #MODEL}：大模型 API 调用（每次 onModelCall 一段）；</li>
+ *   <li>{@link #TOOL}：业务工具执行（默认类别）；</li>
+ *   <li>{@link #MCP}：MCP 接入的外部工具；</li>
+ *   <li>{@link #SKILL}：Skill 技能工具。</li>
+ * </ul>
+ *
+ * <p>MCP 与 SKILL 在框架里同样以 Tool 形态经 onActing 执行，仅凭执行流无法区分，
+ * 由 {@link ToolKindRegistry} 按工具名登记归类，未登记的工具一律落 {@link #TOOL}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum AgentCallKind {
+    MODEL, TOOL, MCP, SKILL
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogConfig.java
@@ -1,0 +1,54 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 智能体调用日志域装配：按 {@code customer-work.call-log.store-mode} 选择存储实现并装配 Sink 与查询服务。
+ *
+ * <p>默认 {@code memory}；{@code jdbc} 落地为 {@link MybatisAgentCallLogStore}，Mapper 由独立的
+ * {@code CustomerWorkPersistenceConfig}（MyBatis-Plus 环境）统一装配，此处经 {@link ObjectProvider}
+ * 惰性取用。Store / Sink / Service 三个 Bean 均 {@code @ConditionalOnMissingBean}，下游可覆盖。
+ * 采集中间件 {@code AgentCallTimingMiddleware} 与 {@code ToolKindRegistry} 走 {@code @Component} 扫描装配。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class AgentCallLogConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentCallLogConfig.class);
+
+    private static final String STORE_MODE_JDBC = "jdbc";
+
+    @Bean
+    @ConditionalOnMissingBean(AgentCallLogStore.class)
+    public AgentCallLogStore agentCallLogStore(CustomerWorkProperties properties,
+                                               ObjectProvider<AgentCallLogMapper> callLogMapperProvider,
+                                               ObjectProvider<AgentCallSegmentMapper> segmentMapperProvider) {
+        String mode = properties.getCallLog().getStoreMode();
+        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+            log.info("agent call log store: jdbc (MyBatis-Plus, tables=cw_agent_call_log/cw_agent_call_segment)");
+            return new MybatisAgentCallLogStore(callLogMapperProvider.getObject(), segmentMapperProvider.getObject());
+        }
+        log.info("agent call log store: memory (进程内，重启不保留，生产建议 store-mode=jdbc)");
+        return new InMemoryAgentCallLogStore();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AgentCallRecordSink.class)
+    public AgentCallRecordSink agentCallRecordSink(AgentCallLogStore agentCallLogStore) {
+        return new StoreAgentCallRecordSink(agentCallLogStore);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AgentCallLogService.class)
+    public AgentCallLogService agentCallLogService(AgentCallLogStore agentCallLogStore) {
+        return new AgentCallLogService(agentCallLogStore);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogQuery.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogQuery.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 调用日志分页 / 汇总 / 趋势的统一查询条件（全部可空，空即不约束该维度）。
+ *
+ * <p>{@code startFromMs}/{@code startToMs} 按主表 {@code start_time}（毫秒时间戳）过滤；
+ * {@code offset}/{@code limit} 仅分页查询用，汇总与趋势忽略。</p>
+ *
+ * @param username    用户名（精确匹配）
+ * @param agentCode   智能体编码（精确匹配）
+ * @param requestId   请求 ID（精确匹配）
+ * @param sessionId   会话 ID（精确匹配）
+ * @param startFromMs 起始时间下界（毫秒，含）
+ * @param startToMs   起始时间上界（毫秒，含）
+ * @param offset      分页偏移（分页查询用）
+ * @param limit       分页大小（分页查询用）
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentCallLogQuery(String username, String agentCode, String requestId, String sessionId,
+                                Long startFromMs, Long startToMs, int offset, int limit) {
+
+    /** 便捷构造：仅分页无过滤。 */
+    public static AgentCallLogQuery page(int offset, int limit) {
+        return new AgentCallLogQuery(null, null, null, null, null, null, offset, limit);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogService.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import java.util.List;
+
+/**
+ * 智能体调用日志查询服务：面向下游（admin-server 报表等）封装存储 SPI 的读侧能力。
+ *
+ * <p>写侧由 {@code AgentCallTimingMiddleware} → {@link AgentCallRecordSink} 异步完成，本服务只做查询：
+ * 分页 / 明细段 / 汇总 / 趋势 / 删除。薄封装，便于下游注入使用，也隔离下游对具体 {@link AgentCallLogStore}
+ * 实现的直接依赖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class AgentCallLogService {
+
+    private final AgentCallLogStore store;
+
+    public AgentCallLogService(AgentCallLogStore store) {
+        this.store = store;
+    }
+
+    /** 分页条件查询主记录（不含明细段）。 */
+    public List<AgentCallRecord> page(AgentCallLogQuery query) {
+        return store.findPage(query);
+    }
+
+    /** 符合条件总数（配合分页）。 */
+    public long count(AgentCallLogQuery query) {
+        return store.count(query);
+    }
+
+    /** 按主记录 id 查分段明细（seq 升序）。 */
+    public List<AgentCallSegment> segments(long callLogId) {
+        return store.findSegments(callLogId);
+    }
+
+    /** 删除一条调用（主记录 + 分段）。 */
+    public boolean delete(long id) {
+        return store.delete(id);
+    }
+
+    /** 汇总统计。 */
+    public AgentCallLogSummary summary(AgentCallLogQuery query) {
+        return store.summary(query);
+    }
+
+    /** 按天 / 小时趋势聚合。 */
+    public List<AgentCallTrendPoint> trend(AgentCallLogQuery query, TrendGranularity granularity) {
+        return store.trend(query, granularity);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogStore.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import java.util.List;
+
+/**
+ * 智能体调用日志存储 SPI（第 9 个持久化扩展点）。
+ *
+ * <p>默认 {@link InMemoryAgentCallLogStore}；生产按 {@code customer-work.call-log.store-mode=jdbc}
+ * 切换为 {@link MybatisAgentCallLogStore}（主表 {@code cw_agent_call_log} + 明细表
+ * {@code cw_agent_call_segment}）。写入一次落主表与全部分段；查询提供分页 / 明细 / 汇总 / 趋势。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface AgentCallLogStore {
+
+    /** 保存一次调用（主表 + 明细段），返回回填了自增主键的主记录（明细段不回带）。 */
+    AgentCallRecord save(AgentCallRecord record);
+
+    /** 分页条件查询主记录（不含明细段），按 id 倒序（最新在前）。 */
+    List<AgentCallRecord> findPage(AgentCallLogQuery query);
+
+    /** 符合条件的主记录总数（配合 {@link #findPage} 做分页总数）。 */
+    long count(AgentCallLogQuery query);
+
+    /** 按主记录 id 查其全部分段明细（按 seq 升序）。 */
+    List<AgentCallSegment> findSegments(long callLogId);
+
+    /** 删除一条调用（主记录 + 其分段明细），返回是否删到主记录。 */
+    boolean delete(long id);
+
+    /** 汇总统计（总数 / 平均总耗时 / 最大总耗时 / 各段平均耗时）。 */
+    AgentCallLogSummary summary(AgentCallLogQuery query);
+
+    /** 按天 / 小时的趋势聚合（每桶：调用数 + 平均总耗时），按桶标签升序。 */
+    List<AgentCallTrendPoint> trend(AgentCallLogQuery query, TrendGranularity granularity);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogSummary.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogSummary.java
@@ -10,14 +10,16 @@ package com.richard.fyoung.customerwork.calllog;
  * @param avgToolMs     平均 TOOL 段耗时（毫秒）
  * @param avgMcpMs      平均 MCP 段耗时（毫秒）
  * @param avgSkillMs    平均 SKILL 段耗时（毫秒）
+ * @param totalTokens   总 token 消耗（符合条件的记录 total_tokens 求和）
+ * @param avgTotalTokens 平均每次 token 消耗
  * @author owlzhangfq@gmail.com
  */
 public record AgentCallLogSummary(long totalCount, double avgDurationMs, long maxDurationMs,
                                   double avgModelMs, double avgToolMs, double avgMcpMs,
-                                  double avgSkillMs) {
+                                  double avgSkillMs, long totalTokens, double avgTotalTokens) {
 
     /** 空结果（无数据时返回，避免 null）。 */
     public static AgentCallLogSummary empty() {
-        return new AgentCallLogSummary(0L, 0d, 0L, 0d, 0d, 0d, 0d);
+        return new AgentCallLogSummary(0L, 0d, 0L, 0d, 0d, 0d, 0d, 0L, 0d);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogSummary.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogSummary.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 调用日志汇总统计（符合查询条件的整体口径）。
+ *
+ * @param totalCount    总调用数
+ * @param avgDurationMs 平均总耗时（毫秒）
+ * @param maxDurationMs 最大总耗时（毫秒）
+ * @param avgModelMs    平均 MODEL 段耗时（毫秒）
+ * @param avgToolMs     平均 TOOL 段耗时（毫秒）
+ * @param avgMcpMs      平均 MCP 段耗时（毫秒）
+ * @param avgSkillMs    平均 SKILL 段耗时（毫秒）
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentCallLogSummary(long totalCount, double avgDurationMs, long maxDurationMs,
+                                  double avgModelMs, double avgToolMs, double avgMcpMs,
+                                  double avgSkillMs) {
+
+    /** 空结果（无数据时返回，避免 null）。 */
+    public static AgentCallLogSummary empty() {
+        return new AgentCallLogSummary(0L, 0d, 0L, 0d, 0d, 0d, 0d);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallMeta.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallMeta.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 一次智能体调用的调用方元数据（不可变），由调用方放入 {@link io.agentscope.core.agent.RuntimeContext}
+ * （{@code ctx.put(AgentCallMeta.class, meta)}），供 {@code AgentCallTimingMiddleware} 采集时读取。
+ *
+ * <p>全部字段可缺失：中间件读不到对应字段时按 {@code RuntimeContext} 的 userId/sessionId 及 MDC 的
+ * requestId 降级，不报错（防御式兜底收敛在中间件）。{@code sessionType} 缺省视为
+ * {@link AgentCallSessionType#CHAT}。</p>
+ *
+ * @param requestId   请求 ID（缺失时中间件回退 MDC 的 requestId）
+ * @param username    用户名（缺失时中间件回退 ctx.getUserId()）
+ * @param agentCode   智能体编码（业务标识，缺失时中间件回退 agent 名称）
+ * @param agentName   智能体名称（缺失时中间件回退 agent 名称）
+ * @param sessionType 会话类型（缺失视为 CHAT）
+ * @param question    用户问题（缺失时中间件回退 onAgent 入参首条用户消息文本）
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentCallMeta(String requestId, String username, String agentCode, String agentName,
+                            AgentCallSessionType sessionType, String question) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecord.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecord.java
@@ -9,6 +9,9 @@ import java.util.List;
  * 分段耗时汇总，{@code segmentCount} 为分段总数，均在 {@link AgentCallCollector#toRecord} 组装时按
  * {@link #segments} 计算，落库时冗余存储以便报表免关联明细即可出各段汇总。</p>
  *
+ * <p>{@code inputTokens/outputTokens/totalTokens} 为请求级 token 消耗汇总（各 MODEL 段 usage 求和，
+ * 与 admin 审计模块同源同口径）；本次调用无任何 usage 时三者均为 {@code null}（区分"未采到"与"用了 0 token"）。</p>
+ *
  * @param id           存储层自增主键（保存前为 0）
  * @param requestId    请求 ID
  * @param userId       用户 ID（ctx.getUserId()）
@@ -27,6 +30,9 @@ import java.util.List;
  * @param mcpMs        MCP 段耗时合计（毫秒）
  * @param skillMs      SKILL 段耗时合计（毫秒）
  * @param segmentCount 分段总数
+ * @param inputTokens  请求级输入 token 合计（缺失为 null）
+ * @param outputTokens 请求级输出 token 合计（缺失为 null）
+ * @param totalTokens  请求级总 token 合计（缺失为 null）
  * @param success      整次调用是否成功
  * @param errorMsg     失败原因（成功时为 null）
  * @param segments     分段明细（按 seq 升序）
@@ -37,13 +43,15 @@ public record AgentCallRecord(long id, String requestId, String userId, String u
                               AgentCallSessionType sessionType, String question, String answer,
                               long startTimeMs, long endTimeMs, long durationMs,
                               long modelMs, long toolMs, long mcpMs, long skillMs,
-                              int segmentCount, boolean success, String errorMsg,
+                              int segmentCount, Long inputTokens, Long outputTokens, Long totalTokens,
+                              boolean success, String errorMsg,
                               List<AgentCallSegment> segments) {
 
     /** 回填自增主键后的副本。 */
     public AgentCallRecord withId(long assignedId) {
         return new AgentCallRecord(assignedId, requestId, userId, username, agentCode, agentName,
             sessionId, sessionType, question, answer, startTimeMs, endTimeMs, durationMs,
-            modelMs, toolMs, mcpMs, skillMs, segmentCount, success, errorMsg, segments);
+            modelMs, toolMs, mcpMs, skillMs, segmentCount, inputTokens, outputTokens, totalTokens,
+            success, errorMsg, segments);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecord.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecord.java
@@ -1,0 +1,49 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import java.util.List;
+
+/**
+ * 一次智能体调用的完整记录（不可变，主表 {@code cw_agent_call_log} + 明细段 {@code cw_agent_call_segment}）。
+ *
+ * <p>{@code id} 为存储层自增主键（保存前为 0，由存储层回填）。{@code modelMs/toolMs/mcpMs/skillMs} 为四类
+ * 分段耗时汇总，{@code segmentCount} 为分段总数，均在 {@link AgentCallCollector#toRecord} 组装时按
+ * {@link #segments} 计算，落库时冗余存储以便报表免关联明细即可出各段汇总。</p>
+ *
+ * @param id           存储层自增主键（保存前为 0）
+ * @param requestId    请求 ID
+ * @param userId       用户 ID（ctx.getUserId()）
+ * @param username     用户名
+ * @param agentCode    智能体编码
+ * @param agentName    智能体名称
+ * @param sessionId    会话 ID
+ * @param sessionType  会话类型
+ * @param question     用户问题
+ * @param answer       智能体回答
+ * @param startTimeMs  调用开始时间戳（毫秒）
+ * @param endTimeMs    调用结束时间戳（毫秒）
+ * @param durationMs   总耗时（毫秒）
+ * @param modelMs      MODEL 段耗时合计（毫秒）
+ * @param toolMs       TOOL 段耗时合计（毫秒）
+ * @param mcpMs        MCP 段耗时合计（毫秒）
+ * @param skillMs      SKILL 段耗时合计（毫秒）
+ * @param segmentCount 分段总数
+ * @param success      整次调用是否成功
+ * @param errorMsg     失败原因（成功时为 null）
+ * @param segments     分段明细（按 seq 升序）
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentCallRecord(long id, String requestId, String userId, String username,
+                              String agentCode, String agentName, String sessionId,
+                              AgentCallSessionType sessionType, String question, String answer,
+                              long startTimeMs, long endTimeMs, long durationMs,
+                              long modelMs, long toolMs, long mcpMs, long skillMs,
+                              int segmentCount, boolean success, String errorMsg,
+                              List<AgentCallSegment> segments) {
+
+    /** 回填自增主键后的副本。 */
+    public AgentCallRecord withId(long assignedId) {
+        return new AgentCallRecord(assignedId, requestId, userId, username, agentCode, agentName,
+            sessionId, sessionType, question, answer, startTimeMs, endTimeMs, durationMs,
+            modelMs, toolMs, mcpMs, skillMs, segmentCount, success, errorMsg, segments);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecordSink.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecordSink.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 智能体调用记录下沉 SPI（采集与落地解耦的扩展点）。
+ *
+ * <p>{@code AgentCallTimingMiddleware} 在每次调用结束时组装 {@link AgentCallRecord} 交给本 Sink。
+ * 默认实现 {@link StoreAgentCallRecordSink} 异步落 starter 自己的 {@link AgentCallLogStore}；下游可声明
+ * 自己的 {@code AgentCallRecordSink} Bean 覆盖（如投递 Kafka / 数仓）。</p>
+ *
+ * <p><b>约定</b>：实现必须非阻塞或自行异步——本方法在响应事件流的终止回调里被调用，阻塞会拖慢响应。
+ * 且实现自身不得抛异常打断主链路（中间件侧已兜底 catch，实现侧仍应自我消化异常）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface AgentCallRecordSink {
+
+    /** 提交一条调用记录（非阻塞）。 */
+    void emit(AgentCallRecord record);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSegment.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSegment.java
@@ -7,15 +7,21 @@ package com.richard.fyoung.customerwork.calllog;
  * {@link ToolKindRegistry} 归为 TOOL/MCP/SKILL）。{@code seq} 为该次调用内的分段序号（从 1 起，
  * 按结算顺序自增）；{@code startTimeMs} 为分段开始的墙上时钟（毫秒），{@code durationMs} 为分段耗时。</p>
  *
- * @param seq         调用内分段序号（从 1 起）
- * @param kind        分段类别
- * @param name        分段名称（模型名 / 工具名）
- * @param startTimeMs 分段开始时间戳（毫秒）
- * @param durationMs  分段耗时（毫秒）
- * @param success     是否成功
- * @param errorMsg    失败原因（成功时为 null）
+ * <p>{@code inputTokens}/{@code outputTokens} 仅 MODEL 段有值（取自框架 {@code ModelCallEndEvent}
+ * 携带的 {@code ChatUsage}，与 admin 审计模块同源同口径）；工具段及 usage 缺失时为 {@code null}。</p>
+ *
+ * @param seq          调用内分段序号（从 1 起）
+ * @param kind         分段类别
+ * @param name         分段名称（模型名 / 工具名）
+ * @param startTimeMs  分段开始时间戳（毫秒）
+ * @param durationMs   分段耗时（毫秒）
+ * @param success      是否成功
+ * @param errorMsg     失败原因（成功时为 null）
+ * @param inputTokens  输入 token（仅 MODEL 段，缺失为 null）
+ * @param outputTokens 输出 token（仅 MODEL 段，缺失为 null）
  * @author owlzhangfq@gmail.com
  */
 public record AgentCallSegment(int seq, AgentCallKind kind, String name, long startTimeMs,
-                               long durationMs, boolean success, String errorMsg) {
+                               long durationMs, boolean success, String errorMsg,
+                               Long inputTokens, Long outputTokens) {
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSegment.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSegment.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 智能体一次调用中的一段耗时明细（不可变）。
+ *
+ * <p>一段对应一次 onModelCall（{@link AgentCallKind#MODEL}）或一次 onActing（工具执行，按
+ * {@link ToolKindRegistry} 归为 TOOL/MCP/SKILL）。{@code seq} 为该次调用内的分段序号（从 1 起，
+ * 按结算顺序自增）；{@code startTimeMs} 为分段开始的墙上时钟（毫秒），{@code durationMs} 为分段耗时。</p>
+ *
+ * @param seq         调用内分段序号（从 1 起）
+ * @param kind        分段类别
+ * @param name        分段名称（模型名 / 工具名）
+ * @param startTimeMs 分段开始时间戳（毫秒）
+ * @param durationMs  分段耗时（毫秒）
+ * @param success     是否成功
+ * @param errorMsg    失败原因（成功时为 null）
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentCallSegment(int seq, AgentCallKind kind, String name, long startTimeMs,
+                               long durationMs, boolean success, String errorMsg) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSessionType.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSessionType.java
@@ -1,0 +1,12 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 智能体调用来源会话类型（区分普通问答与 VibeCoding 场景，供报表分组）。
+ *
+ * <p>8080 客服链路默认 {@link #CHAT}；VibeCoding 类调用方在构造 {@code AgentCallMeta} 时显式置为
+ * {@link #VIBE_CODING}。缺失时中间件降级为 {@link #CHAT}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum AgentCallSessionType {
+    CHAT, VIBE_CODING
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerwork.calllog;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.observability.MdcContextLifter;
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentResultEvent;
@@ -71,13 +72,25 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
         if (!enabled) {
             return next.apply(input);
         }
+        // ctx 归一（关键坑，见方法级 Javadoc）：onAgent 的 ctx 入参在框架废弃的 stream(msgs,options,ctx)
+        // 路径上恒为 null——框架只把调用方 ctx 挂到 Reactor Context 的 RUNTIME_CONTEXT_KEY 上，而
+        // onModelCall/onActing 用的却是从该 key 解析出的真实 rc。故这里也从 Reactor Context 兜底取同一实例，
+        // 保证三个 hook 读写同一个 ctx（collector 互通、meta 可读、sessionId 非空）。deferContextual 在订阅期
+        // 拿到承载 RUNTIME_CONTEXT_KEY 的上下文视图。
+        return Flux.deferContextual(cv -> onAgentWithContext(agent, resolveEffectiveCtx(ctx, cv), input, next));
+    }
+
+    /** 用归一后的 {@code ctx} 执行采集主逻辑（供 {@link #onAgent} 在 deferContextual 内调用）。 */
+    private Flux<AgentEvent> onAgentWithContext(Agent agent, RuntimeContext ctx, AgentInput input,
+                                                Function<AgentInput, Flux<AgentEvent>> next) {
         // 嵌套调用防护：子 agent 若复用同一 RuntimeContext（同链路再次进入 onAgent），不覆盖父采集器、
         // 不另发记录——子 agent 的模型/工具分段经 ctx 里既有采集器自然归入父请求，父级统一结算
         if (collectorOf(ctx) != null) {
             return next.apply(input);
         }
         AgentCallCollector collector = new AgentCallCollector();
-        // 放进 ctx 供 onModelCall/onActing 追加分段；ctx 缺失（如单测直传 null）则仅本 hook 记录，不报错
+        // 放进 ctx 供 onModelCall/onActing 追加分段；ctx 缺失（如单测直传 null 且无 Reactor 上下文）
+        // 则仅本 hook 记录，不报错
         putCollector(ctx, collector);
 
         AgentCallMeta meta = safeMeta(ctx);
@@ -89,6 +102,24 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
             .doOnComplete(() -> settleRecord(ended, collector, agent, ctx, meta, question, true, null))
             .doOnError(e -> settleRecord(ended, collector, agent, ctx, meta, question, false, safeMsg(e)))
             .doOnCancel(() -> settleRecord(ended, collector, agent, ctx, meta, question, false, CANCELLED));
+    }
+
+    /**
+     * ctx 归一：优先用框架直接传入的 ctx 入参（call/streamEvents 路径非空）；入参为 null 时（废弃
+     * stream(msgs,options,ctx) 路径）从 Reactor Context 的 {@link AgentBase#RUNTIME_CONTEXT_KEY} 兜底取，
+     * 这正是 onModelCall/onActing 拿到的同一个调用方 ctx 实例，从而三个 hook 共享同一 ctx。取不到则返回
+     * null（本 hook 仍可独立记录，只是无 meta/分段互通）。
+     */
+    private RuntimeContext resolveEffectiveCtx(RuntimeContext paramCtx, reactor.util.context.ContextView cv) {
+        if (paramCtx != null) {
+            return paramCtx;
+        }
+        try {
+            Object v = cv.getOrDefault(AgentBase.RUNTIME_CONTEXT_KEY, null);
+            return v instanceof RuntimeContext rc ? rc : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @Override

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
@@ -1,0 +1,302 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.observability.MdcContextLifter;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.ModelCallInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * 智能体调用分段耗时采集中间件（2.0 Middleware，「智能体耗时统计报表」通用采集入口）。
+ *
+ * <p>用中间件"包裹"语义按请求采集分段耗时：</p>
+ * <ul>
+ *   <li>{@link #onAgent}：请求级——创建 {@link AgentCallCollector} 放进 {@link RuntimeContext}，
+ *       从事件流的 {@link AgentResultEvent} 采集最终回答，流终止时组装 {@link AgentCallRecord} 交给 Sink；</li>
+ *   <li>{@link #onModelCall}：每次大模型 API 调用计一段（MODEL，段名取模型名）；</li>
+ *   <li>{@link #onActing}：每次工具执行计一段，按 {@link ToolKindRegistry} 归为 TOOL/MCP/SKILL，
+ *       成败取自流中的 {@link ToolResultEndEvent}（异常走 onError）。</li>
+ * </ul>
+ *
+ * <p><b>答案采集方式</b>：直接从 onAgent 事件流的 {@code AGENT_RESULT} 事件（{@link AgentResultEvent}）
+ * 取完整最终消息文本——框架在流末尾回放一个带完整 {@code Msg} 的 AGENT_RESULT，无需自行拼装增量分片，
+ * 可靠。故答案在中间件内采集，无需调用方回写（{@link AgentCallCollector#setAnswer} 仍开放供特殊场景覆盖）。</p>
+ *
+ * <p><b>异常安全</b>（防御式编程唯一收敛处）：采集/组装/下沉的任何异常都在本类内 catch 吞掉并记 error 日志，
+ * 只读透传事件、绝不打断主链路（参考 LatencyMiddleware 的只读透传原则）。开关 {@code customer-work.call-log.enabled}
+ * 关闭时全部 hook 直通。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class AgentCallTimingMiddleware implements MiddlewareBase {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentCallTimingMiddleware.class);
+
+    private static final String UNKNOWN = "unknown";
+    private static final String CANCELLED = "cancelled";
+
+    private final boolean enabled;
+    private final ToolKindRegistry toolKindRegistry;
+    private final AgentCallRecordSink sink;
+
+    public AgentCallTimingMiddleware(CustomerWorkProperties properties,
+                                     ToolKindRegistry toolKindRegistry,
+                                     AgentCallRecordSink sink) {
+        this.enabled = properties.getCallLog().isEnabled();
+        this.toolKindRegistry = toolKindRegistry;
+        this.sink = sink;
+    }
+
+    @Override
+    public Flux<AgentEvent> onAgent(Agent agent, RuntimeContext ctx, AgentInput input,
+                                    Function<AgentInput, Flux<AgentEvent>> next) {
+        if (!enabled) {
+            return next.apply(input);
+        }
+        // 嵌套调用防护：子 agent 若复用同一 RuntimeContext（同链路再次进入 onAgent），不覆盖父采集器、
+        // 不另发记录——子 agent 的模型/工具分段经 ctx 里既有采集器自然归入父请求，父级统一结算
+        if (collectorOf(ctx) != null) {
+            return next.apply(input);
+        }
+        AgentCallCollector collector = new AgentCallCollector();
+        // 放进 ctx 供 onModelCall/onActing 追加分段；ctx 缺失（如单测直传 null）则仅本 hook 记录，不报错
+        putCollector(ctx, collector);
+
+        AgentCallMeta meta = safeMeta(ctx);
+        String question = resolveQuestion(meta, input);
+
+        AtomicBoolean ended = new AtomicBoolean(false);
+        return next.apply(input)
+            .doOnNext(event -> captureAnswer(collector, event))
+            .doOnComplete(() -> settleRecord(ended, collector, agent, ctx, meta, question, true, null))
+            .doOnError(e -> settleRecord(ended, collector, agent, ctx, meta, question, false, safeMsg(e)))
+            .doOnCancel(() -> settleRecord(ended, collector, agent, ctx, meta, question, false, CANCELLED));
+    }
+
+    @Override
+    public Flux<AgentEvent> onModelCall(Agent agent, RuntimeContext ctx, ModelCallInput input,
+                                        Function<ModelCallInput, Flux<AgentEvent>> next) {
+        if (!enabled) {
+            return next.apply(input);
+        }
+        AgentCallCollector collector = collectorOf(ctx);
+        if (collector == null) {
+            return next.apply(input);
+        }
+        String modelName = input.model() != null && input.model().getModelName() != null
+            ? input.model().getModelName() : UNKNOWN;
+        return timeSegment(next.apply(input), collector, AgentCallKind.MODEL, modelName, null);
+    }
+
+    @Override
+    public Flux<AgentEvent> onActing(Agent agent, RuntimeContext ctx, ActingInput input,
+                                     Function<ActingInput, Flux<AgentEvent>> next) {
+        if (!enabled) {
+            return next.apply(input);
+        }
+        AgentCallCollector collector = collectorOf(ctx);
+        if (collector == null) {
+            return next.apply(input);
+        }
+        String toolName = firstToolName(input);
+        AgentCallKind kind = toolKindRegistry.classify(toolName);
+        // 工具执行成败取自流中的 ToolResultEndEvent（onError 兜底捕获异常）
+        AtomicReference<ToolResultState> lastState = new AtomicReference<>(null);
+        Flux<AgentEvent> upstream = next.apply(input)
+            .doOnNext(event -> {
+                if (event instanceof ToolResultEndEvent tre && tre.getState() != null) {
+                    lastState.set(tre.getState());
+                }
+            });
+        return timeSegment(upstream, collector, kind, toolName, lastState);
+    }
+
+    /**
+     * 通用分段计时：doOnSubscribe 记开始，三态终止（complete/error/cancel）各结算一次。
+     * {@code stateRef} 非空时（onActing）complete 分支据 {@link ToolResultState} 判成败，否则视为成功。
+     */
+    private Flux<AgentEvent> timeSegment(Flux<AgentEvent> upstream, AgentCallCollector collector,
+                                         AgentCallKind kind, String name,
+                                         AtomicReference<ToolResultState> stateRef) {
+        long[] startMs = new long[1];
+        long[] startNano = new long[1];
+        AtomicBoolean ended = new AtomicBoolean(false);
+        return upstream
+            .doOnSubscribe(s -> {
+                startMs[0] = System.currentTimeMillis();
+                startNano[0] = System.nanoTime();
+            })
+            .doOnComplete(() -> {
+                if (ended.compareAndSet(false, true)) {
+                    boolean success = isSuccess(stateRef);
+                    String err = success ? null : "tool result state=" + (stateRef == null ? null : stateRef.get());
+                    addSegment(collector, kind, name, startMs[0], startNano[0], success, err);
+                }
+            })
+            .doOnError(e -> {
+                if (ended.compareAndSet(false, true)) {
+                    addSegment(collector, kind, name, startMs[0], startNano[0], false, safeMsg(e));
+                }
+            })
+            .doOnCancel(() -> {
+                if (ended.compareAndSet(false, true)) {
+                    addSegment(collector, kind, name, startMs[0], startNano[0], false, CANCELLED);
+                }
+            });
+    }
+
+    /** onActing 无 stateRef（模型段）或状态为 SUCCESS/RUNNING/空 视为成功；ERROR/DENIED/INTERRUPTED 视为失败。 */
+    private boolean isSuccess(AtomicReference<ToolResultState> stateRef) {
+        if (stateRef == null) {
+            return true;
+        }
+        ToolResultState state = stateRef.get();
+        return state == null || state == ToolResultState.SUCCESS || state == ToolResultState.RUNNING;
+    }
+
+    /** 追加分段（异常安全：采集失败不影响主链路）。 */
+    private void addSegment(AgentCallCollector collector, AgentCallKind kind, String name,
+                            long startMs, long startNano, boolean success, String errorMsg) {
+        try {
+            collector.addSegment(kind, name, startMs, startNano, success, errorMsg);
+        } catch (Exception e) {
+            log.error("agent call segment collect failed, code={}, kind={}, name={}",
+                "CALLLOG-SEGMENT-FAIL", kind, name, e);
+        }
+    }
+
+    /** 从 AGENT_RESULT 事件采集最终回答（异常安全）。 */
+    private void captureAnswer(AgentCallCollector collector, AgentEvent event) {
+        try {
+            if (event instanceof AgentResultEvent are && are.getResult() != null) {
+                String text = are.getResult().getTextContent();
+                if (text != null && !text.isEmpty()) {
+                    collector.setAnswer(text);
+                }
+            }
+        } catch (Exception e) {
+            log.error("agent call answer collect failed, code={}", "CALLLOG-ANSWER-FAIL", e);
+        }
+    }
+
+    /** 组装记录并交 Sink（异常安全：只结算一次，任何异常吞掉不打断主链路）。 */
+    private void settleRecord(AtomicBoolean ended, AgentCallCollector collector, Agent agent,
+                              RuntimeContext ctx, AgentCallMeta meta, String question,
+                              boolean success, String errorMsg) {
+        if (!ended.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            String agentName = agent == null ? null : agent.getName();
+            String requestId = firstNonBlank(meta == null ? null : meta.requestId(), mdcRequestId(), UNKNOWN);
+            String userId = ctx == null ? null : ctx.getUserId();
+            String username = firstNonBlank(meta == null ? null : meta.username(), userId, UNKNOWN);
+            String agentCode = firstNonBlank(meta == null ? null : meta.agentCode(), agentName, UNKNOWN);
+            String resolvedAgentName = firstNonBlank(meta == null ? null : meta.agentName(), agentName, UNKNOWN);
+            String sessionId = ctx == null ? null : ctx.getSessionId();
+            AgentCallSessionType sessionType = meta != null && meta.sessionType() != null
+                ? meta.sessionType() : AgentCallSessionType.CHAT;
+
+            AgentCallRecord record = collector.toRecord(requestId, userId, username, agentCode,
+                resolvedAgentName, sessionId, sessionType, question, System.currentTimeMillis(),
+                success, errorMsg);
+            sink.emit(record);
+        } catch (Exception e) {
+            log.error("agent call record settle failed, code={}", "CALLLOG-SETTLE-FAIL", e);
+        }
+    }
+
+    /** onAgent 入参首条用户消息文本（meta.question 缺失时的兜底问题来源）。 */
+    private String resolveQuestion(AgentCallMeta meta, AgentInput input) {
+        if (meta != null && meta.question() != null && !meta.question().isEmpty()) {
+            return meta.question();
+        }
+        if (input == null || input.msgs() == null || input.msgs().isEmpty()) {
+            return null;
+        }
+        Msg first = input.msgs().get(0);
+        return first == null ? null : first.getTextContent();
+    }
+
+    private String firstToolName(ActingInput input) {
+        List<ToolUseBlock> calls = input == null ? null : input.toolCalls();
+        if (calls == null || calls.isEmpty() || calls.get(0) == null) {
+            return UNKNOWN;
+        }
+        String name = calls.get(0).getName();
+        return name == null || name.isBlank() ? UNKNOWN : name;
+    }
+
+    private void putCollector(RuntimeContext ctx, AgentCallCollector collector) {
+        if (ctx == null) {
+            return;
+        }
+        try {
+            ctx.put(AgentCallCollector.class, collector);
+        } catch (Exception e) {
+            log.error("agent call collector bind failed, code={}", "CALLLOG-BIND-FAIL", e);
+        }
+    }
+
+    private AgentCallCollector collectorOf(RuntimeContext ctx) {
+        if (ctx == null) {
+            return null;
+        }
+        try {
+            return ctx.get(AgentCallCollector.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private AgentCallMeta safeMeta(RuntimeContext ctx) {
+        if (ctx == null) {
+            return null;
+        }
+        try {
+            return ctx.get(AgentCallMeta.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String mdcRequestId() {
+        try {
+            return org.slf4j.MDC.get(MdcContextLifter.REQUEST_ID_KEY);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String safeMsg(Throwable e) {
+        return e == null ? null : e.getMessage();
+    }
+
+    private static String firstNonBlank(String a, String b, String c) {
+        if (a != null && !a.isBlank()) {
+            return a;
+        }
+        if (b != null && !b.isBlank()) {
+            return b;
+        }
+        return c;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
@@ -7,8 +7,10 @@ import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.middleware.ActingInput;
@@ -134,7 +136,16 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
         }
         String modelName = input.model() != null && input.model().getModelName() != null
             ? input.model().getModelName() : UNKNOWN;
-        return timeSegment(next.apply(input), collector, AgentCallKind.MODEL, modelName, null);
+        // token 采集：模型调用结束时框架回放一个带 ChatUsage 的 ModelCallEndEvent（与 admin 审计模块
+        // 的 usage 同源），流内捕获后挂到本 MODEL 分段；usage 缺失（如离线/未上报）时保持 null
+        AtomicReference<ChatUsage> usageRef = new AtomicReference<>(null);
+        Flux<AgentEvent> upstream = next.apply(input)
+            .doOnNext(event -> {
+                if (event instanceof ModelCallEndEvent mce && mce.getUsage() != null) {
+                    usageRef.set(mce.getUsage());
+                }
+            });
+        return timeSegment(upstream, collector, AgentCallKind.MODEL, modelName, null, usageRef);
     }
 
     @Override
@@ -157,16 +168,19 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
                     lastState.set(tre.getState());
                 }
             });
-        return timeSegment(upstream, collector, kind, toolName, lastState);
+        // 工具段无 token 概念，usageRef 传 null
+        return timeSegment(upstream, collector, kind, toolName, lastState, null);
     }
 
     /**
      * 通用分段计时：doOnSubscribe 记开始，三态终止（complete/error/cancel）各结算一次。
      * {@code stateRef} 非空时（onActing）complete 分支据 {@link ToolResultState} 判成败，否则视为成功。
+     * {@code usageRef} 非空时（onModelCall）结算时读取 token 挂到该分段，工具段传 null。
      */
     private Flux<AgentEvent> timeSegment(Flux<AgentEvent> upstream, AgentCallCollector collector,
                                          AgentCallKind kind, String name,
-                                         AtomicReference<ToolResultState> stateRef) {
+                                         AtomicReference<ToolResultState> stateRef,
+                                         AtomicReference<ChatUsage> usageRef) {
         long[] startMs = new long[1];
         long[] startNano = new long[1];
         AtomicBoolean ended = new AtomicBoolean(false);
@@ -179,17 +193,17 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
                 if (ended.compareAndSet(false, true)) {
                     boolean success = isSuccess(stateRef);
                     String err = success ? null : "tool result state=" + (stateRef == null ? null : stateRef.get());
-                    addSegment(collector, kind, name, startMs[0], startNano[0], success, err);
+                    addSegment(collector, kind, name, startMs[0], startNano[0], success, err, usageRef);
                 }
             })
             .doOnError(e -> {
                 if (ended.compareAndSet(false, true)) {
-                    addSegment(collector, kind, name, startMs[0], startNano[0], false, safeMsg(e));
+                    addSegment(collector, kind, name, startMs[0], startNano[0], false, safeMsg(e), usageRef);
                 }
             })
             .doOnCancel(() -> {
                 if (ended.compareAndSet(false, true)) {
-                    addSegment(collector, kind, name, startMs[0], startNano[0], false, CANCELLED);
+                    addSegment(collector, kind, name, startMs[0], startNano[0], false, CANCELLED, usageRef);
                 }
             });
     }
@@ -203,11 +217,19 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
         return state == null || state == ToolResultState.SUCCESS || state == ToolResultState.RUNNING;
     }
 
-    /** 追加分段（异常安全：采集失败不影响主链路）。 */
+    /** 追加分段（异常安全：采集失败不影响主链路）。{@code usageRef} 携带 MODEL 段 token，工具段/缺失为 null。 */
     private void addSegment(AgentCallCollector collector, AgentCallKind kind, String name,
-                            long startMs, long startNano, boolean success, String errorMsg) {
+                            long startMs, long startNano, boolean success, String errorMsg,
+                            AtomicReference<ChatUsage> usageRef) {
+        Long inputTokens = null;
+        Long outputTokens = null;
+        ChatUsage usage = usageRef == null ? null : usageRef.get();
+        if (usage != null) {
+            inputTokens = (long) usage.getInputTokens();
+            outputTokens = (long) usage.getOutputTokens();
+        }
         try {
-            collector.addSegment(kind, name, startMs, startNano, success, errorMsg);
+            collector.addSegment(kind, name, startMs, startNano, success, errorMsg, inputTokens, outputTokens);
         } catch (Exception e) {
             log.error("agent call segment collect failed, code={}, kind={}, name={}",
                 "CALLLOG-SEGMENT-FAIL", kind, name, e);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTrendPoint.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTrendPoint.java
@@ -1,0 +1,12 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 调用趋势聚合的一个时间桶。
+ *
+ * @param bucket        时间桶标签（按天为 {@code yyyy-MM-dd}，按小时为 {@code yyyy-MM-dd HH}）
+ * @param count         该桶内调用数
+ * @param avgDurationMs 该桶内平均总耗时（毫秒）
+ * @author owlzhangfq@gmail.com
+ */
+public record AgentCallTrendPoint(String bucket, long count, double avgDurationMs) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTrendPoint.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTrendPoint.java
@@ -6,7 +6,8 @@ package com.richard.fyoung.customerwork.calllog;
  * @param bucket        时间桶标签（按天为 {@code yyyy-MM-dd}，按小时为 {@code yyyy-MM-dd HH}）
  * @param count         该桶内调用数
  * @param avgDurationMs 该桶内平均总耗时（毫秒）
+ * @param totalTokens   该桶内 token 消耗合计（total_tokens 求和）
  * @author owlzhangfq@gmail.com
  */
-public record AgentCallTrendPoint(String bucket, long count, double avgDurationMs) {
+public record AgentCallTrendPoint(String bucket, long count, double avgDurationMs, long totalTokens) {
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStore.java
@@ -69,6 +69,9 @@ public class InMemoryAgentCallLogStore implements AgentCallLogStore {
             return AgentCallLogSummary.empty();
         }
         long total = list.size();
+        // token 汇总：null 视为 0（与 SQL SUM/AVG 忽略 NULL 的口径略有差异——内存实现仅测试/演示用，
+        // 生产走 MybatisAgentCallLogStore，此处保持简单一致即可）
+        long totalTokens = list.stream().mapToLong(r -> r.totalTokens() == null ? 0L : r.totalTokens()).sum();
         return new AgentCallLogSummary(
             total,
             list.stream().mapToLong(AgentCallRecord::durationMs).average().orElse(0d),
@@ -76,7 +79,9 @@ public class InMemoryAgentCallLogStore implements AgentCallLogStore {
             list.stream().mapToLong(AgentCallRecord::modelMs).average().orElse(0d),
             list.stream().mapToLong(AgentCallRecord::toolMs).average().orElse(0d),
             list.stream().mapToLong(AgentCallRecord::mcpMs).average().orElse(0d),
-            list.stream().mapToLong(AgentCallRecord::skillMs).average().orElse(0d));
+            list.stream().mapToLong(AgentCallRecord::skillMs).average().orElse(0d),
+            totalTokens,
+            (double) totalTokens / total);
     }
 
     @Override
@@ -89,7 +94,8 @@ public class InMemoryAgentCallLogStore implements AgentCallLogStore {
         return grouped.entrySet().stream()
             .sorted(Map.Entry.comparingByKey())
             .map(e -> new AgentCallTrendPoint(e.getKey(), e.getValue().size(),
-                e.getValue().stream().mapToLong(AgentCallRecord::durationMs).average().orElse(0d)))
+                e.getValue().stream().mapToLong(AgentCallRecord::durationMs).average().orElse(0d),
+                e.getValue().stream().mapToLong(r -> r.totalTokens() == null ? 0L : r.totalTokens()).sum()))
             .collect(Collectors.toList());
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStore.java
@@ -1,0 +1,119 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * 进程内智能体调用日志存储（默认实现，测试 / 演示用）。
+ *
+ * <p>{@link ConcurrentHashMap} 承载主记录，{@link AtomicLong} 模拟自增主键；查询/汇总/趋势语义与
+ * {@link MybatisAgentCallLogStore} 对齐（趋势分桶用与 SQL {@code DATE_FORMAT} 等价的
+ * {@link DateTimeFormatter}，时区取系统默认，与 MySQL {@code FROM_UNIXTIME} 一致）。以
+ * {@code @ConditionalOnMissingBean} 注册，下游声明自己的 {@link AgentCallLogStore} Bean 即可覆盖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemoryAgentCallLogStore implements AgentCallLogStore {
+
+    private final Map<Long, AgentCallRecord> records = new ConcurrentHashMap<>();
+    private final AtomicLong idSeq = new AtomicLong(0);
+
+    @Override
+    public AgentCallRecord save(AgentCallRecord record) {
+        AgentCallRecord persisted = record.withId(idSeq.incrementAndGet());
+        records.put(persisted.id(), persisted);
+        return persisted;
+    }
+
+    @Override
+    public List<AgentCallRecord> findPage(AgentCallLogQuery query) {
+        return matched(query)
+            .sorted(Comparator.comparingLong(AgentCallRecord::id).reversed())
+            .skip(Math.max(query.offset(), 0))
+            .limit(Math.max(query.limit(), 0))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public long count(AgentCallLogQuery query) {
+        return matched(query).count();
+    }
+
+    @Override
+    public List<AgentCallSegment> findSegments(long callLogId) {
+        AgentCallRecord record = records.get(callLogId);
+        if (record == null || record.segments() == null) {
+            return List.of();
+        }
+        return record.segments().stream()
+            .sorted(Comparator.comparingInt(AgentCallSegment::seq))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean delete(long id) {
+        return records.remove(id) != null;
+    }
+
+    @Override
+    public AgentCallLogSummary summary(AgentCallLogQuery query) {
+        List<AgentCallRecord> list = matched(query).collect(Collectors.toList());
+        if (list.isEmpty()) {
+            return AgentCallLogSummary.empty();
+        }
+        long total = list.size();
+        return new AgentCallLogSummary(
+            total,
+            list.stream().mapToLong(AgentCallRecord::durationMs).average().orElse(0d),
+            list.stream().mapToLong(AgentCallRecord::durationMs).max().orElse(0L),
+            list.stream().mapToLong(AgentCallRecord::modelMs).average().orElse(0d),
+            list.stream().mapToLong(AgentCallRecord::toolMs).average().orElse(0d),
+            list.stream().mapToLong(AgentCallRecord::mcpMs).average().orElse(0d),
+            list.stream().mapToLong(AgentCallRecord::skillMs).average().orElse(0d));
+    }
+
+    @Override
+    public List<AgentCallTrendPoint> trend(AgentCallLogQuery query, TrendGranularity granularity) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(granularity.javaPattern())
+            .withZone(ZoneId.systemDefault());
+        // 分桶保序（升序）：LinkedHashMap + 先按桶标签排序的分组
+        Map<String, List<AgentCallRecord>> grouped = matched(query)
+            .collect(Collectors.groupingBy(r -> formatter.format(Instant.ofEpochMilli(r.startTimeMs()))));
+        return grouped.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e -> new AgentCallTrendPoint(e.getKey(), e.getValue().size(),
+                e.getValue().stream().mapToLong(AgentCallRecord::durationMs).average().orElse(0d)))
+            .collect(Collectors.toList());
+    }
+
+    /** 应用查询条件（各维度为空即不约束）。 */
+    private java.util.stream.Stream<AgentCallRecord> matched(AgentCallLogQuery query) {
+        Predicate<AgentCallRecord> p = r -> true;
+        if (query.username() != null) {
+            p = p.and(r -> query.username().equals(r.username()));
+        }
+        if (query.agentCode() != null) {
+            p = p.and(r -> query.agentCode().equals(r.agentCode()));
+        }
+        if (query.requestId() != null) {
+            p = p.and(r -> query.requestId().equals(r.requestId()));
+        }
+        if (query.sessionId() != null) {
+            p = p.and(r -> query.sessionId().equals(r.sessionId()));
+        }
+        if (query.startFromMs() != null) {
+            p = p.and(r -> r.startTimeMs() >= query.startFromMs());
+        }
+        if (query.startToMs() != null) {
+            p = p.and(r -> r.startTimeMs() <= query.startToMs());
+        }
+        return records.values().stream().filter(p);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStore.java
@@ -114,7 +114,9 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
                 toDouble(do1.getAvgModelMs()),
                 toDouble(do1.getAvgToolMs()),
                 toDouble(do1.getAvgMcpMs()),
-                toDouble(do1.getAvgSkillMs()));
+                toDouble(do1.getAvgSkillMs()),
+                do1.getTotalTokens() == null ? 0L : do1.getTotalTokens(),
+                toDouble(do1.getAvgTotalTokens()));
         } catch (Exception e) {
             log.error("agent call log summary failed, code={}", "CALLLOG-SUMMARY-FAIL", e);
             return AgentCallLogSummary.empty();
@@ -126,7 +128,8 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
         try {
             return callLogMapper.trend(toParam(query), granularity.mysqlFormat()).stream()
                 .map(d -> new AgentCallTrendPoint(d.getBucket(),
-                    d.getCnt() == null ? 0L : d.getCnt(), toDouble(d.getAvgDurationMs())))
+                    d.getCnt() == null ? 0L : d.getCnt(), toDouble(d.getAvgDurationMs()),
+                    d.getTotalTokens() == null ? 0L : d.getTotalTokens()))
                 .collect(Collectors.toList());
         } catch (Exception e) {
             log.error("agent call log trend failed, code={}", "CALLLOG-TREND-FAIL", e);
@@ -166,6 +169,9 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
         d.setMcpMs(r.mcpMs());
         d.setSkillMs(r.skillMs());
         d.setSegmentCount(r.segmentCount());
+        d.setInputTokens(r.inputTokens());
+        d.setOutputTokens(r.outputTokens());
+        d.setTotalTokens(r.totalTokens());
         d.setSuccess(r.success());
         d.setErrorMsg(r.errorMsg());
         return d;
@@ -179,6 +185,8 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
         d.setName(s.name());
         d.setStartTime(s.startTimeMs());
         d.setDurationMs(s.durationMs());
+        d.setInputTokens(s.inputTokens());
+        d.setOutputTokens(s.outputTokens());
         d.setSuccess(s.success());
         d.setErrorMsg(s.errorMsg());
         return d;
@@ -199,6 +207,7 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
             d.getMcpMs() == null ? 0L : d.getMcpMs(),
             d.getSkillMs() == null ? 0L : d.getSkillMs(),
             d.getSegmentCount() == null ? 0 : d.getSegmentCount(),
+            d.getInputTokens(), d.getOutputTokens(), d.getTotalTokens(),
             d.getSuccess() != null && d.getSuccess(), d.getErrorMsg(), List.of());
     }
 
@@ -210,7 +219,8 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
             d.getStartTime() == null ? 0L : d.getStartTime(),
             d.getDurationMs() == null ? 0L : d.getDurationMs(),
             d.getSuccess() != null && d.getSuccess(),
-            d.getErrorMsg());
+            d.getErrorMsg(),
+            d.getInputTokens(), d.getOutputTokens());
     }
 
     private double toDouble(BigDecimal value) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStore.java
@@ -1,0 +1,219 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallTrendDO;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogQueryParam;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * MyBatis-Plus 智能体调用日志存储（{@code customer-work.call-log.store-mode=jdbc} 时启用）。
+ *
+ * <p>{@link #save} 先落主表回填自增主键，再逐段落明细表（一次调用的分段量级很小，逐条 insert 足够）；
+ * 查询/汇总/趋势委托 Mapper 的手写 SQL。建表由统一的 SchemaInitializer 负责，本类不建表。读侧异常一律
+ * 降级为空结果 + error 日志，不上抛（报表查询失败不该拖垮页面）；写侧异常上抛（由异步 Sink 侧兜底日志）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisAgentCallLogStore implements AgentCallLogStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MybatisAgentCallLogStore.class);
+
+    private final AgentCallLogMapper callLogMapper;
+    private final AgentCallSegmentMapper segmentMapper;
+
+    public MybatisAgentCallLogStore(AgentCallLogMapper callLogMapper,
+                                    AgentCallSegmentMapper segmentMapper) {
+        this.callLogMapper = callLogMapper;
+        this.segmentMapper = segmentMapper;
+    }
+
+    @Override
+    public AgentCallRecord save(AgentCallRecord record) {
+        try {
+            AgentCallLogDO logDO = toLogDO(record);
+            callLogMapper.insert(logDO);
+            Long id = logDO.getId();
+            if (record.segments() != null) {
+                for (AgentCallSegment segment : record.segments()) {
+                    segmentMapper.insert(toSegmentDO(id, segment));
+                }
+            }
+            return record.withId(id);
+        } catch (Exception e) {
+            log.error("agent call log save failed, code={}, requestId={}",
+                "CALLLOG-SAVE-FAIL", record.requestId(), e);
+            throw new IllegalStateException("failed to save agent call log: " + record.requestId(), e);
+        }
+    }
+
+    @Override
+    public List<AgentCallRecord> findPage(AgentCallLogQuery query) {
+        try {
+            return callLogMapper.findPage(toParam(query)).stream()
+                .map(this::toRecordWithoutSegments)
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("agent call log page query failed, code={}", "CALLLOG-PAGE-FAIL", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public long count(AgentCallLogQuery query) {
+        try {
+            return callLogMapper.countBy(toParam(query));
+        } catch (Exception e) {
+            log.error("agent call log count failed, code={}", "CALLLOG-COUNT-FAIL", e);
+            return 0L;
+        }
+    }
+
+    @Override
+    public List<AgentCallSegment> findSegments(long callLogId) {
+        try {
+            return segmentMapper.findByCallLogId(callLogId).stream()
+                .map(this::toSegment)
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("agent call segment query failed, code={}, callLogId={}",
+                "CALLLOG-SEGMENT-QUERY-FAIL", callLogId, e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public boolean delete(long id) {
+        try {
+            segmentMapper.deleteByCallLogId(id);
+            return callLogMapper.deleteById(id) > 0;
+        } catch (Exception e) {
+            log.error("agent call log delete failed, code={}, id={}", "CALLLOG-DELETE-FAIL", id, e);
+            return false;
+        }
+    }
+
+    @Override
+    public AgentCallLogSummary summary(AgentCallLogQuery query) {
+        try {
+            AgentCallSummaryDO do1 = callLogMapper.summary(toParam(query));
+            if (do1 == null || do1.getTotalCount() == null || do1.getTotalCount() == 0L) {
+                return AgentCallLogSummary.empty();
+            }
+            return new AgentCallLogSummary(
+                do1.getTotalCount(),
+                toDouble(do1.getAvgDurationMs()),
+                do1.getMaxDurationMs() == null ? 0L : do1.getMaxDurationMs(),
+                toDouble(do1.getAvgModelMs()),
+                toDouble(do1.getAvgToolMs()),
+                toDouble(do1.getAvgMcpMs()),
+                toDouble(do1.getAvgSkillMs()));
+        } catch (Exception e) {
+            log.error("agent call log summary failed, code={}", "CALLLOG-SUMMARY-FAIL", e);
+            return AgentCallLogSummary.empty();
+        }
+    }
+
+    @Override
+    public List<AgentCallTrendPoint> trend(AgentCallLogQuery query, TrendGranularity granularity) {
+        try {
+            return callLogMapper.trend(toParam(query), granularity.mysqlFormat()).stream()
+                .map(d -> new AgentCallTrendPoint(d.getBucket(),
+                    d.getCnt() == null ? 0L : d.getCnt(), toDouble(d.getAvgDurationMs())))
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("agent call log trend failed, code={}", "CALLLOG-TREND-FAIL", e);
+            return List.of();
+        }
+    }
+
+    private AgentCallLogQueryParam toParam(AgentCallLogQuery query) {
+        AgentCallLogQueryParam param = new AgentCallLogQueryParam();
+        param.setUsername(query.username());
+        param.setAgentCode(query.agentCode());
+        param.setRequestId(query.requestId());
+        param.setSessionId(query.sessionId());
+        param.setStartFromMs(query.startFromMs());
+        param.setStartToMs(query.startToMs());
+        param.setOffset(Math.max(query.offset(), 0));
+        param.setLimit(Math.max(query.limit(), 0));
+        return param;
+    }
+
+    private AgentCallLogDO toLogDO(AgentCallRecord r) {
+        AgentCallLogDO d = new AgentCallLogDO();
+        d.setRequestId(r.requestId());
+        d.setUserId(r.userId());
+        d.setUsername(r.username());
+        d.setAgentCode(r.agentCode());
+        d.setAgentName(r.agentName());
+        d.setSessionId(r.sessionId());
+        d.setSessionType(r.sessionType() == null ? null : r.sessionType().name());
+        d.setQuestion(r.question());
+        d.setAnswer(r.answer());
+        d.setStartTime(r.startTimeMs());
+        d.setEndTime(r.endTimeMs());
+        d.setDurationMs(r.durationMs());
+        d.setModelMs(r.modelMs());
+        d.setToolMs(r.toolMs());
+        d.setMcpMs(r.mcpMs());
+        d.setSkillMs(r.skillMs());
+        d.setSegmentCount(r.segmentCount());
+        d.setSuccess(r.success());
+        d.setErrorMsg(r.errorMsg());
+        return d;
+    }
+
+    private AgentCallSegmentDO toSegmentDO(Long callLogId, AgentCallSegment s) {
+        AgentCallSegmentDO d = new AgentCallSegmentDO();
+        d.setCallLogId(callLogId);
+        d.setSeq(s.seq());
+        d.setKind(s.kind() == null ? null : s.kind().name());
+        d.setName(s.name());
+        d.setStartTime(s.startTimeMs());
+        d.setDurationMs(s.durationMs());
+        d.setSuccess(s.success());
+        d.setErrorMsg(s.errorMsg());
+        return d;
+    }
+
+    /** 主记录反序列化（不含明细段，段按需经 {@link #findSegments} 拉取）。 */
+    private AgentCallRecord toRecordWithoutSegments(AgentCallLogDO d) {
+        return new AgentCallRecord(
+            d.getId(), d.getRequestId(), d.getUserId(), d.getUsername(), d.getAgentCode(),
+            d.getAgentName(), d.getSessionId(),
+            d.getSessionType() == null ? null : AgentCallSessionType.valueOf(d.getSessionType()),
+            d.getQuestion(), d.getAnswer(),
+            d.getStartTime() == null ? 0L : d.getStartTime(),
+            d.getEndTime() == null ? 0L : d.getEndTime(),
+            d.getDurationMs() == null ? 0L : d.getDurationMs(),
+            d.getModelMs() == null ? 0L : d.getModelMs(),
+            d.getToolMs() == null ? 0L : d.getToolMs(),
+            d.getMcpMs() == null ? 0L : d.getMcpMs(),
+            d.getSkillMs() == null ? 0L : d.getSkillMs(),
+            d.getSegmentCount() == null ? 0 : d.getSegmentCount(),
+            d.getSuccess() != null && d.getSuccess(), d.getErrorMsg(), List.of());
+    }
+
+    private AgentCallSegment toSegment(AgentCallSegmentDO d) {
+        return new AgentCallSegment(
+            d.getSeq() == null ? 0 : d.getSeq(),
+            d.getKind() == null ? AgentCallKind.TOOL : AgentCallKind.valueOf(d.getKind()),
+            d.getName(),
+            d.getStartTime() == null ? 0L : d.getStartTime(),
+            d.getDurationMs() == null ? 0L : d.getDurationMs(),
+            d.getSuccess() != null && d.getSuccess(),
+            d.getErrorMsg());
+    }
+
+    private double toDouble(BigDecimal value) {
+        return value == null ? 0d : value.doubleValue();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/StoreAgentCallRecordSink.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/StoreAgentCallRecordSink.java
@@ -1,0 +1,77 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 默认调用记录 Sink：异步落 {@link AgentCallLogStore}，绝不阻塞响应事件流。
+ *
+ * <p>用一个小容量有界线程池承接落库任务（单线程足以顺序落库，峰值排队 2048 条）：{@link #emit} 只做
+ * 提交、立即返回，落库在后台线程执行，采集/落库异常在任务内自我消化。队列打满时按 fast-fail 丢弃并记
+ * error（宁可丢采集数据也不拖垮主链路，符合"采集不打断主链路"约束）。容器关闭时优雅停池。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class StoreAgentCallRecordSink implements AgentCallRecordSink, DisposableBean {
+
+    private static final Logger log = LoggerFactory.getLogger(StoreAgentCallRecordSink.class);
+
+    private static final int QUEUE_CAPACITY = 2048;
+    private static final long SHUTDOWN_WAIT_SECONDS = 5L;
+
+    private final AgentCallLogStore store;
+    private final ThreadPoolExecutor executor;
+
+    public StoreAgentCallRecordSink(AgentCallLogStore store) {
+        this.store = store;
+        AtomicLong threadIndex = new AtomicLong(0);
+        this.executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+            r -> {
+                Thread t = new Thread(r, "agent-call-log-sink-" + threadIndex.incrementAndGet());
+                t.setDaemon(true);
+                return t;
+            });
+    }
+
+    @Override
+    public void emit(AgentCallRecord record) {
+        if (record == null) {
+            return;
+        }
+        try {
+            executor.execute(() -> {
+                try {
+                    store.save(record);
+                } catch (Exception e) {
+                    log.error("agent call log async save failed, code={}, requestId={}",
+                        "CALLLOG-ASYNC-SAVE-FAIL", record.requestId(), e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // 队列打满：丢弃本条采集，绝不反压主链路
+            log.error("agent call log sink saturated, drop record, code={}, requestId={}",
+                "CALLLOG-SINK-SATURATED", record.requestId());
+        }
+    }
+
+    @Override
+    public void destroy() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        log.info("agent call log sink stopped");
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/ToolKindRegistry.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/ToolKindRegistry.java
@@ -1,0 +1,59 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 工具名 → 调用类别登记表（进程级共享，MCP / SKILL 归类的唯一依据）。
+ *
+ * <p>MCP 工具与 Skill 工具在框架里都以普通 Tool 形态经 onActing 执行，执行流无法区分，故在注册点
+ * （{@code McpToolkitConfigurer} 接入 MCP client 时、{@code CustomerServiceAgentFactory#buildSkillBox}
+ * 注册 skill 时）顺手把工具名登记进来。业务工具不登记，{@link #classify} 默认返回 {@link AgentCallKind#TOOL}。</p>
+ *
+ * <p><b>键设计</b>：直接用「工具名」作键。框架里工具名在 Toolkit 内即为唯一标识（onActing 的
+ * {@code ToolUseBlock.getName()} 就是它），同名工具在不同 agent 里语义一致、类别相同，故全局单表登记不会
+ * 产生"同名异类"冲突；重复登记为幂等覆盖。表随会话不断装配而累积，量级等于工具总数，可忽略。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class ToolKindRegistry {
+
+    /** 仅登记 MCP / SKILL；未登记者由 {@link #classify} 兜底为 TOOL。 */
+    private final ConcurrentHashMap<String, AgentCallKind> kinds = new ConcurrentHashMap<>();
+
+    /** 批量登记 MCP 工具名。 */
+    public void registerMcpTools(Collection<String> toolNames) {
+        register(toolNames, AgentCallKind.MCP);
+    }
+
+    /** 批量登记 Skill 工具名。 */
+    public void registerSkillTools(Collection<String> toolNames) {
+        register(toolNames, AgentCallKind.SKILL);
+    }
+
+    private void register(Collection<String> toolNames, AgentCallKind kind) {
+        if (toolNames == null) {
+            return;
+        }
+        for (String name : toolNames) {
+            if (name != null && !name.isBlank()) {
+                kinds.put(name, kind);
+            }
+        }
+    }
+
+    /** 按工具名归类：已登记返回登记类别，否则默认 {@link AgentCallKind#TOOL}。 */
+    public AgentCallKind classify(String toolName) {
+        if (toolName == null) {
+            return AgentCallKind.TOOL;
+        }
+        return kinds.getOrDefault(toolName, AgentCallKind.TOOL);
+    }
+
+    /** 当前登记条目数（测试 / 诊断用）。 */
+    public int size() {
+        return kinds.size();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/TrendGranularity.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/TrendGranularity.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customerwork.calllog;
+
+/**
+ * 趋势聚合粒度：按天 / 按小时。{@link #dateFormat} 为 MySQL {@code DATE_FORMAT} 的格式串，
+ * 同时用于内存实现的 {@link java.time.format.DateTimeFormatter} 分桶（保持两实现桶标签一致）。
+ * @author owlzhangfq@gmail.com
+ */
+public enum TrendGranularity {
+
+    DAY("%Y-%m-%d", "yyyy-MM-dd"),
+    HOUR("%Y-%m-%d %H", "yyyy-MM-dd HH");
+
+    private final String mysqlFormat;
+    private final String javaPattern;
+
+    TrendGranularity(String mysqlFormat, String javaPattern) {
+        this.mysqlFormat = mysqlFormat;
+        this.javaPattern = javaPattern;
+    }
+
+    /** MySQL DATE_FORMAT 格式串。 */
+    public String mysqlFormat() {
+        return mysqlFormat;
+    }
+
+    /** Java DateTimeFormatter 模式串（内存实现分桶用）。 */
+    public String javaPattern() {
+        return javaPattern;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallLogDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallLogDO.java
@@ -37,6 +37,9 @@ public class AgentCallLogDO {
     private Long mcpMs;
     private Long skillMs;
     private Integer segmentCount;
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long totalTokens;
     private Boolean success;
     private String errorMsg;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallLogDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallLogDO.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customerwork.calllog.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 智能体调用主记录表 {@code cw_agent_call_log} 的持久化对象（贫血 DO）。
+ *
+ * <p>主键 {@code id} 自增（{@link IdType#AUTO}），保存后回填。{@code sessionType} 以枚举名字符串存储；
+ * {@code startTime}/{@code endTime} 为毫秒时间戳（沿用本项目 *_ms 约定，趋势聚合用 {@code FROM_UNIXTIME}
+ * 转换）；四类分段耗时冗余存储，报表免关联明细即可出各段汇总。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_agent_call_log")
+public class AgentCallLogDO {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String requestId;
+    private String userId;
+    private String username;
+    private String agentCode;
+    private String agentName;
+    private String sessionId;
+    private String sessionType;
+    private String question;
+    private String answer;
+    private Long startTime;
+    private Long endTime;
+    private Long durationMs;
+    private Long modelMs;
+    private Long toolMs;
+    private Long mcpMs;
+    private Long skillMs;
+    private Integer segmentCount;
+    private Boolean success;
+    private String errorMsg;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSegmentDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSegmentDO.java
@@ -25,6 +25,8 @@ public class AgentCallSegmentDO {
     private String name;
     private Long startTime;
     private Long durationMs;
+    private Long inputTokens;
+    private Long outputTokens;
     private Boolean success;
     private String errorMsg;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSegmentDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSegmentDO.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customerwork.calllog.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 智能体调用分段明细表 {@code cw_agent_call_segment} 的持久化对象（贫血 DO）。
+ *
+ * <p>{@code callLogId} 外键指向 {@code cw_agent_call_log.id}；{@code kind} 以枚举名字符串存储；
+ * {@code startTime} 为分段开始毫秒时间戳。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_agent_call_segment")
+public class AgentCallSegmentDO {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private Long callLogId;
+    private Integer seq;
+    private String kind;
+    private String name;
+    private Long startTime;
+    private Long durationMs;
+    private Boolean success;
+    private String errorMsg;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSummaryDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSummaryDO.java
@@ -18,4 +18,6 @@ public class AgentCallSummaryDO {
     private BigDecimal avgToolMs;
     private BigDecimal avgMcpMs;
     private BigDecimal avgSkillMs;
+    private Long totalTokens;
+    private BigDecimal avgTotalTokens;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSummaryDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSummaryDO.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customerwork.calllog.entity;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 汇总统计查询结果承载（{@code AVG} 返回 {@link BigDecimal}，由 Store 转成领域 {@code AgentCallLogSummary}）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallSummaryDO {
+
+    private Long totalCount;
+    private BigDecimal avgDurationMs;
+    private Long maxDurationMs;
+    private BigDecimal avgModelMs;
+    private BigDecimal avgToolMs;
+    private BigDecimal avgMcpMs;
+    private BigDecimal avgSkillMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallTrendDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallTrendDO.java
@@ -14,4 +14,5 @@ public class AgentCallTrendDO {
     private String bucket;
     private Long cnt;
     private BigDecimal avgDurationMs;
+    private Long totalTokens;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallTrendDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallTrendDO.java
@@ -1,0 +1,17 @@
+package com.richard.fyoung.customerwork.calllog.entity;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 趋势聚合查询结果承载（一个时间桶），由 Store 转成领域 {@code AgentCallTrendPoint}。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallTrendDO {
+
+    private String bucket;
+    private Long cnt;
+    private BigDecimal avgDurationMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/mapper/AgentCallLogMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/mapper/AgentCallLogMapper.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customerwork.calllog.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallTrendDO;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 智能体调用主记录 Mapper。写入走 {@link BaseMapper#insert}（AUTO 主键回填）；分页/汇总/趋势查询
+ * 在 {@code AgentCallLogMapper.xml} 中手写（动态条件、聚合、按 {@code FROM_UNIXTIME} 分桶）。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AgentCallLogMapper extends BaseMapper<AgentCallLogDO> {
+
+    /** 分页条件查询（id 倒序，最新在前）。 */
+    List<AgentCallLogDO> findPage(@Param("q") AgentCallLogQueryParam query);
+
+    /** 符合条件的总数。 */
+    long countBy(@Param("q") AgentCallLogQueryParam query);
+
+    /** 汇总统计（总数 / 平均总耗时 / 最大总耗时 / 各段平均）。 */
+    AgentCallSummaryDO summary(@Param("q") AgentCallLogQueryParam query);
+
+    /** 趋势聚合：{@code dateFormat} 为 MySQL DATE_FORMAT 格式串（按天/小时）。 */
+    List<AgentCallTrendDO> trend(@Param("q") AgentCallLogQueryParam query,
+                                 @Param("dateFormat") String dateFormat);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/mapper/AgentCallLogQueryParam.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/mapper/AgentCallLogQueryParam.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.calllog.mapper;
+
+import lombok.Data;
+
+/**
+ * 主记录查询的 XML 传参对象（把领域 {@code AgentCallLogQuery} 摊平成 MyBatis 可读属性）。
+ *
+ * <p>用可变 POJO 而非 record：XML 里 {@code <if test="q.username != null">} 需按属性名取值，
+ * 摊平成命名清晰的过滤字段，避免在 XML 里引用 record 访问器带来的可读性折损。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AgentCallLogQueryParam {
+
+    private String username;
+    private String agentCode;
+    private String requestId;
+    private String sessionId;
+    private Long startFromMs;
+    private Long startToMs;
+    private int offset;
+    private int limit;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/mapper/AgentCallSegmentMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/mapper/AgentCallSegmentMapper.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customerwork.calllog.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 智能体调用分段明细 Mapper。写入走 {@link BaseMapper#insert}；按主记录 id 查询/删除在
+ * {@code AgentCallSegmentMapper.xml} 中手写。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AgentCallSegmentMapper extends BaseMapper<AgentCallSegmentDO> {
+
+    /** 按主记录 id 查全部分段（seq 升序）。 */
+    List<AgentCallSegmentDO> findByCallLogId(@Param("callLogId") long callLogId);
+
+    /** 按主记录 id 删除其全部分段。 */
+    int deleteByCallLogId(@Param("callLogId") long callLogId);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -560,6 +560,9 @@ public class CustomerWorkProperties {
     /** 聊天日志（会话/工单消息留痕）存储配置。 */
     private final ChatLog chatLog = new ChatLog();
 
+    /** 智能体调用分段耗时统计（采集开关 + 存储模式）。 */
+    private final CallLog callLog = new CallLog();
+
     /** 业务工具后端存储配置（订单/商品/售后/会员/投诉/知识库六域）。 */
     private final ToolBackend toolBackend = new ToolBackend();
 
@@ -699,6 +702,21 @@ public class CustomerWorkProperties {
      */
     @Data
     public static class ChatLog {
+        /** 存储模式：memory（进程内，默认）| jdbc（跨实例共享）。 */
+        private String storeMode = "memory";
+    }
+
+    /**
+     * 智能体调用分段耗时统计配置。
+     *
+     * <p>{@code enabled} 控制 {@code AgentCallTimingMiddleware} 是否采集（默认开，开销极低：仅
+     * nanoTime 计时 + 异步落库，不阻塞响应流）；{@code store-mode} 决定 {@code AgentCallLogStore} 的
+     * 持久化方式（memory 仅单实例 / jdbc 跨实例，落 cw_agent_call_log + cw_agent_call_segment 两表）。</p>
+     */
+    @Data
+    public static class CallLog {
+        /** 是否启用调用分段耗时采集（默认开启）。 */
+        private boolean enabled = true;
         /** 存储模式：memory（进程内，默认）| jdbc（跨实例共享）。 */
         private String storeMode = "memory";
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/PersistenceJdbcCondition.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/PersistenceJdbcCondition.java
@@ -28,6 +28,7 @@ public class PersistenceJdbcCondition implements Condition {
         "customer-work.feedback.store-mode",
         "customer-work.user-auth.store-mode",
         "customer-work.chat-log.store-mode",
+        "customer-work.call-log.store-mode",
         "customer-work.attachment.store-mode",
         "customer-work.sensitive-word.store-mode",
         "customer-work.tool-backend.mode"

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
@@ -1,6 +1,8 @@
 package com.richard.fyoung.customerwork.service;
 
 import com.richard.fyoung.customerwork.agent.CustomerServiceAgentFactory;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.dto.IntentResult;
 import io.agentscope.core.ReActAgent;
@@ -130,6 +132,7 @@ public class CustomerServiceService {
         touchSession(sessionId);
         ReActAgent agent = resolveAgent(sessionId);
         RuntimeContext ctx = agentFactory.contextFor(sessionId);
+        bindCallMeta(ctx, agent, userText);
 
         return withSessionLock(sessionId, () ->
             agent.call(userText, ctx)
@@ -155,6 +158,7 @@ public class CustomerServiceService {
         touchSession(sessionId);
         ReActAgent agent = resolveAgent(sessionId);
         RuntimeContext ctx = agentFactory.contextFor(sessionId);
+        bindCallMeta(ctx, agent, userText);
 
         StreamOptions options = StreamOptions.builder()
             .eventTypes(EventType.REASONING, EventType.AGENT_RESULT)
@@ -344,6 +348,23 @@ public class CustomerServiceService {
     /** 获取热 Agent；未命中时新建（首次 call 自动从 StateStore 恢复历史，无需手工 load）。 */
     private ReActAgent resolveAgent(String sessionId) {
         return sessionAgents.computeIfAbsent(sessionId, agentFactory::createAgent);
+    }
+
+    /**
+     * 绑定本次调用的元数据到 RuntimeContext，供 {@code AgentCallTimingMiddleware} 采集分段耗时。
+     *
+     * <p>8080 客服链路：username 取会话解析出的租户（{@code ctx.getUserId()}），agentCode/agentName 取
+     * Agent 名称，会话类型固定 CHAT，question 为本轮用户输入；requestId 缺省交由中间件回退 MDC。绑定异常
+     * 不影响主对话链路（采集为旁路，防御式兜底最终收敛在中间件）。</p>
+     */
+    private void bindCallMeta(RuntimeContext ctx, ReActAgent agent, String userText) {
+        try {
+            String agentName = agent == null ? null : agent.getName();
+            ctx.put(AgentCallMeta.class, new AgentCallMeta(
+                null, ctx.getUserId(), agentName, agentName, AgentCallSessionType.CHAT, userText));
+        } catch (Exception e) {
+            log.error("bind agent call meta failed, code={}", "CALLLOG-META-BIND-FAIL", e);
+        }
     }
 
     /**

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurer.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.tool;
 
+import com.richard.fyoung.customerwork.calllog.ToolKindRegistry;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.core.tool.mcp.McpClientBuilder;
@@ -9,6 +10,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * MCP 接入装配器（对应特性「MCP 接入」）。
@@ -25,9 +28,12 @@ public class McpToolkitConfigurer {
     private static final Logger log = LoggerFactory.getLogger(McpToolkitConfigurer.class);
 
     private final CustomerWorkProperties properties;
+    /** 工具归类登记表：MCP 工具在此登记名称，供分段耗时统计按类归段。 */
+    private final ToolKindRegistry toolKindRegistry;
 
-    public McpToolkitConfigurer(CustomerWorkProperties properties) {
+    public McpToolkitConfigurer(CustomerWorkProperties properties, ToolKindRegistry toolKindRegistry) {
         this.properties = properties;
+        this.toolKindRegistry = toolKindRegistry;
     }
 
     /** 是否启用 MCP（且配置了至少一个服务）。 */
@@ -45,8 +51,14 @@ public class McpToolkitConfigurer {
             try {
                 McpClientWrapper wrapper = buildClient(server).block();
                 if (wrapper != null) {
+                    // 快照注册前工具名，注册后取增量即为本 MCP 服务贡献的工具，登记为 MCP 类别
+                    // （直接用 toolkit 实际工具名做键，与 onActing 的 ToolUseBlock.getName() 一致，最可靠）
+                    Set<String> before = new HashSet<>(toolkit.getToolNames());
                     toolkit.registerMcpClient(wrapper).block();
-                    log.info("[MCP] 已接入服务 name={} url={}", server.getName(), server.getUrl());
+                    Set<String> added = new HashSet<>(toolkit.getToolNames());
+                    added.removeAll(before);
+                    toolKindRegistry.registerMcpTools(added);
+                    log.info("[MCP] 已接入服务 name={} url={} tools={}", server.getName(), server.getUrl(), added);
                 }
             } catch (Exception e) {
                 // 单个 MCP 服务不可用不应阻断整个应用启动

--- a/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallLogMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallLogMapper.xml
@@ -19,7 +19,7 @@
     <select id="findPage" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO">
         SELECT id, request_id, user_id, username, agent_code, agent_name, session_id, session_type,
                question, answer, start_time, end_time, duration_ms, model_ms, tool_ms, mcp_ms,
-               skill_ms, segment_count, success, error_msg
+               skill_ms, segment_count, input_tokens, output_tokens, total_tokens, success, error_msg
         FROM cw_agent_call_log
         <include refid="whereClause"/>
         ORDER BY id DESC
@@ -34,13 +34,15 @@
 
     <!-- 汇总统计：总数 / 平均总耗时 / 最大总耗时 / 各段平均耗时。 -->
     <select id="summary" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO">
-        SELECT COUNT(*)          AS total_count,
-               AVG(duration_ms)  AS avg_duration_ms,
-               MAX(duration_ms)  AS max_duration_ms,
-               AVG(model_ms)     AS avg_model_ms,
-               AVG(tool_ms)      AS avg_tool_ms,
-               AVG(mcp_ms)       AS avg_mcp_ms,
-               AVG(skill_ms)     AS avg_skill_ms
+        SELECT COUNT(*)            AS total_count,
+               AVG(duration_ms)    AS avg_duration_ms,
+               MAX(duration_ms)    AS max_duration_ms,
+               AVG(model_ms)       AS avg_model_ms,
+               AVG(tool_ms)        AS avg_tool_ms,
+               AVG(mcp_ms)         AS avg_mcp_ms,
+               AVG(skill_ms)       AS avg_skill_ms,
+               COALESCE(SUM(total_tokens), 0) AS total_tokens,
+               AVG(total_tokens)   AS avg_total_tokens
         FROM cw_agent_call_log
         <include refid="whereClause"/>
     </select>
@@ -50,7 +52,8 @@
     <select id="trend" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallTrendDO">
         SELECT DATE_FORMAT(FROM_UNIXTIME(start_time / 1000), #{dateFormat}) AS bucket,
                COUNT(*)         AS cnt,
-               AVG(duration_ms) AS avg_duration_ms
+               AVG(duration_ms) AS avg_duration_ms,
+               COALESCE(SUM(total_tokens), 0) AS total_tokens
         FROM cw_agent_call_log
         <include refid="whereClause"/>
         GROUP BY bucket

--- a/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallLogMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallLogMapper.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper">
+
+    <!-- 公共动态过滤条件（用户 / agentCode / requestId / sessionId / 时间范围）。 -->
+    <sql id="whereClause">
+        <where>
+            <if test="q.username != null">AND username = #{q.username}</if>
+            <if test="q.agentCode != null">AND agent_code = #{q.agentCode}</if>
+            <if test="q.requestId != null">AND request_id = #{q.requestId}</if>
+            <if test="q.sessionId != null">AND session_id = #{q.sessionId}</if>
+            <if test="q.startFromMs != null">AND start_time &gt;= #{q.startFromMs}</if>
+            <if test="q.startToMs != null">AND start_time &lt;= #{q.startToMs}</if>
+        </where>
+    </sql>
+
+    <!-- 分页条件查询：id 倒序取一页（最新在前）。 -->
+    <select id="findPage" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO">
+        SELECT id, request_id, user_id, username, agent_code, agent_name, session_id, session_type,
+               question, answer, start_time, end_time, duration_ms, model_ms, tool_ms, mcp_ms,
+               skill_ms, segment_count, success, error_msg
+        FROM cw_agent_call_log
+        <include refid="whereClause"/>
+        ORDER BY id DESC
+        LIMIT #{q.limit} OFFSET #{q.offset}
+    </select>
+
+    <!-- 符合条件总数。 -->
+    <select id="countBy" resultType="long">
+        SELECT COUNT(*) FROM cw_agent_call_log
+        <include refid="whereClause"/>
+    </select>
+
+    <!-- 汇总统计：总数 / 平均总耗时 / 最大总耗时 / 各段平均耗时。 -->
+    <select id="summary" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSummaryDO">
+        SELECT COUNT(*)          AS total_count,
+               AVG(duration_ms)  AS avg_duration_ms,
+               MAX(duration_ms)  AS max_duration_ms,
+               AVG(model_ms)     AS avg_model_ms,
+               AVG(tool_ms)      AS avg_tool_ms,
+               AVG(mcp_ms)       AS avg_mcp_ms,
+               AVG(skill_ms)     AS avg_skill_ms
+        FROM cw_agent_call_log
+        <include refid="whereClause"/>
+    </select>
+
+    <!-- 趋势聚合：按 dateFormat（天/小时）分桶，每桶调用数 + 平均总耗时，桶标签升序。
+         start_time 为毫秒时间戳，FROM_UNIXTIME 除以 1000 转秒后按本地时区格式化。 -->
+    <select id="trend" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallTrendDO">
+        SELECT DATE_FORMAT(FROM_UNIXTIME(start_time / 1000), #{dateFormat}) AS bucket,
+               COUNT(*)         AS cnt,
+               AVG(duration_ms) AS avg_duration_ms
+        FROM cw_agent_call_log
+        <include refid="whereClause"/>
+        GROUP BY bucket
+        ORDER BY bucket ASC
+    </select>
+
+</mapper>

--- a/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallSegmentMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallSegmentMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper">
+
+    <!-- 按主记录 id 查全部分段，seq 升序。 -->
+    <select id="findByCallLogId" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO">
+        SELECT id, call_log_id, seq, kind, name, start_time, duration_ms, success, error_msg
+        FROM cw_agent_call_segment
+        WHERE call_log_id = #{callLogId}
+        ORDER BY seq ASC
+    </select>
+
+    <!-- 按主记录 id 删除其全部分段（主记录删除时级联清理）。 -->
+    <delete id="deleteByCallLogId">
+        DELETE FROM cw_agent_call_segment WHERE call_log_id = #{callLogId}
+    </delete>
+
+</mapper>

--- a/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallSegmentMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallSegmentMapper.xml
@@ -5,7 +5,8 @@
 
     <!-- 按主记录 id 查全部分段，seq 升序。 -->
     <select id="findByCallLogId" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO">
-        SELECT id, call_log_id, seq, kind, name, start_time, duration_ms, success, error_msg
+        SELECT id, call_log_id, seq, kind, name, start_time, duration_ms, input_tokens, output_tokens,
+               success, error_msg
         FROM cw_agent_call_segment
         WHERE call_log_id = #{callLogId}
         ORDER BY seq ASC

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -162,6 +162,50 @@ CREATE TABLE IF NOT EXISTS `cw_chat_message` (
     INDEX `idx_chat_ticket` (`ticket_id`, `id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='会话/工单聊天消息留痕';
 
+-- 智能体调用主记录表（MybatisAgentCallLogStore）：每次调用一行，含分段耗时冗余汇总。
+CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `request_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
+    `user_id`        VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
+    `username`       VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户名',
+    `agent_code`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '智能体编码',
+    `agent_name`     VARCHAR(255) NOT NULL DEFAULT '' COMMENT '智能体名称',
+    `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+    `session_type`   VARCHAR(32) NOT NULL DEFAULT 'CHAT' COMMENT '会话类型 CHAT/VIBE_CODING',
+    `question`       MEDIUMTEXT COMMENT '用户问题',
+    `answer`         MEDIUMTEXT COMMENT '智能体回答',
+    `start_time`     BIGINT NOT NULL COMMENT '调用开始时间戳（毫秒）',
+    `end_time`       BIGINT NOT NULL COMMENT '调用结束时间戳（毫秒）',
+    `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '总耗时（毫秒）',
+    `model_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'MODEL段耗时合计（毫秒）',
+    `tool_ms`        BIGINT NOT NULL DEFAULT 0 COMMENT 'TOOL段耗时合计（毫秒）',
+    `mcp_ms`         BIGINT NOT NULL DEFAULT 0 COMMENT 'MCP段耗时合计（毫秒）',
+    `skill_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'SKILL段耗时合计（毫秒）',
+    `segment_count`  INT NOT NULL DEFAULT 0 COMMENT '分段总数',
+    `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
+    `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
+    INDEX `idx_call_request` (`request_id`),
+    INDEX `idx_call_username` (`username`),
+    INDEX `idx_call_agent_code` (`agent_code`),
+    INDEX `idx_call_session` (`session_id`),
+    INDEX `idx_call_start` (`start_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用主记录（分段耗时统计）';
+
+-- 智能体调用分段明细表（MybatisAgentCallLogStore）：一次调用的每段耗时一行。
+CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `call_log_id`    BIGINT NOT NULL COMMENT '所属主记录ID',
+    `seq`            INT NOT NULL COMMENT '调用内分段序号（从1起）',
+    `kind`           VARCHAR(16) NOT NULL COMMENT '分段类别 MODEL/TOOL/MCP/SKILL',
+    `name`           VARCHAR(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
+    `start_time`     BIGINT NOT NULL COMMENT '分段开始时间戳（毫秒）',
+    `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
+    `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
+    `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用分段明细';
+
 -- 对话附件表（MybatisAttachmentStore）：上传附件落盘 + 落库，解析文本可追溯。
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
     `id`             VARCHAR(64) NOT NULL COMMENT '附件ID(UUID)',

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -182,6 +182,9 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
     `mcp_ms`         BIGINT NOT NULL DEFAULT 0 COMMENT 'MCP段耗时合计（毫秒）',
     `skill_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'SKILL段耗时合计（毫秒）',
     `segment_count`  INT NOT NULL DEFAULT 0 COMMENT '分段总数',
+    `input_tokens`   BIGINT DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）',
+    `output_tokens`  BIGINT DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）',
+    `total_tokens`   BIGINT DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
@@ -201,6 +204,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `name`           VARCHAR(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
     `start_time`     BIGINT NOT NULL COMMENT '分段开始时间戳（毫秒）',
     `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
+    `input_tokens`   BIGINT DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）',
+    `output_tokens`  BIGINT DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     INDEX `idx_segment_call_log` (`call_log_id`, `seq`)

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/agent/CustomerServiceAgentFactoryTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/agent/CustomerServiceAgentFactoryTest.java
@@ -34,7 +34,7 @@ class CustomerServiceAgentFactoryTest {
             model, props,
             new LongTermMemoryProvider(props, store, factLog),
             new KnowledgeProvider(props),
-            new McpToolkitConfigurer(props),
+            new McpToolkitConfigurer(props, new com.richard.fyoung.customerwork.calllog.ToolKindRegistry()),
             new HigressToolkitConfigurer(props),
             new com.richard.fyoung.customerwork.tool.ToolRegistrar(
                 new com.richard.fyoung.customerwork.tool.backend.MockOrderBackend(),
@@ -50,6 +50,7 @@ class CustomerServiceAgentFactoryTest {
             new com.richard.fyoung.customerwork.config.PermissionConfig().permissionContextState(props),
             new com.richard.fyoung.customerwork.config.NacosPromptService(props),
             new com.richard.fyoung.customerwork.support.TenantResolver(props),
+            new com.richard.fyoung.customerwork.calllog.ToolKindRegistry(),
             null,    // 无可插拔 Hook
             null);   // 无 MeterRegistry（观测降级为仅日志）
     }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallCollectorTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallCollectorTest.java
@@ -18,10 +18,10 @@ class AgentCallCollectorTest {
         AgentCallCollector collector = new AgentCallCollector();
         long now = System.currentTimeMillis();
         long nano = System.nanoTime();
-        collector.addSegment(AgentCallKind.MODEL, "qwen-max", now, nano, true, null);
-        collector.addSegment(AgentCallKind.TOOL, "queryOrder", now, nano, true, null);
-        collector.addSegment(AgentCallKind.MCP, "mcp_weather", now, nano, true, null);
-        collector.addSegment(AgentCallKind.SKILL, "skill_pdf", now, nano, false, "boom");
+        collector.addSegment(AgentCallKind.MODEL, "qwen-max", now, nano, true, null, 120L, 30L);
+        collector.addSegment(AgentCallKind.TOOL, "queryOrder", now, nano, true, null, null, null);
+        collector.addSegment(AgentCallKind.MCP, "mcp_weather", now, nano, true, null, null, null);
+        collector.addSegment(AgentCallKind.SKILL, "skill_pdf", now, nano, false, "boom", null, null);
         collector.setAnswer("最终回答");
 
         AgentCallRecord record = collector.toRecord("req-1", "tenantA", "userA", "agentA",
@@ -33,6 +33,13 @@ class AgentCallCollectorTest {
         assertEquals("req-1", record.requestId());
         assertEquals(AgentCallSessionType.CHAT, record.sessionType());
         assertTrue(record.success());
+        // token 汇总：仅 MODEL 段有 usage（120/30），其余段 null 不计入
+        assertEquals(120L, record.inputTokens(), "请求级输入 token = MODEL 段之和");
+        assertEquals(30L, record.outputTokens(), "请求级输出 token = MODEL 段之和");
+        assertEquals(150L, record.totalTokens(), "请求级总 token = 输入 + 输出");
+        assertEquals(120L, record.segments().get(0).inputTokens(), "MODEL 段输入 token");
+        assertEquals(30L, record.segments().get(0).outputTokens(), "MODEL 段输出 token");
+        assertNull(record.segments().get(1).inputTokens(), "工具段无 token");
         // 每类各一段，各段耗时 >=0，四类互不串味
         assertTrue(record.modelMs() >= 0 && record.toolMs() >= 0
             && record.mcpMs() >= 0 && record.skillMs() >= 0);
@@ -55,6 +62,10 @@ class AgentCallCollectorTest {
         assertEquals(0L, record.toolMs());
         assertEquals(0L, record.mcpMs());
         assertEquals(0L, record.skillMs());
+        // 无分段 → 无 usage：三个 token 字段均 null（区分"未采到"与"用了 0 token"）
+        assertNull(record.inputTokens());
+        assertNull(record.outputTokens());
+        assertNull(record.totalTokens());
         assertNull(record.answer());
         assertFalse(record.success());
         assertEquals("failed", record.errorMsg());

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallCollectorTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallCollectorTest.java
@@ -1,0 +1,63 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 采集器单测：分段序号自增、四类耗时汇总、答案采集、成败与错误信息组装。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallCollectorTest {
+
+    @Test
+    void toRecord_shouldAggregateSegmentsByKind() {
+        AgentCallCollector collector = new AgentCallCollector();
+        long now = System.currentTimeMillis();
+        long nano = System.nanoTime();
+        collector.addSegment(AgentCallKind.MODEL, "qwen-max", now, nano, true, null);
+        collector.addSegment(AgentCallKind.TOOL, "queryOrder", now, nano, true, null);
+        collector.addSegment(AgentCallKind.MCP, "mcp_weather", now, nano, true, null);
+        collector.addSegment(AgentCallKind.SKILL, "skill_pdf", now, nano, false, "boom");
+        collector.setAnswer("最终回答");
+
+        AgentCallRecord record = collector.toRecord("req-1", "tenantA", "userA", "agentA",
+            "客服Agent", "sess-1", AgentCallSessionType.CHAT, "你好", now + 100, true, null);
+
+        assertEquals(4, record.segmentCount(), "分段数");
+        assertEquals(4, record.segments().size());
+        assertEquals("最终回答", record.answer());
+        assertEquals("req-1", record.requestId());
+        assertEquals(AgentCallSessionType.CHAT, record.sessionType());
+        assertTrue(record.success());
+        // 每类各一段，各段耗时 >=0，四类互不串味
+        assertTrue(record.modelMs() >= 0 && record.toolMs() >= 0
+            && record.mcpMs() >= 0 && record.skillMs() >= 0);
+        // 分段序号从 1 起自增
+        assertEquals(1, record.segments().get(0).seq());
+        assertEquals(4, record.segments().get(3).seq());
+        assertEquals(AgentCallKind.SKILL, record.segments().get(3).kind());
+        assertFalse(record.segments().get(3).success());
+        assertEquals("boom", record.segments().get(3).errorMsg());
+    }
+
+    @Test
+    void toRecord_emptySegments_shouldZeroAggregates() {
+        AgentCallCollector collector = new AgentCallCollector();
+        AgentCallRecord record = collector.toRecord("req-2", "u", "u", "a", "a", "s",
+            AgentCallSessionType.VIBE_CODING, "q", System.currentTimeMillis(), false, "failed");
+
+        assertEquals(0, record.segmentCount());
+        assertEquals(0L, record.modelMs());
+        assertEquals(0L, record.toolMs());
+        assertEquals(0L, record.mcpMs());
+        assertEquals(0L, record.skillMs());
+        assertNull(record.answer());
+        assertFalse(record.success());
+        assertEquals("failed", record.errorMsg());
+        assertEquals(AgentCallSessionType.VIBE_CODING, record.sessionType());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddlewareTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddlewareTest.java
@@ -1,0 +1,204 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.ModelCallInput;
+import io.agentscope.core.model.Model;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 分段耗时中间件单测：MODEL/TOOL/MCP/SKILL 分段采集与归类、答案采集、失败判定、异常不打断主链路、开关直通。
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallTimingMiddlewareTest {
+
+    private final Agent agent = mock(Agent.class);
+    private final Model model = mock(Model.class);
+
+    private CustomerWorkProperties enabledProps() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getCallLog().setEnabled(true);
+        return props;
+    }
+
+    private RuntimeContext ctx() {
+        return RuntimeContext.builder().userId("tenantA").sessionId("sess-1").build();
+    }
+
+    private Msg msg(MsgRole role, String text) {
+        return Msg.builder().role(role).name(role.name().toLowerCase())
+            .content(TextBlock.builder().text(text).build()).build();
+    }
+
+    /** onAgent 内嵌 model + tool + mcp 三段，验证完整采集链路。 */
+    @Test
+    void onAgent_shouldCollectSegmentsAnswerAndEmitRecord() {
+        when(agent.getName()).thenReturn("客服Agent");
+        when(model.getModelName()).thenReturn("qwen-max");
+
+        ToolKindRegistry registry = new ToolKindRegistry();
+        registry.registerMcpTools(List.of("mcp_weather"));
+        AtomicReference<AgentCallRecord> captured = new AtomicReference<>();
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(enabledProps(), registry, captured::set);
+
+        RuntimeContext ctx = ctx();
+        Function<AgentInput, Flux<AgentEvent>> inner = ai -> {
+            Flux<AgentEvent> modelFlux = mw.onModelCall(agent, ctx,
+                new ModelCallInput(List.of(), List.of(), null, model),
+                mi -> Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "thinking"))));
+            Flux<AgentEvent> toolFlux = mw.onActing(agent, ctx,
+                new ActingInput(List.of(new ToolUseBlock("t1", "queryOrder", Map.of()))),
+                act -> Flux.just(new ToolResultEndEvent("r", "t1", "queryOrder", ToolResultState.SUCCESS)));
+            Flux<AgentEvent> mcpFlux = mw.onActing(agent, ctx,
+                new ActingInput(List.of(new ToolUseBlock("t2", "mcp_weather", Map.of()))),
+                act -> Flux.just(new ToolResultEndEvent("r", "t2", "mcp_weather", ToolResultState.SUCCESS)));
+            return Flux.concat(modelFlux, toolFlux, mcpFlux,
+                Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "最终回答"))));
+        };
+
+        mw.onAgent(agent, ctx, new AgentInput(List.of(msg(MsgRole.USER, "你好"))), inner).blockLast();
+
+        AgentCallRecord record = captured.get();
+        assertNotNull(record, "应组装并下沉记录");
+        assertEquals(3, record.segmentCount(), "MODEL + TOOL + MCP 三段");
+        assertEquals("最终回答", record.answer(), "从 AGENT_RESULT 采集最终回答");
+        assertEquals("你好", record.question(), "meta 缺失时问题回退首条用户消息");
+        assertEquals("tenantA", record.username(), "username 回退 ctx.userId");
+        assertEquals("客服Agent", record.agentName());
+        assertTrue(record.success());
+        // 三类各一段
+        long model = record.segments().stream().filter(s -> s.kind() == AgentCallKind.MODEL).count();
+        long tool = record.segments().stream().filter(s -> s.kind() == AgentCallKind.TOOL).count();
+        long mcp = record.segments().stream().filter(s -> s.kind() == AgentCallKind.MCP).count();
+        assertEquals(1, model);
+        assertEquals(1, tool);
+        assertEquals(1, mcp);
+        assertEquals("qwen-max", record.segments().stream()
+            .filter(s -> s.kind() == AgentCallKind.MODEL).findFirst().orElseThrow().name());
+    }
+
+    /** onActing 工具结果为 ERROR 时段判失败并记错误信息。 */
+    @Test
+    void onActing_toolResultError_shouldMarkSegmentFailed() {
+        ToolKindRegistry registry = new ToolKindRegistry();
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(enabledProps(), registry, r -> { });
+
+        RuntimeContext ctx = ctx();
+        AgentCallCollector collector = new AgentCallCollector();
+        ctx.put(AgentCallCollector.class, collector);
+
+        mw.onActing(agent, ctx, new ActingInput(List.of(new ToolUseBlock("t1", "queryOrder", Map.of()))),
+            act -> Flux.just(new ToolResultEndEvent("r", "t1", "queryOrder", ToolResultState.ERROR))).blockLast();
+
+        AgentCallRecord record = collector.toRecord("req", "u", "u", "a", "a", "s",
+            AgentCallSessionType.CHAT, "q", System.currentTimeMillis(), true, null);
+        assertEquals(1, record.segmentCount());
+        assertFalse(record.segments().get(0).success(), "ERROR 状态段判失败");
+        assertNotNull(record.segments().get(0).errorMsg());
+    }
+
+    /** onActing 上游抛异常走 onError 分支，段判失败且异常不外泄（本 hook 只读透传）。 */
+    @Test
+    void onActing_upstreamError_shouldRecordFailureAndNotSwallowMainError() {
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(enabledProps(), new ToolKindRegistry(), r -> { });
+        RuntimeContext ctx = ctx();
+        AgentCallCollector collector = new AgentCallCollector();
+        ctx.put(AgentCallCollector.class, collector);
+
+        RuntimeException boom = new RuntimeException("tool boom");
+        AtomicReference<Throwable> seen = new AtomicReference<>();
+        mw.onActing(agent, ctx, new ActingInput(List.of(new ToolUseBlock("t1", "queryOrder", Map.of()))),
+                act -> Flux.<AgentEvent>error(boom))
+            .doOnError(seen::set)
+            .onErrorResume(e -> Flux.empty())
+            .blockLast();
+
+        assertEquals(boom, seen.get(), "主链路错误信号原样透传");
+        List<AgentCallSegment> segs = collector.toRecord("req", "u", "u", "a", "a", "s",
+            AgentCallSessionType.CHAT, "q", System.currentTimeMillis(), false, "x").segments();
+        assertEquals(1, segs.size());
+        assertFalse(segs.get(0).success());
+    }
+
+    /** Sink 抛异常不得打断主对话流（防御式兜底收敛在中间件）。 */
+    @Test
+    void onAgent_sinkThrows_shouldNotBreakMainFlux() {
+        AgentCallRecordSink throwing = r -> {
+            throw new RuntimeException("sink boom");
+        };
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(enabledProps(), new ToolKindRegistry(), throwing);
+
+        AgentEvent last = mw.onAgent(agent, ctx(), new AgentInput(List.of(msg(MsgRole.USER, "hi"))),
+            ai -> Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "ok")))).blockLast();
+
+        assertNotNull(last, "Sink 异常被中间件吞掉，主链路照常产出事件");
+    }
+
+    /** 子 agent 复用同一 RuntimeContext 再次进入 onAgent：不覆盖父采集器、不另发记录，分段归入父请求。 */
+    @Test
+    void onAgent_nestedSameContext_shouldAttributeSegmentsToParentAndEmitOnce() {
+        when(agent.getName()).thenReturn("父Agent");
+        when(model.getModelName()).thenReturn("qwen-max");
+
+        List<AgentCallRecord> emitted = new java.util.concurrent.CopyOnWriteArrayList<>();
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(enabledProps(), new ToolKindRegistry(), emitted::add);
+
+        RuntimeContext ctx = ctx();
+        // 内层：模拟子 agent 在同一 ctx 上再次进入 onAgent，并在其中发生一次模型调用
+        Function<AgentInput, Flux<AgentEvent>> subAgentBody = ai -> mw.onModelCall(agent, ctx,
+            new ModelCallInput(List.of(), List.of(), null, model),
+            mi -> Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "sub thinking"))));
+        Function<AgentInput, Flux<AgentEvent>> outerBody = ai -> Flux.concat(
+            mw.onAgent(agent, ctx, new AgentInput(List.of(msg(MsgRole.USER, "sub task"))), subAgentBody),
+            Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "父回答"))));
+
+        mw.onAgent(agent, ctx, new AgentInput(List.of(msg(MsgRole.USER, "父问题"))), outerBody).blockLast();
+
+        assertEquals(1, emitted.size(), "嵌套调用只由父级结算一次，不重复下沉");
+        AgentCallRecord record = emitted.get(0);
+        assertEquals("父问题", record.question(), "记录归属父请求");
+        assertEquals("父回答", record.answer(), "答案取父级最终 AGENT_RESULT");
+        assertEquals(1, record.segments().stream().filter(s -> s.kind() == AgentCallKind.MODEL).count(),
+            "子 agent 的模型分段归入父请求采集器");
+    }
+
+    /** 开关关闭时全部 hook 直通，不采集、不下沉。 */
+    @Test
+    void disabled_shouldPassThroughAndNotEmit() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getCallLog().setEnabled(false);
+        AtomicReference<AgentCallRecord> captured = new AtomicReference<>();
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(props, new ToolKindRegistry(), captured::set);
+
+        Long count = mw.onAgent(agent, ctx(), new AgentInput(List.of(msg(MsgRole.USER, "hi"))),
+            ai -> Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "ok")))).count().block();
+
+        assertTrue(count != null && count == 1, "事件透传不丢失");
+        assertNull(captured.get(), "关闭时不下沉记录");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddlewareTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddlewareTest.java
@@ -5,8 +5,10 @@ import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultState;
@@ -100,6 +102,40 @@ class AgentCallTimingMiddlewareTest {
         assertEquals(1, mcp);
         assertEquals("qwen-max", record.segments().stream()
             .filter(s -> s.kind() == AgentCallKind.MODEL).findFirst().orElseThrow().name());
+    }
+
+    /** onModelCall 采集 ModelCallEndEvent 携带的 ChatUsage：MODEL 段挂 token，请求级汇总求和。 */
+    @Test
+    void onModelCall_shouldCaptureTokensFromModelCallEndEvent() {
+        when(agent.getName()).thenReturn("客服Agent");
+        when(model.getModelName()).thenReturn("qwen-max");
+
+        AtomicReference<AgentCallRecord> captured = new AtomicReference<>();
+        AgentCallTimingMiddleware mw = new AgentCallTimingMiddleware(enabledProps(), new ToolKindRegistry(), captured::set);
+
+        RuntimeContext ctx = ctx();
+        Function<AgentInput, Flux<AgentEvent>> inner = ai -> {
+            // 模型调用流末尾回放带 usage 的 ModelCallEndEvent（与框架真实行为一致）
+            Flux<AgentEvent> modelFlux = mw.onModelCall(agent, ctx,
+                new ModelCallInput(List.of(), List.of(), null, model),
+                mi -> Flux.just(
+                    new AgentResultEvent(msg(MsgRole.ASSISTANT, "thinking")),
+                    new ModelCallEndEvent("reply-1", new ChatUsage(128, 32, 0.0))));
+            return Flux.concat(modelFlux,
+                Flux.just(new AgentResultEvent(msg(MsgRole.ASSISTANT, "最终回答"))));
+        };
+
+        mw.onAgent(agent, ctx, new AgentInput(List.of(msg(MsgRole.USER, "你好"))), inner).blockLast();
+
+        AgentCallRecord record = captured.get();
+        assertNotNull(record);
+        AgentCallSegment modelSeg = record.segments().stream()
+            .filter(s -> s.kind() == AgentCallKind.MODEL).findFirst().orElseThrow();
+        assertEquals(128L, modelSeg.inputTokens(), "MODEL 段输入 token 取自 ChatUsage");
+        assertEquals(32L, modelSeg.outputTokens(), "MODEL 段输出 token 取自 ChatUsage");
+        assertEquals(128L, record.inputTokens(), "请求级输入 token 汇总");
+        assertEquals(32L, record.outputTokens(), "请求级输出 token 汇总");
+        assertEquals(160L, record.totalTokens(), "请求级总 token = 输入 + 输出");
     }
 
     /** onActing 工具结果为 ERROR 时段判失败并记错误信息。 */

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingRealAgentIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingRealAgentIntegrationTest.java
@@ -1,0 +1,205 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 分段耗时中间件「真实链路」集成测试——用真实 {@link ReActAgent}（离线 stub Model 驱动、真实工具执行、
+ * 真实中间件链）走完整 call/stream，堵住此前"单测直调 hook 传非空 ctx"盖不住的缺陷。
+ *
+ * <p><b>缺陷背景</b>：admin 工作台与 8080 流式对话走框架<b>废弃</b>的
+ * {@code ReActAgent.stream(msgs, options, ctx)}——该路径框架只把调用方 ctx 挂到 Reactor Context 的
+ * {@code RUNTIME_CONTEXT_KEY} 上，{@code onAgent} 的 {@code ctx} 入参恒为 null（而 onModelCall/onActing
+ * 用的是从该 key 解析出的真实 rc）。修复前果：onAgent 读不到 {@link AgentCallMeta}、采集器放进 null ctx
+ * 后 onModelCall/onActing 取不到 → username/requestId/agentName 走兜底、sessionId 空、<b>分段全无</b>
+ * （恰是用户实测的四个现象）。修复：onAgent 从 Reactor Context 兜底归一到同一 ctx。</p>
+ *
+ * <p>本测试正是沿废弃 stream 路径复现该缺陷：修复前四项断言全挂，修复后全绿。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class AgentCallTimingRealAgentIntegrationTest {
+
+    private static final String FINAL_REPLY = "您本月考勤正常，共出勤 21 天。";
+    private static final String MODEL_NAME = "stub-oa-model";
+    private static final String TOOL_NAME = "queryAttendance";
+    private static final Duration BLOCK_TIMEOUT = Duration.ofSeconds(20);
+
+    /** 离线工具：真实注册进 Toolkit，被 ReAct 循环真实调用，产出 TOOL 分段。 */
+    public static class AttendanceTools {
+        @Tool(description = "查询指定日期的 OA 考勤记录。用户问考勤/打卡时调用。")
+        public Mono<String> queryAttendance(
+                @ToolParam(name = "date", description = "查询日期，如 'today'") String date) {
+            return Mono.just("考勤(" + date + ")：09:02 打卡，无异常");
+        }
+    }
+
+    /**
+     * 离线 stub Model：第一次调用返回一次 {@code queryAttendance} 工具调用（驱动 onActing → TOOL 分段），
+     * 之后返回纯文本最终回答（ReAct 收敛）。全程无网络，确定性。
+     */
+    private static Model toolCallingStubModel() {
+        AtomicInteger calls = new AtomicInteger(0);
+        return new Model() {
+            @Override
+            public Flux<ChatResponse> stream(List<Msg> messages, List<ToolSchema> tools,
+                                             GenerateOptions options) {
+                int n = calls.getAndIncrement();
+                if (n == 0) {
+                    ToolUseBlock toolUse = new ToolUseBlock("call-1", TOOL_NAME, Map.of("date", "today"));
+                    return Flux.just(ChatResponse.builder()
+                        .id(UUID.randomUUID().toString())
+                        .content(List.of(toolUse))
+                        .usage(new ChatUsage(1, 1, 0.0))
+                        .finishReason("tool_calls")
+                        .build());
+                }
+                ContentBlock text = TextBlock.builder().text(FINAL_REPLY).build();
+                return Flux.just(ChatResponse.builder()
+                    .id(UUID.randomUUID().toString())
+                    .content(List.of(text))
+                    .usage(new ChatUsage(1, 1, 0.0))
+                    .finishReason("stop")
+                    .build());
+            }
+
+            @Override
+            public String getModelName() {
+                return MODEL_NAME;
+            }
+        };
+    }
+
+    private CustomerWorkProperties enabledProps() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getCallLog().setEnabled(true);
+        return props;
+    }
+
+    private ReActAgent buildAgent(AgentCallTimingMiddleware middleware) {
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerTool(new AttendanceTools());
+        return ReActAgent.builder()
+            .name("AdminAgent-oa-assistant") // 内部名，与用户实测的兜底显示名一致
+            .sysPrompt("你是 OA 考勤助手，遇到考勤查询请调用工具后回答。")
+            .model(toolCallingStubModel())
+            .toolkit(toolkit)
+            .maxIters(3)
+            .middleware(middleware)
+            .build();
+    }
+
+    private AgentCallMeta meta() {
+        return new AgentCallMeta("req-oa-8848", "admin", "oa-assistant",
+            "OA考勤助手", AgentCallSessionType.CHAT, "查一下我这个月的考勤");
+    }
+
+    private Msg userMsg() {
+        return Msg.builder().role(MsgRole.USER).name("user")
+            .content(TextBlock.builder().text("查一下我这个月的考勤").build()).build();
+    }
+
+    /**
+     * 缺陷复现主用例：沿框架废弃的 {@code stream(msgs, options, ctx)} 路径（admin/8080 流式对话实际走法），
+     * 断言 meta 四要素（username/requestId/agentName/sessionId）与分段（MODEL + TOOL）全部正确落地。
+     * 修复前：onAgent 拿到 null ctx → 四项断言全挂。
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedStreamPath_shouldBindMetaAndCollectSegments() {
+        AtomicReference<AgentCallRecord> captured = new AtomicReference<>();
+        AgentCallTimingMiddleware middleware =
+            new AgentCallTimingMiddleware(enabledProps(), new ToolKindRegistry(), captured::set);
+        ReActAgent agent = buildAgent(middleware);
+
+        RuntimeContext ctx = RuntimeContext.builder().userId("oa-assistant").sessionId("sess-oa-1").build();
+        ctx.put(AgentCallMeta.class, meta());
+
+        StreamOptions options = StreamOptions.builder()
+            .eventTypes(EventType.REASONING, EventType.TOOL_RESULT, EventType.AGENT_RESULT)
+            .incremental(true)
+            .build();
+
+        // 废弃三参 stream：正是缺陷路径。走完整订阅。
+        Long events = agent.stream(List.of(userMsg()), options, ctx).count().block(BLOCK_TIMEOUT);
+        assertTrue(events != null && events > 0, "流式路径应至少产出一个事件");
+
+        AgentCallRecord record = captured.get();
+        assertNotNull(record, "应组装并下沉一条记录");
+        // ① meta 四要素来自 RuntimeContext 里绑定的 AgentCallMeta（修复前全走兜底）
+        assertEquals("admin", record.username(), "username 取自 meta，非 unknown");
+        assertEquals("req-oa-8848", record.requestId(), "requestId 取自 meta，非 unknown");
+        assertEquals("OA考勤助手", record.agentName(), "agentName 取自 meta 中文名，非内部名 AdminAgent-oa-assistant");
+        assertEquals("sess-oa-1", record.sessionId(), "sessionId 取自 ctx，非空");
+        // ② 分段：至少一段 MODEL + 至少一段 TOOL（修复前 segments 全无）
+        long modelSegs = record.segments().stream().filter(s -> s.kind() == AgentCallKind.MODEL).count();
+        long toolSegs = record.segments().stream().filter(s -> s.kind() == AgentCallKind.TOOL).count();
+        assertTrue(modelSegs >= 1, "应含至少一段 MODEL 分段，实际=" + record.segments());
+        assertTrue(toolSegs >= 1, "应含至少一段 TOOL 分段，实际=" + record.segments());
+        assertEquals(MODEL_NAME, record.segments().stream()
+            .filter(s -> s.kind() == AgentCallKind.MODEL).findFirst().orElseThrow().name(),
+            "MODEL 分段名取模型名");
+        assertTrue(TOOL_NAME.equals(record.segments().stream()
+            .filter(s -> s.kind() == AgentCallKind.TOOL).findFirst().orElseThrow().name()),
+            "TOOL 分段名取工具名");
+        assertTrue(record.success(), "整次调用成功");
+    }
+
+    /**
+     * 回归护栏：非废弃的 {@code streamEvents(msgs, ctx)} 路径（框架推荐 API）同样正确绑定 meta 与分段，
+     * 确认修复未破坏 ctx 入参非空的正常路径。
+     */
+    @Test
+    void streamEventsPath_shouldBindMetaAndCollectSegments() {
+        AtomicReference<AgentCallRecord> captured = new AtomicReference<>();
+        AgentCallTimingMiddleware middleware =
+            new AgentCallTimingMiddleware(enabledProps(), new ToolKindRegistry(), captured::set);
+        ReActAgent agent = buildAgent(middleware);
+
+        RuntimeContext ctx = RuntimeContext.builder().userId("oa-assistant").sessionId("sess-oa-2").build();
+        ctx.put(AgentCallMeta.class, meta());
+
+        Flux<AgentEvent> flux = agent.streamEvents(List.of(userMsg()), ctx);
+        Long events = flux.count().block(BLOCK_TIMEOUT);
+        assertTrue(events != null && events > 0, "流式路径应至少产出一个事件");
+
+        AgentCallRecord record = captured.get();
+        assertNotNull(record, "应组装并下沉一条记录");
+        assertEquals("admin", record.username());
+        assertEquals("req-oa-8848", record.requestId());
+        assertEquals("OA考勤助手", record.agentName());
+        assertEquals("sess-oa-2", record.sessionId());
+        assertTrue(record.segments().stream().anyMatch(s -> s.kind() == AgentCallKind.MODEL), "含 MODEL 分段");
+        assertTrue(record.segments().stream().anyMatch(s -> s.kind() == AgentCallKind.TOOL), "含 TOOL 分段");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingRealAgentIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingRealAgentIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -173,6 +174,18 @@ class AgentCallTimingRealAgentIntegrationTest {
             .filter(s -> s.kind() == AgentCallKind.TOOL).findFirst().orElseThrow().name()),
             "TOOL 分段名取工具名");
         assertTrue(record.success(), "整次调用成功");
+        // ③ token：stub Model 每次调用返回 ChatUsage(1,1)，两次模型调用 → 请求级 input=2/output=2/total=4，
+        //    每个 MODEL 段各 input=1/output=1；工具段无 token
+        record.segments().stream().filter(s -> s.kind() == AgentCallKind.MODEL).forEach(s -> {
+            assertEquals(1L, s.inputTokens(), "MODEL 段输入 token 取自 stub usage");
+            assertEquals(1L, s.outputTokens(), "MODEL 段输出 token 取自 stub usage");
+        });
+        assertNull(record.segments().stream().filter(s -> s.kind() == AgentCallKind.TOOL)
+            .findFirst().orElseThrow().inputTokens(), "工具段无 token");
+        long modelSegCount = record.segments().stream().filter(s -> s.kind() == AgentCallKind.MODEL).count();
+        assertEquals(Long.valueOf(modelSegCount), record.inputTokens(), "请求级输入 token = 各 MODEL 段之和");
+        assertEquals(Long.valueOf(modelSegCount), record.outputTokens(), "请求级输出 token = 各 MODEL 段之和");
+        assertEquals(Long.valueOf(modelSegCount * 2), record.totalTokens(), "请求级总 token");
     }
 
     /**

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStoreTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -22,12 +23,13 @@ class InMemoryAgentCallLogStoreTest {
         store = new InMemoryAgentCallLogStore();
     }
 
+    /** 每条固定 input=10/output=5/total=15，供 token 汇总/趋势断言确定性。 */
     private AgentCallRecord record(String username, String agentCode, long startMs, long durationMs,
                                    long modelMs, long toolMs, List<AgentCallSegment> segments) {
         return new AgentCallRecord(0L, "req-" + startMs, "u-" + username, username, agentCode,
             "客服Agent", "sess-1", AgentCallSessionType.CHAT, "问题", "回答",
             startMs, startMs + durationMs, durationMs, modelMs, toolMs, 0L, 0L,
-            segments.size(), true, null, segments);
+            segments.size(), 10L, 5L, 15L, true, null, segments);
     }
 
     @Test
@@ -68,13 +70,15 @@ class InMemoryAgentCallLogStoreTest {
     @Test
     void findSegmentsAndDelete_shouldWork() {
         List<AgentCallSegment> segs = List.of(
-            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", 1000L, 30L, true, null),
-            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", 1030L, 20L, true, null));
+            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", 1000L, 30L, true, null, 100L, 20L),
+            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", 1030L, 20L, true, null, null, null));
         AgentCallRecord saved = store.save(record("alice", "A", 1000L, 50L, 30L, 20L, segs));
 
         List<AgentCallSegment> loaded = store.findSegments(saved.id());
         assertEquals(2, loaded.size());
         assertEquals(1, loaded.get(0).seq());
+        assertEquals(100L, loaded.get(0).inputTokens(), "MODEL 段输入 token");
+        assertNull(loaded.get(1).inputTokens(), "工具段无 token");
 
         assertTrue(store.delete(saved.id()));
         assertFalse(store.delete(saved.id()), "重复删除返回 false");
@@ -93,6 +97,9 @@ class InMemoryAgentCallLogStoreTest {
         assertEquals(200L, s.maxDurationMs());
         assertEquals(90d, s.avgModelMs(), 0.001);
         assertEquals(60d, s.avgToolMs(), 0.001);
+        // 每条 total=15，两条求和 30，均值 15
+        assertEquals(30L, s.totalTokens());
+        assertEquals(15d, s.avgTotalTokens(), 0.001);
     }
 
     @Test
@@ -115,6 +122,8 @@ class InMemoryAgentCallLogStoreTest {
         assertTrue(trend.size() >= 1, "应至少产出一个时间桶");
         long total = trend.stream().mapToLong(AgentCallTrendPoint::count).sum();
         assertEquals(3, total, "全部三条计入趋势");
+        // 每条 total=15，三条求和 45（跨桶合计）
+        assertEquals(45L, trend.stream().mapToLong(AgentCallTrendPoint::totalTokens).sum());
         // 桶标签升序
         for (int i = 1; i < trend.size(); i++) {
             assertTrue(trend.get(i - 1).bucket().compareTo(trend.get(i).bucket()) <= 0);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStoreTest.java
@@ -1,0 +1,123 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 内存调用日志存储单测：保存回填主键 + 条件分页 + 明细段 + 删除 + 汇总 + 趋势聚合。
+ * @author owlzhangfq@gmail.com
+ */
+class InMemoryAgentCallLogStoreTest {
+
+    private InMemoryAgentCallLogStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryAgentCallLogStore();
+    }
+
+    private AgentCallRecord record(String username, String agentCode, long startMs, long durationMs,
+                                   long modelMs, long toolMs, List<AgentCallSegment> segments) {
+        return new AgentCallRecord(0L, "req-" + startMs, "u-" + username, username, agentCode,
+            "客服Agent", "sess-1", AgentCallSessionType.CHAT, "问题", "回答",
+            startMs, startMs + durationMs, durationMs, modelMs, toolMs, 0L, 0L,
+            segments.size(), true, null, segments);
+    }
+
+    @Test
+    void save_shouldAssignAutoIncrementId() {
+        AgentCallRecord saved = store.save(record("alice", "A", 1000L, 50L, 30L, 20L, List.of()));
+        assertTrue(saved.id() > 0, "自增主键回填");
+    }
+
+    @Test
+    void findPage_shouldFilterAndOrderByIdDesc() {
+        store.save(record("alice", "A", 1000L, 10L, 5L, 5L, List.of()));
+        store.save(record("bob", "A", 2000L, 20L, 10L, 10L, List.of()));
+        store.save(record("alice", "B", 3000L, 30L, 15L, 15L, List.of()));
+
+        List<AgentCallRecord> byUser = store.findPage(new AgentCallLogQuery(
+            "alice", null, null, null, null, null, 0, 10));
+        assertEquals(2, byUser.size());
+        assertTrue(byUser.get(0).id() > byUser.get(1).id(), "id 倒序（最新在前）");
+
+        List<AgentCallRecord> byAgent = store.findPage(new AgentCallLogQuery(
+            null, "A", null, null, null, null, 0, 10));
+        assertEquals(2, byAgent.size());
+
+        assertEquals(3, store.count(AgentCallLogQuery.page(0, 100)));
+    }
+
+    @Test
+    void findPage_shouldFilterByTimeRange() {
+        store.save(record("alice", "A", 1000L, 10L, 5L, 5L, List.of()));
+        store.save(record("alice", "A", 5000L, 10L, 5L, 5L, List.of()));
+
+        List<AgentCallRecord> ranged = store.findPage(new AgentCallLogQuery(
+            null, null, null, null, 2000L, 9000L, 0, 10));
+        assertEquals(1, ranged.size());
+        assertEquals(5000L, ranged.get(0).startTimeMs());
+    }
+
+    @Test
+    void findSegmentsAndDelete_shouldWork() {
+        List<AgentCallSegment> segs = List.of(
+            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", 1000L, 30L, true, null),
+            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", 1030L, 20L, true, null));
+        AgentCallRecord saved = store.save(record("alice", "A", 1000L, 50L, 30L, 20L, segs));
+
+        List<AgentCallSegment> loaded = store.findSegments(saved.id());
+        assertEquals(2, loaded.size());
+        assertEquals(1, loaded.get(0).seq());
+
+        assertTrue(store.delete(saved.id()));
+        assertFalse(store.delete(saved.id()), "重复删除返回 false");
+        assertTrue(store.findSegments(saved.id()).isEmpty());
+    }
+
+    @Test
+    void summary_shouldAggregate() {
+        store.save(record("alice", "A", 1000L, 100L, 60L, 40L, List.of()));
+        store.save(record("alice", "A", 2000L, 200L, 120L, 80L, List.of()));
+
+        AgentCallLogSummary s = store.summary(new AgentCallLogQuery(
+            "alice", null, null, null, null, null, 0, 0));
+        assertEquals(2, s.totalCount());
+        assertEquals(150d, s.avgDurationMs(), 0.001);
+        assertEquals(200L, s.maxDurationMs());
+        assertEquals(90d, s.avgModelMs(), 0.001);
+        assertEquals(60d, s.avgToolMs(), 0.001);
+    }
+
+    @Test
+    void summary_empty_shouldReturnZero() {
+        AgentCallLogSummary s = store.summary(AgentCallLogQuery.page(0, 0));
+        assertEquals(0L, s.totalCount());
+        assertEquals(0d, s.avgDurationMs(), 0.001);
+    }
+
+    @Test
+    void trend_byDay_shouldBucketAndOrder() {
+        // 2021-01-01 与 2021-01-02（用固定毫秒时间戳，按系统时区分桶，只验证分桶数与计数）
+        long day1 = 1609459200000L; // 2021-01-01T00:00:00Z 附近
+        long day2 = day1 + 86_400_000L * 1;
+        store.save(record("alice", "A", day1, 100L, 0L, 0L, List.of()));
+        store.save(record("alice", "A", day1 + 3600_000L, 300L, 0L, 0L, List.of()));
+        store.save(record("alice", "A", day2, 200L, 0L, 0L, List.of()));
+
+        List<AgentCallTrendPoint> trend = store.trend(AgentCallLogQuery.page(0, 0), TrendGranularity.DAY);
+        assertTrue(trend.size() >= 1, "应至少产出一个时间桶");
+        long total = trend.stream().mapToLong(AgentCallTrendPoint::count).sum();
+        assertEquals(3, total, "全部三条计入趋势");
+        // 桶标签升序
+        for (int i = 1; i < trend.size(); i++) {
+            assertTrue(trend.get(i - 1).bucket().compareTo(trend.get(i).bucket()) <= 0);
+        }
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStoreTest.java
@@ -1,0 +1,125 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
+import com.richard.fyoung.customerwork.support.MybatisTestSupport;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.SqlSessionTemplate;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * MyBatis-Plus 调用日志存储测试（对接本机 MySQL；不可达自动跳过）：
+ * 保存往返（主表 + 明细段）+ 条件分页 + 汇总 + 趋势 + 删除级联。
+ * @author owlzhangfq@gmail.com
+ */
+class MybatisAgentCallLogStoreTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 3306;
+
+    private MybatisAgentCallLogStore store;
+    private HikariDataSource dataSource;
+
+    @BeforeEach
+    void setUp() {
+        assumeTrue(reachable(HOST, PORT), "MySQL 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+
+        dataSource = MybatisTestSupport.mysqlDataSource("test-calllog-pool");
+        MybatisTestSupport.ensureSchema(dataSource);
+        SqlSessionTemplate template = MybatisTestSupport.template(dataSource);
+        store = new MybatisAgentCallLogStore(
+            template.getMapper(AgentCallLogMapper.class),
+            template.getMapper(AgentCallSegmentMapper.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    private static boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private AgentCallRecord newRecord(String username, String agentCode, long startMs) {
+        List<AgentCallSegment> segs = List.of(
+            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", startMs, 30L, true, null),
+            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", startMs + 30, 20L, true, null),
+            new AgentCallSegment(3, AgentCallKind.MCP, "mcp_weather", startMs + 50, 10L, false, "boom"));
+        return new AgentCallRecord(0L, "req-" + UUID.randomUUID(), "u-" + username, username, agentCode,
+            "客服Agent", "sess-" + UUID.randomUUID(), AgentCallSessionType.CHAT, "问题", "回答",
+            startMs, startMs + 60, 60L, 30L, 20L, 10L, 0L, segs.size(), true, null, segs);
+    }
+
+    @Test
+    void save_shouldRoundTripMainAndSegments() {
+        AgentCallRecord saved = store.save(newRecord("alice-" + UUID.randomUUID(), "A", 1_600_000_000_000L));
+        assertTrue(saved.id() > 0, "主键回填");
+
+        List<AgentCallSegment> segs = store.findSegments(saved.id());
+        assertEquals(3, segs.size());
+        assertEquals(AgentCallKind.MODEL, segs.get(0).kind());
+        assertEquals("qwen-max", segs.get(0).name());
+        assertFalse(segs.get(2).success(), "MCP 段失败状态往返");
+        assertEquals("boom", segs.get(2).errorMsg());
+    }
+
+    @Test
+    void findPageAndSummary_shouldFilterByUsername() {
+        String user = "user-" + UUID.randomUUID();
+        store.save(newRecord(user, "A", 1_600_000_000_000L));
+        store.save(newRecord(user, "A", 1_600_000_100_000L));
+
+        AgentCallLogQuery q = new AgentCallLogQuery(user, null, null, null, null, null, 0, 10);
+        List<AgentCallRecord> page = store.findPage(q);
+        assertEquals(2, page.size());
+        assertTrue(page.get(0).id() > page.get(1).id(), "id 倒序");
+        assertEquals(2, store.count(q));
+
+        AgentCallLogSummary summary = store.summary(q);
+        assertEquals(2, summary.totalCount());
+        assertEquals(60d, summary.avgDurationMs(), 0.001);
+        assertEquals(60L, summary.maxDurationMs());
+        assertEquals(30d, summary.avgModelMs(), 0.001);
+    }
+
+    @Test
+    void trend_shouldAggregateByGranularity() {
+        String user = "user-" + UUID.randomUUID();
+        store.save(newRecord(user, "A", 1_600_000_000_000L));
+        store.save(newRecord(user, "A", 1_600_000_050_000L));
+
+        AgentCallLogQuery q = new AgentCallLogQuery(user, null, null, null, null, null, 0, 10);
+        List<AgentCallTrendPoint> trend = store.trend(q, TrendGranularity.HOUR);
+        assertFalse(trend.isEmpty());
+        long total = trend.stream().mapToLong(AgentCallTrendPoint::count).sum();
+        assertEquals(2, total);
+    }
+
+    @Test
+    void delete_shouldCascadeSegments() {
+        AgentCallRecord saved = store.save(newRecord("del-" + UUID.randomUUID(), "A", 1_600_000_000_000L));
+        assertTrue(store.delete(saved.id()));
+        assertTrue(store.findSegments(saved.id()).isEmpty(), "级联删除明细段");
+        assertFalse(store.delete(saved.id()), "重复删除返回 false");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStoreTest.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -62,12 +63,12 @@ class MybatisAgentCallLogStoreTest {
 
     private AgentCallRecord newRecord(String username, String agentCode, long startMs) {
         List<AgentCallSegment> segs = List.of(
-            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", startMs, 30L, true, null),
-            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", startMs + 30, 20L, true, null),
-            new AgentCallSegment(3, AgentCallKind.MCP, "mcp_weather", startMs + 50, 10L, false, "boom"));
+            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", startMs, 30L, true, null, 100L, 20L),
+            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", startMs + 30, 20L, true, null, null, null),
+            new AgentCallSegment(3, AgentCallKind.MCP, "mcp_weather", startMs + 50, 10L, false, "boom", null, null));
         return new AgentCallRecord(0L, "req-" + UUID.randomUUID(), "u-" + username, username, agentCode,
             "客服Agent", "sess-" + UUID.randomUUID(), AgentCallSessionType.CHAT, "问题", "回答",
-            startMs, startMs + 60, 60L, 30L, 20L, 10L, 0L, segs.size(), true, null, segs);
+            startMs, startMs + 60, 60L, 30L, 20L, 10L, 0L, segs.size(), 100L, 20L, 120L, true, null, segs);
     }
 
     @Test
@@ -81,6 +82,10 @@ class MybatisAgentCallLogStoreTest {
         assertEquals("qwen-max", segs.get(0).name());
         assertFalse(segs.get(2).success(), "MCP 段失败状态往返");
         assertEquals("boom", segs.get(2).errorMsg());
+        // token 往返：MODEL 段有值，工具段为 null
+        assertEquals(100L, segs.get(0).inputTokens(), "MODEL 段输入 token 往返");
+        assertEquals(20L, segs.get(0).outputTokens(), "MODEL 段输出 token 往返");
+        assertNull(segs.get(1).inputTokens(), "工具段无 token");
     }
 
     @Test
@@ -100,6 +105,9 @@ class MybatisAgentCallLogStoreTest {
         assertEquals(60d, summary.avgDurationMs(), 0.001);
         assertEquals(60L, summary.maxDurationMs());
         assertEquals(30d, summary.avgModelMs(), 0.001);
+        // 每条 total_tokens=120，两条求和 240，均值 120
+        assertEquals(240L, summary.totalTokens());
+        assertEquals(120d, summary.avgTotalTokens(), 0.001);
     }
 
     @Test

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/ToolKindRegistryTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/ToolKindRegistryTest.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 工具归类登记表单测：默认 TOOL、MCP/SKILL 登记后归类、幂等覆盖、空值兜底。
+ * @author owlzhangfq@gmail.com
+ */
+class ToolKindRegistryTest {
+
+    @Test
+    void classify_unregistered_shouldDefaultToTool() {
+        ToolKindRegistry registry = new ToolKindRegistry();
+        assertEquals(AgentCallKind.TOOL, registry.classify("queryOrder"));
+        assertEquals(AgentCallKind.TOOL, registry.classify(null), "null 工具名兜底 TOOL");
+    }
+
+    @Test
+    void classify_registered_shouldReturnRegisteredKind() {
+        ToolKindRegistry registry = new ToolKindRegistry();
+        registry.registerMcpTools(List.of("mcp_weather", "mcp_stock"));
+        registry.registerSkillTools(List.of("skill_pdf"));
+
+        assertEquals(AgentCallKind.MCP, registry.classify("mcp_weather"));
+        assertEquals(AgentCallKind.MCP, registry.classify("mcp_stock"));
+        assertEquals(AgentCallKind.SKILL, registry.classify("skill_pdf"));
+        assertEquals(AgentCallKind.TOOL, registry.classify("queryOrder"), "未登记仍为 TOOL");
+        assertEquals(3, registry.size());
+    }
+
+    @Test
+    void register_shouldIgnoreBlankAndBeIdempotent() {
+        ToolKindRegistry registry = new ToolKindRegistry();
+        registry.registerMcpTools(java.util.Arrays.asList("mcp_a", null, " ", "mcp_a"));
+        assertEquals(1, registry.size(), "空白/重复不新增条目");
+        assertEquals(AgentCallKind.MCP, registry.classify("mcp_a"));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
@@ -8,6 +8,8 @@ import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.approval.mapper.ApprovalMapper;
 import com.richard.fyoung.customerwork.attachment.mapper.ChatAttachmentMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
+import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
 import com.richard.fyoung.customerwork.chatlog.mapper.ChatMessageMapper;
 import com.richard.fyoung.customerwork.dialog.mapper.DialogStageMapper;
 import com.richard.fyoung.customerwork.feedback.mapper.FeedbackMapper;
@@ -59,7 +61,8 @@ public final class MybatisTestSupport {
         ChatMessageMapper.class, AuditLogMapper.class, OrderMapper.class, ProductMapper.class,
         RefundMapper.class, InvoiceRequestMapper.class, MemberMapper.class, MemberAccountLogMapper.class,
         ComplaintMapper.class, KnowledgeMapper.class, ChatAttachmentMapper.class,
-        SensitiveWordMapper.class, SeatAgentMapper.class
+        SensitiveWordMapper.class, SeatAgentMapper.class,
+        AgentCallLogMapper.class, AgentCallSegmentMapper.class
     };
 
     private MybatisTestSupport() {

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurerTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurerTest.java
@@ -22,7 +22,7 @@ class McpToolkitConfigurerTest {
 
     @Test
     void isEnabled_shouldBeFalse_byDefault() {
-        McpToolkitConfigurer configurer = new McpToolkitConfigurer(new CustomerWorkProperties());
+        McpToolkitConfigurer configurer = new McpToolkitConfigurer(new CustomerWorkProperties(), new com.richard.fyoung.customerwork.calllog.ToolKindRegistry());
         assertFalse(configurer.isEnabled(), "默认不启用 MCP");
     }
 
@@ -30,7 +30,7 @@ class McpToolkitConfigurerTest {
     void isEnabled_shouldBeFalse_whenEnabledButNoServers() {
         CustomerWorkProperties props = new CustomerWorkProperties();
         props.getMcp().setEnabled(true);
-        assertFalse(new McpToolkitConfigurer(props).isEnabled(), "未配置服务时视为未启用");
+        assertFalse(new McpToolkitConfigurer(props, new com.richard.fyoung.customerwork.calllog.ToolKindRegistry()).isEnabled(), "未配置服务时视为未启用");
     }
 
     @Test
@@ -42,7 +42,7 @@ class McpToolkitConfigurerTest {
         server.setUrl("http://localhost:9000/sse");
         props.getMcp().getServers().add(server);
 
-        assertTrue(new McpToolkitConfigurer(props).isEnabled());
+        assertTrue(new McpToolkitConfigurer(props, new com.richard.fyoung.customerwork.calllog.ToolKindRegistry()).isEnabled());
     }
 
     @Test
@@ -50,7 +50,7 @@ class McpToolkitConfigurerTest {
         Toolkit toolkit = new Toolkit();
         int before = toolkit.getToolNames().size();
 
-        new McpToolkitConfigurer(new CustomerWorkProperties()).configure(toolkit);
+        new McpToolkitConfigurer(new CustomerWorkProperties(), new com.richard.fyoung.customerwork.calllog.ToolKindRegistry()).configure(toolkit);
 
         assertEquals(before, toolkit.getToolNames().size(), "未启用时不应改动 toolkit");
     }
@@ -80,7 +80,7 @@ class McpToolkitConfigurerTest {
             server.setHeaders(Map.of("Authorization", "Bearer starter-token"));
             props.getMcp().getServers().add(server);
 
-            new McpToolkitConfigurer(props).configure(new Toolkit());
+            new McpToolkitConfigurer(props, new com.richard.fyoung.customerwork.calllog.ToolKindRegistry()).configure(new Toolkit());
 
             assertEquals("Bearer starter-token", receivedAuth.get(), "配置的 Authorization 头应随请求发出");
         } finally {

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -245,6 +245,9 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
     `mcp_ms`         BIGINT NOT NULL DEFAULT 0 COMMENT 'MCP段耗时合计（毫秒）',
     `skill_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'SKILL段耗时合计（毫秒）',
     `segment_count`  INT NOT NULL DEFAULT 0 COMMENT '分段总数',
+    `input_tokens`   BIGINT DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）',
+    `output_tokens`  BIGINT DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）',
+    `total_tokens`   BIGINT DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
@@ -264,6 +267,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `name`           VARCHAR(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
     `start_time`     BIGINT NOT NULL COMMENT '分段开始时间戳（毫秒）',
     `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
+    `input_tokens`   BIGINT DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）',
+    `output_tokens`  BIGINT DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     INDEX `idx_segment_call_log` (`call_log_id`, `seq`)

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -225,6 +225,50 @@ CREATE TABLE IF NOT EXISTS `cw_chat_message` (
     INDEX `idx_chat_ticket` (`ticket_id`, `id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
+-- 智能体调用主记录表（cw_agent_call_log）：每次调用一行，含分段耗时冗余汇总（MybatisAgentCallLogStore）。
+CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `request_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
+    `user_id`        VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
+    `username`       VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户名',
+    `agent_code`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '智能体编码',
+    `agent_name`     VARCHAR(255) NOT NULL DEFAULT '' COMMENT '智能体名称',
+    `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+    `session_type`   VARCHAR(32) NOT NULL DEFAULT 'CHAT' COMMENT '会话类型 CHAT/VIBE_CODING',
+    `question`       MEDIUMTEXT COMMENT '用户问题',
+    `answer`         MEDIUMTEXT COMMENT '智能体回答',
+    `start_time`     BIGINT NOT NULL COMMENT '调用开始时间戳（毫秒）',
+    `end_time`       BIGINT NOT NULL COMMENT '调用结束时间戳（毫秒）',
+    `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '总耗时（毫秒）',
+    `model_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'MODEL段耗时合计（毫秒）',
+    `tool_ms`        BIGINT NOT NULL DEFAULT 0 COMMENT 'TOOL段耗时合计（毫秒）',
+    `mcp_ms`         BIGINT NOT NULL DEFAULT 0 COMMENT 'MCP段耗时合计（毫秒）',
+    `skill_ms`       BIGINT NOT NULL DEFAULT 0 COMMENT 'SKILL段耗时合计（毫秒）',
+    `segment_count`  INT NOT NULL DEFAULT 0 COMMENT '分段总数',
+    `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
+    `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
+    INDEX `idx_call_request` (`request_id`),
+    INDEX `idx_call_username` (`username`),
+    INDEX `idx_call_agent_code` (`agent_code`),
+    INDEX `idx_call_session` (`session_id`),
+    INDEX `idx_call_start` (`start_time`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- 智能体调用分段明细表（cw_agent_call_segment）：一次调用的每段耗时一行（MybatisAgentCallLogStore）。
+CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `call_log_id`    BIGINT NOT NULL COMMENT '所属主记录ID',
+    `seq`            INT NOT NULL COMMENT '调用内分段序号（从1起）',
+    `kind`           VARCHAR(16) NOT NULL COMMENT '分段类别 MODEL/TOOL/MCP/SKILL',
+    `name`           VARCHAR(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
+    `start_time`     BIGINT NOT NULL COMMENT '分段开始时间戳（毫秒）',
+    `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
+    `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
+    `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
 -- 对话附件表（cw_chat_attachment）：上传附件落盘 + 落库，解析文本可追溯（MybatisAttachmentStore）。
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
     `id`             VARCHAR(64) NOT NULL COMMENT '附件ID(UUID)',


### PR DESCRIPTION
## 需求

统计报表：按用户/时间/智能体/会话类型检索每次智能体调用的耗时，点击条目查看 **大模型/工具/MCP/skill** 分段耗时明细；支持汇总卡片、时间趋势图、跳转对应对话/VibeCoding 会话、删除。

## 实现

### customer-work-starter（通用组件下沉，业务零侵入）
- `AgentCallTimingMiddleware`（AgentScope 2.0 MiddlewareBase）：`onAgent`/`onModelCall`/`onActing` 按请求采集分段耗时；答案从流末 `AGENT_RESULT` 事件直取全文；嵌套子 agent（共享 RuntimeContext）分段自动归入父请求；异常安全全链路唯一收敛处，绝不打断主链路
- `ToolKindRegistry`：MCP client / SkillBox 注册前后 `getToolNames()` diff 登记，onActing 按工具名归类 MCP/SKILL（其余 TOOL）
- `AgentCallRecordSink` SPI：默认异步单线程有界队列（2048）落库，队列满 fast-fail 丢弃不反压
- 第 9 个 Store SPI：`AgentCallLogStore`（InMemory 默认 + MyBatis-Plus），`cw_agent_call_log` 主表 + `cw_agent_call_segment` 明细表，分页/汇总/趋势 SQL 全进 XML
- 配置：`customer-work.call-log.enabled`（默认开）/ `store-mode`（生产建议 jdbc）
- 8080 客服端 `chat`/`chatStream` 已绑定 `AgentCallMeta` 接入采集

### customer-admin-server
- chat + vibecoding 双链路埋点（sessionType 区分），username=Sa-Token 登录账号，question=用户原始输入
- 持久层零重写：admin 库建同名 cw_ 表（V38，刻意保留 cw_ 前缀换取 starter Mapper XML 零改动复用），专用 SqlSessionFactory 不污染主 MyBatis 环境
- `/api/agent-call-stats`：page / {id} / summary / trend / delete，`@SaCheckPermission` agent-call-stats:view / :delete（sys_permission 种子 194/195）
- 双数据源：source=ADMIN 走主库；source=APP 惰性只读连 8080 库 `agent_scope_customer_work`（不可达不影响启动，查询时明确报错）

### customer-admin-web
- `/system/agent-call-stats`：筛选栏（来源/用户/智能体/会话类型/时间范围/请求ID/会话ID）+ 汇总卡片 + echarts 趋势图（day|hour 分桶、按需引入、明暗主题联动）+ 明细列表 + 分段耗时详情抽屉
- 「打开会话」跳转 `/workspace/:agentCode?sessionId=&mode=` 直达对应对话/VibeCoding 会话（补齐 VibeCodingPanel 的 initialSessionId 加载链路，镜像 ChatPanel 既有实现）

## 测试

- starter 721（新增 22，含嵌套调用回归 + MySQL 门控往返）
- admin-server 642（新增 25，含双数据源路由 + APP 源不可达容错）
- app-server / customer-channel / gateway 全绿；前端 `npm run build` 通过
- 独立 code review：1 个重要问题（admin 配置绑定失效）+ 2 个小问题已修复回归；Reactor 结算/SQL 注入面/鉴权/契约对齐核验通过

## 已知限制与决策

- 埋点仅对合入后新请求生效，历史对话无分段数据
- `DELETE ?source=APP` 会删 8080 库日志——经确认保留（管理后台作为日志清理入口，独立删除权限点把关）
- 8080 生产部署需设 `customer-work.call-log.store-mode=jdbc`（默认 memory 与 ChatLog 同款约定）
- 本机 customer_admin 库 V38 已手工同步（含 SET NAMES utf8mb4，HEX 校验无乱码）

🤖 Generated with [Claude Code](https://claude.com/claude-code)