### PR TITLE
feat(attachment): 对话/VibeCoding 附件预览（图片大图/文本内联/下载 + 消息级关联）

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatController.java
@@ -15,7 +15,9 @@ import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.PlanConfirmRequ
 import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
 import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Flux;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -62,7 +66,7 @@ public class ChatController {
     public Flux<ServerSentEvent<String>> stream(@PathVariable String agentCode, @Valid @RequestBody ChatRequest request) {
         // 采集元数据必须在请求线程同步段构建（用户名取自 Sa-Token 的 ThreadLocal）；渠道=admin_chat → CHAT
         AgentCallMeta callMeta = agentCallMetaFactory.build(agentCode, AgentCallSessionType.CHAT, request.message());
-        return chatService.chatStream(agentCode, request.sessionId(), request.message(), request.mode(), callMeta)
+        return chatService.chatStreamWithAttachments(agentCode, request.sessionId(), request.message(), request.mode(), callMeta, request.attachmentIds())
             // data 编码见 ChatStreamChunk#sseData：父 Agent 纯文本，子 Agent 片段 JSON 包装携带来源标识
             .map(chunk -> ServerSentEvent.<String>builder().event(chunk.kind().sseEventName()).data(chunk.sseData()).build())
             .concatWithValues(ServerSentEvent.<String>builder().event("done").data("[DONE]").build());
@@ -116,5 +120,36 @@ public class ChatController {
                                                      @RequestParam(value = "channel", defaultValue = "admin_chat") String channel,
                                                      @RequestParam(value = "sessionId", required = false) String sessionId) {
         return Result.success(chatAttachmentService.parseAttachment(file, channel, sessionId, agentCode));
+    }
+
+    /**
+     * 附件详情：返回 {@link ChatAttachmentDTO}（{@code content}=解析文本，供文本类附件内联预览）。
+     * 校验附件存在 + agent_code 归属，跨 agent 访问统一 fast-fail 成资源不存在。
+     */
+    @SaCheckPermission("workspace")
+    @GetMapping("/attachment/{attachmentId}")
+    public Result<ChatAttachmentDTO> attachmentDetail(@PathVariable String agentCode,
+                                                      @PathVariable String attachmentId) {
+        return Result.success(chatAttachmentService.getDetail(agentCode, attachmentId));
+    }
+
+    /**
+     * 附件原文件下载：返回原始字节。Content-Type 取库中 mimeType（空则 application/octet-stream）；
+     * 统一 {@code Content-Disposition: attachment}（一律作附件下载，不内联），文件名按 RFC 5987
+     * {@code filename*=UTF-8''<url编码>} 支持中文名；加 {@code X-Content-Type-Options: nosniff} 防
+     * html/svg 类附件被浏览器嗅探成可执行内容 inline 执行。校验附件存在 + agent_code 归属。
+     */
+    @SaCheckPermission("workspace")
+    @GetMapping("/attachment/{attachmentId}/file")
+    public ResponseEntity<byte[]> attachmentFile(@PathVariable String agentCode,
+                                                  @PathVariable String attachmentId) {
+        ChatAttachmentService.LoadedFile file = chatAttachmentService.loadFile(agentCode, attachmentId);
+        String encodedName = URLEncoder.encode(file.fileName() == null ? "" : file.fileName(), StandardCharsets.UTF_8)
+            .replace("+", "%20");
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_TYPE, file.mimeType())
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedName)
+            .header("X-Content-Type-Options", "nosniff")
+            .body(file.bytes());
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatAttachmentDTO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatAttachmentDTO.java
@@ -4,11 +4,12 @@ import com.richard.fyoung.customerwork.attachment.AttachmentParseStatus;
 import com.richard.fyoung.customerwork.attachment.ChatAttachment;
 
 /**
- * 附件上传解析结果（前端契约）：{@code {id, fileName, content, parseStatus, errorMessage}}。
+ * 附件上传解析结果（前端契约）：{@code {id, fileName, content, parseStatus, errorMessage, mimeType, fileSize}}。
  *
  * <p>与 admin-web {@code ChatAttachmentResult} 严丝合缝：{@code content} 为解析文本（FAILED 时为空串），
  * {@code parseStatus} 为枚举名字符串（{@code SUCCESS}/{@code FAILED}），{@code errorMessage} 解析失败原因
- * （SUCCESS 时为 {@code null}）。前端据 {@code parseStatus} 决定失败附件标红提示、成功附件拼进消息正文。</p>
+ * （SUCCESS 时为 {@code null}）。前端据 {@code parseStatus} 决定失败附件标红提示、成功附件拼进消息正文。
+ * {@code mimeType}/{@code fileSize} 供前端按类型选预览方式（文本内联 / 图片 / 走下载接口）并展示大小。</p>
  * @author owlzhangfq@gmail.com
  */
 public record ChatAttachmentDTO(
@@ -16,7 +17,9 @@ public record ChatAttachmentDTO(
     String fileName,
     String content,
     String parseStatus,
-    String errorMessage) {
+    String errorMessage,
+    String mimeType,
+    long fileSize) {
 
     /** 领域对象 → 前端 DTO：{@code parsedText} 映射为 {@code content}（空值归一化为空串），枚举取 name()。 */
     public static ChatAttachmentDTO from(ChatAttachment attachment) {
@@ -26,6 +29,8 @@ public record ChatAttachmentDTO(
             attachment.getFileName(),
             attachment.getParsedText() == null ? "" : attachment.getParsedText(),
             status == null ? null : status.name(),
-            attachment.getErrorMessage());
+            attachment.getErrorMessage(),
+            attachment.getMimeType(),
+            attachment.getFileSize());
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatMessageAttachmentVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatMessageAttachmentVO.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customeradmin.workspace.chat.dto;
+
+/**
+ * 历史消息挂载的附件摘要（前端契约）：重新打开历史会话时，随对应用户消息一并返回其绑定的附件。
+ *
+ * <p>只带展示 + 二次拉取所需的轻量字段——{@code id} 供前端点开时调详情接口取解析文本 / 调 file 接口下载原文件，
+ * {@code mimeType}/{@code fileSize} 供选预览方式与展示大小，{@code parseStatus}（{@code SUCCESS}/{@code FAILED}）
+ * 供标红提示解析失败的附件。解析文本 {@code parsedText} 不在历史列表内联（可能上万字），按需走详情接口拉取。</p>
+ *
+ * @param id          附件 ID
+ * @param fileName    原始文件名
+ * @param mimeType    MIME 类型
+ * @param fileSize    文件字节数
+ * @param parseStatus 解析状态：SUCCESS / FAILED（枚举名字符串）
+ * @author owlzhangfq@gmail.com
+ */
+public record ChatMessageAttachmentVO(
+    String id,
+    String fileName,
+    String mimeType,
+    long fileSize,
+    String parseStatus) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatMessageVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatMessageVO.java
@@ -1,12 +1,17 @@
 package com.richard.fyoung.customeradmin.workspace.chat.dto;
 
+import java.util.List;
+
 /**
  * 历史会话消息（重新打开一段历史对话时用）。
  *
- * @param role      user / assistant
- * @param text      文本内容
- * @param timestamp 框架侧时间戳字符串
+ * @param id          框架消息 ID（{@code Msg.getId()}）：附件按此 id 分组挂回对应用户消息
+ * @param role        user / assistant
+ * @param text        文本内容
+ * @param timestamp   框架侧时间戳字符串
+ * @param attachments 该消息绑定的附件（无附件时为空列表，不为 null）
  * @author owlzhangfq@gmail.com
  */
-public record ChatMessageVO(String role, String text, String timestamp) {
+public record ChatMessageVO(String id, String role, String text, String timestamp,
+                            List<ChatMessageAttachmentVO> attachments) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatRequest.java
@@ -2,6 +2,8 @@ package com.richard.fyoung.customeradmin.workspace.chat.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.List;
+
 /**
  * 工作区对话请求。{@code sessionId} 由前端生成并透传，标识同一次多轮对话
  * （与 agentCode 一起构成 RuntimeContext 的 (userId, sessionId)，见 AdminAgentInstanceFactory#contextFor）。
@@ -13,10 +15,15 @@ import jakarta.validation.constraints.NotBlank;
  * <p>{@code mode}（执行模式五档选择器）：随每条消息下发、会话内生效，取值
  * {@code auto/manual/accept_edits/plan/bypass}（见 {@code ExecutionMode}）。对话与 VibeCoding 通用。
  * 可空——旧前端/存量测试不带该字段时回落到全局 {@code admin.sandbox.permission-mode} 语义。</p>
+ *
+ * <p>{@code attachmentIds}（对话附件预览）：本条消息携带的附件 ID 列表（先经 {@code /chat/attachment} 上传
+ * 落库拿到 ID，随消息一起下发）。随消息发送时由服务端把这些附件绑定到本条用户消息（框架 Msg.id），
+ * 供历史接口回显。可空——Jackson 缺字段解析为 null，向后兼容旧前端/存量测试。chat 与 vibecoding 的
+ * {@code /stream} 共用本 DTO。</p>
  * @author owlzhangfq@gmail.com
  */
 public record ChatRequest(String sessionId, @NotBlank(message = "message 不能为空") String message,
-                          Boolean collaboration, String mode) {
+                          Boolean collaboration, String mode, List<String> attachmentIds) {
 
     /** 是否启用协作模式（null 视为关闭）。 */
     public boolean collaborationEnabled() {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/entity/AiChatAttachment.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/entity/AiChatAttachment.java
@@ -26,6 +26,8 @@ public class AiChatAttachment {
 
     /** 会话 ID。 */
     private String sessionId;
+    /** 绑定的用户消息 ID（框架 {@code Msg.id}，空=未绑定；随消息发送时由 admin 私有链路回填）。 */
+    private String messageId;
     /** 智能体编码（一次上传归属的智能体，starter 领域对象不承载，admin 侧补写）。 */
     private String agentCode;
     /** 上传者标识（当前登录管理员 ID）。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentService.java
@@ -5,14 +5,18 @@ import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatAttachmentDTO;
 import com.richard.fyoung.customeradmin.workspace.chat.store.AdminChatAttachmentStore;
+import com.richard.fyoung.customerwork.attachment.AttachmentFileStorage;
 import com.richard.fyoung.customerwork.attachment.AttachmentParseService;
 import com.richard.fyoung.customerwork.attachment.ChatAttachment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * 对话附件解析：委托 starter 的 {@link AttachmentParseService} 完成多格式解析（图片视觉大模型 OCR、
@@ -32,13 +36,19 @@ public class ChatAttachmentService {
 
     private static final Logger log = LoggerFactory.getLogger(ChatAttachmentService.class);
 
+    /** MIME 兜底：库中 mime 为空时按二进制流下发，交由前端/浏览器不做类型嗅探（配合 nosniff）。 */
+    private static final String DEFAULT_MIME = "application/octet-stream";
+
     private final AttachmentParseService attachmentParseService;
     private final AdminChatAttachmentStore attachmentStore;
+    private final AttachmentFileStorage attachmentFileStorage;
 
     public ChatAttachmentService(AttachmentParseService attachmentParseService,
-                                 AdminChatAttachmentStore attachmentStore) {
+                                 AdminChatAttachmentStore attachmentStore,
+                                 AttachmentFileStorage attachmentFileStorage) {
         this.attachmentParseService = attachmentParseService;
         this.attachmentStore = attachmentStore;
+        this.attachmentFileStorage = attachmentFileStorage;
     }
 
     /**
@@ -72,6 +82,68 @@ public class ChatAttachmentService {
         } finally {
             attachmentStore.clearAgentCode();
         }
+    }
+
+    /**
+     * 把一批附件绑定到某条用户消息（随消息发送时回填 session_id + message_id）。
+     *
+     * <p>旁路动作，绝不打断对话主流程：空列表短路；数量不符只 info（部分 id 不存在 / 不属该 agent 属正常，
+     * 前端可能带上历史/他人附件）；持久化异常 {@code catch(Exception)} 只 error 记录（带错误码）。</p>
+     *
+     * @param agentCode     智能体编码（agent 归属兜底，只绑该智能体名下的附件）
+     * @param sessionId     会话 ID（归一后的值，与历史查询口径一致）
+     * @param messageId     绑定的用户消息 ID（框架 Msg.id）
+     * @param attachmentIds 本条消息携带的附件 ID 列表
+     */
+    public void bindToMessage(String agentCode, String sessionId, String messageId, List<String> attachmentIds) {
+        if (CollectionUtils.isEmpty(attachmentIds)) {
+            return;
+        }
+        try {
+            int updated = attachmentStore.bindToMessage(agentCode, sessionId, messageId, attachmentIds);
+            if (updated != attachmentIds.size()) {
+                log.info("chat attachment bind count mismatch, agentCode={}, messageId={}, expected={}, updated={}",
+                    agentCode, messageId, attachmentIds.size(), updated);
+            }
+        } catch (Exception e) {
+            log.error("chat attachment bind failed, code={}, agentCode={}, messageId={}",
+                "ADMIN-ATTACHMENT-BIND-FAIL", agentCode, messageId, e);
+        }
+    }
+
+    /**
+     * 附件详情：校验存在性 + agent 归属后返回前端契约 DTO（{@code content}=解析文本，供文本类附件内联预览）。
+     * 附件不存在或跨 agent 访问统一 fast-fail 成 {@link ResultCode#RESOURCE_NOT_FOUND}（不泄露"是否存在"）。
+     */
+    public ChatAttachmentDTO getDetail(String agentCode, String attachmentId) {
+        return ChatAttachmentDTO.from(requireOwned(agentCode, attachmentId));
+    }
+
+    /**
+     * 读原文件字节：校验存在性 + agent 归属 → 经 {@link AttachmentFileStorage#read} 读回字节，
+     * 返回含 bytes/mimeType/fileName 的小结果对象供 Controller 组装下载响应。mime 为空按二进制流兜底。
+     * 读盘/读对象失败翻译成友好业务异常（不把 IO 细节暴露给前端）。
+     */
+    public LoadedFile loadFile(String agentCode, String attachmentId) {
+        ChatAttachment attachment = requireOwned(agentCode, attachmentId);
+        try {
+            byte[] bytes = attachmentFileStorage.read(attachment.getStoragePath());
+            String mime = StringUtils.hasText(attachment.getMimeType()) ? attachment.getMimeType() : DEFAULT_MIME;
+            return new LoadedFile(bytes, mime, attachment.getFileName());
+        } catch (IOException e) {
+            log.error("chat attachment read file failed, code={}, id={}", "ADMIN-ATTACHMENT-READ-FILE-FAIL", attachmentId, e);
+            throw new BizException(ResultCode.SYSTEM_ERROR, "附件文件读取失败，请稍后重试");
+        }
+    }
+
+    /** 存在性 + agent 归属校验合一：查不到（不存在 / 跨 agent）即 fast-fail 成 NOT_FOUND。 */
+    private ChatAttachment requireOwned(String agentCode, String attachmentId) {
+        return attachmentStore.findByIdAndAgentCode(attachmentId, agentCode)
+            .orElseThrow(() -> new BizException(ResultCode.RESOURCE_NOT_FOUND, "附件不存在"));
+    }
+
+    /** 原文件读取结果：字节 + MIME + 原始文件名（Controller 据此组装 {@code ResponseEntity<byte[]>}）。 */
+    public record LoadedFile(byte[] bytes, String mimeType, String fileName) {
     }
 
     /** 取当前登录管理员 ID 作上传者标识；无 Sa-Token 上下文（如单测）时留空，不阻断上传。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryService.java
@@ -1,11 +1,14 @@
 package com.richard.fyoung.customeradmin.workspace.chat.service;
 
 import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageAttachmentVO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentStateAccessor;
+import com.richard.fyoung.customerwork.attachment.AttachmentStore;
+import com.richard.fyoung.customerwork.attachment.ChatAttachment;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -17,7 +20,9 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * 历史会话查询：会话列表（SQL 级分页）+ 重新打开某次历史会话的完整消息。
@@ -47,15 +52,19 @@ public class ChatHistoryService {
     private final AgentStateAccessor agentStateAccessor;
     private final ChatHistoryCache historyCache;
     private final ChatSessionStateQueryMapper sessionStateQueryMapper;
+    /** 容器里注入的是 admin 自有的 {@code AdminChatAttachmentStore}（落 ai_chat_attachment），见 AdminAttachmentConfig。 */
+    private final AttachmentStore attachmentStore;
 
     public ChatHistoryService(AgentInstanceCache agentInstanceCache, AgentStateStore agentStateStore,
                                AgentStateAccessor agentStateAccessor, ChatHistoryCache historyCache,
-                               ChatSessionStateQueryMapper sessionStateQueryMapper) {
+                               ChatSessionStateQueryMapper sessionStateQueryMapper,
+                               AttachmentStore attachmentStore) {
         this.agentInstanceCache = agentInstanceCache;
         this.agentStateStore = agentStateStore;
         this.agentStateAccessor = agentStateAccessor;
         this.historyCache = historyCache;
         this.sessionStateQueryMapper = sessionStateQueryMapper;
+        this.attachmentStore = attachmentStore;
     }
 
     /**
@@ -110,6 +119,13 @@ public class ChatHistoryService {
 
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
         AgentState state = agentStateAccessor.resolve(agent, agentCode, sessionId);
+        // 该会话的附件按绑定的 message_id 分组（未绑定的跳过）：查询失败 listBySession 已内置兜底返回空列表，
+        // 不影响历史返回。附件通常按用户消息挂载，一条消息可带多个附件。
+        Map<String, List<ChatMessageAttachmentVO>> attachmentsByMessage = attachmentStore.listBySession(sessionId).stream()
+            .filter(a -> StringUtils.hasText(a.getMessageId()))
+            .collect(Collectors.groupingBy(ChatAttachment::getMessageId,
+                Collectors.mapping(this::toAttachmentVO, Collectors.toList())));
+
         List<ChatMessageVO> messages = new ArrayList<>();
         for (Msg msg : state.getContext()) {
             if (msg.getRole() != MsgRole.USER && msg.getRole() != MsgRole.ASSISTANT) {
@@ -119,10 +135,19 @@ public class ChatHistoryService {
             if (!StringUtils.hasText(text)) {
                 continue;
             }
-            messages.add(new ChatMessageVO(msg.getRole() == MsgRole.USER ? "user" : "assistant", text, msg.getTimestamp()));
+            // id=框架 Msg.id：附件按 message_id 挂回对应消息；无附件时给空列表（契约要求非 null）
+            List<ChatMessageAttachmentVO> msgAttachments = attachmentsByMessage.getOrDefault(msg.getId(), List.of());
+            messages.add(new ChatMessageVO(msg.getId(),
+                msg.getRole() == MsgRole.USER ? "user" : "assistant", text, msg.getTimestamp(), msgAttachments));
         }
         historyCache.putMessages(agentCode, sessionId, messages);
         return messages;
+    }
+
+    /** 领域附件 → 历史消息附件摘要 VO（解析状态取枚举名，不内联解析文本）。 */
+    private ChatMessageAttachmentVO toAttachmentVO(ChatAttachment a) {
+        return new ChatMessageAttachmentVO(a.getId(), a.getFileName(), a.getMimeType(), a.getFileSize(),
+            a.getParseStatus() == null ? null : a.getParseStatus().name());
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -31,6 +31,7 @@ import io.agentscope.harness.agent.HarnessAgent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 
@@ -73,17 +74,20 @@ public class ChatService {
     private final AgentMemorySyncService memorySyncService;
     private final ExecutionModeRegistry executionModeRegistry;
     private final PlanConfirmationService planConfirmationService;
+    private final ChatAttachmentService chatAttachmentService;
 
     public ChatService(AgentInstanceCache agentInstanceCache, AdminAgentInstanceFactory agentInstanceFactory,
                         ChatHistoryCache historyCache, AgentMemorySyncService memorySyncService,
                         ExecutionModeRegistry executionModeRegistry,
-                        PlanConfirmationService planConfirmationService) {
+                        PlanConfirmationService planConfirmationService,
+                        ChatAttachmentService chatAttachmentService) {
         this.agentInstanceCache = agentInstanceCache;
         this.agentInstanceFactory = agentInstanceFactory;
         this.historyCache = historyCache;
         this.memorySyncService = memorySyncService;
         this.executionModeRegistry = executionModeRegistry;
         this.planConfirmationService = planConfirmationService;
+        this.chatAttachmentService = chatAttachmentService;
     }
 
     /**
@@ -151,7 +155,20 @@ public class ChatService {
     /** 流式对话（带执行模式 + 调用元数据，无用量观察者）：供对话链路（ChatController）使用，采集耗时统计。 */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText, String mode,
                                              AgentCallMeta callMeta) {
-        return chatStream(agentCode, sessionId, userText, mode, callMeta, usage -> { });
+        return chatStream(agentCode, sessionId, userText, mode, callMeta, (List<String>) null, usage -> { });
+    }
+
+    /**
+     * 流式对话（带执行模式 + 调用元数据 + 附件绑定，无用量观察者）：供对话链路（ChatController）使用。
+     * {@code attachmentIds} 非空时在请求线程同步段把这些附件绑定到本条用户消息（框架 Msg.id）。
+     *
+     * <p>方法名末位加 {@code WithAttachments} 而非再重载六参：六参 {@code (…, callMeta, List)} 会与既有
+     * {@code (…, callMeta, Consumer)} 在实参传 {@code null} 时产生调用歧义，故用具名方法规避。</p>
+     */
+    public Flux<ChatStreamChunk> chatStreamWithAttachments(String agentCode, String sessionId, String userText,
+                                                            String mode, AgentCallMeta callMeta,
+                                                            List<String> attachmentIds) {
+        return chatStream(agentCode, sessionId, userText, mode, callMeta, attachmentIds, usage -> { });
     }
 
     /** 流式对话（带用量观察者，未指定执行模式）：保留旧签名，供既有调用点/测试使用。 */
@@ -163,7 +180,14 @@ public class ChatService {
     /** 流式对话（带执行模式 + 用量观察者，未带调用元数据）：保留旧签名，供既有调用点/测试使用。 */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
                                              String mode, Consumer<ChatUsage> usageTotalObserver) {
-        return chatStream(agentCode, sessionId, userText, mode, null, usageTotalObserver);
+        return chatStream(agentCode, sessionId, userText, mode, null, (List<String>) null, usageTotalObserver);
+    }
+
+    /** 流式对话（带执行模式 + 调用元数据 + 用量观察者，无附件）：保留旧签名，供 VibeCoding 既有调用点/测试使用。 */
+    public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
+                                             String mode, AgentCallMeta callMeta,
+                                             Consumer<ChatUsage> usageTotalObserver) {
+        return chatStream(agentCode, sessionId, userText, mode, callMeta, (List<String>) null, usageTotalObserver);
     }
 
     /**
@@ -179,9 +203,14 @@ public class ChatService {
      * 运行时读取；并打开一个 {@link PlanChannel} 把 {@code plan}/{@code plan_result} 事件合并进 SSE 输出
      * （对话与 VibeCoding 共用同一套挂起/确认闭环）。{@code doFinally} 时摘除模式登记、关闭通道。
      * mode 未指定/非法（{@link ExecutionMode#parse} 返回 null）→ 不登记，中间件回落全局语义。</p>
+     *
+     * <p><b>附件绑定</b>：{@code attachmentIds} 非空时，在<b>请求线程同步段</b>（构建 Flux 前、订阅前）把这些
+     * 附件绑定到本条用户消息（框架 {@code Msg.id}）——用与 Plan/历史一致的归一 {@code safeSession} 落 session_id，
+     * 保证历史接口按同一口径查回。绑定是旁路动作，任何失败只记录、不打断对话主流程（见
+     * {@link ChatAttachmentService#bindToMessage}）。</p>
      */
     public Flux<ChatStreamChunk> chatStream(String agentCode, String sessionId, String userText,
-                                             String mode, AgentCallMeta callMeta,
+                                             String mode, AgentCallMeta callMeta, List<String> attachmentIds,
                                              Consumer<ChatUsage> usageTotalObserver) {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
         RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
@@ -189,6 +218,14 @@ public class ChatService {
         // 缺省（旧调用点/测试）不绑，中间件按 ctx.userId/MDC 降级，不影响主链路。
         if (callMeta != null) {
             ctx.put(AgentCallMeta.class, callMeta);
+        }
+        // 归一 sessionId：与下方 Plan 通道/执行模式登记、以及历史接口读取口径完全一致（hasText ? 原值 : default）。
+        String safeSession = StringUtils.hasText(sessionId) ? sessionId : "default";
+        // 本条用户消息提前构建，供附件绑定拿到稳定的 Msg.id（框架 Msg.Builder 构造即生成随机 UUID）。
+        Msg userMsg = toUserMsg(userText);
+        // 附件绑定：请求线程同步段完成（订阅前），把本条消息 id 与其携带的附件关联，供历史回显。
+        if (!CollectionUtils.isEmpty(attachmentIds)) {
+            chatAttachmentService.bindToMessage(agentCode, safeSession, userMsg.getId(), attachmentIds);
         }
         ToolSourceInfo toolSource = agentInstanceFactory.toolSourceFor(agentCode);
 
@@ -217,7 +254,7 @@ public class ChatService {
         // 也不关闭，前端永远卡在"生成中..."。defer 把方法调用推迟到订阅时执行，任何同步异常都会被
         // Reactor 自动转成 Flux.error(...)，从而能被 onErrorResume 正常捕获、优雅降级成兜底话术。
         Map<String, ChatUsage> usageByMessage = new ConcurrentHashMap<>();
-        Flux<ChatStreamChunk> body = Flux.defer(() -> streamEvents(agent, List.of(toUserMsg(userText)), options, ctx))
+        Flux<ChatStreamChunk> body = Flux.defer(() -> streamEvents(agent, List.of(userMsg), options, ctx))
             .doOnNext(event -> collectUsage(usageByMessage, event))
             .concatMap(event -> Flux.fromIterable(toChunks(event, toolSource, stateBySource)));
 
@@ -242,7 +279,6 @@ public class ChatService {
         // 定位到同一通道。Flux.using 在订阅时（早于 Agent 产出任何事件）打开通道并把 plan/plan_result 事件
         // 合并进输出流；主流结束/取消时完成通道事件流并关闭通道。registry 用 doFirst/doFinally 配对登记与摘除，
         // 未指定/非法模式不登记（中间件回落全局语义）。BYPASS/无高风险时通道恒空、零开销。
-        String safeSession = StringUtils.hasText(sessionId) ? sessionId : "default";
         ExecutionMode executionMode = ExecutionMode.parse(mode);
         return Flux.using(
                 () -> planConfirmationService.openChannel(agentCode, safeSession),

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/store/AdminChatAttachmentStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/store/AdminChatAttachmentStore.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.workspace.chat.store;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.richard.fyoung.customeradmin.workspace.chat.entity.AiChatAttachment;
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.AiChatAttachmentMapper;
 import com.richard.fyoung.customerwork.attachment.AttachmentParseStatus;
@@ -73,6 +74,42 @@ public class AdminChatAttachmentStore implements AttachmentStore {
         }
     }
 
+    /**
+     * 按附件 ID + 智能体编码精确查一条（admin 私有：附件详情/下载链路的存在性 + 归属校验合一）。
+     *
+     * <p>把"附件不存在"与"跨 agent 访问"两种非法情形统一收敛成"查不到"（返回空），交由 Service 层
+     * fast-fail 成同一个业务异常——领域对象 {@link ChatAttachment} 不承载 agent_code，故归属校验必须在
+     * 持久层按列过滤完成，不回填领域对象。</p>
+     */
+    public Optional<ChatAttachment> findByIdAndAgentCode(String attachmentId, String agentCode) {
+        try {
+            QueryWrapper<AiChatAttachment> wrapper = new QueryWrapper<AiChatAttachment>()
+                .eq("id", attachmentId).eq("agent_code", agentCode);
+            AiChatAttachment record = attachmentMapper.selectOne(wrapper);
+            return record == null ? Optional.empty() : Optional.of(toDomain(record));
+        } catch (Exception e) {
+            log.error("attachment findByIdAndAgentCode failed, code={}, id={}",
+                "ADMIN-ATTACHMENT-FIND-FAIL", attachmentId, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 把一批附件绑定到某条用户消息（admin 私有：随消息发送时回填 session_id + message_id）。
+     *
+     * <p>只更新 {@code id IN (attachmentIds)} 且 {@code agent_code=agentCode} 的行（agent 归属兜底，
+     * 防跨智能体误绑），返回实际更新行数供上层校验数量是否相符。持久化异常不在此吞——交上层
+     * {@code catch(Exception)} 统一记录，不打断对话主流程。</p>
+     */
+    public int bindToMessage(String agentCode, String sessionId, String messageId, List<String> attachmentIds) {
+        UpdateWrapper<AiChatAttachment> wrapper = new UpdateWrapper<AiChatAttachment>()
+            .set("session_id", sessionId)
+            .set("message_id", messageId)
+            .eq("agent_code", agentCode)
+            .in("id", attachmentIds);
+        return attachmentMapper.update(null, wrapper);
+    }
+
     @Override
     public List<ChatAttachment> listBySession(String sessionId) {
         try {
@@ -91,6 +128,7 @@ public class AdminChatAttachmentStore implements AttachmentStore {
         AiChatAttachment record = new AiChatAttachment();
         record.setId(a.getId());
         record.setSessionId(a.getSessionId());
+        record.setMessageId(a.getMessageId());
         record.setAgentCode(AGENT_CODE.get() == null ? "" : AGENT_CODE.get());
         record.setUploader(a.getUploader());
         record.setChannel(a.getChannel());
@@ -111,6 +149,7 @@ public class AdminChatAttachmentStore implements AttachmentStore {
         return ChatAttachment.builder()
             .id(record.getId())
             .sessionId(record.getSessionId())
+            .messageId(record.getMessageId())
             .uploader(record.getUploader())
             .channel(record.getChannel())
             .fileName(record.getFileName())

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/controller/VibeCodingController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/controller/VibeCodingController.java
@@ -67,8 +67,8 @@ public class VibeCodingController {
     @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> stream(@PathVariable String agentCode, @Valid @RequestBody ChatRequest request) {
         Flux<com.richard.fyoung.customeradmin.workspace.chat.dto.ChatStreamChunk> source = request.collaborationEnabled()
-            ? collaborativeCodingService.stream(agentCode, request.sessionId(), request.message(), request.mode())
-            : vibeCodingService.stream(agentCode, request.sessionId(), request.message(), request.mode());
+            ? collaborativeCodingService.stream(agentCode, request.sessionId(), request.message(), request.mode(), request.attachmentIds())
+            : vibeCodingService.stream(agentCode, request.sessionId(), request.message(), request.mode(), request.attachmentIds());
         return source
             // data 编码见 ChatStreamChunk#sseData：父 Agent 纯文本，子 Agent 片段 JSON 包装携带来源标识
             .map(chunk -> ServerSentEvent.<String>builder().event(chunk.kind().sseEventName()).data(chunk.sseData()).build())

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
@@ -104,10 +104,17 @@ public class CollaborativeCodingService {
      */
     /** 协作流水（未指定执行模式）：保留三参签名，回落全局模式语义。 */
     public Flux<ChatStreamChunk> stream(String agentCode, String sessionId, String userText) {
-        return stream(agentCode, sessionId, userText, null);
+        return stream(agentCode, sessionId, userText, null, null);
     }
 
+    /** 协作流水（带执行模式，无附件）：保留四参签名，供既有调用点/测试使用。 */
     public Flux<ChatStreamChunk> stream(String agentCode, String sessionId, String userText, String mode) {
+        return stream(agentCode, sessionId, userText, mode, null);
+    }
+
+    /** 协作流水（带执行模式 + 附件）：{@code attachmentIds} 透传给 CODING 角色的 {@link VibeCodingService#stream}。 */
+    public Flux<ChatStreamChunk> stream(String agentCode, String sessionId, String userText, String mode,
+                                         List<String> attachmentIds) {
         requireVibeCodingCapable(agentCode);
         List<AdminCollaborationProperties.Role> roles = properties.effectiveRoles();
         if (CollectionUtils.isEmpty(roles)) {
@@ -131,7 +138,7 @@ public class CollaborativeCodingService {
         for (int i = 0; i < total; i++) {
             AdminCollaborationProperties.Role role = roles.get(i);
             int index = i + 1;
-            stageFluxes.add(roleFlux(agentCode, safeSession, userText, role, index, total, model, context, aborted, tokens, mode));
+            stageFluxes.add(roleFlux(agentCode, safeSession, userText, role, index, total, model, context, aborted, tokens, mode, attachmentIds));
         }
 
         log.info("[collab] collaboration pipeline started, agentCode={}, sessionId={}, roles={}",
@@ -154,10 +161,11 @@ public class CollaborativeCodingService {
     private Flux<ChatStreamChunk> roleFlux(String agentCode, String sessionId, String userText,
                                            AdminCollaborationProperties.Role role, int index, int total,
                                            Model model, AtomicReference<String> context,
-                                           AtomicBoolean aborted, TokenSink tokens, String mode) {
+                                           AtomicBoolean aborted, TokenSink tokens, String mode,
+                                           List<String> attachmentIds) {
         String type = normalizeType(role.getType());
         if (RoleStageEvent.TYPE_CODING.equals(type)) {
-            return codingRoleFlux(agentCode, sessionId, role, index, total, context, aborted, mode);
+            return codingRoleFlux(agentCode, sessionId, role, index, total, context, aborted, mode, attachmentIds);
         }
         // PLAN / REVIEW 均为一次性模型调用，仅提示词构造不同
         return oneShotRoleFlux(agentCode, sessionId, userText, role, type, index, total, model, context, aborted, tokens);
@@ -209,13 +217,14 @@ public class CollaborativeCodingService {
      */
     private Flux<ChatStreamChunk> codingRoleFlux(String agentCode, String sessionId,
                                                  AdminCollaborationProperties.Role role, int index, int total,
-                                                 AtomicReference<String> context, AtomicBoolean aborted, String mode) {
+                                                 AtomicReference<String> context, AtomicBoolean aborted, String mode,
+                                                 List<String> attachmentIds) {
         return Flux.defer(() -> {
             if (aborted.get()) {
                 return Flux.empty();
             }
             String codingPrompt = buildCodingPrompt(role, context.get());
-            Flux<ChatStreamChunk> coding = vibeCodingService.stream(agentCode, sessionId, codingPrompt, mode)
+            Flux<ChatStreamChunk> coding = vibeCodingService.stream(agentCode, sessionId, codingPrompt, mode, attachmentIds)
                 .onErrorResume(err -> {
                     aborted.set(true);
                     log.error("[collab] coding role failed, code={}, agentCode={}, role={}",

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
@@ -153,10 +153,20 @@ public class VibeCodingService {
      */
     /** 流式对话（未指定执行模式）：保留旧三参签名，供协作链路/既有测试使用，回落全局模式语义。 */
     public Flux<ChatStreamChunk> stream(String agentCode, String sessionId, String userText) {
-        return stream(agentCode, sessionId, userText, null);
+        return stream(agentCode, sessionId, userText, null, null);
     }
 
+    /** 流式对话（带执行模式，无附件）：保留旧四参签名，供既有调用点/测试使用。 */
     public Flux<ChatStreamChunk> stream(String agentCode, String sessionId, String userText, String mode) {
+        return stream(agentCode, sessionId, userText, mode, null);
+    }
+
+    /**
+     * 流式对话（带执行模式 + 附件绑定）：{@code attachmentIds} 透传给 {@link ChatService#chatStream}，
+     * 在请求线程同步段把附件绑定到本条用户消息（框架 Msg.id）。VibeCoding 面板上传的附件走此链路。
+     */
+    public Flux<ChatStreamChunk> stream(String agentCode, String sessionId, String userText, String mode,
+                                         List<String> attachmentIds) {
         requireVibeCodingCapable(agentCode);
         // 创建会话子目录（幂等），并以此为基础拍快照，对话结束后 diff 出本轮变更
         Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
@@ -187,7 +197,7 @@ public class VibeCodingService {
         // 执行模式随消息透传给 ChatService：模式登记 + Plan 确认通道（plan/plan_result 合并进流）均由
         // chatStream 统一承接（对话/VibeCoding/协作共用同一套闭环），本类只在其输出上叠加 file_change/
         // test_report 检测与审计，plan 事件作为普通 chunk 透传给前端。
-        Flux<ChatStreamChunk> chatFlux = chatService.chatStream(agentCode, sessionId, enrichedText, mode, callMeta, usageTotal::set)
+        Flux<ChatStreamChunk> chatFlux = chatService.chatStream(agentCode, sessionId, enrichedText, mode, callMeta, attachmentIds, usageTotal::set)
             .concatMap(chunk -> chunk.kind() == ChatNodeKind.TOOL_RESULT
                 // 顺序：原始工具结果 → 结构化 test_report（若可识别为编译/测试执行）→ 实时 file_change
                 ? Flux.concat(Flux.just(chunk),

--- a/customer-admin-server/src/main/resources/db/migration/V40__chat_attachment_message_id.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V40__chat_attachment_message_id.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- 对话附件消息绑定（Flyway V40，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 落地"对话附件预览"需求：附件上传时会话尚未产生用户消息，只能先落库（V21 的 ai_chat_attachment）；
+-- 随后附件随普通消息一起发送，此时才知道其绑定的用户消息 ID（框架 Msg.id）。新增 message_id 列承载
+-- 这层"消息↔附件"关联：随消息发送时由 admin 私有链路（ChatService 请求线程同步段）UPDATE 回填，
+-- 供历史接口按 message_id 分组把附件挂回对应消息。空串=未绑定（仅上传未发送 / 旧数据）。
+--
+-- 查询沿用既有 idx_ai_attachment_session（历史读取先按 session_id 捞该会话全部附件，再在应用层按
+-- message_id 分组），无需为 message_id 单建索引。放 session_id 列之后，与 starter 的 cw_chat_attachment 对齐。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `ai_chat_attachment`
+    ADD COLUMN `message_id` VARCHAR(64) NOT NULL DEFAULT ''
+        COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）' AFTER `session_id`;

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatControllerAttachmentTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/controller/ChatControllerAttachmentTest.java
@@ -1,0 +1,76 @@
+package com.richard.fyoung.customeradmin.workspace.chat.controller;
+
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.workspace.callstats.service.AgentCallMetaFactory;
+import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatAttachmentDTO;
+import com.richard.fyoung.customeradmin.workspace.chat.service.ChatAttachmentService;
+import com.richard.fyoung.customeradmin.workspace.chat.service.ChatHistoryService;
+import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ChatController} 附件详情/下载端点单测（纯单元，构造器注入 mock 服务）：
+ * 重点验证下载端点的响应头契约——Content-Type 取库中 mime、Content-Disposition 用 RFC 5987
+ * {@code filename*=UTF-8''<url编码>}（中文名可解）、附带 {@code X-Content-Type-Options: nosniff}。
+ * @author owlzhangfq@gmail.com
+ */
+class ChatControllerAttachmentTest {
+
+    private static final String AGENT_CODE = "coder";
+
+    private final ChatAttachmentService chatAttachmentService = mock(ChatAttachmentService.class);
+    private final ChatController controller = new ChatController(
+        mock(ChatService.class), mock(ChatHistoryService.class),
+        chatAttachmentService, mock(AgentCallMetaFactory.class));
+
+    @Test
+    void attachmentDetail_shouldDelegateToService() {
+        ChatAttachmentDTO dto = new ChatAttachmentDTO("att-1", "spec.pdf", "文本", "SUCCESS", null,
+            "application/pdf", 2048L);
+        when(chatAttachmentService.getDetail(AGENT_CODE, "att-1")).thenReturn(dto);
+
+        Result<ChatAttachmentDTO> result = controller.attachmentDetail(AGENT_CODE, "att-1");
+
+        assertEquals(dto, result.getData());
+        verify(chatAttachmentService).getDetail(eq(AGENT_CODE), eq("att-1"));
+    }
+
+    @Test
+    void attachmentFile_shouldSetDownloadHeaders_withEncodedChineseName() {
+        byte[] bytes = "原始字节".getBytes(StandardCharsets.UTF_8);
+        when(chatAttachmentService.loadFile(AGENT_CODE, "att-2"))
+            .thenReturn(new ChatAttachmentService.LoadedFile(bytes, "text/plain", "原始 文件.txt"));
+
+        ResponseEntity<byte[]> response = controller.attachmentFile(AGENT_CODE, "att-2");
+
+        assertArrayEquals(bytes, response.getBody());
+        HttpHeaders headers = response.getHeaders();
+        assertEquals("text/plain", headers.getFirst(HttpHeaders.CONTENT_TYPE));
+        // RFC 5987：filename* 前缀 + UTF-8 url 编码（空格编成 %20 而非 +）
+        String disposition = headers.getFirst(HttpHeaders.CONTENT_DISPOSITION);
+        assertEquals("attachment; filename*=UTF-8''%E5%8E%9F%E5%A7%8B%20%E6%96%87%E4%BB%B6.txt", disposition);
+        assertEquals("nosniff", headers.getFirst("X-Content-Type-Options"));
+    }
+
+    @Test
+    void attachmentFile_shouldFallBackToOctetStream_whenMimeIsOctet() {
+        byte[] bytes = new byte[]{1, 2, 3};
+        when(chatAttachmentService.loadFile(AGENT_CODE, "att-3"))
+            .thenReturn(new ChatAttachmentService.LoadedFile(bytes, "application/octet-stream", "blob.bin"));
+
+        ResponseEntity<byte[]> response = controller.attachmentFile(AGENT_CODE, "att-3");
+
+        assertEquals("application/octet-stream", response.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentServiceTest.java
@@ -15,23 +15,31 @@ import com.richard.fyoung.customerwork.attachment.TextAttachmentParser;
 import com.richard.fyoung.customerwork.attachment.TikaDocumentParser;
 import com.richard.fyoung.customerwork.attachment.VisionOcrParser;
 import com.richard.fyoung.customerwork.attachment.VisionOcrService;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link ChatAttachmentService} 单测：委托 starter {@link AttachmentParseService} 的多格式解析落库链路。
@@ -47,6 +55,7 @@ class ChatAttachmentServiceTest {
     private static final String CHANNEL = "admin_chat";
 
     private AiChatAttachmentMapper mapper;
+    private AttachmentFileStorage fileStorage;
     private ChatAttachmentService service;
 
     @BeforeEach
@@ -64,10 +73,10 @@ class ChatAttachmentServiceTest {
             new ExcelMarkdownParser(),
             new TikaDocumentParser(),
             new VisionOcrParser(fakeOcr));
-        AttachmentFileStorage fileStorage = new LocalAttachmentFileStorage(properties.getBaseDir());
+        fileStorage = new LocalAttachmentFileStorage(properties.getBaseDir());
         AttachmentParseService parseService = new AttachmentParseService(parsers, store, fileStorage, properties);
 
-        service = new ChatAttachmentService(parseService, store);
+        service = new ChatAttachmentService(parseService, store, fileStorage);
     }
 
     @Test
@@ -134,5 +143,119 @@ class ChatAttachmentServiceTest {
         assertEquals(AGENT_CODE, saved.getAgentCode());
         assertTrue(saved.getParsedText() == null || saved.getParsedText().isEmpty());
         assertNotNull(saved.getErrorMessage());
+    }
+
+    @Test
+    void parseAttachment_shouldExposeMimeTypeAndFileSize() {
+        byte[] bytes = "纯文本内容".getBytes(StandardCharsets.UTF_8);
+        MockMultipartFile file = new MockMultipartFile("file", "notes.txt", "text/plain", bytes);
+
+        ChatAttachmentDTO dto = service.parseAttachment(file, CHANNEL, "session-1", AGENT_CODE);
+
+        // 前端契约新增字段：mimeType 按扩展名推断、fileSize 为真实字节数
+        assertEquals("text/plain", dto.mimeType());
+        assertEquals(bytes.length, dto.fileSize());
+    }
+
+    // ===== 附件详情 / 原文件读取 / 消息绑定 =====
+
+    @Test
+    void getDetail_shouldReturnDto_whenOwnedByAgent() {
+        AiChatAttachment entity = new AiChatAttachment();
+        entity.setId("att-1");
+        entity.setAgentCode(AGENT_CODE);
+        entity.setFileName("spec.pdf");
+        entity.setMimeType("application/pdf");
+        entity.setFileSize(2048L);
+        entity.setParseStatus("SUCCESS");
+        entity.setParsedText("解析文本");
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(entity);
+
+        ChatAttachmentDTO dto = service.getDetail(AGENT_CODE, "att-1");
+
+        assertEquals("att-1", dto.id());
+        assertEquals("spec.pdf", dto.fileName());
+        assertEquals("解析文本", dto.content());
+        assertEquals("application/pdf", dto.mimeType());
+        assertEquals(2048L, dto.fileSize());
+    }
+
+    @Test
+    void getDetail_shouldThrow_whenNotFoundOrCrossAgent() {
+        // 附件不存在 / agent_code 不匹配：findByIdAndAgentCode 查不到 → 业务异常
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.getDetail("other-agent", "att-x"));
+    }
+
+    @Test
+    void loadFile_shouldReadOriginalBytes_whenOwnedByAgent() throws IOException {
+        byte[] payload = "原始文件字节".getBytes(StandardCharsets.UTF_8);
+        String key = fileStorage.store(payload, "att-2", "txt");
+
+        AiChatAttachment entity = new AiChatAttachment();
+        entity.setId("att-2");
+        entity.setAgentCode(AGENT_CODE);
+        entity.setFileName("原始 文件.txt");
+        entity.setMimeType("text/plain");
+        entity.setStoragePath(key);
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(entity);
+
+        ChatAttachmentService.LoadedFile loaded = service.loadFile(AGENT_CODE, "att-2");
+
+        assertArrayEquals(payload, loaded.bytes());
+        assertEquals("text/plain", loaded.mimeType());
+        assertEquals("原始 文件.txt", loaded.fileName());
+    }
+
+    @Test
+    void loadFile_shouldDefaultMime_whenMimeBlank() throws IOException {
+        byte[] payload = "x".getBytes(StandardCharsets.UTF_8);
+        String key = fileStorage.store(payload, "att-3", "bin");
+        AiChatAttachment entity = new AiChatAttachment();
+        entity.setId("att-3");
+        entity.setAgentCode(AGENT_CODE);
+        entity.setFileName("blob.bin");
+        entity.setMimeType("");
+        entity.setStoragePath(key);
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(entity);
+
+        ChatAttachmentService.LoadedFile loaded = service.loadFile(AGENT_CODE, "att-3");
+
+        assertEquals("application/octet-stream", loaded.mimeType());
+    }
+
+    @Test
+    void loadFile_shouldThrow_whenNotFound() {
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.loadFile(AGENT_CODE, "missing"));
+    }
+
+    @Test
+    void bindToMessage_shouldShortCircuit_whenIdsEmpty() {
+        service.bindToMessage(AGENT_CODE, "s1", "m1", List.of());
+
+        // 空列表短路：不触发任何 UPDATE
+        verify(mapper, never()).update(isNull(), any(UpdateWrapper.class));
+    }
+
+    @Test
+    void bindToMessage_shouldDelegateUpdate_whenIdsPresent() {
+        when(mapper.update(isNull(), any(UpdateWrapper.class))).thenReturn(2);
+
+        service.bindToMessage(AGENT_CODE, "s1", "m1", List.of("a1", "a2"));
+
+        verify(mapper).update(isNull(), any(UpdateWrapper.class));
+    }
+
+    @Test
+    void bindToMessage_shouldNotThrow_whenPersistenceFails() {
+        // 持久化异常被吞（只 log），绝不打断对话主流程
+        when(mapper.update(isNull(), any(UpdateWrapper.class)))
+            .thenThrow(new RuntimeException("db down"));
+
+        service.bindToMessage(AGENT_CODE, "s1", "m1", List.of("a1"));
+        // 无异常抛出即通过
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryCacheTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryCacheTest.java
@@ -45,7 +45,8 @@ class ChatHistoryCacheTest {
 
     @Test
     void putMessages_thenGetMessages_shouldRoundTrip() {
-        List<ChatMessageVO> messages = List.of(new ChatMessageVO("user", "你好", "2026-07-08 12:00:00"));
+        List<ChatMessageVO> messages = List.of(
+            new ChatMessageVO("m1", "user", "你好", "2026-07-08 12:00:00", List.of()));
         String[] stored = new String[1];
         when(jedis.setex(eq("admin:chat:messages:agent-1:s1"), anyLong(), anyString()))
             .thenAnswer(invocation -> {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryServiceTest.java
@@ -1,10 +1,14 @@
 package com.richard.fyoung.customeradmin.workspace.chat.service;
 
 import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentStateAccessor;
+import com.richard.fyoung.customerwork.attachment.AttachmentParseStatus;
+import com.richard.fyoung.customerwork.attachment.AttachmentStore;
+import com.richard.fyoung.customerwork.attachment.ChatAttachment;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -14,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,6 +45,7 @@ class ChatHistoryServiceTest {
     private AgentStateAccessor agentStateAccessor;
     private ChatHistoryCache historyCache;
     private ChatSessionStateQueryMapper sessionStateQueryMapper;
+    private AttachmentStore attachmentStore;
     private ChatHistoryService service;
     private ReActAgent agent;
 
@@ -50,8 +56,9 @@ class ChatHistoryServiceTest {
         agentStateAccessor = mock(AgentStateAccessor.class);
         historyCache = mock(ChatHistoryCache.class);
         sessionStateQueryMapper = mock(ChatSessionStateQueryMapper.class);
+        attachmentStore = mock(AttachmentStore.class);
         service = new ChatHistoryService(agentInstanceCache, agentStateStore, agentStateAccessor,
-            historyCache, sessionStateQueryMapper);
+            historyCache, sessionStateQueryMapper, attachmentStore);
 
         agent = mock(ReActAgent.class);
         when(agentInstanceCache.getOrBuild(AGENT_CODE)).thenReturn(agent);
@@ -123,6 +130,58 @@ class ChatHistoryServiceTest {
         assertEquals(2, result.getTotal());
         assertEquals(1, result.getList().size());
         assertEquals("s2", result.getList().get(0).sessionId());
+    }
+
+    @Test
+    void getMessages_shouldAttachAttachments_groupedByMessageId() {
+        // 缓存未命中 → 回源 state；附件按 message_id 挂回对应用户消息，无附件的消息给空列表（契约要求非 null）。
+        String sessionId = "sess-1";
+        when(historyCache.getMessages(AGENT_CODE, sessionId)).thenReturn(Optional.empty());
+
+        Msg userMsg = Msg.builder().id("m1").role(MsgRole.USER).textContent("看下这个附件").build();
+        Msg assistantMsg = Msg.builder().id("m2").role(MsgRole.ASSISTANT).textContent("好的").build();
+        AgentState state = mock(AgentState.class);
+        when(state.getContext()).thenReturn(List.of(userMsg, assistantMsg));
+        when(agentStateAccessor.resolve(agent, AGENT_CODE, sessionId)).thenReturn(state);
+
+        ChatAttachment attachment = ChatAttachment.builder()
+            .id("att-1").messageId("m1").fileName("spec.pdf").mimeType("application/pdf")
+            .fileSize(2048L).parseStatus(AttachmentParseStatus.SUCCESS).build();
+        when(attachmentStore.listBySession(sessionId)).thenReturn(List.of(attachment));
+
+        List<ChatMessageVO> messages = service.getMessages(AGENT_CODE, sessionId);
+
+        assertEquals(2, messages.size());
+        // 用户消息带附件（id=框架 Msg.id）
+        assertEquals("m1", messages.get(0).id());
+        assertEquals(1, messages.get(0).attachments().size());
+        assertEquals("att-1", messages.get(0).attachments().get(0).id());
+        assertEquals("spec.pdf", messages.get(0).attachments().get(0).fileName());
+        assertEquals("SUCCESS", messages.get(0).attachments().get(0).parseStatus());
+        assertEquals(2048L, messages.get(0).attachments().get(0).fileSize());
+        // 助手消息无附件 → 空列表而非 null
+        assertEquals("m2", messages.get(1).id());
+        assertTrue(messages.get(1).attachments().isEmpty());
+    }
+
+    @Test
+    void getMessages_shouldReturnEmptyAttachments_whenAttachmentUnbound() {
+        // message_id 为空（仅上传未发送）的附件不应挂到任何消息上。
+        String sessionId = "sess-2";
+        when(historyCache.getMessages(AGENT_CODE, sessionId)).thenReturn(Optional.empty());
+        Msg userMsg = Msg.builder().id("m1").role(MsgRole.USER).textContent("hi").build();
+        AgentState state = mock(AgentState.class);
+        when(state.getContext()).thenReturn(List.of(userMsg));
+        when(agentStateAccessor.resolve(agent, AGENT_CODE, sessionId)).thenReturn(state);
+        ChatAttachment unbound = ChatAttachment.builder()
+            .id("att-x").messageId("").fileName("x.txt").mimeType("text/plain")
+            .fileSize(1L).parseStatus(AttachmentParseStatus.SUCCESS).build();
+        when(attachmentStore.listBySession(sessionId)).thenReturn(List.of(unbound));
+
+        List<ChatMessageVO> messages = service.getMessages(AGENT_CODE, sessionId);
+
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).attachments().isEmpty());
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
@@ -35,7 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +61,7 @@ class ChatServiceTest {
     private AdminAgentInstanceFactory agentInstanceFactory;
     private ChatHistoryCache historyCache;
     private AgentMemorySyncService memorySyncService;
+    private ChatAttachmentService chatAttachmentService;
     private ChatService chatService;
     private ReActAgent agent;
 
@@ -67,10 +71,11 @@ class ChatServiceTest {
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
         historyCache = mock(ChatHistoryCache.class);
         memorySyncService = mock(AgentMemorySyncService.class);
+        chatAttachmentService = mock(ChatAttachmentService.class);
         // ExecutionModeRegistry / PlanConfirmationService 用真实实例（进程内内存、无外部依赖）：
         // 未指定模式 + 空通道时行为等价于改造前，不影响本测试聚焦的事件分流断言。
         chatService = new ChatService(agentInstanceCache, agentInstanceFactory, historyCache, memorySyncService,
-            new ExecutionModeRegistry(), new PlanConfirmationService());
+            new ExecutionModeRegistry(), new PlanConfirmationService(), chatAttachmentService);
 
         agent = mock(ReActAgent.class);
         when(agentInstanceCache.getOrBuild("coder")).thenReturn(agent);
@@ -323,6 +328,45 @@ class ChatServiceTest {
         List<ChatStreamChunk> chunks = stream("写一个 Fibonacci.java");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.THINKING_END, ChatNodeKind.ANSWER);
+    }
+
+    // ===== 附件绑定（对话附件预览：随消息发送把附件绑定到本条用户消息 Msg.id）=====
+
+    @Test
+    void chatStream_withAttachmentIds_shouldBindToMessage_inRequestThread() {
+        // attachmentIds 非空 → 请求线程同步段（订阅前）调 bindToMessage：sessionId 用归一值，messageId 为本条用户消息 id。
+        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("已收到附件").build();
+        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        List<String> ids = List.of("att-1", "att-2");
+
+        chatService.chatStreamWithAttachments("coder", "s1", "看下这个附件", null, null, ids).collectList().block();
+
+        verify(chatAttachmentService).bindToMessage(eq("coder"), eq("s1"), anyString(), eq(ids));
+    }
+
+    @Test
+    void chatStream_emptySession_shouldBindWithDefaultSession() {
+        // sessionId 空 → 归一成 "default"，与历史读取/Plan 通道口径一致。
+        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("ok").build();
+        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        List<String> ids = List.of("att-1");
+
+        chatService.chatStreamWithAttachments("coder", "", "看下这个附件", null, null, ids).collectList().block();
+
+        verify(chatAttachmentService).bindToMessage(eq("coder"), eq("default"), anyString(), eq(ids));
+    }
+
+    @Test
+    void chatStream_withoutAttachmentIds_shouldNotBind() {
+        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
+        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+
+        stream("你好");
+
+        verify(chatAttachmentService, never()).bindToMessage(anyString(), anyString(), anyString(), any());
     }
 
     // ===== 子 Agent 事件流透传（harness spawn 出的子 Agent 经 SubagentEventBus 直推父 sink）=====

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/store/AdminChatAttachmentStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/store/AdminChatAttachmentStoreTest.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customeradmin.workspace.chat.store;
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.richard.fyoung.customeradmin.workspace.chat.entity.AiChatAttachment;
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.AiChatAttachmentMapper;
 import com.richard.fyoung.customerwork.attachment.AttachmentParseStatus;
@@ -9,10 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,6 +74,7 @@ class AdminChatAttachmentStoreTest {
         AiChatAttachment entity = new AiChatAttachment();
         entity.setId("a3");
         entity.setSessionId("s3");
+        entity.setMessageId("m3");
         entity.setChannel("admin_chat");
         entity.setFileName("doc.txt");
         entity.setExtension("txt");
@@ -82,16 +89,64 @@ class AdminChatAttachmentStoreTest {
         assertTrue(found.isPresent());
         ChatAttachment domain = found.get();
         assertEquals("a3", domain.getId());
+        assertEquals("m3", domain.getMessageId());
         assertEquals("doc.txt", domain.getFileName());
         assertEquals(AttachmentParseStatus.FAILED, domain.getParseStatus());
         assertEquals("boom", domain.getErrorMessage());
         assertEquals(12L, domain.getFileSize());
     }
 
+    @Test
+    void save_shouldPersistMessageId() {
+        store.save(sample("a4"));
+
+        ArgumentCaptor<AiChatAttachment> captor = ArgumentCaptor.forClass(AiChatAttachment.class);
+        verify(mapper).insert(captor.capture());
+        assertEquals("msg-a4", captor.getValue().getMessageId());
+    }
+
+    @Test
+    void bindToMessage_shouldUpdateSessionAndMessageId_andReturnCount() {
+        when(mapper.update(isNull(), any(UpdateWrapper.class))).thenReturn(2);
+
+        int updated = store.bindToMessage("agent-x", "sess-1", "msg-1", List.of("a1", "a2"));
+
+        assertEquals(2, updated);
+        verify(mapper).update(isNull(), any(UpdateWrapper.class));
+    }
+
+    @Test
+    void findByIdAndAgentCode_shouldReturnDomain_whenMatched() {
+        AiChatAttachment entity = new AiChatAttachment();
+        entity.setId("a5");
+        entity.setAgentCode("agent-x");
+        entity.setFileName("f.pdf");
+        entity.setMimeType("application/pdf");
+        entity.setStoragePath("202607/a5.pdf");
+        entity.setFileSize(9L);
+        entity.setParseStatus("SUCCESS");
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(entity);
+
+        Optional<ChatAttachment> found = store.findByIdAndAgentCode("a5", "agent-x");
+
+        assertTrue(found.isPresent());
+        assertEquals("202607/a5.pdf", found.get().getStoragePath());
+        assertEquals("application/pdf", found.get().getMimeType());
+    }
+
+    @Test
+    void findByIdAndAgentCode_shouldBeEmpty_whenNoMatch() {
+        // agent_code 不匹配 / 附件不存在：SQL 查不到 → 空（Service 层据此 fast-fail 成 NOT_FOUND）
+        when(mapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+
+        assertFalse(store.findByIdAndAgentCode("a6", "other-agent").isPresent());
+    }
+
     private ChatAttachment sample(String id) {
         return ChatAttachment.builder()
             .id(id)
             .sessionId("s")
+            .messageId("msg-" + id)
             .uploader("u")
             .channel("admin_chat")
             .fileName("f.txt")

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
@@ -109,7 +109,7 @@ class VibeCodingServiceTest {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         // stream 会在用户消息头部注入路径指引，所以 chatService 收到的消息不是原始 "write 文件"
         // 而是含指引的 enrichedText，这里用 anyString() 匹配即可。
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any()))
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any()))
             .thenReturn(Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "好的")));
 
         List<ChatStreamChunk> emitted = service.stream("coder", "s1", "write 文件").collectList().block();
@@ -122,7 +122,7 @@ class VibeCodingServiceTest {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
         // 捕获实际传给 chatService 的消息内容
         java.util.concurrent.atomic.AtomicReference<String> capturedText = new java.util.concurrent.atomic.AtomicReference<>();
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenAnswer(inv -> {
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenAnswer(inv -> {
             capturedText.set(inv.getArgument(2));
             return Flux.empty();
         });
@@ -140,7 +140,7 @@ class VibeCodingServiceTest {
     @Test
     void listChangedArtifacts_shouldDetectNewAndModifiedFiles_butNotUntouchedFiles() throws IOException {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(Flux.empty());
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(Flux.empty());
 
         // stream 开始前写两个文件（已存在于快照）
         Path sessionWs = agentRoot.resolve("sessions/s1");
@@ -164,7 +164,7 @@ class VibeCodingServiceTest {
     @Test
     void listChangedArtifacts_differentSessions_shouldBeIsolated() throws IOException {
         when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(Flux.empty());
+        when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(Flux.empty());
 
         // 会话 s1 产出文件
         service.stream("coder", "s1", "任务A").blockLast();
@@ -382,7 +382,7 @@ class VibeCodingServiceTest {
                 Mono.fromRunnable(() -> writeQuietly(sessionWs, "output.txt", "hello"))
                     .thenReturn(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok")),
                 Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-1", "写个文件").collectList().block();
 
@@ -402,7 +402,7 @@ class VibeCodingServiceTest {
             // 没有任何 TOOL_RESULT 节点，文件是在流结束前"悄悄"写入的（异步落盘边界场景）
             Flux<ChatStreamChunk> simulated = Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成"))
                 .doOnComplete(() -> writeQuietly(sessionWs, "late-file.txt", "late"));
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-2", "写个文件").collectList().block();
 
@@ -414,7 +414,7 @@ class VibeCodingServiceTest {
         @Test
         void shouldNotEmitFileChangeEvent_whenNoFileWritten() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「read_file」返回：内容"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
 
@@ -435,7 +435,7 @@ class VibeCodingServiceTest {
                 Mono.fromRunnable(() -> writeQuietly(sessionWs, ".git/hooks/pre-commit.sample", "#!/bin/sh"))
                     .thenReturn(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok")),
                 Flux.just(new ChatStreamChunk(ChatNodeKind.ANSWER, "已完成")));
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(simulated);
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(simulated);
 
             List<ChatStreamChunk> emitted = service.stream("coder", "fc-4", "写个文件").collectList().block();
 
@@ -468,7 +468,7 @@ class VibeCodingServiceTest {
         void shouldEmitTestReport_afterMavenTestExecute() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
             String mvnOk = executeResult(0, "[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0\n[INFO] BUILD SUCCESS");
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, mvnOk),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "测试通过")));
 
@@ -489,7 +489,7 @@ class VibeCodingServiceTest {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
             String fail = executeResult(1, "[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0\n[INFO] BUILD FAILURE");
             // 同一轮对话里连续三次失败的 execute 结果（模拟 Agent 三轮修复仍失败）
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, fail),
                     new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, fail),
                     new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, fail)));
@@ -507,7 +507,7 @@ class VibeCodingServiceTest {
         @Test
         void shouldNotEmitTestReport_forNonExecuteToolResult() {
             when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
-            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any())).thenReturn(
+            when(chatService.chatStream(anyString(), anyString(), anyString(), any(), any(), any(), any())).thenReturn(
                 Flux.just(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, "工具「write_file」返回：ok"),
                     new ChatStreamChunk(ChatNodeKind.ANSWER, "完成")));
 

--- a/customer-admin-web/src/api/chat.ts
+++ b/customer-admin-web/src/api/chat.ts
@@ -1,4 +1,4 @@
-import { request as httpRequest } from './request'
+import { download, request as httpRequest, requestBlob } from './request'
 import { streamSse, type SseHandlers } from '@/utils/sse'
 import type {
   ChatAttachmentResult,
@@ -35,16 +35,44 @@ export function interruptChat(agentCode: string, sessionId: string) {
  * 上传聊天附件并解析为文本（图片走视觉大模型 OCR，pdf/office/html 走 Tika/POI，md/txt/csv/json 直读），
  * 落盘+落库；解析失败时返回体 parseStatus=FAILED、content 为空，由调用方决定是否提示并跳过拼接。
  * channel 区分调用来源：ChatPanel 传 'admin_chat'、VibeCodingPanel 传 'vibecoding'。
+ * sessionId 可选（会话尚未落库前上传也允许），有则一并传给后端关联到具体会话。
  */
-export function parseChatAttachment(agentCode: string, file: File, channel: string) {
+export function parseChatAttachment(agentCode: string, file: File, channel: string, sessionId?: string) {
   const formData = new FormData()
   formData.append('file', file)
+  if (sessionId) {
+    formData.append('sessionId', sessionId)
+  }
   return httpRequest<ChatAttachmentResult>({
     url: `/workspace/${agentCode}/chat/attachment`,
     method: 'post',
     data: formData,
     params: { channel },
   })
+}
+
+/** 附件详情（含解析出的文本 content），用于文本类附件（非图片）的预览弹窗。 */
+export function getChatAttachmentDetail(agentCode: string, attachmentId: string) {
+  return httpRequest<ChatAttachmentResult>({
+    url: `/workspace/${agentCode}/chat/attachment/${attachmentId}`,
+    method: 'get',
+  })
+}
+
+/** 附件原文件字节（图片内联预览的 objectURL 来源、以及下载按钮的数据来源）。 */
+export function fetchChatAttachmentFile(agentCode: string, attachmentId: string) {
+  return requestBlob({
+    url: `/workspace/${agentCode}/chat/attachment/${attachmentId}/file`,
+    method: 'get',
+  })
+}
+
+/** 附件下载：blob 请求 + Content-Disposition 文件名，触发浏览器保存（不走 img 内联预览路径）。 */
+export function downloadChatAttachment(agentCode: string, attachmentId: string, fallbackFilename: string) {
+  return download(
+    { url: `/workspace/${agentCode}/chat/attachment/${attachmentId}/file`, method: 'get' },
+    fallbackFilename,
+  )
 }
 
 /** Plan Mode 计划确认/拒绝（P1-1 HITL，对话面板）：镜像 VibeCoding 的 confirmVibeCodingPlan，

--- a/customer-admin-web/src/api/request.ts
+++ b/customer-admin-web/src/api/request.ts
@@ -78,6 +78,16 @@ function parseFilename(disposition: string | undefined): string | null {
 }
 
 /**
+ * 二进制内容获取（如对话附件原文件，用于图片内联预览的 objectURL）：与 download() 同样以
+ * responseType: 'blob' 请求（带 Authorization header，绕过 Result 拆箱拦截），但只返回 Blob，
+ * 不触发浏览器保存——调用方自己决定拿这个 Blob 做 <img> 预览还是别的用途。
+ */
+export async function requestBlob(config: AxiosRequestConfig): Promise<Blob> {
+  const response = await http.request<Blob, AxiosResponse<Blob>>({ ...config, responseType: 'blob' })
+  return response.data
+}
+
+/**
  * 二进制文件下载（如 SQL 查询结果导出 xlsx）：以 responseType: 'blob' 请求，跳过上面拦截器的
  * Result 拆箱，直接拿原始 AxiosResponse<Blob> 触发浏览器保存。文件名优先取响应头
  * Content-Disposition，取不到则用调用方传入的兜底名。

--- a/customer-admin-web/src/api/vibecoding.ts
+++ b/customer-admin-web/src/api/vibecoding.ts
@@ -17,12 +17,13 @@ import type {
 
 export function streamVibeCoding(agentCode: string, req: ChatRequest, handlers: SseHandlers) {
   // 显式列出请求体字段：collaboration 为协作模式开关（P3-1）；mode 为执行模式（会话内记忆），
-  // 透传给后端多角色流水线/工具执行确认逻辑。
+  // attachmentIds 为本次消息携带的解析成功附件 id 列表；透传给后端多角色流水线/工具执行确认逻辑。
   const body = {
     sessionId: req.sessionId,
     message: req.message,
     collaboration: req.collaboration ?? false,
     mode: req.mode,
+    attachmentIds: req.attachmentIds,
   }
   return streamSse(`/workspace/${agentCode}/vibecoding/stream`, body, handlers)
 }

--- a/customer-admin-web/src/components/attachment/AttachmentPendingList.vue
+++ b/customer-admin-web/src/components/attachment/AttachmentPendingList.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+// 待发送区附件条：Chat/VibeCoding 两个面板共用，替换原先单纯的 📎 文件名 el-tag 循环。
+// 图片附件显示本地 objectURL 缩略图（零后端请求，见 useChatAttachments 里 uploadFile 的即时创建），
+// 点击 el-image 走大图预览；非图片保持原有芯片样式；上传中/失败态与原逻辑一致。
+import { isImageMimeType } from '@/utils/attachment'
+
+export interface PendingAttachmentVM {
+  localId: string
+  name: string
+  status: 'uploading' | 'success' | 'failed'
+  errorMessage?: string
+  mimeType?: string
+  /** 图片附件的本地 objectURL，非图片恒为 undefined。 */
+  previewUrl?: string
+}
+
+defineProps<{ attachments: PendingAttachmentVM[] }>()
+const emit = defineEmits<{ remove: [localId: string] }>()
+</script>
+
+<template>
+  <div class="attachment-pending-list">
+    <div
+      v-for="a in attachments"
+      :key="a.localId"
+      class="pending-item"
+    >
+      <!-- 图片：缩略图 + 悬浮移除按钮 + 上传中遮罩 -->
+      <div
+        v-if="isImageMimeType(a.mimeType) && a.previewUrl"
+        class="pending-thumb"
+        :class="{ 'is-failed': a.status === 'failed' }"
+        :title="a.status === 'failed' ? a.errorMessage : a.name"
+      >
+        <el-image
+          :src="a.previewUrl"
+          :preview-src-list="a.status === 'uploading' ? [] : [a.previewUrl]"
+          fit="cover"
+          class="pending-thumb-img"
+          preview-teleported
+        />
+        <div v-if="a.status === 'uploading'" class="pending-thumb-loading">
+          <el-icon class="is-loading"><Loading /></el-icon>
+        </div>
+        <button
+          v-if="a.status !== 'uploading'"
+          type="button"
+          class="pending-thumb-remove"
+          title="移除"
+          @click.stop="emit('remove', a.localId)"
+        >
+          <el-icon><Close /></el-icon>
+        </button>
+      </div>
+      <!-- 非图片：原有芯片样式 -->
+      <el-tag
+        v-else
+        :closable="a.status !== 'uploading'"
+        :type="a.status === 'failed' ? 'danger' : undefined"
+        size="small"
+        :title="a.status === 'failed' ? a.errorMessage : undefined"
+        @close="emit('remove', a.localId)"
+      >
+        <el-icon v-if="a.status === 'uploading'" class="is-loading"><Loading /></el-icon>
+        📎 {{ a.name }}
+      </el-tag>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.attachment-pending-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pending-item {
+  display: flex;
+  align-items: center;
+}
+
+.pending-thumb {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--el-border-color-lighter);
+}
+
+.pending-thumb.is-failed {
+  border-color: var(--el-color-danger);
+}
+
+.pending-thumb-img {
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.pending-thumb-img :deep(img) {
+  object-fit: cover;
+}
+
+.pending-thumb-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+}
+
+.pending-thumb-remove {
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 0 0 0 6px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  cursor: pointer;
+  padding: 0;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.pending-thumb-remove:hover {
+  background: var(--el-color-danger);
+}
+
+.pending-thumb-remove .el-icon {
+  font-size: 10px;
+}
+</style>

--- a/customer-admin-web/src/components/attachment/MessageAttachments.vue
+++ b/customer-admin-web/src/components/attachment/MessageAttachments.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+// 消息附件区（用户气泡下方）：Chat/VibeCoding 两个面板共用，服务两种来源——
+// 刚发送成功的消息（attachments[].previewUrl 是本地 objectURL，零请求直接展示）与
+// 历史消息（后端只给 id/mimeType/fileSize/parseStatus，图片缩略图要按需拉一次原文件 blob）。
+// 非图片一律芯片，点击弹窗看解析出的文本；所有附件都带下载按钮（blob + a[download]，见 downloadChatAttachment）。
+import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { downloadChatAttachment, fetchChatAttachmentFile, getChatAttachmentDetail } from '@/api/chat'
+import { formatFileSize, isImageMimeType, type MessageAttachmentVM } from '@/utils/attachment'
+
+const props = defineProps<{ agentCode: string; attachments: MessageAttachmentVM[] }>()
+
+// 后端 blob 懒加载出的图片 objectURL：key 是 attachment.id。ownedIds 记录"这个 URL 是本组件自己
+// createObjectURL 出来的"——只有这些才在组件卸载时 revoke；props 传入的 previewUrl 归消息对象所有，
+// 不属于本组件的生命周期管理范围（发送方 store 已经把所有权从待发送区转移过来了）。
+const resolvedUrls = reactive<Record<string, string>>({})
+const loadingIds = reactive(new Set<string>())
+const failedIds = reactive(new Set<string>())
+const ownedIds = new Set<string>()
+
+function imageSrc(a: MessageAttachmentVM): string | undefined {
+  return a.previewUrl ?? resolvedUrls[a.id]
+}
+
+async function loadImage(a: MessageAttachmentVM) {
+  if (a.previewUrl || resolvedUrls[a.id] || loadingIds.has(a.id)) {
+    return
+  }
+  loadingIds.add(a.id)
+  try {
+    const blob = await fetchChatAttachmentFile(props.agentCode, a.id)
+    resolvedUrls[a.id] = URL.createObjectURL(blob)
+    ownedIds.add(a.id)
+  } catch {
+    failedIds.add(a.id)
+  } finally {
+    loadingIds.delete(a.id)
+  }
+}
+
+onMounted(() => {
+  for (const a of props.attachments) {
+    if (isImageMimeType(a.mimeType)) {
+      loadImage(a)
+    }
+  }
+})
+
+onUnmounted(() => {
+  for (const id of ownedIds) {
+    URL.revokeObjectURL(resolvedUrls[id])
+  }
+})
+
+/** 同一条消息内的多张图片共享一份大图预览列表，可左右切换。 */
+const imagePreviewList = computed(() =>
+  props.attachments
+    .filter((a) => isImageMimeType(a.mimeType))
+    .map((a) => imageSrc(a))
+    .filter((url): url is string => !!url),
+)
+
+function imagePreviewIndex(a: MessageAttachmentVM): number {
+  const src = imageSrc(a)
+  return src ? imagePreviewList.value.indexOf(src) : 0
+}
+
+// 非图片附件文本预览弹窗（调详情接口拿解析出的 content）
+const detailVisible = ref(false)
+const detailLoading = ref(false)
+const detailError = ref('')
+const detailFileName = ref('')
+const detailContent = ref('')
+
+async function openDetail(a: MessageAttachmentVM) {
+  detailVisible.value = true
+  detailLoading.value = true
+  detailError.value = ''
+  detailContent.value = ''
+  detailFileName.value = a.fileName
+  try {
+    const result = await getChatAttachmentDetail(props.agentCode, a.id)
+    if (result.parseStatus === 'FAILED') {
+      detailError.value = result.errorMessage || '解析失败，无可预览的文本内容'
+    } else {
+      detailContent.value = result.content
+    }
+  } catch (error) {
+    detailError.value = error instanceof Error ? error.message : String(error)
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+async function handleDownload(a: MessageAttachmentVM) {
+  try {
+    await downloadChatAttachment(props.agentCode, a.id, a.fileName)
+  } catch {
+    // 失败原因（网络异常/后端业务异常）已由 request.ts 拦截器统一 ElMessage 提示，这里只吞掉避免未处理的 rejection
+  }
+}
+</script>
+
+<template>
+  <div class="message-attachments">
+    <template v-for="a in attachments" :key="a.id">
+      <!-- 图片：缩略图 + 悬浮下载按钮 -->
+      <div v-if="isImageMimeType(a.mimeType)" class="msg-attach-image">
+        <el-image
+          v-if="imageSrc(a)"
+          :src="imageSrc(a)"
+          :preview-src-list="imagePreviewList"
+          :initial-index="imagePreviewIndex(a)"
+          fit="cover"
+          class="msg-attach-image-img"
+          preview-teleported
+        />
+        <div v-else-if="loadingIds.has(a.id)" class="msg-attach-image-placeholder">
+          <el-icon class="is-loading"><Loading /></el-icon>
+        </div>
+        <div v-else class="msg-attach-image-placeholder" :title="failedIds.has(a.id) ? '原图加载失败' : ''">
+          <el-icon><Picture /></el-icon>
+        </div>
+        <button type="button" class="msg-attach-download-btn" title="下载原文件" @click.stop="handleDownload(a)">
+          <el-icon><Download /></el-icon>
+        </button>
+      </div>
+      <!-- 非图片：芯片，点击看解析文本，右侧下载 -->
+      <el-tag
+        v-else
+        :type="a.parseStatus === 'FAILED' ? 'danger' : undefined"
+        size="small"
+        class="msg-attach-chip"
+        @click="openDetail(a)"
+      >
+        <el-icon><Document /></el-icon>
+        <span class="msg-attach-chip-name">{{ a.fileName }}</span>
+        <span v-if="a.fileSize" class="msg-attach-chip-size">{{ formatFileSize(a.fileSize) }}</span>
+        <el-icon class="msg-attach-chip-download" title="下载" @click.stop="handleDownload(a)"><Download /></el-icon>
+      </el-tag>
+    </template>
+
+    <!-- 文本类附件解析内容预览弹窗 -->
+    <el-dialog v-model="detailVisible" :title="detailFileName" width="600px" append-to-body>
+      <div v-if="detailLoading" class="msg-attach-detail-loading">
+        <el-icon class="is-loading"><Loading /></el-icon>
+        <span>加载中…</span>
+      </div>
+      <el-alert v-else-if="detailError" type="error" :closable="false" :title="detailError" show-icon />
+      <el-scrollbar v-else max-height="60vh">
+        <pre class="msg-attach-detail-content">{{ detailContent || '（无解析内容）' }}</pre>
+      </el-scrollbar>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.message-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.msg-attach-image {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--el-border-color-lighter);
+}
+
+.msg-attach-image-img {
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.msg-attach-image-img :deep(img) {
+  object-fit: cover;
+}
+
+.msg-attach-image-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--el-text-color-secondary);
+  background: var(--el-fill-color-light);
+  font-size: 20px;
+}
+
+.msg-attach-download-btn {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.msg-attach-image:hover .msg-attach-download-btn {
+  opacity: 1;
+}
+
+.msg-attach-chip {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 220px;
+}
+
+.msg-attach-chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.msg-attach-chip-size {
+  flex-shrink: 0;
+  opacity: 0.7;
+  font-size: 11px;
+}
+
+.msg-attach-chip-download {
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
+.msg-attach-chip-download:hover {
+  color: var(--theme-primary, var(--el-color-primary));
+}
+
+.msg-attach-detail-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+  color: var(--el-text-color-secondary);
+}
+
+.msg-attach-detail-content {
+  margin: 0;
+  padding: 4px 2px;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--el-text-color-primary);
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+}
+</style>

--- a/customer-admin-web/src/composables/useChatAttachments.ts
+++ b/customer-admin-web/src/composables/useChatAttachments.ts
@@ -2,6 +2,7 @@ import { ElMessage } from 'element-plus'
 import type { UploadRequestOptions } from 'element-plus'
 import { parseChatAttachment } from '@/api/chat'
 import { generateUuid } from '@/utils/uuid'
+import { isImageMimeType, revokeAttachmentPreviews } from '@/utils/attachment'
 
 // 与 starter AttachmentParseService 的白名单/大小限制保持一致（后端 customer-work.attachment.max-file-size-mb=10）
 export const ATTACHMENT_ACCEPT =
@@ -17,9 +18,16 @@ export interface AttachmentItem {
   content: string
   status: 'uploading' | 'success' | 'failed'
   errorMessage?: string
+  /** 文件 MIME 类型：选中/粘贴时就地取自 File.type，上传成功后用后端返回值校正。 */
+  mimeType?: string
+  fileSize?: number
+  /** 图片附件的本地 objectURL（零后端请求的即时缩略图），非图片恒为 undefined。
+   * 所有权随消息发送转移给消息对象；移除/放弃时由调用方负责 revoke，见 revokeAttachmentPreviews。 */
+  previewUrl?: string
 }
 
 interface AttachmentConversation {
+  sessionId: string
   attachments: AttachmentItem[]
 }
 
@@ -56,10 +64,21 @@ export function useChatAttachments(options: {
   async function uploadFile(file: File) {
     const conv = options.getConversation()
     if (!conv) return
-    const attachment: AttachmentItem = { localId: generateUuid(), name: file.name, content: '', status: 'uploading' }
+    // 图片附件立即用本地 File 生成 objectURL 做缩略图——零后端请求，不等上传结果；
+    // 非图片该字段留空，待发送区走既有芯片样式。
+    const previewUrl = isImageMimeType(file.type) ? URL.createObjectURL(file) : undefined
+    const attachment: AttachmentItem = {
+      localId: generateUuid(),
+      name: file.name,
+      content: '',
+      status: 'uploading',
+      mimeType: file.type,
+      fileSize: file.size,
+      previewUrl,
+    }
     conv.attachments.push(attachment)
     try {
-      const result = await parseChatAttachment(options.agentCode(), file, options.channel)
+      const result = await parseChatAttachment(options.agentCode(), file, options.channel, conv.sessionId)
       const target = conv.attachments.find((a) => a.localId === attachment.localId)
       if (!target) {
         return // 结果返回前用户已手动移除该附件，迟到的结果直接丢弃
@@ -73,6 +92,9 @@ export function useChatAttachments(options: {
         target.content = result.content
         target.status = 'success'
       }
+      // 以后端落库的 mimeType/fileSize 为准做一次校正（一般与本地 File 值一致，兜底服务端归一化差异）
+      target.mimeType = result.mimeType || target.mimeType
+      target.fileSize = result.fileSize ?? target.fileSize
     } catch (error) {
       const target = conv.attachments.find((a) => a.localId === attachment.localId)
       const message = error instanceof Error ? error.message : String(error)
@@ -112,9 +134,14 @@ export function useChatAttachments(options: {
     }
   }
 
+  /** 移除待发送区某个附件：图片附件的本地 objectURL 尚未转移给任何消息，立即 revoke 防泄漏。 */
   function removeAttachment(localId: string) {
     const conv = options.getConversation()
     if (!conv) return
+    const target = conv.attachments.find((a) => a.localId === localId)
+    if (target) {
+      revokeAttachmentPreviews([target])
+    }
     conv.attachments = conv.attachments.filter((a) => a.localId !== localId)
   }
 

--- a/customer-admin-web/src/store/chatConversations.ts
+++ b/customer-admin-web/src/store/chatConversations.ts
@@ -3,6 +3,7 @@ import { getChatSessionMessages, interruptChat, streamChat } from '@/api/chat'
 import { generateUuid } from '@/utils/uuid'
 import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
 import { createPlanCard, type PlanCard } from '@/utils/planCard'
+import { revokeAttachmentPreviews, type MessageAttachmentVM } from '@/utils/attachment'
 import type { TraceNode } from '@/components/TraceTimeline.vue'
 import type { ExecutionMode, LiveSession, PlanEvent, PlanResultEvent } from '@/types/api'
 
@@ -12,6 +13,8 @@ export interface ChatMessage {
   nodes: TraceNode[]
   // 本条助手消息内的 Plan Mode 确认卡片（P1-1），Manual/高风险操作待人工确认
   plans?: PlanCard[]
+  // 该条消息携带的附件（用户消息才有）；历史消息来自后端，新发送消息由 send() 本地拼装并转移 previewUrl 所有权
+  attachments?: MessageAttachmentVM[]
 }
 
 /** localId 是前端本地生成的临时 key，用于 v-for/移除定位（上传过程中后端 id 还不存在）；
@@ -23,6 +26,10 @@ export interface ChatAttachmentItem {
   content: string
   status: 'uploading' | 'success' | 'failed'
   errorMessage?: string
+  mimeType?: string
+  fileSize?: number
+  /** 图片附件本地 objectURL（零后端请求的即时缩略图）；发送时所有权转移给消息对象，移除/放弃时需 revoke。 */
+  previewUrl?: string
 }
 
 /**
@@ -68,11 +75,19 @@ export function createChatConversation(sessionId: string, messages: ChatMessage[
   }
 }
 
-/** 会话预览文案：取首条有内容的用户消息。 */
+/**
+ * 会话预览文案：取首条有内容的用户消息。文字为空但带了附件（只发附件不写字）时，
+ * 回退成附件文件名列表——附件现在挂在结构化的 attachments 字段而不是拼进 text，
+ * 不这样兜底的话纯附件消息在侧边栏会显示空白预览。
+ */
 export function previewOfMessages(messages: ChatMessage[]): string {
-  const firstUser = messages.find((m) => m.role === 'user' && m.text.trim().length > 0)
+  const firstUser = messages.find((m) => m.role === 'user' && (m.text.trim().length > 0 || (m.attachments?.length ?? 0) > 0))
   if (!firstUser) return ''
-  const text = firstUser.text
+  const text = firstUser.text.trim()
+  if (!text) {
+    const names = (firstUser.attachments ?? []).map((a) => a.fileName).join('、')
+    return names ? `📎 ${names}` : ''
+  }
   return text.length > PREVIEW_MAX_LENGTH ? text.slice(0, PREVIEW_MAX_LENGTH) + '...' : text
 }
 
@@ -130,6 +145,8 @@ export const useChatConversationsStore = defineStore('chatConversations', {
       const cur = agent.conversations[agent.activeId]
       if (cur && cur.messages.length === 0 && !cur.streaming) {
         cur.input = ''
+        // 复用空白会话相当于放弃这些待发送附件（不会再被发送），立即 revoke 图片本地 objectURL 防泄漏
+        revokeAttachmentPreviews(cur.attachments)
         cur.attachments = []
         return
       }
@@ -152,7 +169,13 @@ export const useChatConversationsStore = defineStore('chatConversations', {
       const history = await getChatSessionMessages(agentCode, targetSessionId)
       agent.conversations[targetSessionId] = createChatConversation(
         targetSessionId,
-        history.map((msg) => ({ role: msg.role, text: msg.text, nodes: [] })),
+        history.map((msg) => ({
+          role: msg.role,
+          text: msg.text,
+          nodes: [],
+          // 历史附件没有本地 previewUrl，图片缩略图交给 MessageAttachments 组件按需拉后端 blob
+          attachments: msg.attachments.length > 0 ? msg.attachments : undefined,
+        })),
       )
       agent.activeId = targetSessionId
     },
@@ -168,16 +191,29 @@ export const useChatConversationsStore = defineStore('chatConversations', {
       const text = conv.input.trim()
       // 输入框内容自动去首尾空白：纯空白输入被拦下时框里的空格也一并清掉，避免"有空格但发不出去"的困惑
       conv.input = text
-      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
+      const successfulAttachments = conv.attachments.filter((a) => a.status === 'success' && a.id)
       // 有解析成功的附件时允许"只发附件不写文字"（正文即附件内容，满足后端 message 非空要求）
-      if ((!text && attachedNames.length === 0) || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
+      if ((!text && successfulAttachments.length === 0) || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
       conv.interrupted = false
       const messageToSend = buildMessage(conv, text)
-      // 用户气泡只展示原始输入 + 附件文件名提示，不把拼进正文的附件全文也显示出来（那部分只是发给模型看的）。
+      const attachmentIds = successfulAttachments.length > 0 ? successfulAttachments.map((a) => a.id as string) : undefined
+      // 用户气泡展示原始输入 + 独立的附件区（图片缩略图/文件芯片），不把拼进正文的附件全文也显示出来
+      // （那部分只是发给模型看的）。previewUrl 所有权从待发送区转移给消息对象——发送后立即清空
+      // conv.attachments（见下方），这里转移完就不再由待发送区持有，也不 revoke，气泡还要接着用它。
       conv.messages.push({
         role: 'user',
-        text: attachedNames.length > 0 ? `${text ? text + '\n' : ''}📎 ${attachedNames.join('、')}` : text,
+        text,
         nodes: [],
+        attachments: successfulAttachments.length > 0
+          ? successfulAttachments.map((a) => ({
+              id: a.id as string,
+              fileName: a.name,
+              mimeType: a.mimeType ?? '',
+              fileSize: a.fileSize ?? 0,
+              parseStatus: 'SUCCESS',
+              previewUrl: a.previewUrl,
+            }))
+          : undefined,
       })
       conv.messages.push({ role: 'assistant', text: '', nodes: [] })
       // 坑：不能拿 push 前创建的原始对象引用去改——响应式数组对存进去的对象是"读取时才转代理"，
@@ -188,7 +224,7 @@ export const useChatConversationsStore = defineStore('chatConversations', {
       conv.streaming = true
       const sid = conv.sessionId
 
-      conv.abort = streamChat(agentCode, { sessionId: sid, message: messageToSend, mode: conv.mode }, {
+      conv.abort = streamChat(agentCode, { sessionId: sid, message: messageToSend, mode: conv.mode, attachmentIds }, {
         onEvent: (event) => {
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (!c) return

--- a/customer-admin-web/src/store/vibeConversations.ts
+++ b/customer-admin-web/src/store/vibeConversations.ts
@@ -4,6 +4,7 @@ import { getChatSessionMessages } from '@/api/chat'
 import { generateUuid } from '@/utils/uuid'
 import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
 import { createPlanCard, type PlanCard } from '@/utils/planCard'
+import { revokeAttachmentPreviews, type MessageAttachmentVM } from '@/utils/attachment'
 import type { TraceNode } from '@/components/TraceTimeline.vue'
 import type {
   ExecutionMode,
@@ -31,6 +32,8 @@ export interface VibeChatMessage {
   plans?: PlanCard[]
   // 协作模式多角色阶段进度（P3-1），按 role_stage 事件到达顺序累积
   stages?: RoleStageEvent[]
+  // 该条消息携带的附件（用户消息才有）；历史消息来自后端，新发送消息由 send() 本地拼装并转移 previewUrl 所有权
+  attachments?: MessageAttachmentVM[]
 }
 
 /** localId 是前端本地生成的临时 key；status 驱动 loading/失败态展示，失败附件不参与拼接。 */
@@ -41,6 +44,10 @@ export interface VibeAttachmentItem {
   content: string
   status: 'uploading' | 'success' | 'failed'
   errorMessage?: string
+  mimeType?: string
+  fileSize?: number
+  /** 图片附件本地 objectURL（零后端请求的即时缩略图）；发送时所有权转移给消息对象，移除/放弃时需 revoke。 */
+  previewUrl?: string
 }
 
 /**
@@ -144,6 +151,8 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
       const cur = agent.conversations[agent.activeId]
       if (cur && cur.messages.length === 0 && !cur.streaming) {
         cur.input = ''
+        // 复用空白会话相当于放弃这些待发送附件（不会再被发送），立即 revoke 图片本地 objectURL 防泄漏
+        revokeAttachmentPreviews(cur.attachments)
         cur.attachments = []
         cur.fileChanges = []
         cur.fileNodes = []
@@ -181,7 +190,13 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
       const history = await getChatSessionMessages(agentCode, targetSessionId)
       const conv = createVibeConversation(
         targetSessionId,
-        history.map((msg) => ({ role: msg.role, text: msg.text, nodes: [] })),
+        history.map((msg) => ({
+          role: msg.role,
+          text: msg.text,
+          nodes: [],
+          // 历史附件没有本地 previewUrl，图片缩略图交给 MessageAttachments 组件按需拉后端 blob
+          attachments: msg.attachments.length > 0 ? msg.attachments : undefined,
+        })),
       )
       const firstUserMessage = history.find((msg) => msg.role === 'user')
       conv.sandboxMode = firstUserMessage ? parseSandboxModeFromMessage(firstUserMessage.text) : null
@@ -219,15 +234,27 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
       const text = conv.input.trim()
       // 输入框内容自动去首尾空白：纯空白输入被拦下时框里的空格也一并清掉，避免"有空格但发不出去"的困惑
       conv.input = text
-      const attachedNames = conv.attachments.filter((a) => a.status === 'success').map((a) => a.name)
+      const successfulAttachments = conv.attachments.filter((a) => a.status === 'success' && a.id)
       // 有解析成功的附件时允许"只发附件不写文字"（正文即附件内容，满足后端 message 非空要求）
-      if ((!text && attachedNames.length === 0) || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
+      if ((!text && successfulAttachments.length === 0) || conv.streaming || conv.attachments.some((a) => a.status === 'uploading')) return
       conv.interrupted = false
       const messageToSend = buildMessage(conv, text)
+      const attachmentIds = successfulAttachments.length > 0 ? successfulAttachments.map((a) => a.id as string) : undefined
+      // previewUrl 所有权从待发送区转移给消息对象（不 revoke）——见下方 conv.attachments 清空前的说明
       conv.messages.push({
         role: 'user',
-        text: attachedNames.length > 0 ? `${text ? text + '\n' : ''}📎 ${attachedNames.join('、')}` : text,
+        text,
         nodes: [],
+        attachments: successfulAttachments.length > 0
+          ? successfulAttachments.map((a) => ({
+              id: a.id as string,
+              fileName: a.name,
+              mimeType: a.mimeType ?? '',
+              fileSize: a.fileSize ?? 0,
+              parseStatus: 'SUCCESS',
+              previewUrl: a.previewUrl,
+            }))
+          : undefined,
       })
       conv.messages.push({ role: 'assistant', text: '', nodes: [], testReports: [] })
       // 同 chat store：push 完再取，拿响应式代理而不是原始对象
@@ -237,7 +264,7 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
       conv.streaming = true
       const sid = conv.sessionId
 
-      conv.abort = streamVibeCoding(agentCode, { sessionId: sid, message: messageToSend, collaboration, mode: conv.mode }, {
+      conv.abort = streamVibeCoding(agentCode, { sessionId: sid, message: messageToSend, collaboration, mode: conv.mode, attachmentIds }, {
         onEvent: (event) => {
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (!c) return

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -727,6 +727,8 @@ export interface ChatRequest {
   collaboration?: boolean
   /** 执行模式（会话内记忆，未传时后端按 auto 处理）。 */
   mode?: ExecutionMode
+  /** 本次消息携带的解析成功附件 id 列表（对话附件预览，未携带附件时省略）。 */
+  attachmentIds?: string[]
 }
 
 export interface ChatSessionSummary {
@@ -748,10 +750,22 @@ export interface LiveSession {
   streaming: boolean
 }
 
+/** 历史消息里挂的附件摘要（不含正文 content，需要文本预览时另调详情接口）。 */
+export interface ChatMessageAttachment {
+  id: string
+  fileName: string
+  mimeType: string
+  fileSize: number
+  parseStatus: 'SUCCESS' | 'FAILED'
+}
+
 export interface ChatMessageVO {
+  id: string
   role: 'user' | 'assistant'
   text: string
   timestamp: string
+  /** 该条消息携带的附件，恒为数组（可能为空数组）。 */
+  attachments: ChatMessageAttachment[]
 }
 
 /** 附件上传解析结果（落盘+落库，解析失败时 content 为空、errorMessage 说明原因，由调用方决定是否拼进消息） */
@@ -761,6 +775,8 @@ export interface ChatAttachmentResult {
   content: string
   parseStatus: 'SUCCESS' | 'FAILED'
   errorMessage: string | null
+  mimeType: string
+  fileSize: number
 }
 
 // ---------- workspace.project ----------

--- a/customer-admin-web/src/utils/attachment.ts
+++ b/customer-admin-web/src/utils/attachment.ts
@@ -1,0 +1,43 @@
+import type { ChatMessageAttachment } from '@/types/api'
+
+/**
+ * 对话附件预览共用的纯函数：判定是否图片、格式化文件大小、批量释放本地 objectURL。
+ * Chat/VibeCoding 两个面板与其共用组件都依赖这里，避免各处判断逻辑漂移。
+ */
+
+/**
+ * 消息气泡里展示用的附件视图模型：在后端 ChatMessageAttachment 基础上加 previewUrl——
+ * 仅刚发送成功的图片消息才有（复用待发送区已创建的本地 objectURL，省一次后端请求）；
+ * 历史消息该字段恒为空，走 MessageAttachments 组件里按需的后端 blob 懒加载。
+ */
+export interface MessageAttachmentVM extends ChatMessageAttachment {
+  previewUrl?: string
+}
+
+/** 判定图片：mimeType 以 image/ 开头（含 svg），展示走 blob objectURL 是安全的。 */
+export function isImageMimeType(mimeType?: string | null): boolean {
+  return !!mimeType && mimeType.startsWith('image/')
+}
+
+/** 文件大小人性化展示（B/KB/MB），非法值兜底显示空串。 */
+export function formatFileSize(bytes?: number | null): string {
+  if (bytes == null || Number.isNaN(bytes) || bytes < 0) {
+    return ''
+  }
+  if (bytes < 1024) {
+    return `${bytes}B`
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`
+  }
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`
+}
+
+/** 批量释放待发送区图片附件的本地 objectURL（移除/放弃时调用），已发送的附件所有权转移给消息对象，不在此列。 */
+export function revokeAttachmentPreviews(items: Array<{ previewUrl?: string }>): void {
+  for (const item of items) {
+    if (item.previewUrl) {
+      URL.revokeObjectURL(item.previewUrl)
+    }
+  }
+}

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -7,6 +7,8 @@ import TraceTimeline from '@/components/TraceTimeline.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import ExecutionModeSelect from '@/components/ExecutionModeSelect.vue'
 import PlanConfirmCard from '@/components/PlanConfirmCard.vue'
+import AttachmentPendingList from '@/components/attachment/AttachmentPendingList.vue'
+import MessageAttachments from '@/components/attachment/MessageAttachments.vue'
 import { useThemeStore } from '@/store/theme'
 import {
   useChatConversationsStore,
@@ -168,6 +170,12 @@ defineExpose({ newSession })
             />
             <MarkdownRenderer v-if="msg.role === 'assistant'" :text="msg.text" />
             <template v-else>{{ msg.text }}</template>
+            <!-- 用户消息携带的附件：图片缩略图/文本芯片，历史消息与刚发送的消息共用同一组件 -->
+            <MessageAttachments
+              v-if="msg.role === 'user' && msg.attachments && msg.attachments.length > 0"
+              :agent-code="agentCode"
+              :attachments="msg.attachments"
+            />
             <!-- Plan Mode 确认卡片（P1-1 HITL）：高风险操作待人工确认，批准/拒绝按钮 + 倒计时 -->
             <PlanConfirmCard
               v-if="msg.role === 'assistant' && msg.plans && msg.plans.length > 0"
@@ -179,19 +187,12 @@ defineExpose({ newSession })
         </div>
         <el-empty v-if="(active?.messages.length ?? 0) === 0" description="开始和智能体对话吧" />
       </div>
-      <div v-if="active && active.attachments.length > 0" class="attachment-tags">
-        <el-tag
-          v-for="a in active.attachments"
-          :key="a.localId"
-          :closable="a.status !== 'uploading'"
-          :type="a.status === 'failed' ? 'danger' : undefined"
-          size="small"
-          @close="removeAttachment(a.localId)"
-        >
-          <el-icon v-if="a.status === 'uploading'" class="is-loading"><Loading /></el-icon>
-          📎 {{ a.name }}
-        </el-tag>
-      </div>
+      <AttachmentPendingList
+        v-if="active && active.attachments.length > 0"
+        class="attachment-tags"
+        :attachments="active.attachments"
+        @remove="removeAttachment"
+      />
       <div class="input-bar">
         <el-upload
           :show-file-list="false"

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -18,6 +18,8 @@ import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import ReviewReport from '@/components/ReviewReport.vue'
 import ExecutionModeSelect from '@/components/ExecutionModeSelect.vue'
 import PlanConfirmCard from '@/components/PlanConfirmCard.vue'
+import AttachmentPendingList from '@/components/attachment/AttachmentPendingList.vue'
+import MessageAttachments from '@/components/attachment/MessageAttachments.vue'
 import { useThemeStore } from '@/store/theme'
 import {
   useVibeConversationsStore,
@@ -609,24 +611,23 @@ defineExpose({ newSession })
               @decision="handlePlanDecision"
             />
             <template v-if="msg.role === 'user'">{{ msg.text }}</template>
+            <!-- 用户消息携带的附件：图片缩略图/文本芯片，历史消息与刚发送的消息共用同一组件 -->
+            <MessageAttachments
+              v-if="msg.role === 'user' && msg.attachments && msg.attachments.length > 0"
+              :agent-code="agentCode"
+              :attachments="msg.attachments"
+            />
             <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && (active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1">生成中…</span>
           </div>
         </div>
         <el-empty v-if="(active?.messages.length ?? 0) === 0" description="描述你想让智能体生成/修改的代码" />
       </div>
-      <div v-if="active && active.attachments.length > 0" class="attachment-tags">
-        <el-tag
-          v-for="a in active.attachments"
-          :key="a.localId"
-          :closable="a.status !== 'uploading'"
-          :type="a.status === 'failed' ? 'danger' : undefined"
-          size="small"
-          @close="removeAttachment(a.localId)"
-        >
-          <el-icon v-if="a.status === 'uploading'" class="is-loading"><Loading /></el-icon>
-          📎 {{ a.name }}
-        </el-tag>
-      </div>
+      <AttachmentPendingList
+        v-if="active && active.attachments.length > 0"
+        class="attachment-tags"
+        :attachments="active.attachments"
+        @remove="removeAttachment"
+      />
       <div class="input-bar">
         <el-upload :show-file-list="false" :http-request="handleAttachmentUpload" :before-upload="beforeAttachmentUpload" :accept="ATTACHMENT_ACCEPT">
           <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/AttachmentFileStorage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/AttachmentFileStorage.java
@@ -23,4 +23,13 @@ public interface AttachmentFileStorage {
      * @throws IOException 存储失败（本地落盘或对象上传失败，语义与原本地盘一致）
      */
     String store(byte[] data, String id, String ext) throws IOException;
+
+    /**
+     * 按相对 key 读回原始文件字节（供附件预览 / 下载链路）。
+     *
+     * @param storagePath {@link #store} 返回并落 DB 的相对 key（形如 {@code 202607/{id}.{ext}}）
+     * @return 文件全量字节
+     * @throws IOException 文件不存在或读取失败（本地盘读不到 / 对象不存在，语义与 store 失败一致，交上层翻译）
+     */
+    byte[] read(String storagePath) throws IOException;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/ChatAttachment.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/ChatAttachment.java
@@ -25,6 +25,8 @@ public class ChatAttachment {
     private String id;
     /** 会话 ID。 */
     private String sessionId;
+    /** 绑定的用户消息 ID（框架 {@code Msg.id}，空=未绑定；上传时未知，随对话发送时由 admin 私有链路回填）。 */
+    private String messageId;
     /** 上传者标识。 */
     private String uploader;
     /** 来源渠道：user_chat / admin_chat / vibecoding。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/LocalAttachmentFileStorage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/LocalAttachmentFileStorage.java
@@ -41,4 +41,19 @@ public class LocalAttachmentFileStorage implements AttachmentFileStorage {
         log.info("attachment stored to local disk, id={}, path={}, size={}", id, relativePath, data.length);
         return relativePath;
     }
+
+    @Override
+    public byte[] read(String storagePath) throws IOException {
+        // 路径穿越唯一防御点：storagePath 来自 DB，规范化后必须仍落在 baseDir 之内，否则 fast-fail。
+        // 非法路径（如 ../../etc/passwd）直接 IllegalArgumentException，不做静默兜底。
+        Path base = Paths.get(baseDir).normalize().toAbsolutePath();
+        Path target = base.resolve(storagePath).normalize().toAbsolutePath();
+        if (!target.startsWith(base)) {
+            throw new IllegalArgumentException("illegal storage path escapes base dir: " + storagePath);
+        }
+        if (!Files.exists(target) || Files.isDirectory(target)) {
+            throw new IOException("attachment file not found: " + storagePath);
+        }
+        return Files.readAllBytes(target);
+    }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/MinioAttachmentFileStorage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/MinioAttachmentFileStorage.java
@@ -1,6 +1,8 @@
 package com.richard.fyoung.customerwork.attachment;
 
 import io.minio.BucketExistsArgs;
+import io.minio.GetObjectArgs;
+import io.minio.GetObjectResponse;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
@@ -67,6 +69,20 @@ public class MinioAttachmentFileStorage implements AttachmentFileStorage {
         }
         log.info("attachment stored to minio, id={}, bucket={}, key={}, size={}", id, bucket, objectKey, data.length);
         return objectKey;
+    }
+
+    @Override
+    public byte[] read(String storagePath) throws IOException {
+        // 读路径不做 ensureBucket：读不到对象（桶/对象不存在）本身即"不存在"，getObject 抛异常包成 IOException。
+        try (GetObjectResponse resp = client.getObject(GetObjectArgs.builder()
+            .bucket(bucket)
+            .object(storagePath)
+            .build())) {
+            return resp.readAllBytes();
+        } catch (Exception e) {
+            // 与 store 失败同语义：包成 IOException 抛出，交上层翻译成业务错误
+            throw new IOException("failed to get object from minio, bucket=" + bucket + ", key=" + storagePath, e);
+        }
     }
 
     /** 惰性确保 bucket 存在：首次调用检查 / 按需创建，之后凭 volatile 标志短路，不再触网。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/MybatisAttachmentStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/MybatisAttachmentStore.java
@@ -70,6 +70,7 @@ public class MybatisAttachmentStore implements AttachmentStore {
         ChatAttachmentDO record = new ChatAttachmentDO();
         record.setId(a.getId());
         record.setSessionId(a.getSessionId());
+        record.setMessageId(a.getMessageId());
         record.setUploader(a.getUploader());
         record.setChannel(a.getChannel());
         record.setFileName(a.getFileName());
@@ -89,6 +90,7 @@ public class MybatisAttachmentStore implements AttachmentStore {
         return ChatAttachment.builder()
             .id(record.getId())
             .sessionId(record.getSessionId())
+            .messageId(record.getMessageId())
             .uploader(record.getUploader())
             .channel(record.getChannel())
             .fileName(record.getFileName())

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/entity/ChatAttachmentDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/attachment/entity/ChatAttachmentDO.java
@@ -24,6 +24,7 @@ public class ChatAttachmentDO {
     private String id;
 
     private String sessionId;
+    private String messageId;
     private String uploader;
     private String channel;
     private String fileName;

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -215,6 +215,7 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
     `id`             VARCHAR(64) NOT NULL COMMENT '附件ID(UUID)',
     `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+    `message_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）',
     `uploader`       VARCHAR(128) NOT NULL DEFAULT '' COMMENT '上传者标识',
     `channel`        VARCHAR(32) NOT NULL DEFAULT '' COMMENT '来源渠道:user_chat/admin_chat/vibecoding',
     `file_name`      VARCHAR(255) NOT NULL COMMENT '原始文件名',

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/attachment/LocalAttachmentFileStorageTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/attachment/LocalAttachmentFileStorageTest.java
@@ -1,0 +1,49 @@
+package com.richard.fyoung.customerwork.attachment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link LocalAttachmentFileStorage} 本地盘存-读往返 + 路径穿越防御测试（全程离线，临时目录）。
+ *
+ * <p>read 是附件预览/下载链路的唯一路径穿越防御点：storagePath 来自 DB，规范化后必须仍在 baseDir 内，
+ * 非法（{@code ../} 逃逸）直接 {@link IllegalArgumentException} fast-fail；文件不存在抛 {@link IOException}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class LocalAttachmentFileStorageTest {
+
+    @Test
+    void storeThenRead_shouldRoundTripBytes(@TempDir Path baseDir) throws IOException {
+        LocalAttachmentFileStorage storage = new LocalAttachmentFileStorage(baseDir.toString());
+        byte[] payload = "hello-local-storage".getBytes(StandardCharsets.UTF_8);
+
+        String key = storage.store(payload, "attach-1", "txt");
+        byte[] readBack = storage.read(key);
+
+        assertArrayEquals(payload, readBack, "读回字节应与写入一致");
+    }
+
+    @Test
+    void read_shouldRejectPathTraversal(@TempDir Path baseDir) {
+        LocalAttachmentFileStorage storage = new LocalAttachmentFileStorage(baseDir.toString());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> storage.read("../../etc/passwd"));
+        assertTrue(ex.getMessage().contains("escapes base dir"));
+    }
+
+    @Test
+    void read_shouldThrowIOException_whenFileMissing(@TempDir Path baseDir) {
+        LocalAttachmentFileStorage storage = new LocalAttachmentFileStorage(baseDir.toString());
+
+        assertThrows(IOException.class, () -> storage.read("202607/not-exist.txt"));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/attachment/MinioAttachmentFileStorageIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/attachment/MinioAttachmentFileStorageIntegrationTest.java
@@ -76,4 +76,39 @@ class MinioAttachmentFileStorageIntegrationTest {
             client.removeObject(RemoveObjectArgs.builder().bucket(IT_BUCKET).object(key).build());
         }
     }
+
+    @Test
+    void read_shouldReturnStoredBytes_fromRealMinio() throws Exception {
+        String endpoint = endpoint();
+        assumeTrue(reachable(endpoint), "MinIO 不可达（" + endpoint + "），跳过该集成测试");
+
+        MinioAttachmentFileStorage storage = new MinioAttachmentFileStorage(
+            endpoint, ACCESS_KEY, SECRET_KEY, IT_BUCKET, true);
+
+        String id = UUID.randomUUID().toString().replace("-", "");
+        byte[] payload = ("read-minio-" + id).getBytes(StandardCharsets.UTF_8);
+        String key = storage.store(payload, id, "txt");
+
+        try {
+            // 走 storage.read 读回（附件预览/下载链路），断言字节完全一致
+            byte[] readBack = storage.read(key);
+            assertArrayEquals(payload, readBack, "storage.read 读回字节应与写入一致");
+        } finally {
+            MinioClient client = MinioClient.builder()
+                .endpoint(endpoint).credentials(ACCESS_KEY, SECRET_KEY).build();
+            client.removeObject(RemoveObjectArgs.builder().bucket(IT_BUCKET).object(key).build());
+        }
+    }
+
+    @Test
+    void read_shouldThrowIOException_whenObjectMissing() {
+        String endpoint = endpoint();
+        assumeTrue(reachable(endpoint), "MinIO 不可达（" + endpoint + "），跳过该集成测试");
+
+        MinioAttachmentFileStorage storage = new MinioAttachmentFileStorage(
+            endpoint, ACCESS_KEY, SECRET_KEY, IT_BUCKET, true);
+
+        org.junit.jupiter.api.Assertions.assertThrows(java.io.IOException.class,
+            () -> storage.read("202607/not-exist-" + UUID.randomUUID() + ".txt"));
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/attachment/MybatisAttachmentStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/attachment/MybatisAttachmentStoreTest.java
@@ -58,7 +58,7 @@ class MybatisAttachmentStoreTest {
 
     private ChatAttachment sample(String id, String session, AttachmentParseStatus status) {
         return ChatAttachment.builder()
-            .id(id).sessionId(session).uploader("u-" + id).channel("user_chat")
+            .id(id).sessionId(session).messageId("msg-" + id).uploader("u-" + id).channel("user_chat")
             .fileName("f-" + id + ".pdf").extension("pdf").mimeType("application/pdf")
             .fileSize(1024).storagePath("202607/" + id + ".pdf")
             .parseStatus(status).parsedText(status == AttachmentParseStatus.SUCCESS ? "解析文本" : null)
@@ -73,6 +73,7 @@ class MybatisAttachmentStoreTest {
 
         ChatAttachment found = store.findById(id).orElseThrow();
         assertEquals("application/pdf", found.getMimeType());
+        assertEquals("msg-" + id, found.getMessageId());
         assertEquals(AttachmentParseStatus.SUCCESS, found.getParseStatus());
         assertEquals("解析文本", found.getParsedText());
         assertEquals(1024, found.getFileSize());

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
@@ -132,6 +132,9 @@ public final class MybatisTestSupport {
         populator.setCommentPrefixes("--");
         populator.execute(dataSource);
         ensureHandoffRoutingColumns(dataSource);
+        // 对话附件·消息绑定：存量 cw_chat_attachment 幂等补齐 message_id 列（CREATE TABLE IF NOT EXISTS 不追加新列）
+        ensureColumn(dataSource, "cw_chat_attachment", "message_id",
+            "VARCHAR(64) NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）'");
     }
 
     /** 智能路由中控·工单智能分配：为存量 cw_handoff_ticket 幂等补齐增强列（列已存在则跳过）。 */

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -278,6 +278,7 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
     `id`             VARCHAR(64) NOT NULL COMMENT '附件ID(UUID)',
     `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+    `message_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）',
     `uploader`       VARCHAR(128) NOT NULL DEFAULT '' COMMENT '上传者标识',
     `channel`        VARCHAR(32) NOT NULL DEFAULT '' COMMENT '来源渠道:user_chat/admin_chat/vibecoding',
     `file_name`      VARCHAR(255) NOT NULL COMMENT '原始文件名',

--- a/mysql/02-customer-admin/40-V40__chat_attachment_message_id.sql
+++ b/mysql/02-customer-admin/40-V40__chat_attachment_message_id.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- 对话附件消息绑定（Flyway V40，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 落地"对话附件预览"需求：附件上传时会话尚未产生用户消息，只能先落库（V21 的 ai_chat_attachment）；
+-- 随后附件随普通消息一起发送，此时才知道其绑定的用户消息 ID（框架 Msg.id）。新增 message_id 列承载
+-- 这层"消息↔附件"关联：随消息发送时由 admin 私有链路（ChatService 请求线程同步段）UPDATE 回填，
+-- 供历史接口按 message_id 分组把附件挂回对应消息。空串=未绑定（仅上传未发送 / 旧数据）。
+--
+-- 查询沿用既有 idx_ai_attachment_session（历史读取先按 session_id 捞该会话全部附件，再在应用层按
+-- message_id 分组），无需为 message_id 单建索引。放 session_id 列之后，与 starter 的 cw_chat_attachment 对齐。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `ai_chat_attachment`
+    ADD COLUMN `message_id` VARCHAR(64) NOT NULL DEFAULT ''
+        COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）' AFTER `session_id`;


### PR DESCRIPTION
## 需求

智能体对话（ChatPanel）与 VibeCoding 上传的附件此前只显示 `📎 文件名`，原始文件落库落存储后没有任何读取通道。本 PR 补齐预览能力：**待发送区 + 消息历史**双场景，图片大图预览、文本类（pdf/word/excel/txt…）内联展示解析文本、全类型下载。

## 后端

- **starter**（通用能力下沉）：`AttachmentFileStorage` 补 `read(storagePath)`——local 实现含唯一一处路径穿越防御，MinIO 实现走 `getObject`；领域对象/`cw_chat_attachment` 增加 `message_id`（starter schema 与 `mysql/01` 双处同步）。
- **admin**：
  - Flyway `V40`：`ai_chat_attachment` 加 `message_id`（空串=未绑定；沿用 `idx_ai_attachment_session`，不加新索引）。
  - 消息-附件关联：`ChatRequest` 加 `attachmentIds`，`chatStreamWithAttachments` 在请求线程同步段把附件 UPDATE 绑定到框架 `Msg.id`（仅限 `agent_code` 匹配的行；绑定失败只记日志不打断对话）。Vibe 普通/协作链路均透传。已实证 `Msg.id` 在 `ai_chat_session_state` 序列化往返中保留，历史匹配可靠。
  - 历史接口：`ChatMessageVO` 扩展为 `{id, role, text, timestamp, attachments}`，按 `message_id` 分组挂回对应消息。
  - 新端点（均 `@SaCheckPermission("workspace")` + agentCode 归属校验）：
    - `GET /chat/attachment/{id}` 附件详情（含解析文本，供内联预览）
    - `GET /chat/attachment/{id}/file` 原文件字节，统一 `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff`（防 html/svg 附件被内联执行）

## 前端（Chat/Vibe 共用组件）

- `AttachmentPendingList`：待发送区，图片用本地 File 的 objectURL 缩略图（零后端请求）+ el-image 大图，非图片保持芯片语义，上传中/失败态沿用现状。
- `MessageAttachments`：气泡附件区，图片经 axios blob 懒加载（Authorization 在 header，`<img>` 直连不可行），文本类点击弹窗展示解析文本，全类型可下载（blob + a[download]）。
- objectURL 生命周期：发送时所有权转移给消息对象（不 revoke 展示中的 URL），移除/弃用即回收；组件只 revoke 自己创建的 URL。
- 上传补传 `sessionId`，stream 请求体携带 `attachmentIds`。

## 测试

- starter：730 通过（含 MinIO 门控 read 用例、路径穿越拒绝；仅 `RedisSessionPersistenceTest` 为已知本机环境不一致）。
- admin-server：663 全绿（新增端点契约/中文文件名编码/绑定/历史组装用例）。
- 前端：`vue-tsc + vite build` 零错误。

## 部署注意

- 生产库需手工同步 `V40`（文件已带 `SET NAMES utf8mb4` 防 stdin 管道中文 COMMENT 写坏）；`cw_chat_attachment` 同步加 `message_id` 列。

🤖 Generated with [Claude Code](https://claude.com/claude-code)