### PR TITLE
feat(rag): AI 配置新增 RAG 知识库检索并接入对话/VibeCoding

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentSaveRequest.java
@@ -6,9 +6,13 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 /**
- * 智能体新建/编辑请求。{@code mcpIds}/{@code skillIds}/{@code systemToolIds}/{@code subAgentIds} 可选多选；
- * {@code modelId}（主模型）必填；{@code backupModelIds} 为有序备用模型列表（可空=无备模型），运行时主模型失败按序切换。
+ * 智能体新建/编辑请求。{@code mcpIds}/{@code skillIds}/{@code systemToolIds}/{@code subAgentIds}/
+ * {@code knowledgeBaseIds} 可选多选；{@code modelId}（主模型）必填；{@code backupModelIds} 为有序备用模型列表
+ * （可空=无备模型），运行时主模型失败按序切换。
  * 5 个高级参数全部选填，null 表示使用框架/工厂默认值（取值范围校验见 AgentService#validate）。
+ *
+ * <p>{@code knowledgeBaseIds} 追加在末尾而非与其它 {@code xxxIds} 并列：记录组件顺序即位置构造器签名，
+ * 插在中间会让所有既有位置构造调用点静默错位（类型恰好相同的相邻参数不会编译报错），追加则安全。</p>
  * @author owlzhangfq@gmail.com
  */
 public record AgentSaveRequest(
@@ -28,5 +32,7 @@ public record AgentSaveRequest(
     Integer toolTimeoutSeconds,
     Integer toolMaxAttempts,
     Integer compressTriggerMsgs,
-    Integer compressKeepMsgs) {
+    Integer compressKeepMsgs,
+    /** 绑定的 RAG 知识库 ID 列表（可空=不做知识库检索），只允许绑定启用且连通性测试成功的知识库。 */
+    List<Long> knowledgeBaseIds) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/dto/AgentVO.java
@@ -37,4 +37,9 @@ public class AgentVO {
     private Integer toolMaxAttempts;
     private Integer compressTriggerMsgs;
     private Integer compressKeepMsgs;
+
+    /** 绑定的 RAG 知识库 id 列表。 */
+    private List<Long> knowledgeBaseIds;
+    /** 与 {@link #knowledgeBaseIds} 一一对应的知识库名称（列表页直接展示，免前端再查一次）。 */
+    private List<String> knowledgeBaseNames;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
@@ -15,6 +15,11 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSubAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.mapper.AiMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelTestResult;
 import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
@@ -67,6 +72,8 @@ public class AgentService {
     /** 主模型连通性门禁失败的日志错误码。 */
     private static final String CODE_MODEL_TEST_FAIL = "AGENT-MODEL-TEST-FAIL";
     private static final String CAPABILITY_SUBAGENT = "subagent";
+    /** 启用态（知识库/资源通用）。 */
+    private static final int STATUS_ENABLED = 1;
 
     // ---- 高级参数取值范围（选填，null 不校验） ----
     private static final int MAX_ITERS_MIN = 1;
@@ -90,6 +97,8 @@ public class AgentService {
     private final AiSkillMapper skillMapper;
     private final AiAgentSystemToolMapper agentSystemToolMapper;
     private final AiSystemToolMapper systemToolMapper;
+    private final AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
+    private final AiKnowledgeBaseMapper knowledgeBaseMapper;
     private final MenuVersionHolder menuVersionHolder;
     private final AgentInstanceCache agentInstanceCache;
     private final ModelConfigService modelConfigService;
@@ -101,6 +110,8 @@ public class AgentService {
                          AiModelConfigMapper modelConfigMapper,
                          AiMcpMapper mcpMapper, AiSkillMapper skillMapper,
                          AiAgentSystemToolMapper agentSystemToolMapper, AiSystemToolMapper systemToolMapper,
+                         AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper,
+                         AiKnowledgeBaseMapper knowledgeBaseMapper,
                          MenuVersionHolder menuVersionHolder, AgentInstanceCache agentInstanceCache,
                          ModelConfigService modelConfigService,
                          CustomerWorkConfigPublisher runtimeConfigPublisher) {
@@ -114,6 +125,8 @@ public class AgentService {
         this.skillMapper = skillMapper;
         this.agentSystemToolMapper = agentSystemToolMapper;
         this.systemToolMapper = systemToolMapper;
+        this.agentKnowledgeBaseMapper = agentKnowledgeBaseMapper;
+        this.knowledgeBaseMapper = knowledgeBaseMapper;
         this.menuVersionHolder = menuVersionHolder;
         this.agentInstanceCache = agentInstanceCache;
         this.modelConfigService = modelConfigService;
@@ -153,7 +166,7 @@ public class AgentService {
         fillFromRequest(agent, request);
         agentMapper.insert(agent);
         replaceRelations(agent.getId(), request.backupModelIds(), request.mcpIds(), request.skillIds(),
-            request.systemToolIds(), request.subAgentIds());
+            request.systemToolIds(), request.subAgentIds(), request.knowledgeBaseIds());
         menuVersionHolder.bump();
         // 命中渠道绑定则热下发运行时配置到 8080（默认关闭，未启用即跳过）
         runtimeConfigPublisher.publishForAgentId(agent.getId());
@@ -172,7 +185,7 @@ public class AgentService {
         fillFromRequest(agent, request);
         agentMapper.updateById(agent);
         replaceRelations(id, request.backupModelIds(), request.mcpIds(), request.skillIds(),
-            request.systemToolIds(), request.subAgentIds());
+            request.systemToolIds(), request.subAgentIds(), request.knowledgeBaseIds());
         menuVersionHolder.bump();
         // agentCode 理论上不应改变，但仍按新旧两个 code 双清，避免缓存键错位残留旧实例
         agentInstanceCache.evict(oldAgentCode);
@@ -209,6 +222,8 @@ public class AgentService {
         agentSystemToolMapper.delete(new LambdaQueryWrapper<AiAgentSystemTool>().eq(AiAgentSystemTool::getAgentId, id));
         agentBackupModelMapper.delete(new LambdaQueryWrapper<AiAgentBackupModel>().eq(AiAgentBackupModel::getAgentId, id));
         agentSubAgentMapper.delete(new LambdaQueryWrapper<AiAgentSubAgent>().eq(AiAgentSubAgent::getAgentId, id));
+        agentKnowledgeBaseMapper.delete(
+            new LambdaQueryWrapper<AiAgentKnowledgeBase>().eq(AiAgentKnowledgeBase::getAgentId, id));
         menuVersionHolder.bump();
         agentInstanceCache.evict(agent.getAgentCode());
     }
@@ -257,8 +272,31 @@ public class AgentService {
             throw new BizException(ResultCode.PARAM_INVALID,
                 "capabilities 仅支持 chat/vibecoding/subagent/plan/tasklist/skill-learning/dynamic-subagent/memory");
         }
+        validateKnowledgeBaseIds(request);
         validateAdvancedParams(request);
         validateSubAgentIds(request, selfId);
+    }
+
+    /**
+     * 知识库多选校验：每个 id 必须真实存在，且当前<b>启用</b>并且<b>连通性测试成功</b>——
+     * 绑一个连不上的知识库，运行时每轮对话都要白白等一次超时，配置期就该 fast fail 拦住。
+     * （下拉选项接口 {@code /options} 本就只返回可用项，这里是后端侧的兜底校验。）
+     */
+    private void validateKnowledgeBaseIds(AgentSaveRequest request) {
+        if (CollectionUtils.isEmpty(request.knowledgeBaseIds())) {
+            return;
+        }
+        List<AiKnowledgeBase> knowledgeBases = knowledgeBaseMapper.selectBatchIds(request.knowledgeBaseIds());
+        if (knowledgeBases.size() != request.knowledgeBaseIds().size()) {
+            throw new BizException(ResultCode.PARAM_INVALID, "存在无效的 knowledgeBaseIds");
+        }
+        for (AiKnowledgeBase knowledgeBase : knowledgeBases) {
+            if (!Integer.valueOf(STATUS_ENABLED).equals(knowledgeBase.getStatus())
+                || !Integer.valueOf(KnowledgeBaseTestResult.STATUS_SUCCESS).equals(knowledgeBase.getTestStatus())) {
+                throw new BizException(ResultCode.PARAM_INVALID,
+                    "仅可绑定已启用且连通性测试成功的知识库: " + knowledgeBase.getKbName());
+            }
+        }
     }
 
     /** 高级参数取值范围校验（全部选填，null 表示用默认值不校验）。 */
@@ -328,7 +366,7 @@ public class AgentService {
 
     /** 关联表整体替换：先清空该智能体现有关联行，再按本次提交的 ids 批量插入（比对差异做增量删改无必要，行数很少）。 */
     private void replaceRelations(Long agentId, List<Long> backupModelIds, List<Long> mcpIds, List<Long> skillIds,
-                                  List<Long> systemToolIds, List<Long> subAgentIds) {
+                                  List<Long> systemToolIds, List<Long> subAgentIds, List<Long> knowledgeBaseIds) {
         agentBackupModelMapper.delete(new LambdaQueryWrapper<AiAgentBackupModel>().eq(AiAgentBackupModel::getAgentId, agentId));
         List<Long> orderedBackupIds = distinctBackupIds(backupModelIds);
         for (int i = 0; i < orderedBackupIds.size(); i++) {
@@ -372,6 +410,16 @@ public class AgentService {
                 relation.setAgentId(agentId);
                 relation.setSubAgentId(subAgentId);
                 agentSubAgentMapper.insert(relation);
+            }
+        }
+        agentKnowledgeBaseMapper.delete(
+            new LambdaQueryWrapper<AiAgentKnowledgeBase>().eq(AiAgentKnowledgeBase::getAgentId, agentId));
+        if (!CollectionUtils.isEmpty(knowledgeBaseIds)) {
+            for (Long knowledgeBaseId : knowledgeBaseIds) {
+                AiAgentKnowledgeBase relation = new AiAgentKnowledgeBase();
+                relation.setAgentId(agentId);
+                relation.setKnowledgeBaseId(knowledgeBaseId);
+                agentKnowledgeBaseMapper.insert(relation);
             }
         }
     }
@@ -422,7 +470,23 @@ public class AgentService {
         vo.setToolMaxAttempts(agent.getToolMaxAttempts());
         vo.setCompressTriggerMsgs(agent.getCompressTriggerMsgs());
         vo.setCompressKeepMsgs(agent.getCompressKeepMsgs());
+        fillKnowledgeBases(vo, agent.getId());
         return vo;
+    }
+
+    /** 回填绑定的知识库 id 与名称：名称走一次批量查询（避免 N+1 单查），与 {@link #fillBackupModels} 同款手法。 */
+    private void fillKnowledgeBases(AgentVO vo, Long agentId) {
+        List<Long> knowledgeBaseIds = agentKnowledgeBaseMapper.selectList(
+                new LambdaQueryWrapper<AiAgentKnowledgeBase>().eq(AiAgentKnowledgeBase::getAgentId, agentId))
+            .stream().map(AiAgentKnowledgeBase::getKnowledgeBaseId).collect(Collectors.toList());
+        vo.setKnowledgeBaseIds(knowledgeBaseIds);
+        if (CollectionUtils.isEmpty(knowledgeBaseIds)) {
+            vo.setKnowledgeBaseNames(List.of());
+            return;
+        }
+        Map<Long, String> nameById = knowledgeBaseMapper.selectBatchIds(knowledgeBaseIds).stream()
+            .collect(Collectors.toMap(AiKnowledgeBase::getId, AiKnowledgeBase::getKbName));
+        vo.setKnowledgeBaseNames(knowledgeBaseIds.stream().map(nameById::get).collect(Collectors.toList()));
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeBaseEndpoint.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeBaseEndpoint.java
@@ -1,0 +1,41 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import java.math.BigDecimal;
+
+/**
+ * 一次检索所需的知识库连接参数（apiKey 已解密）。刻意与实体 {@code AiKnowledgeBase} 解耦：
+ * 检索客户端只依赖这几个值，既不碰 MyBatis 实体，也让单测能脱离数据库直接构造。
+ *
+ * @param id             知识库 ID（日志定位用）
+ * @param kbName         知识库名称（注入内容里标注来源用）
+ * @param baseUrl        RAG 服务基址
+ * @param appId          知识库应用 ID
+ * @param apiKey         AppKey 明文
+ * @param contentType    请求 Content-Type
+ * @param extraHeaders   自定义请求头（JSON 对象字符串，空=无）
+ * @param topN           单库返回条数
+ * @param scoreThreshold 相关度阈值（低于该值丢弃；0=不过滤）
+ * @author owlzhangfq@gmail.com
+ */
+public record KnowledgeBaseEndpoint(Long id, String kbName, String baseUrl, String appId, String apiKey,
+                                    String contentType, String extraHeaders, Integer topN,
+                                    BigDecimal scoreThreshold) {
+
+    /** 默认返回条数（配置留空时用）。 */
+    public static final int DEFAULT_TOP_N = 5;
+    /** 默认 Content-Type（配置留空时用）。 */
+    public static final String DEFAULT_CONTENT_TYPE = "application/json";
+
+    public int effectiveTopN() {
+        return topN == null || topN <= 0 ? DEFAULT_TOP_N : topN;
+    }
+
+    public String effectiveContentType() {
+        return contentType == null || contentType.isBlank() ? DEFAULT_CONTENT_TYPE : contentType;
+    }
+
+    /** 阈值为空视为 0（不过滤）。 */
+    public BigDecimal effectiveScoreThreshold() {
+        return scoreThreshold == null ? BigDecimal.ZERO : scoreThreshold;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeBaseHttpGuard.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeBaseHttpGuard.java
@@ -1,0 +1,132 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * RAG 知识库地址校验：本链路唯一的地址防御点，由 {@link KnowledgeSearchClient} 在发起请求前调用
+ * （fast fail，命中即抛业务异常，不进入真实请求）。
+ *
+ * <p><b>与 {@code SystemToolHttpGuard} 的信任边界差异（这也是不复用它、另起白名单的原因）</b>：
+ * 系统工具的目标地址由<b>大模型</b>决定，默认必须拒内网；RAG 知识库的地址由<b>持
+ * {@code knowledge-base:add/edit} 权限的管理员</b>在后台显式配置，且企业 RAG 服务基本都在内网
+ * （用户本机即 {@code localhost:20002}）。因此这里默认放行内网/环回，否则功能直接不可用。
+ * 复用系统工具的白名单会把 RAG 的内网地址一并授信给模型可控的 HTTP 工具，绝不可取。</p>
+ *
+ * <p>两种模式（见 {@link AdminRagProperties#getAllowedHosts()}）：
+ * <ul>
+ *   <li>默认（白名单为空）：只做两件事——协议必须是 http/https；DNS 解析后拒绝<b>链路本地</b>地址
+ *       （169.254.0.0/16 与 IPv6 fe80::/10，云元数据服务 169.254.169.254 是典型 SSRF 目标，
+ *       且绝无可能是一台 RAG 服务）。内网/环回一律放行；</li>
+ *   <li>白名单非空（收紧模式）：只按 host 字符串匹配白名单，命中放行、否则拒绝（白名单本身即信任边界，
+ *       不再做 DNS 与地址判定）。生产建议显式配置，把信任边界收敛到已知的几台 RAG 服务。</li>
+ * </ul></p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class KnowledgeBaseHttpGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(KnowledgeBaseHttpGuard.class);
+
+    private static final String ERROR_CODE = "RAG-HTTP-FORBIDDEN";
+    private static final String WILDCARD_PREFIX = "*.";
+    private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+    private final AdminRagProperties properties;
+
+    public KnowledgeBaseHttpGuard(AdminRagProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * 校验目标 RAG 基址是否允许访问；不允许则 fast fail 抛出 {@link BizException}。
+     * @param baseUrl 知识库配置里的服务基址
+     */
+    public void checkAllowed(String baseUrl) {
+        URI uri = parseUri(baseUrl);
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!ALLOWED_SCHEMES.contains(scheme)) {
+            log.error("rag base url blocked by scheme, code={}, url={}", ERROR_CODE, baseUrl);
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN, "仅支持 http/https 协议: " + baseUrl);
+        }
+        String host = uri.getHost();
+        if (!StringUtils.hasText(host)) {
+            log.error("rag base url without host, code={}, url={}", ERROR_CODE, baseUrl);
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN, "URL 缺少 host: " + baseUrl);
+        }
+
+        List<String> whitelist = properties.getAllowedHosts();
+        if (!CollectionUtils.isEmpty(whitelist)) {
+            // 收紧模式：仅放行白名单内 host，不再做 DNS 与地址判定
+            if (!hostWhitelisted(host, whitelist)) {
+                log.error("rag base url blocked by whitelist, code={}, host={}", ERROR_CODE, host);
+                throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN, "目标 host 不在白名单内: " + host);
+            }
+            return;
+        }
+
+        // 默认模式：放行内网/环回（RAG 通常内网部署），仅拦截链路本地（云元数据服务等）
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            log.error("rag base url dns resolve failed, code={}, host={}", ERROR_CODE, host, e);
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN, "目标 host 无法解析: " + host);
+        }
+        for (InetAddress address : addresses) {
+            if (address.isLinkLocalAddress()) {
+                log.error("rag base url blocked link-local address, code={}, host={}, ip={}",
+                    ERROR_CODE, host, address.getHostAddress());
+                throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN,
+                    "目标地址指向链路本地/元数据服务，已拦截: " + host);
+            }
+        }
+    }
+
+    /** 解析 URL；URL 为空或格式非法直接 fast fail。 */
+    private URI parseUri(String baseUrl) {
+        if (!StringUtils.hasText(baseUrl)) {
+            log.error("rag base url blank, code={}", ERROR_CODE);
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN, "baseUrl 不能为空");
+        }
+        try {
+            return URI.create(baseUrl.trim());
+        } catch (Exception e) {
+            log.error("rag base url malformed, code={}, url={}", ERROR_CODE, baseUrl, e);
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_HTTP_FORBIDDEN, "baseUrl 格式非法: " + baseUrl);
+        }
+    }
+
+    /** host 是否命中白名单：精确域名 equalsIgnoreCase，或 {@code *.example.com} 匹配其子域。 */
+    boolean hostWhitelisted(String host, List<String> whitelist) {
+        String lowerHost = host.toLowerCase(Locale.ROOT);
+        for (String pattern : whitelist) {
+            if (!StringUtils.hasText(pattern)) {
+                continue;
+            }
+            String lowerPattern = pattern.trim().toLowerCase(Locale.ROOT);
+            if (lowerPattern.startsWith(WILDCARD_PREFIX)) {
+                String suffix = lowerPattern.substring(WILDCARD_PREFIX.length() - 1); // 保留前导点 ".example.com"
+                if (lowerHost.endsWith(suffix)) {
+                    return true;
+                }
+            } else if (lowerHost.equals(lowerPattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeNode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeNode.java
@@ -1,0 +1,16 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import java.math.BigDecimal;
+
+/**
+ * 一条召回片段（对应外部接口响应里的 {@code data.nodes[]}）。
+ *
+ * @param kbName  召回来源知识库名称（多库合并后据此标注来源）
+ * @param content 片段正文
+ * @param score   相关度分数（外部服务的 rerank 分数，实测量级 0.1x）
+ * @param docId   文档 ID
+ * @param chunkId 分块 ID
+ * @author owlzhangfq@gmail.com
+ */
+public record KnowledgeNode(String kbName, String content, BigDecimal score, String docId, String chunkId) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClient.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClient.java
@@ -65,6 +65,8 @@ public class KnowledgeSearchClient {
     private static final String HEADER_CONTENT_TYPE = "Content-Type";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String CODE_SEARCH_FAIL = "RAG-SEARCH-FAIL";
+    /** 非 JSON 错误响应体透出的最大字符数（避免把网关 HTML 错误页整页塞进提示）。 */
+    private static final int ERROR_BODY_MAX_CHARS = 200;
     private static final String CODE_HEADER_INVALID = "RAG-HEADER-INVALID";
 
     /**
@@ -129,8 +131,10 @@ public class KnowledgeSearchClient {
 
             HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {
+                // 错误详情只在响应体里（如 code=APP_ACCESS_DENIED / message=该 API Key 未被授权调用应用 xxx），
+                // 只报状态码等于把唯一有用的线索丢掉，使用者无从判断是密钥错、应用未授权还是服务内部故障
                 throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED,
-                    "知识库服务返回 HTTP " + response.statusCode());
+                    "知识库服务返回 HTTP " + response.statusCode() + describeErrorBody(response.body()));
             }
             return parseNodes(objectMapper, endpoint.kbName(), response.body());
         } catch (BizException e) {
@@ -140,6 +144,30 @@ public class KnowledgeSearchClient {
                 endpoint.id(), endpoint.kbName(), e);
             throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, diagnose(e, endpoint));
         }
+    }
+
+    /**
+     * 提取非 200 响应体里的错误详情：优先取约定的 {@code code}/{@code message} 字段，
+     * 结构不符则退回原文截断（{@value #ERROR_BODY_MAX_CHARS} 字符）。响应体为空时返回空串。
+     */
+    static String describeErrorBody(String body) {
+        if (!StringUtils.hasText(body)) {
+            return "";
+        }
+        try {
+            JsonNode root = new ObjectMapper().readTree(body);
+            String code = root.path("code").asText("");
+            String message = root.path("message").asText("");
+            if (StringUtils.hasText(code) || StringUtils.hasText(message)) {
+                return "（" + (StringUtils.hasText(code) ? code : "-")
+                    + (StringUtils.hasText(message) ? ": " + message : "") + "）";
+            }
+        } catch (Exception ignored) {
+            // 非 JSON 响应体（如网关 HTML 错误页），退回原文截断
+        }
+        String trimmed = body.strip();
+        return "（" + (trimmed.length() > ERROR_BODY_MAX_CHARS
+            ? trimmed.substring(0, ERROR_BODY_MAX_CHARS) + "..." : trimmed) + "）";
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClient.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClient.java
@@ -1,0 +1,257 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * 外部 RAG 知识库检索客户端（JDK 内置 {@link HttpClient}，与 {@code AdminModelFactory}/
+ * {@code DashScopeEmbeddingClient} 同款手法，不引入 RestTemplate/WebClient）。
+ *
+ * <p>接口契约：{@code POST {baseUrl}/api/v1/knowledge/search}，请求头
+ * {@code Authorization: Bearer {appkey}} + Content-Type + 可选自定义头，
+ * 请求体 {@code {"query","app_id","top_n"}}；判成功 = HTTP 200 且响应体 {@code code == "OK"}。</p>
+ *
+ * <p><b>两层 API 的职责分工</b>：
+ * <ul>
+ *   <li>{@link #searchOne}：单库检索，返回<b>原始</b>召回（不做阈值过滤、不截断），失败 fast fail 抛
+ *       {@link BizException}——供保存门禁与连通性测试使用（它们需要知道"到底哪里失败了"与真实命中条数）；</li>
+ *   <li>{@link #searchAll}：多库<b>并发</b>检索 + 阈值过滤 + 合并按 score 倒排取 top-n，
+ *       <b>任何失败/超时都吞掉并返回已成功的部分</b>——供对话链路使用，检索绝不打断对话。
+ *       这是本功能唯一的防御式编程收敛处。</li>
+ * </ul></p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class KnowledgeSearchClient {
+
+    private static final Logger log = LoggerFactory.getLogger(KnowledgeSearchClient.class);
+
+    private static final String SEARCH_PATH = "/api/v1/knowledge/search";
+    private static final String RESPONSE_CODE_OK = "OK";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String CODE_SEARCH_FAIL = "RAG-SEARCH-FAIL";
+    private static final String CODE_HEADER_INVALID = "RAG-HEADER-INVALID";
+
+    /**
+     * 自定义头里被禁止覆盖的保留头：Authorization/Content-Type 由本客户端按知识库配置统一设置，
+     * JDK HttpRequest 的 {@code header()} 是追加而非覆盖，重复设置会产生两个同名头，行为不可控。
+     */
+    private static final Set<String> RESERVED_HEADERS =
+        Set.of(HEADER_AUTHORIZATION.toLowerCase(Locale.ROOT), HEADER_CONTENT_TYPE.toLowerCase(Locale.ROOT));
+
+    /**
+     * 多库并发检索专用线程池：与 Tomcat 请求线程、以及 ForkJoin common pool 都隔离——
+     * common pool 是全 JVM 共享的，把可能阻塞数秒的 HTTP 调用丢进去会拖垮其它并行任务。
+     * 检索是低频短任务，固定 8 线程足够；守护线程，不阻塞 JVM 退出。
+     */
+    private static final ExecutorService SEARCH_EXECUTOR = Executors.newFixedThreadPool(8, r -> {
+        Thread thread = new Thread(r, "rag-search-worker");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final KnowledgeBaseHttpGuard httpGuard;
+    private final AdminRagProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient;
+
+    public KnowledgeSearchClient(KnowledgeBaseHttpGuard httpGuard, AdminRagProperties properties) {
+        this.httpGuard = httpGuard;
+        this.properties = properties;
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(properties.getConnectTimeoutSeconds()))
+            .build();
+    }
+
+    /**
+     * 单库检索，返回原始召回（不过滤、不截断）。地址校验在此收口（{@link KnowledgeBaseHttpGuard}）。
+     * 任何失败（地址被拦截 / 网络异常 / 非 200 / code != OK / 响应结构非法）均抛 {@link BizException}。
+     */
+    public List<KnowledgeNode> searchOne(KnowledgeBaseEndpoint endpoint, String query) {
+        httpGuard.checkAllowed(endpoint.baseUrl());
+        try {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("query", query);
+            payload.put("app_id", endpoint.appId());
+            payload.put("top_n", endpoint.effectiveTopN());
+            String body = objectMapper.writeValueAsString(payload);
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(trimTrailingSlash(endpoint.baseUrl()) + SEARCH_PATH))
+                .timeout(Duration.ofSeconds(properties.getRequestTimeoutSeconds()))
+                .header(HEADER_CONTENT_TYPE, endpoint.effectiveContentType())
+                .header(HEADER_AUTHORIZATION, BEARER_PREFIX + endpoint.apiKey())
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+            parseExtraHeaders(objectMapper, endpoint.extraHeaders()).forEach(builder::header);
+
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED,
+                    "知识库服务返回 HTTP " + response.statusCode());
+            }
+            return parseNodes(objectMapper, endpoint.kbName(), response.body());
+        } catch (BizException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("rag search failed, code={}, kbId={}, kbName={}", CODE_SEARCH_FAIL,
+                endpoint.id(), endpoint.kbName(), e);
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * 多库并发检索：各库独立请求（互不阻塞），按各自 {@code scoreThreshold} 过滤后合并，
+     * 全局按 score 倒排取 top-n。
+     *
+     * <p><b>降级约定</b>：单库失败只记 error 日志并当作空召回，整体超时同样按已完成部分处理，
+     * 绝不向上抛异常——对话链路的可用性优先于检索完整性。</p>
+     *
+     * <p>合并后的条数上限取各库 {@code topN} 的最大值：每个库自己声明"我最多贡献几条"，
+     * 合并时用最宽松的那个当全局上限，既不会因为某个库配了 1 条就把其它库的召回砍掉，
+     * 也不会无上限地把全部库的召回都塞进上下文。</p>
+     */
+    public List<KnowledgeNode> searchAll(List<KnowledgeBaseEndpoint> endpoints, String query) {
+        if (CollectionUtils.isEmpty(endpoints) || !StringUtils.hasText(query)) {
+            return List.of();
+        }
+        List<CompletableFuture<List<KnowledgeNode>>> futures = endpoints.stream()
+            .map(endpoint -> CompletableFuture
+                .supplyAsync(() -> filterByThreshold(searchOne(endpoint, query), endpoint), SEARCH_EXECUTOR)
+                .exceptionally(ex -> {
+                    log.error("rag search degraded to empty, code={}, kbId={}, kbName={}",
+                        CODE_SEARCH_FAIL, endpoint.id(), endpoint.kbName(), ex);
+                    return List.<KnowledgeNode>of();
+                }))
+            .collect(Collectors.toList());
+
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .get(properties.getRetrievalTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("rag search wait timeout or interrupted, code={}, kbCount={}",
+                "RAG-SEARCH-TIMEOUT", endpoints.size(), e);
+        }
+
+        List<KnowledgeNode> merged = new ArrayList<>();
+        for (CompletableFuture<List<KnowledgeNode>> future : futures) {
+            // 整体超时后仍未完成的库直接跳过（getNow 给默认空值），已完成的照常合并
+            merged.addAll(future.getNow(List.of()));
+        }
+        int limit = endpoints.stream().mapToInt(KnowledgeBaseEndpoint::effectiveTopN).max()
+            .orElse(KnowledgeBaseEndpoint.DEFAULT_TOP_N);
+        return merged.stream()
+            .sorted(Comparator.comparing(KnowledgeNode::score, Comparator.reverseOrder()))
+            .limit(limit)
+            .collect(Collectors.toList());
+    }
+
+    /** 按知识库自身阈值过滤：score 严格小于阈值即丢弃；阈值为 0（默认）时全部保留。 */
+    private List<KnowledgeNode> filterByThreshold(List<KnowledgeNode> nodes, KnowledgeBaseEndpoint endpoint) {
+        BigDecimal threshold = endpoint.effectiveScoreThreshold();
+        if (threshold.signum() <= 0) {
+            return nodes;
+        }
+        return nodes.stream()
+            .filter(node -> node.score().compareTo(threshold) >= 0)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 解析检索响应：{@code {"code":"OK","data":{"nodes":[{content,score,doc_id,chunk_id}]}}}。
+     * 包级可见 + 静态，便于离线单测直接喂样例响应。
+     */
+    static List<KnowledgeNode> parseNodes(ObjectMapper mapper, String kbName, String responseBody) throws Exception {
+        JsonNode root = mapper.readTree(responseBody);
+        String code = root.path("code").asText("");
+        if (!RESPONSE_CODE_OK.equals(code)) {
+            String message = root.path("message").asText("响应 code 非 OK");
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, "知识库服务返回 code=" + code + ", message=" + message);
+        }
+        JsonNode nodes = root.path("data").path("nodes");
+        if (!nodes.isArray()) {
+            return List.of();
+        }
+        List<KnowledgeNode> result = new ArrayList<>(nodes.size());
+        for (JsonNode node : nodes) {
+            String content = node.path("content").asText("");
+            if (!StringUtils.hasText(content)) {
+                continue;
+            }
+            result.add(new KnowledgeNode(kbName, content,
+                BigDecimal.valueOf(node.path("score").asDouble(0d)),
+                node.path("doc_id").asText(""),
+                node.path("chunk_id").asText("")));
+        }
+        return result;
+    }
+
+    /**
+     * 解析自定义请求头（JSON 对象字符串 → header map），保留头被忽略。
+     * 静态且公开：保存时校验（{@code KnowledgeBaseService}）与运行时解析共用同一份实现，避免两处规则漂移。
+     *
+     * @throws IllegalArgumentException JSON 非法或不是对象结构
+     */
+    public static Map<String, String> parseExtraHeaders(ObjectMapper mapper, String extraHeaders) {
+        if (!StringUtils.hasText(extraHeaders)) {
+            return Map.of();
+        }
+        JsonNode root;
+        try {
+            root = mapper.readTree(extraHeaders);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("extraHeaders 不是合法 JSON: " + e.getMessage(), e);
+        }
+        if (!root.isObject()) {
+            throw new IllegalArgumentException("extraHeaders 必须是 JSON 对象，如 {\"X-Tenant\":\"a\"}");
+        }
+        Map<String, String> headers = new HashMap<>();
+        Iterator<Map.Entry<String, JsonNode>> fields = root.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field = fields.next();
+            String name = field.getKey();
+            if (!StringUtils.hasText(name)) {
+                continue;
+            }
+            if (RESERVED_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
+                log.info("[rag] reserved header ignored in extraHeaders, code={}, header={}", CODE_HEADER_INVALID, name);
+                continue;
+            }
+            headers.put(name, field.getValue().asText(""));
+        }
+        return headers;
+    }
+
+    private static String trimTrailingSlash(String url) {
+        return url != null && url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClient.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClient.java
@@ -12,10 +12,14 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
+import java.net.ConnectException;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -89,9 +93,18 @@ public class KnowledgeSearchClient {
     public KnowledgeSearchClient(KnowledgeBaseHttpGuard httpGuard, AdminRagProperties properties) {
         this.httpGuard = httpGuard;
         this.properties = properties;
+        // 强制 HTTP/1.1：JDK HttpClient 默认 HTTP_2，对 http:// 会先发 h2c upgrade 协商；
+        // 实测部分自建 RAG 服务（如 Node 实现）既不支持该协商也不回错误，导致请求挂起到超时。
+        // RAG 检索是小报文短连接，用不上 HTTP/2 多路复用，固定 1.1 最稳。
         this.httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
             .connectTimeout(Duration.ofSeconds(properties.getConnectTimeoutSeconds()))
             .build();
+    }
+
+    /** 当前使用的 HTTP 协议版本（同包测试用于守住"必须固定 HTTP/1.1"这条约束）。 */
+    HttpClient.Version httpClientVersion() {
+        return httpClient.version();
     }
 
     /**
@@ -125,8 +138,29 @@ public class KnowledgeSearchClient {
         } catch (Exception e) {
             log.error("rag search failed, code={}, kbId={}, kbName={}", CODE_SEARCH_FAIL,
                 endpoint.id(), endpoint.kbName(), e);
-            throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, e.getMessage());
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, diagnose(e, endpoint));
         }
+    }
+
+    /**
+     * 把底层网络异常翻译成能直接定位问题的提示。
+     *
+     * <p>JDK 的连接类异常 message 常为 null（如 {@code ConnectException: null}），直接透出等于没有信息，
+     * 使用者无从下手；这里按异常类型给出具体排查方向。</p>
+     */
+    String diagnose(Exception e, KnowledgeBaseEndpoint endpoint) {
+        if (e instanceof ConnectException || e instanceof HttpConnectTimeoutException) {
+            return "无法建立连接（" + endpoint.baseUrl() + "）：请确认服务已启动、地址与端口正确；"
+                + "若地址用的是 localhost 而服务只监听 IPv6，可改填 http://[::1]:端口";
+        }
+        if (e instanceof UnknownHostException) {
+            return "域名无法解析（" + endpoint.baseUrl() + "）：请检查服务地址拼写与 DNS";
+        }
+        if (e instanceof HttpTimeoutException) {
+            return "请求超时（超过 " + properties.getRequestTimeoutSeconds() + " 秒未返回）：知识库服务响应过慢，"
+                + "或该服务不支持 HTTP/2 协商导致挂起；可调大 admin.rag.request-timeout-seconds 后重试";
+        }
+        return StringUtils.hasText(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/controller/KnowledgeBaseController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/controller/KnowledgeBaseController.java
@@ -1,0 +1,102 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseOptionVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.service.KnowledgeBaseService;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * RAG 知识库配置管理：CRUD + 分页/搜索 + 启停 + 连通性测试 + 智能体表单下拉。
+ *
+ * <p>{@code test-connectivity} 返回 {@link CompletableFuture}：Spring MVC 异步支持下，
+ * 该请求在等待外部 RAG 服务响应期间释放 Tomcat 请求线程（与 {@code ModelConfigController} 同款）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/aiconfig/knowledge-base")
+public class KnowledgeBaseController {
+
+    private final KnowledgeBaseService knowledgeBaseService;
+
+    public KnowledgeBaseController(KnowledgeBaseService knowledgeBaseService) {
+        this.knowledgeBaseService = knowledgeBaseService;
+    }
+
+    @SaCheckPermission("knowledge-base:view")
+    @GetMapping("/page")
+    public Result<PageResult<KnowledgeBaseVO>> page(PageQuery query) {
+        return Result.success(knowledgeBaseService.page(query));
+    }
+
+    @SaCheckPermission("knowledge-base:view")
+    @GetMapping("/{id}")
+    public Result<KnowledgeBaseVO> get(@PathVariable Long id) {
+        return Result.success(knowledgeBaseService.get(id));
+    }
+
+    /** 智能体表单下拉：仅 status=1 且 testStatus=1 的知识库，权限点复用 view。 */
+    @SaCheckPermission("knowledge-base:view")
+    @GetMapping("/options")
+    public Result<List<KnowledgeBaseOptionVO>> options() {
+        return Result.success(knowledgeBaseService.options());
+    }
+
+    @SaCheckPermission("knowledge-base:add")
+    @OperationLog(operation = "新建知识库", target = "ai_knowledge_base")
+    @PostMapping
+    public Result<Void> create(@Valid @RequestBody KnowledgeBaseSaveRequest request) {
+        knowledgeBaseService.create(request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("knowledge-base:edit")
+    @OperationLog(operation = "编辑知识库", target = "ai_knowledge_base")
+    @PutMapping("/{id}")
+    public Result<Void> update(@PathVariable Long id, @Valid @RequestBody KnowledgeBaseSaveRequest request) {
+        knowledgeBaseService.update(id, request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("knowledge-base:delete")
+    @OperationLog(operation = "删除知识库", target = "ai_knowledge_base")
+    @DeleteMapping("/{id}")
+    public Result<Void> delete(@PathVariable Long id) {
+        knowledgeBaseService.delete(id);
+        return Result.success();
+    }
+
+    @SaCheckPermission("knowledge-base:edit")
+    @OperationLog(operation = "知识库启停", target = "ai_knowledge_base")
+    @PutMapping("/{id}/status")
+    public Result<Void> updateStatus(@PathVariable Long id, @RequestParam int status) {
+        knowledgeBaseService.updateStatus(id, status);
+        return Result.success();
+    }
+
+    /** 不修改配置，仅探测可达性，复用 knowledge-base:view 权限点即可，不额外新增权限点。 */
+    @SaCheckPermission("knowledge-base:view")
+    @OperationLog(operation = "知识库连通性测试", target = "ai_knowledge_base")
+    @PostMapping("/{id}/test-connectivity")
+    public CompletableFuture<Result<KnowledgeBaseTestResult>> testConnectivity(@PathVariable Long id) {
+        return knowledgeBaseService.testConnectivity(id).thenApply(Result::success);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseOptionVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseOptionVO.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto;
+
+/**
+ * 知识库下拉选项（智能体表单用）：只返回 status=1 且 testStatus=1 的知识库。
+ *
+ * @param id     知识库 ID
+ * @param kbName 知识库名称
+ * @author owlzhangfq@gmail.com
+ */
+public record KnowledgeBaseOptionVO(Long id, String kbName) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseSaveRequest.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+/**
+ * 知识库新建/编辑请求。新建时 {@code apiKey} 必填；编辑时可不传（留空=不改 AppKey，
+ * 避免每次编辑都要求重新输入明文密钥，与 {@code ModelSaveRequest} 同款约定）。
+ *
+ * @param kbName         知识库名称（唯一）
+ * @param baseUrl        RAG 服务基址（不含 /api/v1/knowledge/search 路径）
+ * @param appId          知识库应用 ID（请求体 app_id）
+ * @param apiKey         AppKey 明文；编辑留空=不改
+ * @param contentType    请求 Content-Type，留空按 application/json
+ * @param extraHeaders   自定义请求头（JSON 对象字符串），留空=无
+ * @param topN           单次检索返回条数，留空按 5
+ * @param scoreThreshold 相关度阈值，留空按 0（不过滤）
+ * @param status         0禁用 / 1启用，留空按启用
+ * @param remark         备注
+ * @author owlzhangfq@gmail.com
+ */
+public record KnowledgeBaseSaveRequest(
+    @NotBlank(message = "kbName 不能为空") String kbName,
+    @NotBlank(message = "baseUrl 不能为空") String baseUrl,
+    @NotBlank(message = "appId 不能为空") String appId,
+    String apiKey,
+    String contentType,
+    String extraHeaders,
+    Integer topN,
+    BigDecimal scoreThreshold,
+    Integer status,
+    String remark) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseTestResult.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseTestResult.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 知识库连通性测试结果。用固定探测语句真实发一次检索请求，{@code hitCount} 为本次召回条数
+ * （0 条也算连通成功——判成功的标准是 HTTP 200 且响应体 {@code code == "OK"}，与召回多寡无关）。
+ *
+ * @param testStatus 0未测试 / 1成功 / 2失败
+ * @param testTime   本次测试时间
+ * @param message    失败原因（成功时为 null）
+ * @param hitCount   本次探测召回条数
+ * @author owlzhangfq@gmail.com
+ */
+public record KnowledgeBaseTestResult(int testStatus, LocalDateTime testTime, String message, int hitCount) {
+
+    public static final int STATUS_UNTESTED = 0;
+    public static final int STATUS_SUCCESS = 1;
+    public static final int STATUS_FAILED = 2;
+
+    public static KnowledgeBaseTestResult success(int hitCount) {
+        return new KnowledgeBaseTestResult(STATUS_SUCCESS, LocalDateTime.now(), null, hitCount);
+    }
+
+    public static KnowledgeBaseTestResult failed(String message) {
+        return new KnowledgeBaseTestResult(STATUS_FAILED, LocalDateTime.now(), message, 0);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseVO.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 知识库视图对象。{@code apiKeyMasked} 只保留末 4 位，真实密文永不出现在响应体中。
+ * 字段名为前端契约，不可改动。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class KnowledgeBaseVO {
+    private Long id;
+    private String kbName;
+    private String baseUrl;
+    private String appId;
+    private String apiKeyMasked;
+    private String contentType;
+    private String extraHeaders;
+    private Integer topN;
+    private BigDecimal scoreThreshold;
+    private Integer status;
+    private Integer testStatus;
+    private LocalDateTime testTime;
+    private String remark;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/entity/AiAgentKnowledgeBase.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/entity/AiAgentKnowledgeBase.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 智能体-知识库 关联（纯关系表，无审计列，仿 {@code ai_agent_mcp}）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_agent_knowledge_base")
+public class AiAgentKnowledgeBase {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private Long agentId;
+    private Long knowledgeBaseId;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/entity/AiKnowledgeBase.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/entity/AiKnowledgeBase.java
@@ -1,0 +1,59 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * RAG 知识库配置（一行 = 一个外部知识库：baseUrl + appId + apiKey）。
+ * {@code apiKey} 为 AES/GCM 密文，永不通过接口原样返回给前端（{@code @JsonIgnore} 兜底，
+ * 真正的回显值走 {@code KnowledgeBaseVO.apiKeyMasked} 掩码字段）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_knowledge_base")
+public class AiKnowledgeBase {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String kbName;
+    /** RAG 服务基址（不含 {@code /api/v1/knowledge/search} 路径）。 */
+    private String baseUrl;
+    /** 知识库应用 ID（检索请求体 {@code app_id}）。 */
+    private String appId;
+    @JsonIgnore
+    private String apiKey;
+    private String contentType;
+    /** 自定义请求头（JSON 对象字符串，空串=无）。 */
+    private String extraHeaders;
+    /** 单次检索返回条数（请求体 {@code top_n}）。 */
+    private Integer topN;
+    /** 相关度阈值：低于该值的召回丢弃；0=不过滤（外部 rerank 分数量级仅 0.1x）。 */
+    private BigDecimal scoreThreshold;
+    /** 0禁用 / 1启用。 */
+    private Integer status;
+    /** 0未测试 / 1成功 / 2失败。 */
+    private Integer testStatus;
+    private LocalDateTime testTime;
+    private String remark;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private Long updateBy;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    @TableLogic
+    private Integer deleted;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/mapper/AiAgentKnowledgeBaseMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/mapper/AiAgentKnowledgeBaseMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+
+/**
+ * 智能体-知识库关联 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiAgentKnowledgeBaseMapper extends BaseMapper<AiAgentKnowledgeBase> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/mapper/AiKnowledgeBaseMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/mapper/AiKnowledgeBaseMapper.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+/**
+ * RAG 知识库配置 Mapper。
+ *
+ * <p>下面两个方法专门绕开 MyBatis-Plus 的逻辑删除过滤：{@code ai_knowledge_base.uk_ai_kb_name} 是
+ * <b>不含 deleted 列</b>的纯数据库唯一约束，被软删除的行仍然占着名字，而 {@code LambdaQueryWrapper}
+ * 会自动追加 {@code AND deleted=0} 从而查不到它——必须用原生 SQL 才能看见/复活。手法与
+ * {@code SysUserMapper#selectByUsernameIgnoreLogicDelete}/{@code reviveDeletedUser} 完全一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiKnowledgeBaseMapper extends BaseMapper<AiKnowledgeBase> {
+
+    /**
+     * 按名称查一条<b>已被软删除</b>的知识库行（{@code deleted=1}）。用原生 {@code @Select}，
+     * 不会被自动追加 {@code AND deleted=0}，因此能看见被逻辑删除、但仍占着唯一索引的那一行。
+     */
+    @Select("SELECT * FROM ai_knowledge_base WHERE kb_name = #{kbName} AND deleted = 1 LIMIT 1")
+    AiKnowledgeBase selectDeletedByName(@Param("kbName") String kbName);
+
+    /**
+     * "复活"一个被软删除的知识库行：只把 {@code deleted} 置回 0，其余业务字段由调用方随后用
+     * {@code updateById} 按新的保存请求整体覆盖（复活后该行对 MyBatis-Plus 重新可见）。
+     * 同样用原生 {@code @Update} 才能命中当前 {@code deleted=1} 的目标行。
+     */
+    @Update("UPDATE ai_knowledge_base SET deleted = 0 WHERE id = #{id} AND deleted = 1")
+    int reviveDeleted(@Param("id") Long id);
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalMiddleware.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalMiddleware.java
@@ -1,0 +1,171 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime;
+
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.ReasoningInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * 知识库召回内容的<b>瞬态</b>注入中间件：每轮推理前把召回块挂成一条只对模型可见的消息。
+ *
+ * <p><b>为什么是中间件而不是在 ChatService 拼用户消息文本</b>（评审后改造，两个实证问题一并解决）：</p>
+ * <ol>
+ *   <li><b>不阻塞 Tomcat 请求线程</b>：{@code ChatController.stream()} 返回 {@code Flux} 不代表
+ *       {@code ChatService.chatStream(...)} 方法体是异步的——方法体在 Tomcat worker 线程跑完才返回，
+ *       原来在那里同步做 HTTP 检索会最长占住一个请求线程 10s，RAG 后端变慢会连累登录等无关接口
+ *       （Tomcat 默认 200 线程全模块共享）。挪到 {@code onReasoning} 后，检索发生在 Agent 执行期间的
+ *       reactive 线程上，并进一步用 {@link Schedulers#boundedElastic()} 承接这次阻塞调用。</li>
+ *   <li><b>不污染会话历史</b>：{@code onReasoning} 拿到的 {@code ReasoningInput.messages()} 是框架为
+ *       "本次模型调用"临时组装的列表（{@code ReActAgent} 里 {@code prependSystemMsg(...)} 的产物），
+ *       核心逻辑只把它交给 {@code reasoningStream(...)} 发给模型，<b>不会写回 AgentState</b>——
+ *       只有模型产出的最终消息才会进 {@code state.contextMutable()}。框架自带的
+ *       {@code TaskReminderMiddleware} 正是靠这一点做 {@code <system-reminder>} 注入，其类注释原文：
+ *       "The reminder is appended <i>transiently</i> to the reasoning input only; it is never written
+ *       into AgentState.context, so it is never persisted, compacted, or recalled."
+ *       已废弃的 {@code GenericRAGHook} 当年也是同样手法（拦 PreCallEvent 往 inputMessages 追加一条
+ *       USER 消息）。因此用户可见的历史里永远不会出现 {@code <retrieved_knowledge>}，
+ *       也不存在"旧召回块每轮重发、token 线性累积"的问题。</li>
+ * </ol>
+ *
+ * <p><b>注入形态</b>：不改用户那条消息，而是在消息列表<b>末尾追加</b>一条独立的 USER 消息
+ * （与 {@code TaskReminderMiddleware}/{@code GenericRAGHook} 一致：追加独立消息而非改写原消息，
+ * 原消息的 {@code Msg.id} 因此天然保持稳定，附件绑定不受影响）。消息带
+ * {@link Msg#METADATA_SYNTHETIC} 标记，任何观察到它的消费方都能识别为框架合成消息而跳过。
+ * 放末尾是让参考资料紧邻用户提问，符合"上下文放末尾"的注意力分布。</p>
+ *
+ * <p><b>每轮只检索一次</b>：ReAct 循环里每迭代一次就会调一次 {@code onReasoning}，若每次都去检索，
+ * 一轮对话会打出 N 次 HTTP。这里把首次结果缓存进 {@link RuntimeContext}（
+ * {@code AdminAgentInstanceFactory#contextFor} 每次调用新建一个，天然是"一轮一份"），
+ * 后续迭代直接复用同一个块重新注入——既保证工具调用循环里模型始终看得到参考资料，又只付一次检索代价。</p>
+ *
+ * <p><b>失败绝不打断对话</b>：{@link KnowledgeRetrievalService#retrieve} 内部已 catch 一切异常回退
+ * null，本类再叠一层 {@code onErrorResume} 兜住调度层面的意外，任何情况下都会照常 {@code next.apply}。</p>
+ *
+ * <p>本中间件<b>按智能体实例构建</b>（{@code agentCode} 构建期绑定，见
+ * {@code AdminAgentInstanceFactory#buildInnerReActAgent}），不是共享单例 Bean——省得运行时再从
+ * 上下文反推"当前是哪个 agent"。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class KnowledgeRetrievalMiddleware implements MiddlewareBase {
+
+    private static final Logger log = LoggerFactory.getLogger(KnowledgeRetrievalMiddleware.class);
+
+    private static final String CODE_INJECT_FAIL = "RAG-INJECT-FAIL";
+    /** 注入消息的 {@code name}：与框架 {@code TaskReminderMiddleware} 的合成消息保持一致。 */
+    private static final String INJECTED_MSG_NAME = "system";
+    /** 合成消息的类别标记，便于排查时把它与待办提醒等其它合成消息区分开。 */
+    private static final String REMINDER_KIND = "retrieved_knowledge";
+    /** 本轮召回缓存在 RuntimeContext 里的键前缀，拼上 agentCode 做命名空间：
+     *  子 Agent 可能与父 Agent 共用同一个 RuntimeContext，不按 agentCode 隔离会让子 Agent 复用到父的召回块。 */
+    private static final String CACHE_KEY_PREFIX = "rag.retrieved.";
+
+    private final KnowledgeRetrievalService retrievalService;
+    private final String agentCode;
+
+    public KnowledgeRetrievalMiddleware(KnowledgeRetrievalService retrievalService, String agentCode) {
+        this.retrievalService = retrievalService;
+        this.agentCode = agentCode;
+    }
+
+    @Override
+    public Flux<AgentEvent> onReasoning(Agent agent, RuntimeContext ctx, ReasoningInput input,
+                                         Function<ReasoningInput, Flux<AgentEvent>> next) {
+        String cacheKey = CACHE_KEY_PREFIX + agentCode;
+        RetrievedBlock cached = ctx == null ? null : ctx.get(cacheKey, RetrievedBlock.class);
+        if (cached != null) {
+            // 本轮已检索过（ReAct 循环的第 2+ 次推理）：复用同一个块，不再发 HTTP
+            return next.apply(withKnowledge(input, cached.block()));
+        }
+        String query = resolveQuery(ctx, input);
+        if (!StringUtils.hasText(query)) {
+            return next.apply(input);
+        }
+        // 阻塞式 HTTP 检索强制丢到 boundedElastic：不管本流被谁订阅（Spring MVC 的 SSE 适配器可能在
+        // 请求线程上订阅），都保证不会占住 Tomcat 请求线程。
+        return Mono.fromCallable(() -> retrievalService.retrieve(agentCode, query))
+            .subscribeOn(Schedulers.boundedElastic())
+            // retrieve 返回 null 时 fromCallable 发出的是空信号，统一归一成空串走同一条注入分支
+            .defaultIfEmpty("")
+            .onErrorResume(e -> {
+                log.error("[rag] retrieval dispatch failed, code={}, agentCode={}", CODE_INJECT_FAIL, agentCode, e);
+                return Mono.just("");
+            })
+            .flatMapMany(block -> {
+                if (ctx != null) {
+                    ctx.put(cacheKey, RetrievedBlock.class, new RetrievedBlock(block));
+                }
+                return next.apply(withKnowledge(input, block));
+            });
+    }
+
+    /**
+     * 把召回块挂成一条独立的瞬态消息追加到消息列表末尾。块为空则原样返回入参，
+     * 连列表拷贝都不做（未绑知识库/未命中时零开销）。
+     */
+    private ReasoningInput withKnowledge(ReasoningInput input, String block) {
+        if (!StringUtils.hasText(block)) {
+            return input;
+        }
+        List<Msg> messages = CollectionUtils.isEmpty(input.messages())
+            ? new ArrayList<>() : new ArrayList<>(input.messages());
+        messages.add(Msg.builder()
+            .role(MsgRole.USER)
+            .name(INJECTED_MSG_NAME)
+            .content(TextBlock.builder().text(block).build())
+            .metadata(Map.of(Msg.METADATA_SYNTHETIC, true, Msg.METADATA_REMINDER_KIND, REMINDER_KIND))
+            .build());
+        return new ReasoningInput(messages, input.tools(), input.options());
+    }
+
+    /**
+     * 检索用的查询语句：优先取 {@link AgentCallMeta#question()}，回退到消息列表里最后一条 USER 消息文本。
+     *
+     * <p>为什么优先用 callMeta：VibeCoding 链路送进 Agent 的是"路径指引 + 用户提问"的拼接文本
+     * （见 {@code VibeCodingService} 的 FILE_DIRECTIVE_TEMPLATE），拿它去检索等于给 RAG 喂一大段与业务
+     * 无关的指令噪声；而 {@code AgentCallMeta.question} 在对话与 VibeCoding 两条链路上装的都是
+     * <b>用户真实提问原文</b>，正好是检索需要的东西。回退取最后一条 USER 消息是
+     * {@code GenericRAGHook#extractQueryFromMessages} 的同款手法（不能取最后一条消息——ReAct 循环里
+     * 它可能是 ASSISTANT/TOOL），覆盖未绑定 callMeta 的旧调用点。</p>
+     */
+    private String resolveQuery(RuntimeContext ctx, ReasoningInput input) {
+        AgentCallMeta meta = ctx == null ? null : ctx.get(AgentCallMeta.class);
+        if (meta != null && StringUtils.hasText(meta.question())) {
+            return meta.question();
+        }
+        List<Msg> messages = input.messages();
+        if (CollectionUtils.isEmpty(messages)) {
+            return null;
+        }
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            Msg msg = messages.get(i);
+            if (msg != null && msg.getRole() == MsgRole.USER && StringUtils.hasText(msg.getTextContent())) {
+                return msg.getTextContent();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 本轮召回结果在 {@link RuntimeContext} 里的载体。用具名类型而非裸 String 作 key，
+     * 避免与上下文里其它字符串属性撞车；{@code block} 为空串表示"本轮检索过但无需注入"，
+     * 与"尚未检索"（键不存在）区分开。
+     */
+    private record RetrievedBlock(String block) { }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalService.java
@@ -1,0 +1,161 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeBaseEndpoint;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeNode;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeSearchClient;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 每轮对话的知识库检索（对话 + VibeCoding 共用）：只负责"按提问召回并渲染成注入块"，
+ * <b>不负责往哪儿注入</b>——注入由 {@link KnowledgeRetrievalMiddleware} 在推理阶段完成。
+ *
+ * <p><b>触发方式刻意不做成工具</b>：做成 {@code @Tool} 要靠模型自己决定调不调、调几次，
+ * 对"每轮都应该带上业务知识"的客服/编码场景不可靠。这里改成每轮推理前自动检索、把召回内容
+ * 随消息一起送进模型，模型无需决策。</p>
+ *
+ * <p><b>零开销约定</b>：智能体没绑定任何知识库时不发任何请求（只查一次关联表就返回 null）。</p>
+ *
+ * <p><b>为什么本类只返回块、不再拼接用户消息文本</b>（评审后改造）：早先的实现把召回块拼在用户
+ * 消息文本尾部，导致注入内容随用户消息一起进了框架 {@code AgentState} 被持久化——历史接口会把
+ * {@code <retrieved_knowledge>} 原样回显给用户，且该块进了会话记忆后每轮都会重发给模型、
+ * token 随命中轮次线性累积。现在改为只返回渲染好的块，由中间件在 {@code onReasoning} 阶段挂成
+ * 一条<b>瞬态</b>消息，只对本次模型调用可见，绝不进会话历史。</p>
+ *
+ * <p><b>唯一防御点</b>：本类的 {@link #retrieve} 捕获一切异常并回退为 null（=不注入），配合
+ * {@link KnowledgeSearchClient#searchAll} 的单库降级，保证检索链路任何故障都不会打断对话。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class KnowledgeRetrievalService {
+
+    private static final Logger log = LoggerFactory.getLogger(KnowledgeRetrievalService.class);
+
+    private static final String CODE_RETRIEVAL_FAIL = "RAG-RETRIEVAL-FAIL";
+    private static final int STATUS_ENABLED = 1;
+
+    private static final String BLOCK_OPEN = "<retrieved_knowledge>";
+    private static final String BLOCK_CLOSE = "</retrieved_knowledge>";
+    private static final String BLOCK_HINT =
+        "以下是根据用户本轮提问从知识库检索到的参考资料。请优先依据这些资料作答，"
+        + "引用时标注对应编号；若资料与问题无关，忽略即可，不要强行使用。";
+
+    private final AiAgentMapper agentMapper;
+    private final AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
+    private final AiKnowledgeBaseMapper knowledgeBaseMapper;
+    private final AesGcmCryptoUtil cryptoUtil;
+    private final KnowledgeSearchClient searchClient;
+
+    public KnowledgeRetrievalService(AiAgentMapper agentMapper,
+                                      AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper,
+                                      AiKnowledgeBaseMapper knowledgeBaseMapper,
+                                      AesGcmCryptoUtil cryptoUtil, KnowledgeSearchClient searchClient) {
+        this.agentMapper = agentMapper;
+        this.agentKnowledgeBaseMapper = agentKnowledgeBaseMapper;
+        this.knowledgeBaseMapper = knowledgeBaseMapper;
+        this.cryptoUtil = cryptoUtil;
+        this.searchClient = searchClient;
+    }
+
+    /**
+     * 按提问检索并渲染成注入块。未绑定知识库 / 召回为空 / 任何异常，一律返回 {@code null}
+     * （= 本轮不注入；召回为空时绝不注入空标签，避免污染上下文）。
+     *
+     * <p><b>本方法会阻塞调用线程</b>（内部是同步 {@code HttpClient.send}，上限由
+     * {@code admin.rag.retrieval-timeout-seconds} 兜死）。调用方必须保证它不跑在 Tomcat 请求线程上——
+     * 唯一调用方 {@link KnowledgeRetrievalMiddleware} 用 {@code Schedulers.boundedElastic()} 承接。</p>
+     *
+     * @param agentCode 智能体编码
+     * @param query     检索用的用户原始提问（VibeCoding 链路要用未被路径指引污染的原文）
+     * @return 渲染好的注入块；不需要注入时返回 null
+     */
+    public String retrieve(String agentCode, String query) {
+        if (!StringUtils.hasText(agentCode) || !StringUtils.hasText(query)) {
+            return null;
+        }
+        try {
+            List<KnowledgeBaseEndpoint> endpoints = resolveEndpoints(agentCode);
+            if (CollectionUtils.isEmpty(endpoints)) {
+                return null;
+            }
+            List<KnowledgeNode> nodes = searchClient.searchAll(endpoints, query);
+            if (CollectionUtils.isEmpty(nodes)) {
+                log.info("[rag] retrieval hit nothing, agentCode={}, kbCount={}", agentCode, endpoints.size());
+                return null;
+            }
+            log.info("[rag] retrieval hit, agentCode={}, kbCount={}, nodeCount={}",
+                agentCode, endpoints.size(), nodes.size());
+            return renderBlock(nodes);
+        } catch (Exception e) {
+            // 检索是旁路增强：任何失败都只记录，绝不打断对话（本功能唯一防御式编程收敛处之一）
+            log.error("[rag] retrieval failed, code={}, agentCode={}", CODE_RETRIEVAL_FAIL, agentCode, e);
+            return null;
+        }
+    }
+
+    /**
+     * 解析该智能体当前可用的知识库端点：关联表 → 知识库行 → 过滤（启用 + 测试成功）→ 解密 AppKey。
+     * 绑定时已校验过可用性，这里再按<b>当前</b>状态过滤一次，保证知识库被停用后运行时立刻不再参与检索。
+     */
+    private List<KnowledgeBaseEndpoint> resolveEndpoints(String agentCode) {
+        AiAgent agent = agentMapper.selectOne(
+            new LambdaQueryWrapper<AiAgent>().eq(AiAgent::getAgentCode, agentCode));
+        if (agent == null) {
+            return List.of();
+        }
+        List<Long> kbIds = agentKnowledgeBaseMapper.selectList(
+                new LambdaQueryWrapper<AiAgentKnowledgeBase>().eq(AiAgentKnowledgeBase::getAgentId, agent.getId()))
+            .stream().map(AiAgentKnowledgeBase::getKnowledgeBaseId).collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(kbIds)) {
+            // 未绑定任何知识库：零开销直接返回，不发任何 HTTP 请求
+            return List.of();
+        }
+        return knowledgeBaseMapper.selectBatchIds(kbIds).stream()
+            .filter(kb -> Integer.valueOf(STATUS_ENABLED).equals(kb.getStatus()))
+            .filter(kb -> Integer.valueOf(KnowledgeBaseTestResult.STATUS_SUCCESS).equals(kb.getTestStatus()))
+            .map(this::toEndpoint)
+            .collect(Collectors.toList());
+    }
+
+    private KnowledgeBaseEndpoint toEndpoint(AiKnowledgeBase kb) {
+        return new KnowledgeBaseEndpoint(kb.getId(), kb.getKbName(), kb.getBaseUrl(), kb.getAppId(),
+            cryptoUtil.decrypt(kb.getApiKey()), kb.getContentType(), kb.getExtraHeaders(), kb.getTopN(),
+            kb.getScoreThreshold());
+    }
+
+    /**
+     * 渲染注入块：带序号 + 来源（知识库名 / doc_id / chunk_id）+ 分数，方便模型在回答里标注引用来源，
+     * 也方便排查"这句话是从哪条召回来的"。
+     */
+    private String renderBlock(List<KnowledgeNode> nodes) {
+        StringBuilder builder = new StringBuilder(BLOCK_OPEN).append('\n').append(BLOCK_HINT).append('\n');
+        for (int i = 0; i < nodes.size(); i++) {
+            KnowledgeNode node = nodes.get(i);
+            builder.append('\n')
+                .append('[').append(i + 1).append("] ")
+                .append("knowledge_base=").append(node.kbName())
+                .append(" doc_id=").append(node.docId())
+                .append(" chunk_id=").append(node.chunkId())
+                .append(" score=").append(node.score().toPlainString())
+                .append('\n')
+                .append(node.content())
+                .append('\n');
+        }
+        return builder.append(BLOCK_CLOSE).toString();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseService.java
@@ -1,0 +1,349 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeBaseEndpoint;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeSearchClient;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseOptionVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+/**
+ * RAG 知识库配置管理：CRUD + AppKey 加密存储 + 启停 + 连通性测试 + <b>保存门禁</b>。
+ *
+ * <p><b>保存门禁</b>（需求硬要求）：新建必测；编辑仅在连接参数（baseUrl/appId/apiKey/contentType/
+ * extraHeaders）真正发生变更时才测——只改名称/备注/阈值/启停不重测，避免每次改个备注都去打一次外部
+ * 服务、也避免外部服务临时抖动时连改备注都改不了。实测不通过直接抛 {@link BizException} 阻止保存
+ * （同 {@code AgentService#assertPrimaryModelConnectivity} 的现场实测模式，不读 test_status 字段）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class KnowledgeBaseService {
+
+    private static final Logger log = LoggerFactory.getLogger(KnowledgeBaseService.class);
+
+    /** 连通性测试专用线程池：与 Tomcat 请求线程隔离，低频操作，池子不需要大（同 ModelConfigService）。 */
+    private static final ExecutorService TEST_EXECUTOR = Executors.newFixedThreadPool(4, r -> {
+        Thread thread = new Thread(r, "kb-test-worker");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private static final long TEST_FUTURE_TIMEOUT_SECONDS = 10;
+    private static final String CODE_TEST_FAIL = "KB-TEST-FAIL";
+    private static final int STATUS_ENABLED = 1;
+
+    private final AiKnowledgeBaseMapper knowledgeBaseMapper;
+    private final AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
+    private final AesGcmCryptoUtil cryptoUtil;
+    private final KnowledgeSearchClient searchClient;
+    private final AdminRagProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public KnowledgeBaseService(AiKnowledgeBaseMapper knowledgeBaseMapper,
+                                 AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper,
+                                 AesGcmCryptoUtil cryptoUtil, KnowledgeSearchClient searchClient,
+                                 AdminRagProperties properties) {
+        this.knowledgeBaseMapper = knowledgeBaseMapper;
+        this.agentKnowledgeBaseMapper = agentKnowledgeBaseMapper;
+        this.cryptoUtil = cryptoUtil;
+        this.searchClient = searchClient;
+        this.properties = properties;
+    }
+
+    public PageResult<KnowledgeBaseVO> page(PageQuery query) {
+        LambdaQueryWrapper<AiKnowledgeBase> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(query.getKeyword())) {
+            wrapper.like(AiKnowledgeBase::getKbName, query.getKeyword());
+        }
+        if (query.getStatus() != null) {
+            wrapper.eq(AiKnowledgeBase::getStatus, query.getStatus());
+        }
+        wrapper.orderBy(true, "asc".equalsIgnoreCase(query.getSortOrder()), AiKnowledgeBase::getCreateTime);
+
+        IPage<AiKnowledgeBase> page = knowledgeBaseMapper.selectPage(
+            new Page<>(query.getPageNum(), query.getPageSize()), wrapper);
+        return PageResult.of(page.convert(this::toVo));
+    }
+
+    public KnowledgeBaseVO get(Long id) {
+        return toVo(requireKnowledgeBase(id));
+    }
+
+    /** 智能体表单下拉：只给可用的知识库（启用 + 连通性测试成功），不可用的不允许被绑定。 */
+    public List<KnowledgeBaseOptionVO> options() {
+        return knowledgeBaseMapper.selectList(new LambdaQueryWrapper<AiKnowledgeBase>()
+                .eq(AiKnowledgeBase::getStatus, STATUS_ENABLED)
+                .eq(AiKnowledgeBase::getTestStatus, KnowledgeBaseTestResult.STATUS_SUCCESS)
+                .orderByAsc(AiKnowledgeBase::getId))
+            .stream()
+            .map(kb -> new KnowledgeBaseOptionVO(kb.getId(), kb.getKbName()))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void create(KnowledgeBaseSaveRequest request) {
+        if (!StringUtils.hasText(request.apiKey())) {
+            throw new BizException(ResultCode.PARAM_MISSING, "新建知识库必须提供 apiKey");
+        }
+        assertNameAvailable(request.kbName(), null);
+        validateExtraHeaders(request.extraHeaders());
+
+        AiKnowledgeBase entity = new AiKnowledgeBase();
+        fillFromRequest(entity, request);
+        entity.setApiKey(cryptoUtil.encrypt(request.apiKey()));
+        // 保存门禁：现场实测，不通过直接抛异常阻止保存
+        KnowledgeBaseTestResult result = assertConnectivity(toEndpoint(entity, request.apiKey()));
+        entity.setTestStatus(result.testStatus());
+        entity.setTestTime(result.testTime());
+
+        // 坑：ai_knowledge_base.uk_ai_kb_name 是不含 deleted 列的纯数据库唯一约束，而 delete() 走的是
+        // 逻辑删除（@TableLogic 只把 deleted 置 1，行还在、名字还占着）。上面的 assertNameAvailable 走
+        // LambdaQueryWrapper 会被自动追加 deleted=0，于是判定"名称可用"，但直接 INSERT 必然撞唯一约束抛
+        // DuplicateKeyException（与 AuthService#findOrCreateLdapUser 完全同款的坑）。这里先看有没有被软
+        // 删除过的同名旧行，有就"复活"它再整体覆盖字段，而不是插新行——若只把异常兜成友好提示，一个名字
+        // 被删过一次就永久不能再用，那是功能缺陷而不只是错误信息不友好。复活复用旧行 id，
+        // create_by/create_time 保留旧值（与 AuthService 的复活语义一致，不额外重置）。
+        AiKnowledgeBase softDeleted = knowledgeBaseMapper.selectDeletedByName(request.kbName());
+        if (softDeleted != null) {
+            knowledgeBaseMapper.reviveDeleted(softDeleted.getId());
+            entity.setId(softDeleted.getId());
+            knowledgeBaseMapper.updateById(entity);
+            log.info("[rag] revived soft-deleted knowledge base for re-create, kbName={}, kbId={}",
+                request.kbName(), softDeleted.getId());
+            return;
+        }
+        // 纯并发竞争（两个请求同时创建同名知识库，都没查到对方尚未提交的行）仍可能撞唯一键：兜成友好的
+        // 业务异常，不让 DuplicateKeyException 裸奔到 GlobalExceptionHandler 变成不明所以的 SYSTEM_ERROR。
+        try {
+            knowledgeBaseMapper.insert(entity);
+        } catch (DuplicateKeyException e) {
+            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "知识库名称已存在: " + request.kbName());
+        }
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void update(Long id, KnowledgeBaseSaveRequest request) {
+        AiKnowledgeBase entity = requireKnowledgeBase(id);
+        assertNameAvailable(request.kbName(), id);
+        validateExtraHeaders(request.extraHeaders());
+
+        // 连接参数是否变更要在字段被覆盖前判断；apiKey 留空=沿用旧值，故不算变更
+        boolean connectionChanged = isConnectionChanged(entity, request);
+        String plainApiKey = StringUtils.hasText(request.apiKey())
+            ? request.apiKey() : cryptoUtil.decrypt(entity.getApiKey());
+
+        fillFromRequest(entity, request);
+        if (StringUtils.hasText(request.apiKey())) {
+            entity.setApiKey(cryptoUtil.encrypt(request.apiKey()));
+        }
+        if (connectionChanged) {
+            KnowledgeBaseTestResult result = assertConnectivity(toEndpoint(entity, plainApiKey));
+            entity.setTestStatus(result.testStatus());
+            entity.setTestTime(result.testTime());
+        }
+        // 改名撞上被软删除的同名旧行同样会抛 DuplicateKeyException（原因同 create 里的注释）。改名场景
+        // 不能走"复活"（那会变成两行同名），只能给出友好提示让用户换个名字。
+        try {
+            knowledgeBaseMapper.updateById(entity);
+        } catch (DuplicateKeyException e) {
+            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "知识库名称已存在: " + request.kbName());
+        }
+    }
+
+    public void delete(Long id) {
+        requireKnowledgeBase(id);
+        if (agentKnowledgeBaseMapper.exists(new LambdaQueryWrapper<AiAgentKnowledgeBase>()
+            .eq(AiAgentKnowledgeBase::getKnowledgeBaseId, id))) {
+            throw new BizException(ResultCode.RESOURCE_IN_USE, "该知识库正被智能体引用，无法删除");
+        }
+        knowledgeBaseMapper.deleteById(id);
+    }
+
+    /** 启用/停用（生命周期），不改动其余字段。停用后运行时立即不再参与检索。 */
+    public void updateStatus(Long id, int status) {
+        requireKnowledgeBase(id);
+        AiKnowledgeBase update = new AiKnowledgeBase();
+        update.setId(id);
+        update.setStatus(status);
+        knowledgeBaseMapper.updateById(update);
+    }
+
+    /**
+     * 连通性测试：用固定探测语句真实发一次检索请求，派发到独立线程池执行并硬性超时兜底，
+     * 不占用调用方（Tomcat）线程。Controller 侧以 {@link CompletableFuture} 异步返回。
+     */
+    public CompletableFuture<KnowledgeBaseTestResult> testConnectivity(Long id) {
+        AiKnowledgeBase entity = requireKnowledgeBase(id);
+        KnowledgeBaseEndpoint endpoint = toEndpoint(entity, cryptoUtil.decrypt(entity.getApiKey()));
+
+        return CompletableFuture
+            .supplyAsync(() -> probe(endpoint), TEST_EXECUTOR)
+            .orTimeout(TEST_FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .exceptionally(ex -> {
+                if (ex.getCause() instanceof TimeoutException || ex instanceof TimeoutException) {
+                    log.error("knowledge base connectivity test hard-timeout, code={}, kbId={}",
+                        "KB-TEST-HARD-TIMEOUT", id, ex);
+                } else {
+                    log.error("knowledge base connectivity test unexpected error, code={}, kbId={}",
+                        "KB-TEST-UNEXPECTED", id, ex);
+                }
+                return KnowledgeBaseTestResult.failed("连通性测试超时或执行异常");
+            })
+            .thenApply(result -> {
+                persistTestResult(id, result);
+                return result;
+            });
+    }
+
+    /** 真实发一次探测检索：成功返回命中条数，失败转成失败态结果（不抛异常，供异步链路统一处理）。 */
+    private KnowledgeBaseTestResult probe(KnowledgeBaseEndpoint endpoint) {
+        try {
+            return KnowledgeBaseTestResult.success(
+                searchClient.searchOne(endpoint, properties.getTestQuery()).size());
+        } catch (Exception e) {
+            log.error("knowledge base probe failed, code={}, kbId={}", CODE_TEST_FAIL, endpoint.id(), e);
+            return KnowledgeBaseTestResult.failed(e.getMessage());
+        }
+    }
+
+    /**
+     * 保存门禁：同步实测连通性，非成功即抛业务异常阻止保存。走请求线程直连——
+     * {@link KnowledgeSearchClient} 的请求级超时（{@code admin.rag.request-timeout-seconds}，默认 8s）
+     * 已经把等待时间兜死，不需要再叠一层线程池 + future 超时（新建场景也还没有 id 可供
+     * {@link #testConnectivity} 使用）。
+     */
+    private KnowledgeBaseTestResult assertConnectivity(KnowledgeBaseEndpoint endpoint) {
+        KnowledgeBaseTestResult result = probe(endpoint);
+        if (result.testStatus() != KnowledgeBaseTestResult.STATUS_SUCCESS) {
+            throw new BizException(ResultCode.KNOWLEDGE_BASE_TEST_FAILED,
+                "知识库连通性测试未通过: " + result.message());
+        }
+        log.info("[rag] knowledge base connectivity gate passed, kbName={}, hitCount={}",
+            endpoint.kbName(), result.hitCount());
+        return result;
+    }
+
+    private void persistTestResult(Long id, KnowledgeBaseTestResult result) {
+        AiKnowledgeBase update = new AiKnowledgeBase();
+        update.setId(id);
+        update.setTestStatus(result.testStatus());
+        update.setTestTime(result.testTime());
+        knowledgeBaseMapper.updateById(update);
+    }
+
+    /** 名称唯一（库上有唯一索引，这里提前查一次给出可读错误，避免抛出裸的约束冲突异常）。 */
+    private void assertNameAvailable(String kbName, Long selfId) {
+        LambdaQueryWrapper<AiKnowledgeBase> wrapper = new LambdaQueryWrapper<AiKnowledgeBase>()
+            .eq(AiKnowledgeBase::getKbName, kbName);
+        if (selfId != null) {
+            wrapper.ne(AiKnowledgeBase::getId, selfId);
+        }
+        if (knowledgeBaseMapper.exists(wrapper)) {
+            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "知识库名称已存在: " + kbName);
+        }
+    }
+
+    /** 自定义请求头保存时校验一次（fast fail），运行时不再重复校验规则。 */
+    private void validateExtraHeaders(String extraHeaders) {
+        try {
+            KnowledgeSearchClient.parseExtraHeaders(objectMapper, extraHeaders);
+        } catch (IllegalArgumentException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, e.getMessage());
+        }
+    }
+
+    /** 连接参数（决定"能不能连上"的那几项）是否变更；apiKey 留空视为不改，不算变更。 */
+    private boolean isConnectionChanged(AiKnowledgeBase entity, KnowledgeBaseSaveRequest request) {
+        return StringUtils.hasText(request.apiKey())
+            || !Objects.equals(entity.getBaseUrl(), request.baseUrl())
+            || !Objects.equals(entity.getAppId(), request.appId())
+            || !Objects.equals(entity.getContentType(), normalizeContentType(request.contentType()))
+            || !Objects.equals(entity.getExtraHeaders(), normalizeExtraHeaders(request.extraHeaders()));
+    }
+
+    private void fillFromRequest(AiKnowledgeBase entity, KnowledgeBaseSaveRequest request) {
+        entity.setKbName(request.kbName());
+        entity.setBaseUrl(request.baseUrl());
+        entity.setAppId(request.appId());
+        entity.setContentType(normalizeContentType(request.contentType()));
+        entity.setExtraHeaders(normalizeExtraHeaders(request.extraHeaders()));
+        entity.setTopN(request.topN() == null || request.topN() <= 0
+            ? KnowledgeBaseEndpoint.DEFAULT_TOP_N : request.topN());
+        entity.setScoreThreshold(request.scoreThreshold() == null ? BigDecimal.ZERO : request.scoreThreshold());
+        entity.setStatus(request.status() == null ? STATUS_ENABLED : request.status());
+        entity.setRemark(request.remark());
+    }
+
+    private String normalizeContentType(String contentType) {
+        return StringUtils.hasText(contentType) ? contentType : KnowledgeBaseEndpoint.DEFAULT_CONTENT_TYPE;
+    }
+
+    private String normalizeExtraHeaders(String extraHeaders) {
+        return StringUtils.hasText(extraHeaders) ? extraHeaders : "";
+    }
+
+    /** 实体 + 明文 apiKey → 检索端点参数（供门禁/探测/运行时检索共用同一份组装逻辑）。 */
+    private KnowledgeBaseEndpoint toEndpoint(AiKnowledgeBase entity, String plainApiKey) {
+        return new KnowledgeBaseEndpoint(entity.getId(), entity.getKbName(), entity.getBaseUrl(), entity.getAppId(),
+            plainApiKey, entity.getContentType(), entity.getExtraHeaders(), entity.getTopN(),
+            entity.getScoreThreshold());
+    }
+
+    private KnowledgeBaseVO toVo(AiKnowledgeBase entity) {
+        KnowledgeBaseVO vo = new KnowledgeBaseVO();
+        vo.setId(entity.getId());
+        vo.setKbName(entity.getKbName());
+        vo.setBaseUrl(entity.getBaseUrl());
+        vo.setAppId(entity.getAppId());
+        vo.setApiKeyMasked(AesGcmCryptoUtil.mask(cryptoUtil.decrypt(entity.getApiKey())));
+        vo.setContentType(entity.getContentType());
+        vo.setExtraHeaders(entity.getExtraHeaders());
+        vo.setTopN(entity.getTopN());
+        vo.setScoreThreshold(entity.getScoreThreshold());
+        vo.setStatus(entity.getStatus());
+        vo.setTestStatus(entity.getTestStatus());
+        vo.setTestTime(entity.getTestTime());
+        vo.setRemark(entity.getRemark());
+        vo.setCreateTime(entity.getCreateTime());
+        vo.setUpdateTime(entity.getUpdateTime());
+        return vo;
+    }
+
+    /** 知识库存在性校验（本模块唯一防御点）。 */
+    private AiKnowledgeBase requireKnowledgeBase(Long id) {
+        AiKnowledgeBase entity = knowledgeBaseMapper.selectById(id);
+        if (entity == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "知识库不存在: " + id);
+        }
+        return entity;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -72,6 +72,10 @@ public enum ResultCode {
     KNOWLEDGE_INDEX_BUILDING(40031, "该索引正在构建中，请等待构建完成后再操作"),
     MENU_REORDER_CONFLICT(40032, "菜单排序正在被其他管理员调整，请稍后重试"),
     AGENT_MEMORY_OPERATION_FAILED(40033, "智能体记忆操作失败，请稍后重试"),
+    // 外部 RAG 知识库检索（40032/40033 已占用，故从 40034 起）
+    KNOWLEDGE_BASE_TEST_FAILED(40034, "知识库连通性测试失败"),
+    KNOWLEDGE_BASE_HTTP_FORBIDDEN(40035, "知识库服务地址不在允许访问范围内，已被安全策略拦截"),
+    KNOWLEDGE_BASE_SEARCH_FAILED(40036, "知识库检索失败"),
 
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminRagProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminRagProperties.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customeradmin.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 外部 RAG 知识库检索参数：{@code admin.rag.*}。
+ *
+ * <p><b>为什么不复用 {@code admin.system-tool.http.allowed-hosts}</b>：两者的信任边界方向相反。
+ * 系统工具的 HTTP 请求工具，目标地址是<b>大模型自己决定</b>的，必须默认拒内网防 SSRF；
+ * 而 RAG 知识库的地址是<b>管理员在后台显式配置</b>的，且企业 RAG 服务基本都部署在内网
+ * （用户本机就是 {@code localhost:20002}），默认拒内网等于功能不可用。两套白名单各自独立，
+ * 互不污染——把 RAG 的内网地址加进系统工具白名单，会顺带把模型可控的 HTTP 工具也放进内网。</p>
+ *
+ * <p>判定逻辑见 {@code KnowledgeBaseHttpGuard}，它是本链路唯一的地址防御点。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "admin.rag")
+public class AdminRagProperties {
+
+    /**
+     * 允许访问的 RAG 服务 host 白名单。为空=默认模式（放行内网/环回，仅拦截链路本地地址，
+     * 即云元数据服务 169.254.169.254 一类绝不可能是 RAG 服务的目标）；
+     * 非空=收紧模式（仅放行白名单内 host，支持精确域名与 {@code *.example.com} 通配后缀）。
+     */
+    private List<String> allowedHosts = new ArrayList<>();
+
+    /** TCP 连接超时（秒）。 */
+    private int connectTimeoutSeconds = 5;
+
+    /** 单次检索请求的请求级超时（秒），检索与连通性探测共用。 */
+    private int requestTimeoutSeconds = 8;
+
+    /** 对话链路多库并发检索的整体等待上限（秒）：超时即按空召回降级，绝不拖死对话。 */
+    private int retrievalTimeoutSeconds = 10;
+
+    /** 连通性测试用的固定探测语句（真实发一次检索请求，返回命中条数）。 */
+    private String testQuery = "连通性测试";
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -221,6 +221,11 @@ public class ChatService {
         }
         // 归一 sessionId：与下方 Plan 通道/执行模式登记、以及历史接口读取口径完全一致（hasText ? 原值 : default）。
         String safeSession = StringUtils.hasText(sessionId) ? sessionId : "default";
+        // 知识库自动检索<b>不在这里做</b>：请求线程同步段做 HTTP 检索会最长占住一个 Tomcat 请求线程 10s
+        // （返回 Flux 不等于方法体异步，方法体跑完才返回），RAG 后端变慢会连累登录等无关接口；而且拼进
+        // 用户消息文本会让召回块随消息进 AgentState 被持久化，用户在历史里看到 <retrieved_knowledge> 原文、
+        // 且每轮重发累积 token。现改由 KnowledgeRetrievalMiddleware 在推理阶段做瞬态注入（挂载点见
+        // AdminAgentInstanceFactory#buildInnerReActAgent），本方法只管把用户原文送进去。
         // 本条用户消息提前构建，供附件绑定拿到稳定的 Msg.id（框架 Msg.Builder 构造即生成随机 UUID）。
         Msg userMsg = toUserMsg(userText);
         // 附件绑定：请求线程同步段完成（订阅前），把本条消息 id 与其携带的附件关联，供历史回显。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -11,6 +11,8 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSubAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime.KnowledgeRetrievalMiddleware;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime.KnowledgeRetrievalService;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.entity.AiMcp;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.mapper.AiMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.runtime.AdminMcpFactory;
@@ -162,6 +164,8 @@ public class AdminAgentInstanceFactory {
     private final AgentCallTimingMiddleware agentCallTimingMiddleware;
     /** 工具名→类别登记表：装配 MCP/Skill 时把工具名登记进来，采集时 onActing 据此归 MCP/SKILL（否则默认 TOOL）。 */
     private final ToolKindRegistry agentCallToolKindRegistry;
+    /** 知识库检索服务：供每个智能体各挂一份 {@link KnowledgeRetrievalMiddleware} 做每轮召回注入。 */
+    private final KnowledgeRetrievalService knowledgeRetrievalService;
 
     /**
      * {@code agentCode -> ToolSourceInfo}：{@link #build} 每次重建都会覆盖写入，天然跟着
@@ -184,7 +188,8 @@ public class AdminAgentInstanceFactory {
                                       ModelCircuitBreakerRegistry circuitBreakerRegistry,
                                       AgentMemorySyncService memorySyncService,
                                       AgentCallTimingMiddleware agentCallTimingMiddleware,
-                                      ToolKindRegistry agentCallToolKindRegistry) {
+                                      ToolKindRegistry agentCallToolKindRegistry,
+                                      KnowledgeRetrievalService knowledgeRetrievalService) {
         this.agentMapper = agentMapper;
         this.agentMcpMapper = agentMcpMapper;
         this.agentSkillMapper = agentSkillMapper;
@@ -209,6 +214,7 @@ public class AdminAgentInstanceFactory {
         this.memorySyncService = memorySyncService;
         this.agentCallTimingMiddleware = agentCallTimingMiddleware;
         this.agentCallToolKindRegistry = agentCallToolKindRegistry;
+        this.knowledgeRetrievalService = knowledgeRetrievalService;
     }
 
     /** 查该智能体当前已装配的工具来源登记表；从未 {@link #build} 过（比如尚未触发过对话）时返回空表。 */
@@ -297,6 +303,11 @@ public class AdminAgentInstanceFactory {
         // permission-mode=bypass 时纯透传，行为等价于挂载前。顺序关键（first = outermost）：模式闸门在最外层
         // 先看到原始命令挂起/拦改，护栏在内层作最后防线（下方仅 vibecoding 挂载）。
         builder.middleware(executionModeMiddleware);
+        // 知识库检索注入：按 agentCode 现建一份（中间件需要知道"本智能体绑了哪些知识库"，构建期绑定
+        // 比运行时反推更直接）。挂在这里=注入只影响每次模型调用的输入消息，不进持久化 AgentState，
+        // 且 HTTP 检索发生在 reactive 线程（boundedElastic）而非 Tomcat 请求线程——两点都是刻意的，
+        // 详见 KnowledgeRetrievalMiddleware 类注释。未绑知识库的智能体在中间件内一次关联表查询即返回。
+        builder.middleware(new KnowledgeRetrievalMiddleware(knowledgeRetrievalService, agentCode));
         if (capabilities.contains(CAPABILITY_VIBECODING)) {
             // 只有 vibecoding 能力的 agent 才会跑到文件系统/shell 工具，护栏只对这类 agent 挂载作最后防线——
             // 即便高风险被人工批准/放行，catastrophic 命令仍会被护栏改写，护栏不被绕过（需求 §4.4.2.5「两者叠加」）。

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -139,6 +139,17 @@ admin:
       # 非空=收紧模式（仅放行白名单内 host，支持精确域名与 *.example.com 通配后缀）。
       # 逗号分隔多个 host，如 api.example.com,*.internal.corp
       allowed-hosts: ${ADMIN_SYSTEM_TOOL_HTTP_ALLOWED_HOSTS:}
+  rag:
+    # 外部 RAG 知识库检索。白名单与上面 system-tool 的<刻意分开>：系统工具的目标地址由大模型决定，
+    # 必须默认拒内网；RAG 地址由管理员在后台显式配置且通常就在内网（本机 localhost:20002），
+    # 故默认放行内网、仅拦链路本地（169.254/16 等云元数据地址）。生产建议显式配置收紧。
+    allowed-hosts: ${ADMIN_RAG_ALLOWED_HOSTS:}
+    connect-timeout-seconds: ${ADMIN_RAG_CONNECT_TIMEOUT_SECONDS:5}
+    # 单次检索请求的请求级超时；保存门禁的实测就靠它兜死等待时间
+    request-timeout-seconds: ${ADMIN_RAG_REQUEST_TIMEOUT_SECONDS:8}
+    # 对话链路多库并发检索的整体等待上限，超时按空召回降级，绝不拖死对话
+    retrieval-timeout-seconds: ${ADMIN_RAG_RETRIEVAL_TIMEOUT_SECONDS:10}
+    test-query: ${ADMIN_RAG_TEST_QUERY:连通性测试}
   sandbox:
     # VibeCoding 代码沙箱：local（默认，无隔离，直接跑宿主机）｜docker（容器隔离，需本机/服务器已装 Docker）。
     mode: ${ADMIN_SANDBOX_MODE:local}

--- a/customer-admin-server/src/main/resources/db/migration/V41__rag_knowledge_base.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V41__rag_knowledge_base.sql
@@ -1,0 +1,66 @@
+-- =============================================================================
+-- RAG 知识库检索（Flyway V41，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 落地"AI 配置 → 知识库管理"：一条 ai_knowledge_base 记录 = 一个外部 RAG 知识库
+-- （base_url + app_id + api_key 同属一行，不做"服务/应用"两级拆分——外部接口本身就是
+-- 按 app_id 分库检索，拆两级只会让配置更绕）。智能体通过 ai_agent_knowledge_base 多选绑定，
+-- 运行时每轮对话自动检索并把召回内容注入用户消息（不是工具，模型无需决策是否调用）。
+--
+-- api_key 走 AES/GCM 加密存储（复用 AesGcmCryptoUtil，与 ai_model_config.api_key 同款），
+-- 接口只回显掩码值；extra_headers 存 JSON 对象字符串（默认空串=无自定义头）。
+--
+-- score_threshold 默认 0：外部服务返回的是 rerank 分数，实测量级仅 0.13~0.19，
+-- 按常见的 0.5 拍脑袋设阈值会把全部召回丢光。默认 0 = 不过滤（外部服务已按相关度排序），
+-- 确有噪声时由使用方按自己知识库的真实分数分布调高。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+--
+-- 菜单/权限种子：id 从 200 起（V38 显式 id 用到 195，200 起留足安全空间）。
+-- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接
+-- 返回全部权限点（沿用 V36/V38 同款做法，普通角色需在角色管理页手工授权）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+-- 知识库配置：一行 = 一个外部 RAG 知识库（url + appkey + app_id）。
+CREATE TABLE IF NOT EXISTS `ai_knowledge_base` (
+    `id`               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `kb_name`          VARCHAR(64) NOT NULL COMMENT '知识库名称（唯一标识，供智能体表单展示）',
+    `base_url`         VARCHAR(255) NOT NULL COMMENT 'RAG 服务基址（不含 /api/v1/knowledge/search 路径）',
+    `app_id`           VARCHAR(128) NOT NULL COMMENT '知识库应用ID（请求体 app_id）',
+    `api_key`          VARCHAR(512) NOT NULL COMMENT 'AppKey（AES/GCM 加密存储，请求头 Authorization: Bearer）',
+    `content_type`     VARCHAR(64) NOT NULL DEFAULT 'application/json' COMMENT '请求 Content-Type',
+    `extra_headers`    VARCHAR(1024) NOT NULL DEFAULT '' COMMENT '自定义请求头（JSON 对象字符串，空=无）',
+    `top_n`            INT NOT NULL DEFAULT 5 COMMENT '单次检索返回条数（请求体 top_n）',
+    `score_threshold`  DECIMAL(6,4) NOT NULL DEFAULT 0.0000 COMMENT '相关度阈值：低于该值的召回丢弃，0=不过滤（rerank 分数量级仅 0.1x）',
+    `status`           TINYINT NOT NULL DEFAULT 1 COMMENT '状态：0禁用 / 1启用',
+    `test_status`      TINYINT NOT NULL DEFAULT 0 COMMENT '最近测试结果：0未测试 / 1成功 / 2失败',
+    `test_time`        DATETIME COMMENT '最近测试时间',
+    `remark`           VARCHAR(512) COMMENT '备注',
+    `create_by`        BIGINT COMMENT '创建人ID',
+    `create_time`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`        BIGINT COMMENT '更新人ID',
+    `update_time`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`          TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    UNIQUE KEY `uk_ai_kb_name` (`kb_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='RAG 知识库配置';
+
+-- 智能体-知识库关联（多选），结构对齐 ai_agent_mcp / ai_agent_skill。
+CREATE TABLE IF NOT EXISTS `ai_agent_knowledge_base` (
+    `id`                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `agent_id`          BIGINT NOT NULL COMMENT '智能体ID',
+    `knowledge_base_id` BIGINT NOT NULL COMMENT '知识库ID',
+    UNIQUE KEY `uk_ai_agent_kb` (`agent_id`, `knowledge_base_id`),
+    INDEX `idx_ai_agent_kb_base` (`knowledge_base_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-知识库关联';
+
+-- 二级菜单：知识库管理（挂"AI 配置" id=2 下，sort=8 排在渠道接入 sort=7 之后）。菜单可见性即 view 权限点。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (200, 2, '知识库管理', 'knowledge-base:view', 1, '/aiconfig/knowledge-base', 'Collection', 'library', 8);
+
+-- 三级：按钮/接口权限点（type=2，挂 200 下）。连通性测试复用 view，不单独发权限点。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (201, 200, '新增知识库', 'knowledge-base:add',    2, 1),
+    (202, 200, '编辑知识库', 'knowledge-base:edit',   2, 2),
+    (203, 200, '删除知识库', 'knowledge-base:delete', 2, 3);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentServiceTest.java
@@ -13,6 +13,11 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSubAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.entity.AiMcp;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.mapper.AiMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelTestResult;
@@ -63,6 +68,8 @@ class AgentServiceTest {
     private AiSkillMapper skillMapper;
     private AiAgentSystemToolMapper agentSystemToolMapper;
     private AiSystemToolMapper systemToolMapper;
+    private AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
+    private AiKnowledgeBaseMapper knowledgeBaseMapper;
     private ModelConfigService modelConfigService;
     private MenuVersionHolder menuVersionHolder;
     private AgentService service;
@@ -75,6 +82,7 @@ class AgentServiceTest {
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentSubAgent.class);
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentSystemTool.class);
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentBackupModel.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentKnowledgeBase.class);
     }
 
     @BeforeEach
@@ -89,6 +97,8 @@ class AgentServiceTest {
         skillMapper = mock(AiSkillMapper.class);
         agentSystemToolMapper = mock(AiAgentSystemToolMapper.class);
         systemToolMapper = mock(AiSystemToolMapper.class);
+        agentKnowledgeBaseMapper = mock(AiAgentKnowledgeBaseMapper.class);
+        knowledgeBaseMapper = mock(AiKnowledgeBaseMapper.class);
         modelConfigService = mock(ModelConfigService.class);
         menuVersionHolder = new MenuVersionHolder();
         AgentInstanceCache agentInstanceCache = mock(AgentInstanceCache.class);
@@ -96,6 +106,7 @@ class AgentServiceTest {
             mock(com.richard.fyoung.customeradmin.aiconfig.channel.publish.CustomerWorkConfigPublisher.class);
         service = new AgentService(agentMapper, agentMcpMapper, agentSkillMapper, agentBackupModelMapper,
             agentSubAgentMapper, modelConfigMapper, mcpMapper, skillMapper, agentSystemToolMapper, systemToolMapper,
+            agentKnowledgeBaseMapper, knowledgeBaseMapper,
             menuVersionHolder, agentInstanceCache, modelConfigService, runtimeConfigPublisher);
 
         when(modelConfigMapper.selectById(1L)).thenReturn(new AiModelConfig());
@@ -107,7 +118,7 @@ class AgentServiceTest {
     private AgentSaveRequest validRequest() {
         return new AgentSaveRequest("客服助手", "customer-helper", 1L, null, List.of(10L), List.of(20L), List.of(30L),
             "你是客服助手", List.of("chat", "vibecoding"), "robot", 1,
-            null, null, null, null, null, null);
+            null, null, null, null, null, null, null);
     }
 
     /** 只带 5 个高级参数的请求（能力固定 chat），供取值范围校验用例复用。 */
@@ -115,20 +126,20 @@ class AgentServiceTest {
                                                Integer compressTriggerMsgs, Integer compressKeepMsgs) {
         return new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
             null, List.of("chat"), null, 1,
-            null, maxIters, toolTimeoutSeconds, toolMaxAttempts, compressTriggerMsgs, compressKeepMsgs);
+            null, maxIters, toolTimeoutSeconds, toolMaxAttempts, compressTriggerMsgs, compressKeepMsgs, null);
     }
 
     /** 只带 capabilities + subAgentIds 的请求，供子智能体校验用例复用。 */
     private AgentSaveRequest requestWithSubAgents(List<String> capabilities, List<Long> subAgentIds) {
         return new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
             null, capabilities, null, 1,
-            subAgentIds, null, null, null, null, null);
+            subAgentIds, null, null, null, null, null, null);
     }
 
     @Test
     void create_shouldRejectInvalidAgentCode() {
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "Customer_Helper", 1L, null, null, null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -137,7 +148,7 @@ class AgentServiceTest {
     void create_shouldRejectUnknownModelId() {
         when(modelConfigMapper.selectById(999L)).thenReturn(null);
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 999L, null, null, null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -146,7 +157,7 @@ class AgentServiceTest {
     void create_shouldRejectInvalidMcpIds() {
         when(mcpMapper.selectBatchIds(List.of(10L))).thenReturn(List.of()); // 只有 0 条命中，说明 10L 不存在
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, List.of(10L), null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -155,7 +166,7 @@ class AgentServiceTest {
     void create_shouldRejectInvalidSystemToolIds() {
         when(systemToolMapper.selectBatchIds(List.of(30L))).thenReturn(List.of()); // 0 条命中，说明 30L 不存在
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, List.of(30L),
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -163,7 +174,7 @@ class AgentServiceTest {
     @Test
     void create_shouldRejectInvalidCapability() {
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
-            null, List.of("not-a-real-capability"), null, 1, null, null, null, null, null, null);
+            null, List.of("not-a-real-capability"), null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -272,7 +283,7 @@ class AgentServiceTest {
     @Test
     void create_shouldRejectBackupContainingPrimaryModel() {
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(1L), null, null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -282,7 +293,7 @@ class AgentServiceTest {
         when(modelConfigMapper.selectById(1L)).thenReturn(new AiModelConfig());
         when(modelConfigMapper.selectBatchIds(List.of(2L))).thenReturn(List.of()); // 0 条命中，2L 不存在
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(2L), null, null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
     }
@@ -293,7 +304,7 @@ class AgentServiceTest {
         // 去重后为 [2L, 3L]，两个都存在
         when(modelConfigMapper.selectBatchIds(List.of(2L, 3L))).thenReturn(List.of(new AiModelConfig(), new AiModelConfig()));
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, List.of(2L, 3L, 2L),
-            null, null, null, null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, null, null, null, 1, null, null, null, null, null, null, null);
 
         service.create(request);
 
@@ -311,7 +322,7 @@ class AgentServiceTest {
         when(modelConfigService.testConnectivity(any())).thenReturn(CompletableFuture.completedFuture(
             new ModelTestResult(ModelTestResult.STATUS_FAILED, LocalDateTime.now(), "HTTP 401")));
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         assertThrows(BizException.class, () -> service.create(request));
         verify(agentMapper, never()).insert(any(AiAgent.class));
@@ -340,7 +351,7 @@ class AgentServiceTest {
         when(agentMapper.selectById(1L)).thenReturn(existing);
         when(modelConfigMapper.selectById(2L)).thenReturn(new AiModelConfig());
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 2L, null, null, null, null,
-            null, null, null, 1, null, null, null, null, null, null);
+            null, null, null, 1, null, null, null, null, null, null, null);
 
         service.update(1L, request);
 
@@ -354,7 +365,7 @@ class AgentServiceTest {
         // subagent 能力单独用例覆盖（勾选后必须选子智能体），此处覆盖其余新能力编码
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
             null, List.of("chat", "plan", "tasklist", "skill-learning", "dynamic-subagent"), null, 1,
-            null, null, null, null, null, null);
+            null, null, null, null, null, null, null);
 
         service.create(request);
 
@@ -502,5 +513,110 @@ class AgentServiceTest {
         assertEquals(100, vo.getCompressTriggerMsgs());
         assertEquals(10, vo.getCompressKeepMsgs());
         assertEquals(List.of("chat", "subagent"), vo.getCapabilities());
+    }
+
+    // ---- 知识库多选关联（validate / replaceRelations / toVo 三处对称扩展） ----
+
+    /** 构造一条"可用"的知识库行（启用 + 连通性测试成功）。 */
+    private AiKnowledgeBase usableKnowledgeBase(Long id, String name) {
+        AiKnowledgeBase kb = new AiKnowledgeBase();
+        kb.setId(id);
+        kb.setKbName(name);
+        kb.setStatus(1);
+        kb.setTestStatus(KnowledgeBaseTestResult.STATUS_SUCCESS);
+        return kb;
+    }
+
+    private AgentSaveRequest requestWithKnowledgeBases(List<Long> knowledgeBaseIds) {
+        return new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
+            null, List.of("chat"), null, 1,
+            null, null, null, null, null, null, knowledgeBaseIds);
+    }
+
+    @Test
+    void create_shouldInsertKnowledgeBaseRelations() {
+        when(knowledgeBaseMapper.selectBatchIds(List.of(40L)))
+            .thenReturn(List.of(usableKnowledgeBase(40L, "产品知识库")));
+
+        service.create(requestWithKnowledgeBases(List.of(40L)));
+
+        verify(agentKnowledgeBaseMapper).insert(any(AiAgentKnowledgeBase.class));
+    }
+
+    @Test
+    void create_shouldRejectInvalidKnowledgeBaseIds() {
+        when(knowledgeBaseMapper.selectBatchIds(List.of(40L))).thenReturn(List.of()); // 0 条命中 = 40L 不存在
+
+        assertThrows(BizException.class, () -> service.create(requestWithKnowledgeBases(List.of(40L))));
+    }
+
+    @Test
+    void create_shouldRejectDisabledKnowledgeBase() {
+        AiKnowledgeBase disabled = usableKnowledgeBase(40L, "已停用知识库");
+        disabled.setStatus(0);
+        when(knowledgeBaseMapper.selectBatchIds(List.of(40L))).thenReturn(List.of(disabled));
+
+        assertThrows(BizException.class, () -> service.create(requestWithKnowledgeBases(List.of(40L))));
+    }
+
+    @Test
+    void create_shouldRejectUntestedKnowledgeBase() {
+        AiKnowledgeBase untested = usableKnowledgeBase(40L, "未测试知识库");
+        untested.setTestStatus(KnowledgeBaseTestResult.STATUS_FAILED);
+        when(knowledgeBaseMapper.selectBatchIds(List.of(40L))).thenReturn(List.of(untested));
+
+        assertThrows(BizException.class, () -> service.create(requestWithKnowledgeBases(List.of(40L))));
+    }
+
+    @Test
+    void create_shouldNotTouchKnowledgeBaseRelations_whenIdsEmpty() {
+        service.create(requestWithKnowledgeBases(null));
+
+        verify(agentKnowledgeBaseMapper, never()).insert(any(AiAgentKnowledgeBase.class));
+    }
+
+    @Test
+    void update_shouldReplaceKnowledgeBaseRelations_deleteThenInsert() {
+        AiAgent existing = new AiAgent();
+        existing.setId(1L);
+        when(agentMapper.selectById(1L)).thenReturn(existing);
+        when(knowledgeBaseMapper.selectBatchIds(List.of(40L)))
+            .thenReturn(List.of(usableKnowledgeBase(40L, "产品知识库")));
+
+        service.update(1L, requestWithKnowledgeBases(List.of(40L)));
+
+        verify(agentKnowledgeBaseMapper).delete(any());
+        verify(agentKnowledgeBaseMapper).insert(any(AiAgentKnowledgeBase.class));
+    }
+
+    @Test
+    void get_shouldReturnKnowledgeBaseIdsAndNames() {
+        AiAgent existing = new AiAgent();
+        existing.setId(1L);
+        existing.setCapabilities("chat");
+        when(agentMapper.selectById(1L)).thenReturn(existing);
+        AiAgentKnowledgeBase relation = new AiAgentKnowledgeBase();
+        relation.setAgentId(1L);
+        relation.setKnowledgeBaseId(40L);
+        when(agentKnowledgeBaseMapper.selectList(any())).thenReturn(List.of(relation));
+        when(knowledgeBaseMapper.selectBatchIds(List.of(40L)))
+            .thenReturn(List.of(usableKnowledgeBase(40L, "产品知识库")));
+
+        AgentVO vo = service.get(1L);
+
+        assertEquals(List.of(40L), vo.getKnowledgeBaseIds());
+        assertEquals(List.of("产品知识库"), vo.getKnowledgeBaseNames());
+    }
+
+    @Test
+    void delete_shouldClearKnowledgeBaseRelations() {
+        AiAgent existing = new AiAgent();
+        existing.setId(1L);
+        existing.setAgentCode("customer-helper");
+        when(agentMapper.selectById(1L)).thenReturn(existing);
+
+        service.delete(1L);
+
+        verify(agentKnowledgeBaseMapper).delete(any());
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeBaseHttpGuardTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeBaseHttpGuardTest.java
@@ -1,0 +1,78 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link KnowledgeBaseHttpGuard} 单测：默认放行内网（与系统工具的信任边界相反，这是本类存在的理由）、
+ * 拦截非法协议/链路本地地址、白名单收紧模式的精确与通配匹配。
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeBaseHttpGuardTest {
+
+    private KnowledgeBaseHttpGuard guard(String... allowedHosts) {
+        AdminRagProperties properties = new AdminRagProperties();
+        properties.setAllowedHosts(List.of(allowedHosts));
+        return new KnowledgeBaseHttpGuard(properties);
+    }
+
+    @Test
+    void checkAllowed_shouldPassLocalhost_byDefault() {
+        // RAG 一般内网部署（用户本机就是 localhost:20002），默认策略必须放行，否则功能直接不可用
+        assertDoesNotThrow(() -> guard().checkAllowed("http://localhost:20002"));
+        assertDoesNotThrow(() -> guard().checkAllowed("http://127.0.0.1:20002/"));
+    }
+
+    @Test
+    void checkAllowed_shouldPassPrivateNetwork_byDefault() {
+        assertDoesNotThrow(() -> guard().checkAllowed("http://192.168.1.10:8080"));
+        assertDoesNotThrow(() -> guard().checkAllowed("http://10.0.0.7"));
+    }
+
+    @Test
+    void checkAllowed_shouldRejectLinkLocalMetadataAddress_byDefault() {
+        // 169.254.169.254 是云元数据服务，绝无可能是 RAG 服务，默认模式下唯一被拦的一类地址
+        assertThrows(BizException.class, () -> guard().checkAllowed("http://169.254.169.254/latest/meta-data"));
+    }
+
+    @Test
+    void checkAllowed_shouldRejectNonHttpScheme() {
+        assertThrows(BizException.class, () -> guard().checkAllowed("file:///etc/passwd"));
+        assertThrows(BizException.class, () -> guard().checkAllowed("ftp://example.com"));
+    }
+
+    @Test
+    void checkAllowed_shouldRejectBlankOrHostlessUrl() {
+        assertThrows(BizException.class, () -> guard().checkAllowed(""));
+        assertThrows(BizException.class, () -> guard().checkAllowed("http:///no-host"));
+    }
+
+    @Test
+    void checkAllowed_shouldOnlyAllowWhitelistedHosts_whenWhitelistConfigured() {
+        KnowledgeBaseHttpGuard guard = guard("rag.internal.corp", "*.example.com");
+
+        assertDoesNotThrow(() -> guard.checkAllowed("http://rag.internal.corp:20002"));
+        assertDoesNotThrow(() -> guard.checkAllowed("https://kb.example.com/api"));
+        assertThrows(BizException.class, () -> guard.checkAllowed("http://localhost:20002"));
+        assertThrows(BizException.class, () -> guard.checkAllowed("https://evil.com"));
+    }
+
+    @Test
+    void hostWhitelisted_shouldMatchExactAndWildcardSuffix() {
+        KnowledgeBaseHttpGuard guard = guard();
+        List<String> whitelist = List.of("rag.internal.corp", "*.example.com");
+
+        assertTrue(guard.hostWhitelisted("RAG.INTERNAL.CORP", whitelist), "精确匹配应忽略大小写");
+        assertTrue(guard.hostWhitelisted("a.b.example.com", whitelist), "通配后缀应匹配多级子域");
+        assertFalse(guard.hostWhitelisted("example.com", whitelist), "*.example.com 不匹配裸域名");
+        assertFalse(guard.hostWhitelisted("notexample.com", whitelist));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientIntegrationTest.java
@@ -1,0 +1,61 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * {@link KnowledgeSearchClient} 门控集成测试：本机 RAG 服务（localhost:20002）可达且提供了
+ * 真实凭据时才真正发一次检索，否则自动跳过（同仓库既有门控约定）。
+ *
+ * <p>凭据不入库不硬编码，从环境变量取：{@code RAG_IT_BASE_URL}（默认 http://localhost:20002）、
+ * {@code RAG_IT_APP_ID}、{@code RAG_IT_API_KEY}。后两者缺失即跳过——本用例的价值在于验证
+ * 真实接口契约（HTTP 200 + code=OK + data.nodes 结构），拿假 Key 跑没有意义。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeSearchClientIntegrationTest {
+
+    private static final String DEFAULT_BASE_URL = "http://localhost:20002";
+    private static final int DEFAULT_PORT = 20002;
+    private static final int PROBE_TIMEOUT_MILLIS = 800;
+
+    @Test
+    void searchOne_shouldHitRealRagService() {
+        String baseUrl = envOrDefault("RAG_IT_BASE_URL", DEFAULT_BASE_URL);
+        String appId = System.getenv("RAG_IT_APP_ID");
+        String apiKey = System.getenv("RAG_IT_API_KEY");
+        assumeTrue(appId != null && apiKey != null, "未提供 RAG_IT_APP_ID / RAG_IT_API_KEY，跳过该集成测试");
+        assumeTrue(reachable(), "RAG 服务不可达（" + DEFAULT_BASE_URL + "），跳过该集成测试");
+
+        AdminRagProperties properties = new AdminRagProperties();
+        KnowledgeSearchClient client = new KnowledgeSearchClient(new KnowledgeBaseHttpGuard(properties), properties);
+        KnowledgeBaseEndpoint endpoint = new KnowledgeBaseEndpoint(1L, "it-kb", baseUrl, appId, apiKey,
+            "application/json", "", 5, BigDecimal.ZERO);
+
+        List<KnowledgeNode> nodes = client.searchOne(endpoint, properties.getTestQuery());
+
+        // 召回 0 条也算连通成功（判成功的标准是 HTTP 200 + code=OK），只断言解析没炸
+        assertNotNull(nodes);
+    }
+
+    private String envOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", DEFAULT_PORT), PROBE_TIMEOUT_MILLIS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientTest.java
@@ -59,6 +59,31 @@ class KnowledgeSearchClientTest {
             "HTTP 版本必须固定为 1.1，否则对不支持 h2c 协商的服务会挂起到超时");
     }
 
+    /**
+     * 非 200 时必须透出响应体里的 code/message——实测该服务把真正原因放在响应体
+     * （401 INVALID_API_KEY、403 APP_ACCESS_DENIED），只报状态码等于丢掉唯一线索。
+     */
+    @Test
+    void describeErrorBody_shouldSurfaceCodeAndMessage() {
+        String desc = KnowledgeSearchClient.describeErrorBody(
+            "{\"code\":\"APP_ACCESS_DENIED\",\"message\":\"该 API Key 未被授权调用应用 app_x\"}");
+
+        assertTrue(desc.contains("APP_ACCESS_DENIED"), "应带上错误码");
+        assertTrue(desc.contains("该 API Key 未被授权调用应用 app_x"), "应带上服务端 message");
+    }
+
+    /** 非 JSON 响应体（网关 HTML 错误页）截断透出，不能整页塞进提示，也不能吞掉。 */
+    @Test
+    void describeErrorBody_shouldTruncateNonJsonBody() {
+        assertEquals("", KnowledgeSearchClient.describeErrorBody(null));
+        assertEquals("", KnowledgeSearchClient.describeErrorBody("  "));
+
+        String html = "<html>" + "x".repeat(500) + "</html>";
+        String desc = KnowledgeSearchClient.describeErrorBody(html);
+        assertTrue(desc.endsWith("...）"), "超长非 JSON 响应体应截断");
+        assertTrue(desc.length() < 230, "截断后长度应受控，实际=" + desc.length());
+    }
+
     /** 连接类异常的 message 常为 null，必须翻译成可排查的提示（含 IPv6 only 的排查方向）。 */
     @Test
     void diagnose_shouldGiveActionableHint_forConnectException() {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientTest.java
@@ -1,0 +1,188 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+/**
+ * {@link KnowledgeSearchClient} 单测（全部离线，不依赖真实 RAG 服务）：
+ * 响应解析、自定义头解析、阈值过滤、多库合并排序取 top-n、单库失败降级为空而不抛异常。
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeSearchClientTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private KnowledgeSearchClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new KnowledgeSearchClient(mock(KnowledgeBaseHttpGuard.class), new AdminRagProperties());
+    }
+
+    private KnowledgeBaseEndpoint endpoint(Long id, String name, int topN, String threshold) {
+        return new KnowledgeBaseEndpoint(id, name, "http://localhost:20002", "app_" + id, "sk-test",
+            "application/json", "", topN, new BigDecimal(threshold));
+    }
+
+    private KnowledgeNode node(String kbName, String content, String score) {
+        return new KnowledgeNode(kbName, content, new BigDecimal(score), "doc-1", "chunk-1");
+    }
+
+    // ---- 响应解析 ----
+
+    @Test
+    void parseNodes_shouldExtractContentScoreAndIds() throws Exception {
+        String body = """
+            {"code":"OK","message":"success","data":{"nodes":[
+              {"content":"公积金提取流程","score":0.183,"doc_id":"d1","chunk_id":"c1","metadata":{}},
+              {"content":"公积金缴存比例","score":0.131,"doc_id":"d2","chunk_id":"c2"}
+            ],"request_id":"r1"},"request_id":"r1"}
+            """;
+
+        List<KnowledgeNode> nodes = KnowledgeSearchClient.parseNodes(MAPPER, "产品知识库", body);
+
+        assertEquals(2, nodes.size());
+        assertEquals("公积金提取流程", nodes.get(0).content());
+        assertEquals("产品知识库", nodes.get(0).kbName());
+        assertEquals("d1", nodes.get(0).docId());
+        assertEquals("c1", nodes.get(0).chunkId());
+        assertEquals(0, nodes.get(0).score().compareTo(new BigDecimal("0.183")));
+    }
+
+    @Test
+    void parseNodes_shouldThrow_whenCodeIsNotOk() {
+        String body = "{\"code\":\"UNAUTHORIZED\",\"message\":\"invalid appkey\"}";
+
+        BizException e = assertThrows(BizException.class,
+            () -> KnowledgeSearchClient.parseNodes(MAPPER, "kb", body));
+        assertTrue(e.getMessage().contains("UNAUTHORIZED"));
+    }
+
+    @Test
+    void parseNodes_shouldReturnEmpty_whenNodesMissingOrContentBlank() throws Exception {
+        assertTrue(KnowledgeSearchClient.parseNodes(MAPPER, "kb", "{\"code\":\"OK\",\"data\":{}}").isEmpty());
+        assertTrue(KnowledgeSearchClient.parseNodes(MAPPER, "kb",
+            "{\"code\":\"OK\",\"data\":{\"nodes\":[{\"content\":\"\",\"score\":0.5}]}}").isEmpty());
+    }
+
+    // ---- 自定义请求头 ----
+
+    @Test
+    void parseExtraHeaders_shouldParseJsonObject() {
+        Map<String, String> headers = KnowledgeSearchClient.parseExtraHeaders(MAPPER, "{\"X-Tenant\":\"acme\"}");
+
+        assertEquals(Map.of("X-Tenant", "acme"), headers);
+    }
+
+    @Test
+    void parseExtraHeaders_shouldReturnEmpty_whenBlank() {
+        assertTrue(KnowledgeSearchClient.parseExtraHeaders(MAPPER, null).isEmpty());
+        assertTrue(KnowledgeSearchClient.parseExtraHeaders(MAPPER, "  ").isEmpty());
+    }
+
+    @Test
+    void parseExtraHeaders_shouldRejectMalformedOrNonObjectJson() {
+        assertThrows(IllegalArgumentException.class, () -> KnowledgeSearchClient.parseExtraHeaders(MAPPER, "{not-json"));
+        assertThrows(IllegalArgumentException.class, () -> KnowledgeSearchClient.parseExtraHeaders(MAPPER, "[1,2]"));
+    }
+
+    @Test
+    void parseExtraHeaders_shouldIgnoreReservedHeaders() {
+        // Authorization / Content-Type 由客户端按知识库配置统一设置，JDK HttpRequest 的 header() 是追加而非覆盖
+        Map<String, String> headers = KnowledgeSearchClient.parseExtraHeaders(MAPPER,
+            "{\"authorization\":\"Bearer hack\",\"Content-Type\":\"text/plain\",\"X-Ok\":\"1\"}");
+
+        assertEquals(Map.of("X-Ok", "1"), headers);
+    }
+
+    // ---- 多库并发检索：过滤 / 合并 / 降级 ----
+
+    @Test
+    void searchAll_shouldReturnEmpty_whenNoEndpointsOrBlankQuery() {
+        assertTrue(client.searchAll(List.of(), "问题").isEmpty());
+        assertTrue(client.searchAll(List.of(endpoint(1L, "kb1", 5, "0")), "  ").isEmpty());
+    }
+
+    @Test
+    void searchAll_shouldDropNodesBelowThreshold() {
+        KnowledgeSearchClient spyClient = spy(client);
+        KnowledgeBaseEndpoint ep = endpoint(1L, "kb1", 5, "0.15");
+        doReturn(List.of(node("kb1", "高分", "0.183"), node("kb1", "低分", "0.131")))
+            .when(spyClient).searchOne(eq(ep), anyString());
+
+        List<KnowledgeNode> nodes = spyClient.searchAll(List.of(ep), "问题");
+
+        assertEquals(1, nodes.size());
+        assertEquals("高分", nodes.get(0).content());
+    }
+
+    @Test
+    void searchAll_shouldKeepAll_whenThresholdIsZero() {
+        // rerank 分数量级只有 0.1x，默认阈值必须是 0（不过滤），否则常见的 0.5 会把全部召回丢光
+        KnowledgeSearchClient spyClient = spy(client);
+        KnowledgeBaseEndpoint ep = endpoint(1L, "kb1", 5, "0");
+        doReturn(List.of(node("kb1", "a", "0.183"), node("kb1", "b", "0.131")))
+            .when(spyClient).searchOne(eq(ep), anyString());
+
+        assertEquals(2, spyClient.searchAll(List.of(ep), "问题").size());
+    }
+
+    @Test
+    void searchAll_shouldMergeMultipleKnowledgeBases_sortedByScoreDescAndLimited() {
+        KnowledgeSearchClient spyClient = spy(client);
+        KnowledgeBaseEndpoint first = endpoint(1L, "kb1", 2, "0");
+        KnowledgeBaseEndpoint second = endpoint(2L, "kb2", 3, "0");
+        doReturn(List.of(node("kb1", "a", "0.11"), node("kb1", "c", "0.19"))).when(spyClient).searchOne(eq(first), anyString());
+        doReturn(List.of(node("kb2", "b", "0.15"), node("kb2", "d", "0.13"))).when(spyClient).searchOne(eq(second), anyString());
+
+        List<KnowledgeNode> nodes = spyClient.searchAll(List.of(first, second), "问题");
+
+        // 合并上限取各库 topN 的最大值（3），按 score 倒排：0.19 / 0.15 / 0.13
+        assertEquals(3, nodes.size());
+        assertEquals(List.of("c", "b", "d"), nodes.stream().map(KnowledgeNode::content).toList());
+    }
+
+    @Test
+    void searchAll_shouldDegradeToPartialResult_whenOneKnowledgeBaseFails() {
+        KnowledgeSearchClient spyClient = spy(client);
+        KnowledgeBaseEndpoint healthy = endpoint(1L, "kb1", 5, "0");
+        KnowledgeBaseEndpoint broken = endpoint(2L, "kb2", 5, "0");
+        doReturn(List.of(node("kb1", "ok", "0.18"))).when(spyClient).searchOne(eq(healthy), anyString());
+        doThrow(new IllegalStateException("connection refused")).when(spyClient).searchOne(eq(broken), anyString());
+
+        List<KnowledgeNode> nodes = assertDoesNotThrow(() -> spyClient.searchAll(List.of(healthy, broken), "问题"));
+
+        assertEquals(1, nodes.size(), "单库失败只能损失该库的召回，不得打断整体检索");
+        assertEquals("ok", nodes.get(0).content());
+    }
+
+    @Test
+    void searchAll_shouldReturnEmptyAndNotThrow_whenAllKnowledgeBasesFail() {
+        KnowledgeSearchClient spyClient = spy(client);
+        doThrow(new IllegalStateException("boom")).when(spyClient).searchOne(any(KnowledgeBaseEndpoint.class), anyString());
+
+        List<KnowledgeNode> nodes = assertDoesNotThrow(
+            () -> spyClient.searchAll(List.of(endpoint(1L, "kb1", 5, "0")), "问题"));
+
+        assertTrue(nodes.isEmpty(), "检索失败绝不抛异常打断对话");
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/client/KnowledgeSearchClientTest.java
@@ -47,6 +47,50 @@ class KnowledgeSearchClientTest {
         return new KnowledgeNode(kbName, content, new BigDecimal(score), "doc-1", "chunk-1");
     }
 
+    // ---- HTTP 协议版本与错误诊断 ----
+
+    /**
+     * 必须固定 HTTP/1.1：默认的 HTTP_2 会对 http:// 发 h2c upgrade 协商，
+     * 实测自建 Node RAG 服务不响应该协商导致请求挂起到超时（HTTP_2 超时 8s vs HTTP_1_1 正常 928ms）。
+     */
+    @Test
+    void httpClient_shouldPinHttp11_toAvoidH2cUpgradeHang() {
+        assertEquals(java.net.http.HttpClient.Version.HTTP_1_1, client.httpClientVersion(),
+            "HTTP 版本必须固定为 1.1，否则对不支持 h2c 协商的服务会挂起到超时");
+    }
+
+    /** 连接类异常的 message 常为 null，必须翻译成可排查的提示（含 IPv6 only 的排查方向）。 */
+    @Test
+    void diagnose_shouldGiveActionableHint_forConnectException() {
+        KnowledgeBaseEndpoint ep = endpoint(1L, "kb", 5, "0");
+
+        String msg = client.diagnose(new java.net.ConnectException(), ep);
+
+        assertTrue(msg.contains("无法建立连接"), "应说明是连接失败");
+        assertTrue(msg.contains("http://localhost:20002"), "应带上实际地址便于核对");
+        assertTrue(msg.contains("[::1]"), "应提示 IPv6 only 的排查方向");
+    }
+
+    /** 超时提示要给出当前超时值与可调配置项，并点出 HTTP/2 协商这个隐蔽成因。 */
+    @Test
+    void diagnose_shouldGiveActionableHint_forTimeout() {
+        KnowledgeBaseEndpoint ep = endpoint(1L, "kb", 5, "0");
+
+        String msg = client.diagnose(new java.net.http.HttpTimeoutException("request timed out"), ep);
+
+        assertTrue(msg.contains("请求超时"), "应说明是超时");
+        assertTrue(msg.contains("admin.rag.request-timeout-seconds"), "应给出可调的配置项");
+    }
+
+    /** 其余异常保留原始 message；message 为空时退回类名，不能出现 "null"。 */
+    @Test
+    void diagnose_shouldFallbackToClassName_whenMessageBlank() {
+        KnowledgeBaseEndpoint ep = endpoint(1L, "kb", 5, "0");
+
+        assertEquals("boom", client.diagnose(new IllegalStateException("boom"), ep));
+        assertEquals("IllegalStateException", client.diagnose(new IllegalStateException(), ep));
+    }
+
     // ---- 响应解析 ----
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/controller/KnowledgeBaseControllerTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/controller/KnowledgeBaseControllerTest.java
@@ -1,0 +1,109 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.controller;
+
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseOptionVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.service.KnowledgeBaseService;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link KnowledgeBaseController} 单测：各端点薄委托 Service，并用统一 {@link Result} 包裹（code=0）。
+ * 鉴权注解由 Sa-Token 拦截，非单测范畴。
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeBaseControllerTest {
+
+    private KnowledgeBaseService service;
+    private KnowledgeBaseController controller;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(KnowledgeBaseService.class);
+        controller = new KnowledgeBaseController(service);
+    }
+
+    @Test
+    void page_shouldWrapServiceResult() {
+        PageResult<KnowledgeBaseVO> pageResult = new PageResult<>();
+        PageQuery query = new PageQuery();
+        when(service.page(query)).thenReturn(pageResult);
+
+        Result<PageResult<KnowledgeBaseVO>> result = controller.page(query);
+
+        assertEquals(ResultCode.SUCCESS.getCode(), result.getCode());
+        assertSame(pageResult, result.getData());
+    }
+
+    @Test
+    void get_shouldWrapServiceResult() {
+        KnowledgeBaseVO vo = new KnowledgeBaseVO();
+        when(service.get(1L)).thenReturn(vo);
+
+        assertSame(vo, controller.get(1L).getData());
+    }
+
+    @Test
+    void options_shouldWrapServiceResult() {
+        List<KnowledgeBaseOptionVO> options = List.of(new KnowledgeBaseOptionVO(1L, "产品知识库"));
+        when(service.options()).thenReturn(options);
+
+        assertSame(options, controller.options().getData());
+    }
+
+    @Test
+    void create_shouldDelegateToService() {
+        KnowledgeBaseSaveRequest request = new KnowledgeBaseSaveRequest("产品知识库", "http://localhost:20002",
+            "app_1", "sk-1", null, null, 5, BigDecimal.ZERO, 1, null);
+
+        assertEquals(ResultCode.SUCCESS.getCode(), controller.create(request).getCode());
+        verify(service).create(request);
+    }
+
+    @Test
+    void update_shouldDelegateToServiceWithPathId() {
+        KnowledgeBaseSaveRequest request = new KnowledgeBaseSaveRequest("产品知识库", "http://localhost:20002",
+            "app_1", "", null, null, 5, BigDecimal.ZERO, 1, null);
+
+        assertEquals(ResultCode.SUCCESS.getCode(), controller.update(7L, request).getCode());
+        verify(service).update(7L, request);
+    }
+
+    @Test
+    void delete_shouldDelegateToService() {
+        assertEquals(ResultCode.SUCCESS.getCode(), controller.delete(7L).getCode());
+        verify(service).delete(7L);
+    }
+
+    @Test
+    void updateStatus_shouldDelegateToService() {
+        assertEquals(ResultCode.SUCCESS.getCode(), controller.updateStatus(7L, 0).getCode());
+        verify(service).updateStatus(7L, 0);
+    }
+
+    @Test
+    void testConnectivity_shouldWrapAsyncServiceResult() throws Exception {
+        KnowledgeBaseTestResult testResult = KnowledgeBaseTestResult.success(3);
+        when(service.testConnectivity(7L)).thenReturn(CompletableFuture.completedFuture(testResult));
+
+        Result<KnowledgeBaseTestResult> result = controller.testConnectivity(7L).get();
+
+        assertEquals(ResultCode.SUCCESS.getCode(), result.getCode());
+        assertSame(testResult, result.getData());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalMiddlewareTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalMiddlewareTest.java
@@ -1,0 +1,218 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime;
+
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.ReasoningInput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link KnowledgeRetrievalMiddleware} 单测：守住评审定下的三条硬约束。
+ *
+ * <ol>
+ *   <li>检索不得跑在调用方（Tomcat 请求）线程上 → 断言 retrieve 实际执行线程不是测试线程；</li>
+ *   <li>注入只对本次模型调用可见 → 断言原消息对象与入参列表一个字节都没被改动，
+ *       注入是<b>新增</b>的一条带 synthetic 标记的消息；</li>
+ *   <li>检索失败/无召回绝不打断对话 → 断言仍然照常 next.apply。</li>
+ * </ol>
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeRetrievalMiddlewareTest {
+
+    private static final String AGENT_CODE = "kb-agent";
+    private static final String BLOCK = "<retrieved_knowledge>\n[1] knowledge_base=产品库 内容\n</retrieved_knowledge>";
+
+    private KnowledgeRetrievalService retrievalService;
+    private KnowledgeRetrievalMiddleware middleware;
+
+    @BeforeEach
+    void setUp() {
+        retrievalService = mock(KnowledgeRetrievalService.class);
+        middleware = new KnowledgeRetrievalMiddleware(retrievalService, AGENT_CODE);
+    }
+
+    private Msg userMsg(String text) {
+        return Msg.builder().role(MsgRole.USER).name("user")
+            .content(TextBlock.builder().text(text).build()).build();
+    }
+
+    private ReasoningInput inputOf(Msg... msgs) {
+        return new ReasoningInput(List.of(msgs), List.of(), null);
+    }
+
+    /** 捕获中间件真正传给下游的 ReasoningInput（即最终发给模型的消息列表）。 */
+    private Function<ReasoningInput, Flux<AgentEvent>> capturing(AtomicReference<ReasoningInput> sink) {
+        return input -> {
+            sink.set(input);
+            return Flux.empty();
+        };
+    }
+
+    @Test
+    void shouldRunRetrievalOffCallerThread() {
+        AtomicReference<String> retrievalThread = new AtomicReference<>();
+        when(retrievalService.retrieve(anyString(), anyString())).thenAnswer(inv -> {
+            retrievalThread.set(Thread.currentThread().getName());
+            return BLOCK;
+        });
+
+        RuntimeContext ctx = RuntimeContext.builder().userId(AGENT_CODE).sessionId("s1").build();
+        middleware.onReasoning(null, ctx, inputOf(userMsg("公积金怎么提取")), input -> Flux.empty())
+            .blockLast();
+
+        // 硬约束1：阻塞式 HTTP 检索必须被 subscribeOn(boundedElastic) 挪走，绝不占用调用方线程。
+        // 调用方线程在生产上就是 Tomcat worker（ChatController.stream 返回 Flux 不代表方法体异步）。
+        assertNotEquals(Thread.currentThread().getName(), retrievalThread.get(),
+            "检索不得在调用方线程执行，否则 RAG 后端变慢会拖垮整个 admin-server 的请求线程池");
+        assertTrue(retrievalThread.get().startsWith("boundedElastic-"),
+            "应落在 boundedElastic 弹性线程池，实际=" + retrievalThread.get());
+    }
+
+    @Test
+    void shouldInjectAsExtraTransientMessage_withoutTouchingUserMessage() {
+        when(retrievalService.retrieve(anyString(), anyString())).thenReturn(BLOCK);
+        Msg original = userMsg("公积金怎么提取");
+        ReasoningInput input = inputOf(original);
+        AtomicReference<ReasoningInput> passed = new AtomicReference<>();
+
+        middleware.onReasoning(null, RuntimeContext.builder().sessionId("s1").build(), input, capturing(passed))
+            .blockLast();
+
+        List<Msg> sent = passed.get().messages();
+        assertEquals(2, sent.size(), "注入应是新增一条消息，而不是改写原消息");
+        // 硬约束2的关键：用户那条消息（会被框架写进 AgentState 并回显给用户）必须原封不动——
+        // 同一个对象引用、同一个 Msg.id、同一段文本，注入痕迹一个字符都不能沾。
+        assertSame(original, sent.get(0));
+        assertEquals("公积金怎么提取", sent.get(0).getTextContent());
+        assertFalse(sent.get(0).getTextContent().contains("<retrieved_knowledge>"));
+        // 入参列表本身也不能被就地改动（框架复用该列表做别的事时不能被污染）
+        assertEquals(1, input.messages().size(), "不得就地修改传入的消息列表");
+
+        Msg injected = sent.get(1);
+        assertEquals(BLOCK, injected.getTextContent());
+        assertEquals(MsgRole.USER, injected.getRole());
+        assertEquals(Boolean.TRUE, injected.getMetadata().get(Msg.METADATA_SYNTHETIC),
+            "注入消息必须打 synthetic 标记，任何观察到它的消费方都能识别并跳过");
+    }
+
+    @Test
+    void shouldRetrieveOncePerTurn_andReinjectOnLaterReasoningSteps() {
+        when(retrievalService.retrieve(anyString(), anyString())).thenReturn(BLOCK);
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("s1").build();
+        AtomicReference<ReasoningInput> second = new AtomicReference<>();
+
+        // ReAct 循环：一轮对话里 onReasoning 会被调多次（每次工具返回后再推理一次）
+        middleware.onReasoning(null, ctx, inputOf(userMsg("问题")), input -> Flux.empty()).blockLast();
+        middleware.onReasoning(null, ctx, inputOf(userMsg("问题")), capturing(second)).blockLast();
+
+        verify(retrievalService, times(1)).retrieve(eq(AGENT_CODE), anyString());
+        assertEquals(2, second.get().messages().size(), "后续推理步仍要注入（缓存复用），模型才始终看得到参考资料");
+    }
+
+    /** 子 Agent 可能与父 Agent 共用同一个 RuntimeContext：缓存必须按 agentCode 隔离，否则子 Agent 会用到父的召回块。 */
+    @Test
+    void shouldNotShareCacheAcrossAgents_onSameRuntimeContext() {
+        when(retrievalService.retrieve(eq(AGENT_CODE), anyString())).thenReturn(BLOCK);
+        when(retrievalService.retrieve(eq("sub-agent"), anyString())).thenReturn(null);
+        RuntimeContext sharedCtx = RuntimeContext.builder().sessionId("s1").build();
+        KnowledgeRetrievalMiddleware subMiddleware =
+            new KnowledgeRetrievalMiddleware(retrievalService, "sub-agent");
+        AtomicReference<ReasoningInput> subPassed = new AtomicReference<>();
+
+        middleware.onReasoning(null, sharedCtx, inputOf(userMsg("问题")), input -> Flux.empty()).blockLast();
+        ReasoningInput subInput = inputOf(userMsg("问题"));
+        subMiddleware.onReasoning(null, sharedCtx, subInput, capturing(subPassed)).blockLast();
+
+        verify(retrievalService).retrieve("sub-agent", "问题");
+        assertSame(subInput, subPassed.get(), "子 Agent 自己没召回到东西，就不该被父 Agent 的缓存块污染");
+    }
+
+    @Test
+    void shouldPreferCallMetaQuestion_overRawMessageText() {
+        when(retrievalService.retrieve(anyString(), anyString())).thenReturn(null);
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("s1").build();
+        ctx.put(AgentCallMeta.class,
+            new AgentCallMeta("req-1", "tester", AGENT_CODE, "KB助手", null, "写一个冒泡排序"));
+        // VibeCoding 链路送进 Agent 的是"路径指引 + 提问"，拿它检索等于给 RAG 喂指令噪声
+        String directivePrefixed = "[VibeCoding指引-local] 本次对话的会话目录为: sessions/s1/\n\n写一个冒泡排序";
+
+        middleware.onReasoning(null, ctx, inputOf(userMsg(directivePrefixed)), input -> Flux.empty()).blockLast();
+
+        verify(retrievalService).retrieve(AGENT_CODE, "写一个冒泡排序");
+    }
+
+    @Test
+    void shouldFallBackToLastUserMessage_whenNoCallMeta() {
+        when(retrievalService.retrieve(anyString(), anyString())).thenReturn(null);
+
+        // 最后一条消息是 ASSISTANT（ReAct 循环中常见），必须回溯到最后一条 USER 消息
+        ReasoningInput input = new ReasoningInput(List.of(
+            userMsg("公积金怎么提取"),
+            Msg.builder().role(MsgRole.ASSISTANT).name("bot")
+                .content(TextBlock.builder().text("让我查一下").build()).build()), List.of(), null);
+
+        middleware.onReasoning(null, RuntimeContext.builder().sessionId("s1").build(), input,
+            in -> Flux.empty()).blockLast();
+
+        verify(retrievalService).retrieve(AGENT_CODE, "公积金怎么提取");
+    }
+
+    @Test
+    void shouldPassThrough_whenNothingRetrieved() {
+        when(retrievalService.retrieve(anyString(), anyString())).thenReturn(null);
+        ReasoningInput input = inputOf(userMsg("问题"));
+        AtomicReference<ReasoningInput> passed = new AtomicReference<>();
+
+        middleware.onReasoning(null, RuntimeContext.builder().sessionId("s1").build(), input, capturing(passed))
+            .blockLast();
+
+        assertSame(input, passed.get(), "无召回时连列表拷贝都不做，原样透传");
+    }
+
+    @Test
+    void shouldNotBreakConversation_whenRetrievalThrows() {
+        when(retrievalService.retrieve(anyString(), anyString())).thenThrow(new IllegalStateException("boom"));
+        ReasoningInput input = inputOf(userMsg("问题"));
+        AtomicReference<ReasoningInput> passed = new AtomicReference<>();
+
+        // 硬约束3：检索失败绝不打断对话——不抛异常，照常把原始输入交给下游继续推理
+        middleware.onReasoning(null, RuntimeContext.builder().sessionId("s1").build(), input, capturing(passed))
+            .blockLast();
+
+        assertSame(input, passed.get());
+    }
+
+    @Test
+    void shouldSkipRetrieval_whenNoQueryResolvable() {
+        ReasoningInput input = new ReasoningInput(List.of(), List.of(), null);
+        AtomicReference<ReasoningInput> passed = new AtomicReference<>();
+
+        middleware.onReasoning(null, RuntimeContext.builder().sessionId("s1").build(), input, capturing(passed))
+            .blockLast();
+
+        verify(retrievalService, never()).retrieve(anyString(), anyString());
+        assertSame(input, passed.get());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalServiceTest.java
@@ -1,0 +1,191 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime;
+
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeBaseEndpoint;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeNode;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeSearchClient;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link KnowledgeRetrievalService} 单测：未绑定知识库零开销（不发请求）、召回为空不注入、
+ * 注入内容追加在消息末尾（不能破坏 VibeCoding 的头部路径指引）、停用/未测试的知识库不参与检索、
+ * 检索异常降级为原文不打断对话。
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeRetrievalServiceTest {
+
+    private static final String TEST_SECRET_KEY = "0123456789abcdef";
+    private static final String AGENT_CODE = "customer-helper";
+
+    private AiAgentMapper agentMapper;
+    private AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
+    private AiKnowledgeBaseMapper knowledgeBaseMapper;
+    private KnowledgeSearchClient searchClient;
+    private KnowledgeRetrievalService service;
+
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgent.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentKnowledgeBase.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiKnowledgeBase.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        agentMapper = mock(AiAgentMapper.class);
+        agentKnowledgeBaseMapper = mock(AiAgentKnowledgeBaseMapper.class);
+        knowledgeBaseMapper = mock(AiKnowledgeBaseMapper.class);
+        searchClient = mock(KnowledgeSearchClient.class);
+        service = new KnowledgeRetrievalService(agentMapper, agentKnowledgeBaseMapper, knowledgeBaseMapper,
+            new AesGcmCryptoUtil(TEST_SECRET_KEY), searchClient);
+
+        AiAgent agent = new AiAgent();
+        agent.setId(1L);
+        agent.setAgentCode(AGENT_CODE);
+        when(agentMapper.selectOne(any())).thenReturn(agent);
+    }
+
+    private void bindKnowledgeBase(AiKnowledgeBase knowledgeBase) {
+        AiAgentKnowledgeBase relation = new AiAgentKnowledgeBase();
+        relation.setAgentId(1L);
+        relation.setKnowledgeBaseId(knowledgeBase.getId());
+        when(agentKnowledgeBaseMapper.selectList(any())).thenReturn(List.of(relation));
+        when(knowledgeBaseMapper.selectBatchIds(anyList())).thenReturn(List.of(knowledgeBase));
+    }
+
+    private AiKnowledgeBase usableKnowledgeBase() {
+        AiKnowledgeBase kb = new AiKnowledgeBase();
+        kb.setId(40L);
+        kb.setKbName("产品知识库");
+        kb.setBaseUrl("http://localhost:20002");
+        kb.setAppId("app_123");
+        kb.setApiKey(new AesGcmCryptoUtil(TEST_SECRET_KEY).encrypt("sk-1"));
+        kb.setContentType("application/json");
+        kb.setExtraHeaders("");
+        kb.setTopN(5);
+        kb.setScoreThreshold(BigDecimal.ZERO);
+        kb.setStatus(1);
+        kb.setTestStatus(KnowledgeBaseTestResult.STATUS_SUCCESS);
+        return kb;
+    }
+
+    @Test
+    void retrieve_shouldNotSearch_whenAgentHasNoKnowledgeBase() {
+        when(agentKnowledgeBaseMapper.selectList(any())).thenReturn(List.of());
+
+        assertNull(service.retrieve(AGENT_CODE, "公积金怎么提取"), "未绑定知识库=不注入");
+        verify(searchClient, never()).searchAll(anyList(), anyString());
+    }
+
+    @Test
+    void retrieve_shouldNotSearch_whenAgentNotFound() {
+        when(agentMapper.selectOne(any())).thenReturn(null);
+
+        assertNull(service.retrieve(AGENT_CODE, "问题"));
+        verify(searchClient, never()).searchAll(anyList(), anyString());
+    }
+
+    @Test
+    void retrieve_shouldReturnOriginal_whenQueryOrAgentCodeBlank() {
+        assertNull(service.retrieve("", "问题"));
+        assertNull(service.retrieve(AGENT_CODE, "  "));
+        verify(searchClient, never()).searchAll(anyList(), anyString());
+    }
+
+    @Test
+    void retrieve_shouldNotInjectEmptyBlock_whenNothingRetrieved() {
+        bindKnowledgeBase(usableKnowledgeBase());
+        when(searchClient.searchAll(anyList(), anyString())).thenReturn(List.of());
+
+        assertNull(service.retrieve(AGENT_CODE, "公积金怎么提取"), "召回为空时绝不注入空标签污染上下文");
+    }
+
+    @Test
+    void retrieve_shouldRenderSelfContainedBlock_withSourceAndScore() {
+        bindKnowledgeBase(usableKnowledgeBase());
+        when(searchClient.searchAll(anyList(), anyString())).thenReturn(List.of(
+            new KnowledgeNode("产品知识库", "提取需先满足封存满半年", new BigDecimal("0.183"), "doc-9", "chunk-3")));
+
+        String result = service.retrieve(AGENT_CODE, "公积金怎么提取");
+
+        // 返回的必须是"自包含的注入块"本身，不含用户提问原文——拼接由中间件挂成独立瞬态消息完成，
+        // 本服务不再碰用户消息文本（那正是召回块曾被持久化进会话历史的根因）。
+        assertTrue(result.startsWith("<retrieved_knowledge>"));
+        assertTrue(result.endsWith("</retrieved_knowledge>"));
+        assertFalse(result.contains("公积金怎么提取"), "块内不得夹带用户提问原文");
+        assertTrue(result.contains("提取需先满足封存满半年"));
+        assertTrue(result.contains("doc_id=doc-9"));
+        assertTrue(result.contains("chunk_id=chunk-3"));
+        assertTrue(result.contains("score=0.183"));
+        assertTrue(result.contains("knowledge_base=产品知识库"));
+    }
+
+    @Test
+    void retrieve_shouldSkipDisabledKnowledgeBase() {
+        AiKnowledgeBase disabled = usableKnowledgeBase();
+        disabled.setStatus(0);
+        bindKnowledgeBase(disabled);
+
+        // 停用后运行时立刻不再参与检索：可用端点被过滤空 → 直接零开销返回，一个请求都不发
+        assertNull(service.retrieve(AGENT_CODE, "问题"));
+        verify(searchClient, never()).searchAll(anyList(), anyString());
+    }
+
+    @Test
+    void retrieve_shouldSkipUntestedKnowledgeBase() {
+        AiKnowledgeBase untested = usableKnowledgeBase();
+        untested.setTestStatus(KnowledgeBaseTestResult.STATUS_FAILED);
+        bindKnowledgeBase(untested);
+
+        assertNull(service.retrieve(AGENT_CODE, "问题"));
+        verify(searchClient, never()).searchAll(anyList(), anyString());
+    }
+
+    @Test
+    void retrieve_shouldReturnNull_whenSearchThrows() {
+        bindKnowledgeBase(usableKnowledgeBase());
+        when(searchClient.searchAll(anyList(), anyString())).thenThrow(new IllegalStateException("boom"));
+
+        assertNull(assertDoesNotThrow(() -> service.retrieve(AGENT_CODE, "问题")),
+            "检索异常必须降级为不注入，绝不打断对话");
+    }
+
+    @Test
+    void retrieve_shouldPassDecryptedApiKeyToClient() {
+        bindKnowledgeBase(usableKnowledgeBase());
+        when(searchClient.searchAll(anyList(), anyString())).thenReturn(List.of());
+
+        service.retrieve(AGENT_CODE, "问题");
+
+        verify(searchClient).searchAll(List.of(new KnowledgeBaseEndpoint(40L, "产品知识库",
+            "http://localhost:20002", "app_123", "sk-1", "application/json", "", 5, BigDecimal.ZERO)), "问题");
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseServiceTest.java
@@ -1,0 +1,360 @@
+package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.service;
+
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeBaseEndpoint;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeNode;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.client.KnowledgeSearchClient;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseOptionVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseSaveRequest;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseTestResult;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto.KnowledgeBaseVO;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link KnowledgeBaseService} 单测：AppKey 加密落库/掩码回显/"留空=不改"、名称唯一、
+ * <b>保存门禁</b>（实测失败阻止保存 / 只改名不重测）、被引用时拒删、连通性测试落库、下拉选项过滤。
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeBaseServiceTest {
+
+    private static final String TEST_SECRET_KEY = "0123456789abcdef";
+
+    private AiKnowledgeBaseMapper knowledgeBaseMapper;
+    private AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
+    private KnowledgeSearchClient searchClient;
+    private KnowledgeBaseService service;
+
+    /**
+     * MyBatis-Plus 的 Lambda 包装器依赖实体 TableInfo 缓存，纯 Mockito 单测无容器，需手动注册一次，
+     * 否则 LambdaQueryWrapper 会抛 "can not find lambda cache"。
+     */
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiKnowledgeBase.class);
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentKnowledgeBase.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        knowledgeBaseMapper = mock(AiKnowledgeBaseMapper.class);
+        agentKnowledgeBaseMapper = mock(AiAgentKnowledgeBaseMapper.class);
+        searchClient = mock(KnowledgeSearchClient.class);
+        service = new KnowledgeBaseService(knowledgeBaseMapper, agentKnowledgeBaseMapper,
+            new AesGcmCryptoUtil(TEST_SECRET_KEY), searchClient, new AdminRagProperties());
+        // 默认探测成功（个别用例覆写为失败）
+        when(searchClient.searchOne(any(KnowledgeBaseEndpoint.class), anyString()))
+            .thenReturn(List.of(new KnowledgeNode("kb", "片段", new BigDecimal("0.18"), "d1", "c1")));
+    }
+
+    private KnowledgeBaseSaveRequest request(String kbName, String apiKey) {
+        return new KnowledgeBaseSaveRequest(kbName, "http://localhost:20002", "app_123", apiKey,
+            null, null, null, null, 1, "备注");
+    }
+
+    private AiKnowledgeBase existing(Long id, String plainApiKey) {
+        AiKnowledgeBase kb = new AiKnowledgeBase();
+        kb.setId(id);
+        kb.setKbName("产品知识库");
+        kb.setBaseUrl("http://localhost:20002");
+        kb.setAppId("app_123");
+        kb.setApiKey(new AesGcmCryptoUtil(TEST_SECRET_KEY).encrypt(plainApiKey));
+        kb.setContentType("application/json");
+        kb.setExtraHeaders("");
+        kb.setTopN(5);
+        kb.setScoreThreshold(BigDecimal.ZERO);
+        kb.setStatus(1);
+        kb.setTestStatus(KnowledgeBaseTestResult.STATUS_SUCCESS);
+        return kb;
+    }
+
+    // ---- 加密 / 掩码 / 留空不改 ----
+
+    @Test
+    void create_shouldEncryptApiKey_notStorePlainText() {
+        ArgumentCaptor<AiKnowledgeBase> captor = ArgumentCaptor.forClass(AiKnowledgeBase.class);
+
+        service.create(request("产品知识库", "sk-plain-secret-1234"));
+
+        verify(knowledgeBaseMapper).insert(captor.capture());
+        assertNotEquals("sk-plain-secret-1234", captor.getValue().getApiKey());
+        assertTrue(captor.getValue().getApiKey().length() > 0);
+    }
+
+    @Test
+    void create_shouldRejectMissingApiKey() {
+        assertThrows(BizException.class, () -> service.create(request("产品知识库", null)));
+    }
+
+    @Test
+    void create_shouldApplyDefaults_whenOptionalFieldsBlank() {
+        ArgumentCaptor<AiKnowledgeBase> captor = ArgumentCaptor.forClass(AiKnowledgeBase.class);
+
+        service.create(request("产品知识库", "sk-1"));
+
+        verify(knowledgeBaseMapper).insert(captor.capture());
+        AiKnowledgeBase saved = captor.getValue();
+        assertEquals("application/json", saved.getContentType());
+        assertEquals("", saved.getExtraHeaders());
+        assertEquals(KnowledgeBaseEndpoint.DEFAULT_TOP_N, saved.getTopN());
+        // 阈值默认 0：外部 rerank 分数量级只有 0.1x，按 0.5 之类拍脑袋会把召回全丢光
+        assertEquals(0, saved.getScoreThreshold().compareTo(BigDecimal.ZERO));
+    }
+
+    @Test
+    void update_shouldKeepOldApiKey_whenRequestApiKeyBlank() {
+        AiKnowledgeBase kb = existing(1L, "sk-original-secret");
+        String originalCipher = kb.getApiKey();
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(kb);
+
+        service.update(1L, request("产品知识库", ""));
+
+        ArgumentCaptor<AiKnowledgeBase> captor = ArgumentCaptor.forClass(AiKnowledgeBase.class);
+        verify(knowledgeBaseMapper).updateById(captor.capture());
+        assertEquals(originalCipher, captor.getValue().getApiKey());
+    }
+
+    @Test
+    void get_shouldReturnMaskedApiKey_notCiphertextOrPlainText() {
+        AiKnowledgeBase kb = existing(1L, "sk-abcd1234wxyz");
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(kb);
+
+        KnowledgeBaseVO vo = service.get(1L);
+
+        assertNotEquals("sk-abcd1234wxyz", vo.getApiKeyMasked());
+        assertNotEquals(kb.getApiKey(), vo.getApiKeyMasked());
+        assertTrue(vo.getApiKeyMasked().endsWith("wxyz"));
+    }
+
+    // ---- 保存门禁 ----
+
+    @Test
+    void create_shouldBlockSave_whenConnectivityProbeFails() {
+        when(searchClient.searchOne(any(KnowledgeBaseEndpoint.class), anyString()))
+            .thenThrow(new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, "connection refused"));
+
+        assertThrows(BizException.class, () -> service.create(request("产品知识库", "sk-1")));
+        verify(knowledgeBaseMapper, never()).insert(any(AiKnowledgeBase.class));
+    }
+
+    @Test
+    void create_shouldPersistTestSuccess_whenGatePassed() {
+        ArgumentCaptor<AiKnowledgeBase> captor = ArgumentCaptor.forClass(AiKnowledgeBase.class);
+
+        service.create(request("产品知识库", "sk-1"));
+
+        verify(knowledgeBaseMapper).insert(captor.capture());
+        assertEquals(KnowledgeBaseTestResult.STATUS_SUCCESS, captor.getValue().getTestStatus());
+    }
+
+    @Test
+    void update_shouldSkipProbe_whenOnlyNameOrRemarkChanged() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+
+        // 连接参数（baseUrl/appId/apiKey/contentType/extraHeaders）全部未变，只改名
+        service.update(1L, new KnowledgeBaseSaveRequest("新名字", "http://localhost:20002", "app_123", "",
+            "application/json", "", 5, BigDecimal.ZERO, 1, "新备注"));
+
+        verify(searchClient, never()).searchOne(any(KnowledgeBaseEndpoint.class), anyString());
+    }
+
+    @Test
+    void update_shouldProbe_whenBaseUrlChanged() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+
+        service.update(1L, new KnowledgeBaseSaveRequest("产品知识库", "http://localhost:30003", "app_123", "",
+            "application/json", "", 5, BigDecimal.ZERO, 1, null));
+
+        verify(searchClient).searchOne(any(KnowledgeBaseEndpoint.class), anyString());
+    }
+
+    @Test
+    void update_shouldBlockSave_whenChangedConnectionFailsProbe() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        when(searchClient.searchOne(any(KnowledgeBaseEndpoint.class), anyString()))
+            .thenThrow(new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, "unauthorized"));
+
+        assertThrows(BizException.class, () -> service.update(1L,
+            new KnowledgeBaseSaveRequest("产品知识库", "http://localhost:20002", "app_999", "",
+                "application/json", "", 5, BigDecimal.ZERO, 1, null)));
+        verify(knowledgeBaseMapper, never()).updateById(any(AiKnowledgeBase.class));
+    }
+
+    // ---- 校验 / 删除 / 状态 ----
+
+    @Test
+    void create_shouldRejectDuplicateName() {
+        when(knowledgeBaseMapper.exists(any())).thenReturn(true);
+
+        assertThrows(BizException.class, () -> service.create(request("产品知识库", "sk-1")));
+    }
+
+    @Test
+    void create_shouldRejectMalformedExtraHeaders() {
+        KnowledgeBaseSaveRequest request = new KnowledgeBaseSaveRequest("产品知识库", "http://localhost:20002",
+            "app_123", "sk-1", null, "{not-json", null, null, 1, null);
+
+        assertThrows(BizException.class, () -> service.create(request));
+    }
+
+    @Test
+    void delete_shouldRejectUnknownId() {
+        when(knowledgeBaseMapper.selectById(999L)).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.delete(999L));
+    }
+
+    @Test
+    void delete_shouldRejectWhenReferencedByAgent() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        when(agentKnowledgeBaseMapper.exists(any())).thenReturn(true);
+
+        assertThrows(BizException.class, () -> service.delete(1L));
+        verify(knowledgeBaseMapper, never()).deleteById(1L);
+    }
+
+    @Test
+    void delete_shouldSucceed_whenNotReferenced() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        when(agentKnowledgeBaseMapper.exists(any())).thenReturn(false);
+
+        service.delete(1L);
+
+        verify(knowledgeBaseMapper).deleteById(1L);
+    }
+
+    @Test
+    void updateStatus_shouldOnlyUpdateStatusColumn() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        ArgumentCaptor<AiKnowledgeBase> captor = ArgumentCaptor.forClass(AiKnowledgeBase.class);
+
+        service.updateStatus(1L, 0);
+
+        verify(knowledgeBaseMapper).updateById(captor.capture());
+        assertEquals(0, captor.getValue().getStatus());
+        assertEquals(null, captor.getValue().getKbName(), "启停不应连带改动其它字段");
+    }
+
+    // ---- 连通性测试 / 下拉选项 ----
+
+    @Test
+    void testConnectivity_shouldPersistResultAndReturnHitCount() throws Exception {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+
+        KnowledgeBaseTestResult result = service.testConnectivity(1L).get();
+
+        assertEquals(KnowledgeBaseTestResult.STATUS_SUCCESS, result.testStatus());
+        assertEquals(1, result.hitCount());
+        verify(knowledgeBaseMapper).updateById(any(AiKnowledgeBase.class));
+    }
+
+    @Test
+    void testConnectivity_shouldPersistFailure_whenProbeThrows() throws Exception {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        when(searchClient.searchOne(any(KnowledgeBaseEndpoint.class), anyString()))
+            .thenThrow(new BizException(ResultCode.KNOWLEDGE_BASE_SEARCH_FAILED, "timeout"));
+
+        KnowledgeBaseTestResult result = service.testConnectivity(1L).get();
+
+        assertEquals(KnowledgeBaseTestResult.STATUS_FAILED, result.testStatus());
+        verify(knowledgeBaseMapper).updateById(any(AiKnowledgeBase.class));
+    }
+
+    @Test
+    void options_shouldOnlyReturnEnabledAndTestedKnowledgeBases() {
+        // 过滤条件下沉到 SQL（status=1 且 test_status=1），这里断言映射结果
+        when(knowledgeBaseMapper.selectList(any())).thenReturn(List.of(existing(1L, "sk-1")));
+
+        List<KnowledgeBaseOptionVO> options = service.options();
+
+        assertEquals(1, options.size());
+        assertEquals(1L, options.get(0).id());
+        assertEquals("产品知识库", options.get(0).kbName());
+    }
+
+    // ---- 软删除 + 不含 deleted 列的唯一索引 ----
+
+    /**
+     * 删除（逻辑删除）后用同名重建：旧行仍占着 uk_ai_kb_name，直接 insert 必撞唯一约束报 500。
+     * 修法是复活旧行再整体覆盖字段——名字必须能被重新使用，否则删过一次就永久占用。
+     */
+    @Test
+    void create_shouldReviveSoftDeletedRow_whenSameNameRecreated() {
+        AiKnowledgeBase softDeleted = existing(7L, "sk-old");
+        when(knowledgeBaseMapper.selectDeletedByName("产品知识库")).thenReturn(softDeleted);
+
+        service.create(request("产品知识库", "sk-new"));
+
+        verify(knowledgeBaseMapper).reviveDeleted(7L);
+        verify(knowledgeBaseMapper, never()).insert(any(AiKnowledgeBase.class));
+        ArgumentCaptor<AiKnowledgeBase> captor = ArgumentCaptor.forClass(AiKnowledgeBase.class);
+        verify(knowledgeBaseMapper).updateById(captor.capture());
+        // 复活的是旧行 id，但业务字段整体按本次请求覆盖（含新 AppKey）
+        assertEquals(7L, captor.getValue().getId());
+        assertEquals("sk-new", new AesGcmCryptoUtil(TEST_SECRET_KEY).decrypt(captor.getValue().getApiKey()));
+    }
+
+    /** 无同名软删行时走正常 insert，不该有多余的复活调用。 */
+    @Test
+    void create_shouldInsertNormally_whenNoSoftDeletedRowHoldsTheName() {
+        when(knowledgeBaseMapper.selectDeletedByName(anyString())).thenReturn(null);
+
+        service.create(request("新知识库", "sk-1"));
+
+        verify(knowledgeBaseMapper).insert(any(AiKnowledgeBase.class));
+        verify(knowledgeBaseMapper, never()).reviveDeleted(any());
+    }
+
+    /** 并发竞争撞唯一键：必须兜成友好的业务异常，而不是让 DuplicateKeyException 变成 SYSTEM_ERROR 500。 */
+    @Test
+    void create_shouldFailFriendly_whenInsertRacesOnUniqueKey() {
+        when(knowledgeBaseMapper.selectDeletedByName(anyString())).thenReturn(null);
+        when(knowledgeBaseMapper.insert(any(AiKnowledgeBase.class)))
+            .thenThrow(new DuplicateKeyException("Duplicate entry '产品知识库' for key 'uk_ai_kb_name'"));
+
+        BizException ex = assertThrows(BizException.class, () -> service.create(request("产品知识库", "sk-1")));
+
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, ex.getResultCode());
+        assertTrue(ex.getMessage().contains("产品知识库"));
+    }
+
+    /** 改名撞上软删旧行：改名不能走复活（会变成两行同名），只能给友好提示让用户换名。 */
+    @Test
+    void update_shouldFailFriendly_whenRenameHitsSoftDeletedName() {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        when(knowledgeBaseMapper.updateById(any(AiKnowledgeBase.class)))
+            .thenThrow(new DuplicateKeyException("Duplicate entry '归档库' for key 'uk_ai_kb_name'"));
+
+        BizException ex = assertThrows(BizException.class, () -> service.update(1L, request("归档库", null)));
+
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, ex.getResultCode());
+        assertTrue(ex.getMessage().contains("归档库"));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
@@ -20,9 +20,12 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import io.agentscope.core.model.ChatUsage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -31,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -524,5 +528,51 @@ class ChatServiceTest {
         chatService.chatStream("coder", "s1", "你好", observed::set).collectList().block();
 
         assertNull(observed.get(), "无任何用量信息时应回调 null，区分“没有用量”与“用了 0 token”");
+    }
+
+    // ---- 知识库自动检索注入 ----
+
+    /** 捕获真正送进 Agent 的用户消息文本。 */
+    @SuppressWarnings("unchecked")
+    private String capturedUserText() {
+        ArgumentCaptor<List<Msg>> captor = ArgumentCaptor.forClass(List.class);
+        verify(agent).stream(captor.capture(), any(StreamOptions.class), any(RuntimeContext.class));
+        return captor.getValue().get(0).getTextContent();
+    }
+
+    private void stubEmptyStream() {
+        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("好的").build();
+        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+    }
+
+    /**
+     * 送进 Agent（→ 进 AgentState → 进用户可见历史）的用户消息必须是<b>原文</b>：知识库召回内容
+     * 已改由 {@code KnowledgeRetrievalMiddleware} 在推理阶段挂成瞬态消息，不再拼进这条消息文本。
+     * 这条断言就是"用户历史里绝不出现 &lt;retrieved_knowledge&gt;"的守门测试。
+     */
+    @Test
+    void chatStream_shouldSendRawUserTextToAgent_withoutAnyInjection() {
+        stubEmptyStream();
+
+        chatService.chatStream("coder", "s1", "公积金怎么提取").collectList().block();
+
+        String sent = capturedUserText();
+        assertEquals("公积金怎么提取", sent);
+        assertFalse(sent.contains("<retrieved_knowledge>"),
+            "召回内容绝不能拼进用户消息——那会随 AgentState 持久化并回显给用户，且每轮重发累积 token");
+    }
+
+    /** VibeCoding 链路同理：送进 Agent 的仍是"路径指引 + 提问"原文，不得被检索结果污染。 */
+    @Test
+    void chatStream_shouldNotAlterVibeCodingDirectiveText() {
+        stubEmptyStream();
+        String directivePrefixed = "[VibeCoding指引-local] 本次对话的会话目录为: sessions/s1/\n\n写一个冒泡排序";
+        AgentCallMeta callMeta = new AgentCallMeta("req-1", "admin", "coder", "编码助手",
+            AgentCallSessionType.VIBE_CODING, "写一个冒泡排序");
+
+        chatService.chatStream("coder", "s1", directivePrefixed, null, callMeta).collectList().block();
+
+        assertEquals(directivePrefixed, capturedUserText());
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
@@ -27,7 +27,7 @@ class AdminAgentInstanceFactoryTest {
     /** 构造器纯字段赋值，路径解析只依赖常量，传 null 依赖即可单测 resolveSessionWorkspace 的防御逻辑。 */
     private AdminAgentInstanceFactory newFactoryForPathTest() {
         return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @Test

--- a/customer-admin-web/src/api/knowledgeBase.ts
+++ b/customer-admin-web/src/api/knowledgeBase.ts
@@ -1,0 +1,45 @@
+import { request } from './request'
+import type {
+  KnowledgeBaseOption,
+  KnowledgeBaseSaveRequest,
+  KnowledgeBaseTestResult,
+  KnowledgeBaseVO,
+  PageQuery,
+  PageResult,
+} from '@/types/api'
+
+/** 保存/测试连通性专用超时：后端会同步实测 RAG 服务连通性，远慢于普通 CRUD（对齐 LLM_TIMEOUT_MS 同类取舍）。 */
+export const KNOWLEDGE_BASE_TIMEOUT_MS = 60000
+
+export function pageKnowledgeBases(query: PageQuery) {
+  return request<PageResult<KnowledgeBaseVO>>({ url: '/aiconfig/knowledge-base/page', method: 'get', params: query })
+}
+
+export function createKnowledgeBase(data: KnowledgeBaseSaveRequest) {
+  return request<void>({ url: '/aiconfig/knowledge-base', method: 'post', data, timeout: KNOWLEDGE_BASE_TIMEOUT_MS })
+}
+
+export function updateKnowledgeBase(id: number, data: KnowledgeBaseSaveRequest) {
+  return request<void>({ url: `/aiconfig/knowledge-base/${id}`, method: 'put', data, timeout: KNOWLEDGE_BASE_TIMEOUT_MS })
+}
+
+export function deleteKnowledgeBase(id: number) {
+  return request<void>({ url: `/aiconfig/knowledge-base/${id}`, method: 'delete' })
+}
+
+export function testKnowledgeBaseConnectivity(id: number) {
+  return request<KnowledgeBaseTestResult>({
+    url: `/aiconfig/knowledge-base/${id}/test-connectivity`,
+    method: 'post',
+    timeout: KNOWLEDGE_BASE_TIMEOUT_MS,
+  })
+}
+
+export function updateKnowledgeBaseStatus(id: number, status: number) {
+  return request<void>({ url: `/aiconfig/knowledge-base/${id}/status`, method: 'put', params: { status } })
+}
+
+/** 智能体表单知识库多选下拉项：仅启用且测试通过的知识库。 */
+export function fetchKnowledgeBaseOptions() {
+  return request<KnowledgeBaseOption[]>({ url: '/aiconfig/knowledge-base/options', method: 'get' })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -19,6 +19,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),
   '/aiconfig/agent': () => import('@/views/aiconfig/AgentManage.vue'),
   '/aiconfig/system-tool': () => import('@/views/aiconfig/SystemToolManage.vue'),
+  '/aiconfig/knowledge-base': () => import('@/views/aiconfig/KnowledgeBaseManage.vue'),
   '/aiconfig/scheduled-task': () => import('@/views/aiconfig/ScheduledTaskManage.vue'),
   '/aiconfig/channel-robot': () => import('@/views/aiconfig/ChannelRobotManage.vue'),
   '/ticket/user-ticket': () => import('@/views/ticket/UserTicketManage.vue'),

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -323,6 +323,56 @@ export interface ModelTestResult {
   message: string | null
 }
 
+// ---------- aiconfig.knowledge-base ----------
+// RAG 知识库检索：一条记录 = 一个外部 RAG 服务，保存时后端会同步强制实测连通性
+// （耗时可达数秒，前端调用需用更长 timeout）。智能体只能挂载测试通过的知识库。
+export interface KnowledgeBaseVO {
+  id: number
+  kbName: string
+  baseUrl: string
+  appId: string | null
+  apiKeyMasked: string
+  contentType: string
+  /** 自定义请求头，JSON 字符串，如 {"X-Tenant":"abc"}，可为空 */
+  extraHeaders: string | null
+  topN: number
+  /** 召回分数阈值，该 RAG 服务 score 尺度很小（0.13~0.19 量级），低于此分数的召回结果不注入 */
+  scoreThreshold: number
+  status: number
+  testStatus: number
+  testTime: string | null
+  remark: string | null
+  createTime: string
+  updateTime: string
+}
+
+export interface KnowledgeBaseSaveRequest {
+  kbName: string
+  baseUrl: string
+  appId?: string | null
+  /** 编辑时留空 = 不修改，与模型配置 apiKey 语义一致 */
+  apiKey?: string | null
+  contentType?: string | null
+  extraHeaders?: string | null
+  topN?: number | null
+  scoreThreshold?: number | null
+  status?: number | null
+  remark?: string | null
+}
+
+export interface KnowledgeBaseTestResult {
+  testStatus: number
+  testTime: string | null
+  message: string | null
+  hitCount: number | null
+}
+
+/** 智能体表单知识库多选下拉项：仅启用且测试通过的知识库 */
+export interface KnowledgeBaseOption {
+  id: number
+  kbName: string
+}
+
 // ---------- aiconfig.mcp ----------
 export interface McpVO {
   id: number
@@ -453,6 +503,9 @@ export interface AgentVO {
   mcpIds: number[]
   skillIds: number[]
   systemToolIds: number[]
+  /** 挂载的 RAG 知识库 ID 列表，检索由后端在对话时自动执行 */
+  knowledgeBaseIds: number[]
+  knowledgeBaseNames: string[]
   systemPrompt: string | null
   capabilities: string[]
   icon: string | null
@@ -487,6 +540,7 @@ export interface AgentSaveRequest {
   mcpIds?: number[] | null
   skillIds?: number[] | null
   systemToolIds?: number[] | null
+  knowledgeBaseIds?: number[] | null
   systemPrompt?: string | null
   capabilities?: string[] | null
   icon?: string | null

--- a/customer-admin-web/src/views/aiconfig/AgentManage.vue
+++ b/customer-admin-web/src/views/aiconfig/AgentManage.vue
@@ -7,10 +7,11 @@ import { pageModels, testModelConnectivity } from '@/api/model'
 import { pageMcps } from '@/api/mcp'
 import { pageSkills } from '@/api/skill'
 import { fetchSystemTools } from '@/api/system-tool'
+import { fetchKnowledgeBaseOptions } from '@/api/knowledgeBase'
 import { useMenuStore } from '@/store/menu'
 import IconPicker from '@/components/IconPicker.vue'
 import ChannelBindingDrawer from '@/views/aiconfig/ChannelBindingDrawer.vue'
-import type { AgentSaveRequest, AgentVO, McpVO, ModelVO, PageQuery, SkillVO, SystemToolVO } from '@/types/api'
+import type { AgentSaveRequest, AgentVO, KnowledgeBaseOption, McpVO, ModelVO, PageQuery, SkillVO, SystemToolVO } from '@/types/api'
 
 const menuStore = useMenuStore()
 
@@ -26,6 +27,8 @@ const modelOptions = ref<ModelVO[]>([])
 const mcpOptions = ref<McpVO[]>([])
 const skillOptions = ref<SkillVO[]>([])
 const systemToolOptions = ref<SystemToolVO[]>([])
+// 知识库选项：/options 接口已过滤"启用且测试通过"，无需前端二次筛选
+const knowledgeBaseOptions = ref<KnowledgeBaseOption[]>([])
 // 智能体选项复用于「子Agent协作」多选，无独立全量接口，拉大页分页兜底
 const AGENT_OPTION_PAGE_SIZE = 200
 const agentOptions = ref<AgentVO[]>([])
@@ -61,6 +64,7 @@ const formRef = ref<FormInstance>()
 const editingId = ref<number | null>(null)
 const form = reactive<AgentSaveRequest>({
   agentName: '', agentCode: '', modelId: undefined as unknown as number, backupModelIds: [], mcpIds: [], skillIds: [], systemToolIds: [],
+  knowledgeBaseIds: [],
   systemPrompt: '', capabilities: ['chat'], icon: '', status: 1,
   subAgentIds: [], maxIters: null, toolTimeoutSeconds: null, toolMaxAttempts: null,
   compressTriggerMsgs: null, compressKeepMsgs: null,
@@ -147,12 +151,13 @@ async function loadList() {
 }
 
 async function loadOptions() {
-  const [models, mcps, skills, systemTools, agents] = await Promise.all([
+  const [models, mcps, skills, systemTools, agents, knowledgeBases] = await Promise.all([
     pageModels({ pageNum: 1, pageSize: 100 }),
     pageMcps({ pageNum: 1, pageSize: 100 }),
     pageSkills({ pageNum: 1, pageSize: 100 }),
     fetchSystemTools({ pageNum: 1, pageSize: 100 }),
     pageAgents({ pageNum: 1, pageSize: AGENT_OPTION_PAGE_SIZE }),
+    fetchKnowledgeBaseOptions(),
   ])
   modelOptions.value = models.list
   mcpOptions.value = mcps.list
@@ -160,6 +165,7 @@ async function loadOptions() {
   // 只展示已启用的系统工具供挂载（停用的不出现在下拉里）。
   systemToolOptions.value = systemTools.list.filter((t) => t.enabled === 1)
   agentOptions.value = agents.list
+  knowledgeBaseOptions.value = knowledgeBases
 }
 
 function handleSearch() {
@@ -172,6 +178,7 @@ function openCreate() {
   editingId.value = null
   Object.assign(form, {
     agentName: '', agentCode: '', modelId: undefined, backupModelIds: [], mcpIds: [], skillIds: [], systemToolIds: [],
+    knowledgeBaseIds: [],
     systemPrompt: '', capabilities: ['chat'], icon: '', status: 1,
     subAgentIds: [], maxIters: null, toolTimeoutSeconds: null, toolMaxAttempts: null,
     compressTriggerMsgs: null, compressKeepMsgs: null,
@@ -187,7 +194,9 @@ function openEdit(row: AgentVO) {
   editingId.value = row.id
   Object.assign(form, {
     agentName: row.agentName, agentCode: row.agentCode, modelId: row.modelId, backupModelIds: [...(row.backupModelIds ?? [])],
-    mcpIds: row.mcpIds, skillIds: row.skillIds, systemToolIds: row.systemToolIds, systemPrompt: row.systemPrompt,
+    mcpIds: row.mcpIds, skillIds: row.skillIds, systemToolIds: row.systemToolIds,
+    knowledgeBaseIds: [...(row.knowledgeBaseIds ?? [])],
+    systemPrompt: row.systemPrompt,
     capabilities: row.capabilities, icon: row.icon, status: row.status,
     subAgentIds: row.subAgentIds ?? [], maxIters: row.maxIters ?? null,
     toolTimeoutSeconds: row.toolTimeoutSeconds ?? null, toolMaxAttempts: row.toolMaxAttempts ?? null,
@@ -433,6 +442,11 @@ onMounted(() => {
         <el-form-item label="系统工具">
           <el-select v-model="form.systemToolIds" multiple style="width: 100%" placeholder="可选">
             <el-option v-for="t in systemToolOptions" :key="t.id" :label="t.toolName" :value="t.id" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="知识库">
+          <el-select v-model="form.knowledgeBaseIds" multiple style="width: 100%" placeholder="可选，仅展示连通性测试通过的知识库">
+            <el-option v-for="k in knowledgeBaseOptions" :key="k.id" :label="k.kbName" :value="k.id" />
           </el-select>
         </el-form-item>
         <el-form-item label="能力">

--- a/customer-admin-web/src/views/aiconfig/KnowledgeBaseManage.vue
+++ b/customer-admin-web/src/views/aiconfig/KnowledgeBaseManage.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import type { FormInstance } from 'element-plus'
+import {
+  createKnowledgeBase,
+  deleteKnowledgeBase,
+  pageKnowledgeBases,
+  testKnowledgeBaseConnectivity,
+  updateKnowledgeBase,
+  updateKnowledgeBaseStatus,
+} from '@/api/knowledgeBase'
+import { useCrudPage } from '@/composables/useCrudPage'
+import type { KnowledgeBaseSaveRequest, KnowledgeBaseVO, PageQuery } from '@/types/api'
+
+const testingId = ref<number | null>(null)
+// 保存会触发后端同步实测连通性（可达数秒），单独维护提交中状态给保存按钮加 loading，
+// 不进 useCrudPage（该动作是本页特有的耗时语义，composable 只收敛通用 CRUD 状态机）。
+const submitting = ref(false)
+const formRef = ref<FormInstance>()
+
+const {
+  loading, list, total, query,
+  dialogVisible, dialogMode, form,
+  loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
+} = useCrudPage<KnowledgeBaseVO, PageQuery, KnowledgeBaseSaveRequest>({
+  page: pageKnowledgeBases,
+  formRef,
+  create: createKnowledgeBase,
+  update: updateKnowledgeBase,
+  remove: (row) => deleteKnowledgeBase(row.id),
+  initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+  initForm: () => ({
+    kbName: '', baseUrl: '', appId: '', apiKey: '', contentType: 'application/json',
+    extraHeaders: '', topN: 5, scoreThreshold: 0.15, status: 1, remark: '',
+  }),
+  // 编辑回填时 apiKey 置空表示"留空则不修改"，与模型配置 apiKey 完全同款语义
+  toForm: (row) => ({
+    kbName: row.kbName, baseUrl: row.baseUrl, appId: row.appId ?? '', apiKey: '',
+    contentType: row.contentType || 'application/json', extraHeaders: row.extraHeaders ?? '',
+    topN: row.topN, scoreThreshold: row.scoreThreshold, status: row.status, remark: row.remark ?? '',
+  }),
+  beforeSubmit: (mode, f) => {
+    if (mode === 'create' && !f.apiKey) {
+      ElMessage.warning('新建知识库必须填写 AppKey')
+      return false
+    }
+    return true
+  },
+  deleteConfirm: (row) => `确认删除知识库「${row.kbName}」？`,
+})
+
+const testStatusMap: Record<number, { label: string; type: 'info' | 'success' | 'danger' }> = {
+  0: { label: '未测试', type: 'info' },
+  1: { label: '连通成功', type: 'success' },
+  2: { label: '连通失败', type: 'danger' },
+}
+
+/** 自定义 Header 是 JSON 字符串，默认为空；非空时必须是合法 JSON，否则阻止提交。 */
+function validateExtraHeadersJson(_rule: unknown, value: string, callback: (error?: Error) => void) {
+  if (!value) {
+    callback()
+    return
+  }
+  try {
+    JSON.parse(value)
+    callback()
+  } catch {
+    callback(new Error('自定义 Header 必须是合法 JSON'))
+  }
+}
+
+async function handleSubmitWithLoading() {
+  submitting.value = true
+  try {
+    await handleSubmit()
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function handleTest(row: KnowledgeBaseVO) {
+  testingId.value = row.id
+  try {
+    const result = await testKnowledgeBaseConnectivity(row.id)
+    if (result.testStatus === 1) {
+      ElMessage.success(`连通性测试成功，召回 ${result.hitCount ?? 0} 条`)
+    } else {
+      ElMessage.error(result.message || '连通性测试失败')
+    }
+    await loadList()
+  } finally {
+    testingId.value = null
+  }
+}
+
+// 状态开关直接调专用状态接口，不走整条更新（与"启用/停用"作为独立操作的语义一致）
+async function handleToggleStatus(row: KnowledgeBaseVO) {
+  const nextStatus = row.status === 1 ? 0 : 1
+  await updateKnowledgeBaseStatus(row.id, nextStatus)
+  ElMessage.success(nextStatus === 1 ? '已启用' : '已停用')
+  await loadList()
+}
+
+onMounted(loadList)
+</script>
+
+<template>
+  <div class="page">
+    <el-card>
+      <div class="toolbar">
+        <el-input v-model="query.keyword" placeholder="按知识库名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
+        <el-button type="primary" @click="handleSearch">搜索</el-button>
+        <el-button v-permission="'knowledge-base:add'" type="primary" @click="openCreate">新建知识库</el-button>
+      </div>
+
+      <el-table v-loading="loading" :data="list" style="width: 100%">
+        <el-table-column prop="kbName" label="知识库名称" />
+        <el-table-column prop="baseUrl" label="服务地址" show-overflow-tooltip />
+        <el-table-column prop="appId" label="app_id" width="140" />
+        <el-table-column label="appkey" width="140">
+          <template #default="{ row }">{{ row.apiKeyMasked }}</template>
+        </el-table-column>
+        <el-table-column prop="topN" label="top_n" width="80" />
+        <el-table-column label="状态" width="90">
+          <template #default="{ row }">
+            <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '停用' }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="连通性" width="140">
+          <template #default="{ row }">
+            <el-tooltip :content="row.testTime ? `测试时间：${row.testTime}` : '尚未测试'" placement="top">
+              <el-tag :type="testStatusMap[row.testStatus]?.type ?? 'info'">{{ testStatusMap[row.testStatus]?.label ?? '未测试' }}</el-tag>
+            </el-tooltip>
+          </template>
+        </el-table-column>
+        <el-table-column prop="remark" label="备注" show-overflow-tooltip />
+        <el-table-column label="操作" width="280" fixed="right">
+          <template #default="{ row }">
+            <el-button link type="primary" :loading="testingId === row.id" @click="handleTest(row)">测试连通性</el-button>
+            <el-button v-permission="'knowledge-base:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
+            <el-button v-permission="'knowledge-base:edit'" link type="primary" @click="handleToggleStatus(row)">
+              {{ row.status === 1 ? '停用' : '启用' }}
+            </el-button>
+            <el-button v-permission="'knowledge-base:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-model:current-page="query.pageNum"
+        v-model:page-size="query.pageSize"
+        :total="total"
+        layout="total, prev, pager, next"
+        style="margin-top: 16px; justify-content: flex-end"
+        @current-change="loadList"
+      />
+    </el-card>
+
+    <el-dialog v-model="dialogVisible" :title="dialogMode === 'create' ? '新建知识库' : '编辑知识库'" width="560px">
+      <el-form ref="formRef" :model="form" label-width="110px">
+        <el-form-item label="知识库名称" prop="kbName" :rules="[{ required: true, message: '请输入知识库名称' }]">
+          <el-input v-model="form.kbName" />
+        </el-form-item>
+        <el-form-item label="服务地址" prop="baseUrl" :rules="[{ required: true, message: '请输入服务地址' }]">
+          <el-input v-model="form.baseUrl" placeholder="如 https://rag.example.com" />
+        </el-form-item>
+        <el-form-item label="app_id" prop="appId">
+          <el-input v-model="form.appId!" />
+        </el-form-item>
+        <el-form-item label="AppKey">
+          <el-input v-model="form.apiKey!" type="password" show-password :placeholder="dialogMode === 'edit' ? '留空则不修改' : '必填'" />
+        </el-form-item>
+        <el-form-item label="Content-Type" prop="contentType">
+          <el-input v-model="form.contentType!" placeholder="默认 application/json" />
+        </el-form-item>
+        <el-form-item label="自定义 Header" prop="extraHeaders" :rules="[{ validator: validateExtraHeadersJson }]">
+          <el-input
+            v-model="form.extraHeaders!"
+            type="textarea"
+            :rows="3"
+            placeholder='JSON 格式，如 {"X-Tenant": "abc"}，可留空'
+          />
+        </el-form-item>
+        <el-form-item label="top_n" prop="topN">
+          <el-input-number v-model="form.topN!" :min="1" :max="50" style="width: 100%" />
+        </el-form-item>
+        <el-form-item label="score 阈值" prop="scoreThreshold">
+          <el-input-number v-model="form.scoreThreshold!" :min="0" :max="1" :step="0.01" :precision="4" style="width: 100%" />
+          <div class="score-hint">该 RAG 服务 score 尺度较小（常见 0.13~0.19 区间），低于此分数的召回结果不会注入对话</div>
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-switch v-model="form.status" :active-value="1" :inactive-value="0" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="form.remark!" type="textarea" :rows="2" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleSubmitWithLoading">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.score-hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+</style>


### PR DESCRIPTION
## 需求

1. AI 配置新增 RAG 知识库检索：配置 url / appkey / Content-Type / 自定义 header，**连通性测试通过才算添加成功**。
2. 智能体新增/编辑可选择知识库（只能选测试通过的），对话与 VibeCoding 中可使用 RAG 检索。

外部接口：`POST {baseUrl}/api/v1/knowledge/search`，`Authorization: Bearer {appkey}`，body `{"query","app_id","top_n"}`。

## 已确认的产品决策

| 点 | 决策 |
|---|---|
| app_id 归属 | 一条配置 = 一个知识库（url+appkey+app_id 同一条） |
| 检索触发 | 每轮自动检索注入（非工具自主调用） |
| 智能体绑定 | 多选 |
| 保存门禁 | 保存时后端强制实测，不通过则保存失败 |

## 实现要点

### 知识库配置模块 `aiconfig/knowledgebase/`
照 `aiconfig/model` 模板：appkey AES-GCM 加密存储 / 掩码回显 / 编辑留空=不改；CRUD + 分页 + 启停 + 连通性测试（专用线程池 + 10s 硬超时 + 落 test_status）；被智能体引用时拒绝删除。菜单 `/aiconfig/knowledge-base`（AI 配置下 sort=8）。

### 检索注入（关键设计，经两轮修正）
`KnowledgeRetrievalMiddleware` 在 `onReasoning` 追加**瞬态消息**，而非拼进用户消息文本：

- **不污染会话历史、不累积 token**：框架 `ReActAgent` 只把模型产出写回 `AgentState`，中间件改过的 `ReasoningInput.messages()` 不落库——与框架自带 `TaskReminderMiddleware` 同款手法（其类注释明写 "never written into AgentState.context, so it is never persisted"）。
- **不阻塞请求线程**：检索走 `Mono.fromCallable(...).subscribeOn(boundedElastic)`，不占 Tomcat worker。
- **每轮只检索一次**：ReAct 多轮迭代会重复触发 `onReasoning`，用 `RuntimeContext` 缓存（按 agentCode 命名空间隔离，防子 Agent 串用父的召回块）。
- 多库并发检索（专用 `rag-search-worker` 池）+ score 阈值过滤 + 合并按分排序；检索失败/超时降级为不注入，**绝不打断对话**；未绑定知识库时零开销不发请求。

### 其他
- 智能体多选：`AgentSaveRequest`/`AgentVO`/`AgentService`(validate/replaceRelations/toVo) 三处对称扩展，只允许绑定启用且测试通过的知识库。对话与 VibeCoding 共用同一 Agent 实例，两条链路自动生效。
- 独立 SSRF 白名单 `admin.rag.allowed-hosts`：RAG 多为内网部署，默认放行内网但拦截云元数据地址，与系统工具 HTTP 工具的信任边界刻意分离（后者面向模型可控输入，必须拒内网）。
- score 阈值默认 **0（不过滤）**：实测该服务 rerank 分数在 0.13~0.19 量级，按惯例的 0.5 会把召回全丢光；噪声由 top_n 控制，使用方按自己知识库分数分布调高。
- 软删除 + 唯一索引：同名重建走**复活旧行**（否则名字删一次就永久不可用），并发/改名冲突捕获 `DuplicateKeyException` 给友好错误。

## 评审与修复

独立 review 抓出 2 个严重问题，均已修复并有测试守门：
1. 原实现在 Tomcat 请求线程同步检索最长 10s（RAG 变慢会拖垮含登录在内的全部接口），且代码注释声称"Msg id 无法预先固定"——被 `SensitiveWordMiddleware` 的 `Msg.builder().id(原id)` 反例证伪。
2. 原实现把召回块拼进用户消息并被持久化：历史回放会显示原始 `&lt;retrieved_knowledge&gt;` XML，且后续每轮重发累积 token。

改用中间件瞬态注入后两者一并消失。

## 测试

customer-admin-server **742 tests, 0 failures, 0 errors**（新增约 80 个用例：检索客户端阈值/合并/降级、中间件不污染用户消息与执行线程断言、SSRF 白名单、保存门禁、软删复活、Controller）；前端 `npm run build` 通过。

## 部署说明

- V41 迁移建两表 + 权限种子 200-203（本机 `customer_admin` 已 apply 并做 HEX 字节校验）。
- 新配置项 `admin.rag.*`（超时、白名单、线程池），均有默认值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 自测阶段修复（对接真实 RAG 服务时暴露）

**1. 请求挂起到超时（c43843c）**

JDK `HttpClient` 默认 `HTTP_2`，对 `http://` 会先发 h2c upgrade 协商；自建 Node RAG 服务既不支持该协商也不返回错误，请求挂起至超时。同一请求实测对比：

| 协议 | 结果 |
|---|---|
| HTTP_2 | 超时 8013ms |
| HTTP_1_1 | HTTP 200，928ms，5035 字节 |

固定为 HTTP/1.1（检索是小报文短连接，用不上多路复用）。

同类隐患未处理：`AdminModelFactory` / `DashScopeEmbeddingClient` 也用默认 HTTP/2 的 JDK HttpClient，目前对接的云服务支持 HTTP/2 故未暴露，但接自建 OpenAI 兼容服务（vLLM/Ollama/one-api）时可能踩同样的坑。

**2. 错误信息无法定位问题（c43843c + fa2d8c9）**

- 连接类异常的 message 常为 null（`ConnectException: null`），按异常类型翻译成可排查提示：连接失败带地址与「服务可能只监听 IPv6」的排查方向、超时带当前超时值与可调配置项、DNS 失败提示检查地址拼写。
- 非 200 只报状态码，丢弃了响应体——而该服务的失败原因全在响应体里（401 `INVALID_API_KEY`、403 `APP_ACCESS_DENIED`「该 API Key 未被授权调用应用 xxx」、400 `INVALID_PARAM`「topN must be at least 1」）。改为优先透出 `code: message`，非 JSON 响应体截断 200 字符透出。

两处修复共补 6 个测试守门；知识库模块测试 79 个全绿。
