### PR TITLE
feat(call-stats): 补落缓存 token 与模型自报耗时，看板出缓存命中率

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/entity/AiCodingAuditLog.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/entity/AiCodingAuditLog.java
@@ -45,6 +45,8 @@ public class AiCodingAuditLog {
     private Integer inputTokens;
     private Integer outputTokens;
     private Integer totalTokens;
+    /** 命中 prompt 缓存的输入 token（<b>inputTokens 的子集，不计入 totalTokens</b>）；缓存读通常按 1/10 计价。 */
+    private Integer cachedTokens;
 
     /** 操作耗时（毫秒）。 */
     private Long durationMs;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditService.java
@@ -92,6 +92,9 @@ public class AiCodingAuditService {
         entry.setInputTokens(usage.getInputTokens());
         entry.setOutputTokens(usage.getOutputTokens());
         entry.setTotalTokens(usage.getTotalTokens());
+        // 缓存量此前一直被丢弃：它是 input 的子集、按 1/10 计价，不留就没法准确核算成本，
+        // 也看不出 prompt 缓存有没有生效
+        entry.setCachedTokens(usage.getCachedTokens());
     }
 
     /** 把变更文件清单序列化进审计条目（空清单存空值，省存储且查询语义明确）。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallSegmentVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallSegmentVO.java
@@ -17,6 +17,10 @@ public class AgentCallSegmentVO {
     /** token 消耗（仅 MODEL 段有值，缺失为 null）。 */
     private Long inputTokens;
     private Long outputTokens;
+    /** 命中缓存的输入 token（仅 MODEL 段）。 */
+    private Long cachedTokens;
+    /** 模型自报耗时（毫秒，仅 MODEL 段）。 */
+    private Long modelReportedMs;
     private Boolean success;
     private String errorMsg;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsDetailVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsDetailVO.java
@@ -33,5 +33,9 @@ public class AgentCallStatsDetailVO {
     private Long inputTokens;
     private Long outputTokens;
     private Long totalTokens;
+    /** 命中缓存的输入 token（inputTokens 的子集，不计入 totalTokens）。 */
+    private Long cachedTokens;
+    /** 模型自报耗时合计（毫秒），与 modelMs 之差即网络/排队开销。 */
+    private Long modelReportedMs;
     private List<AgentCallSegmentVO> segments;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsRowVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsRowVO.java
@@ -32,4 +32,8 @@ public class AgentCallStatsRowVO {
     private Long inputTokens;
     private Long outputTokens;
     private Long totalTokens;
+    /** 命中缓存的输入 token（inputTokens 的子集，不计入 totalTokens）。 */
+    private Long cachedTokens;
+    /** 模型自报耗时合计（毫秒），与 modelMs 之差即网络/排队开销。 */
+    private Long modelReportedMs;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSummaryVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/dto/AgentCallStatsSummaryVO.java
@@ -20,4 +20,13 @@ public class AgentCallStatsSummaryVO {
     private Long totalTokens;
     /** 平均每次 token 消耗。 */
     private Double avgTotalTokens;
+
+    /** 总输入 token（缓存命中率的分母）。 */
+    private Long inputTokens;
+
+    /** 总命中缓存的输入 token（inputTokens 的子集，各家通常按 1/10 计价）。 */
+    private Long cachedTokens;
+
+    /** 缓存命中率 = cachedTokens / inputTokens；判断 prompt 缓存有没有真生效的唯一直接信号。 */
+    private Double cacheHitRate;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
@@ -165,6 +165,8 @@ public class AgentCallStatsService {
         vo.setInputTokens(d.getInputTokens());
         vo.setOutputTokens(d.getOutputTokens());
         vo.setTotalTokens(d.getTotalTokens());
+        vo.setCachedTokens(d.getCachedTokens());
+        vo.setModelReportedMs(d.getModelReportedMs());
         return vo;
     }
 
@@ -190,6 +192,8 @@ public class AgentCallStatsService {
         vo.setInputTokens(d.getInputTokens());
         vo.setOutputTokens(d.getOutputTokens());
         vo.setTotalTokens(d.getTotalTokens());
+        vo.setCachedTokens(d.getCachedTokens());
+        vo.setModelReportedMs(d.getModelReportedMs());
         List<AgentCallSegmentVO> segmentVOs = new ArrayList<>();
         if (!CollectionUtils.isEmpty(segments)) {
             for (AgentCallSegmentDO segment : segments) {
@@ -209,6 +213,8 @@ public class AgentCallStatsService {
         vo.setDurationMs(d.getDurationMs());
         vo.setInputTokens(d.getInputTokens());
         vo.setOutputTokens(d.getOutputTokens());
+        vo.setCachedTokens(d.getCachedTokens());
+        vo.setModelReportedMs(d.getModelReportedMs());
         vo.setSuccess(d.getSuccess());
         vo.setErrorMsg(d.getErrorMsg());
         return vo;
@@ -226,6 +232,9 @@ public class AgentCallStatsService {
             vo.setAvgSkillMs(0d);
             vo.setTotalTokens(0L);
             vo.setAvgTotalTokens(0d);
+            vo.setInputTokens(0L);
+            vo.setCachedTokens(0L);
+            vo.setCacheHitRate(0d);
             return vo;
         }
         vo.setTotalCalls(d.getTotalCount());
@@ -237,6 +246,12 @@ public class AgentCallStatsService {
         vo.setAvgSkillMs(toDouble(d.getAvgSkillMs()));
         vo.setTotalTokens(d.getTotalTokens() == null ? 0L : d.getTotalTokens());
         vo.setAvgTotalTokens(toDouble(d.getAvgTotalTokens()));
+        long inputTokens = d.getInputTokens() == null ? 0L : d.getInputTokens();
+        long cachedTokens = d.getCachedTokens() == null ? 0L : d.getCachedTokens();
+        vo.setInputTokens(inputTokens);
+        vo.setCachedTokens(cachedTokens);
+        // 命中率在后端算：分母是输入总量（缓存量是它的子集），这个口径一旦让各展示端各理解一遍就会错
+        vo.setCacheHitRate(inputTokens == 0L ? 0d : (double) cachedTokens / (double) inputTokens);
         return vo;
     }
 

--- a/customer-admin-server/src/main/resources/callstats/AgentCallStatsExtMapper.xml
+++ b/customer-admin-server/src/main/resources/callstats/AgentCallStatsExtMapper.xml
@@ -21,7 +21,8 @@
     <select id="findPage" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO">
         SELECT id, request_id, user_id, username, agent_code, agent_name, session_id, session_type,
                question, answer, start_time, end_time, duration_ms, model_ms, tool_ms, mcp_ms,
-               skill_ms, segment_count, input_tokens, output_tokens, total_tokens, success, error_msg
+               skill_ms, segment_count, input_tokens, output_tokens, total_tokens,
+               cached_tokens, model_reported_ms, success, error_msg
         FROM cw_agent_call_log
         <include refid="whereClause"/>
         ORDER BY id DESC
@@ -44,7 +45,9 @@
                AVG(mcp_ms)         AS avg_mcp_ms,
                AVG(skill_ms)       AS avg_skill_ms,
                COALESCE(SUM(total_tokens), 0) AS total_tokens,
-               AVG(total_tokens)   AS avg_total_tokens
+               AVG(total_tokens)   AS avg_total_tokens,
+               COALESCE(SUM(cached_tokens), 0) AS cached_tokens,
+               COALESCE(SUM(input_tokens), 0)  AS input_tokens
         FROM cw_agent_call_log
         <include refid="whereClause"/>
     </select>

--- a/customer-admin-server/src/main/resources/db/migration/V43__audit_cached_tokens.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V43__audit_cached_tokens.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- AI 编码审计日志补 cached_tokens（Flyway V43，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 框架 ChatUsage 一直返回 cachedTokens（命中 prompt 缓存的输入 token），但 AiCodingAuditService#applyUsage
+-- 此前只取了 input/output/total 三个字段——采到了、算过了、直接扔掉。
+--
+-- 为什么这个字段值得单独存：cachedTokens 是 input_tokens 的**子集**（不是额外量），各家计价通常只按
+-- 1/10 左右收。不留它就有两个后果：一是成本核算永远偏高（把缓存命中的部分按全价算），二是看不出
+-- prompt 缓存到底有没有生效——命中率长期为 0 说明系统提示词或历史每次都在变，那笔本可省下的钱一直在白花。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `ai_coding_audit_log`
+    ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL
+        COMMENT '命中缓存的输入token（input_tokens的子集，不计入total_tokens）' AFTER `total_tokens`;

--- a/customer-admin-server/src/main/resources/db/migration/V44__agent_call_stats_cached_tokens.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V44__agent_call_stats_cached_tokens.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- admin 库的调用统计两表补 cached_tokens / model_reported_ms（Flyway V44，生产手工同步）
+-- =============================================================================
+-- 补 V43 的漏：cw_agent_call_log / cw_agent_call_segment 这两张表**两个库各有一份**——
+-- 客服端库 agent_scope_customer_work（8080 客服链路写入）与 admin 库 customer_admin
+-- （V38/V39 建，后台工作区对话写入）。AgentCallStatsService 按 source 参数路由：
+-- ADMIN 查 admin 库、APP 查客服端库，而**默认值是 ADMIN**。
+--
+-- V43 只补了客服端库那份（走 schema.sql 的手工 ALTER），admin 库这份没动，
+-- 于是后台"调用统计"页一打开就报 Unknown column 'cached_tokens'。
+--
+-- 教训记在这里：cw_ 前缀的同名表凡是同时存在于两个库的，加列必须两边都改——
+-- 客服端库走 customer-work-schema.sql 的注释式 ALTER（SchemaInitializer 不会加列），
+-- admin 库走 Flyway 迁移。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `cw_agent_call_log`
+    ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL
+        COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）' AFTER `total_tokens`,
+    ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL
+        COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销' AFTER `cached_tokens`;
+
+ALTER TABLE `cw_agent_call_segment`
+    ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL
+        COMMENT '命中缓存的输入token（仅MODEL段）' AFTER `output_tokens`,
+    ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL
+        COMMENT '模型自报耗时（毫秒，仅MODEL段）' AFTER `cached_tokens`;

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -174,6 +174,8 @@ export interface AiCodingAuditLog {
   inputTokens: number | null
   outputTokens: number | null
   totalTokens: number | null
+  /** 命中缓存的输入 token（inputTokens 的子集，不计入 totalTokens）。 */
+  cachedTokens: number | null
   durationMs: number | null
   result: number
   errorCode: string | null
@@ -236,6 +238,10 @@ export interface AgentCallStatsRow {
   inputTokens: number | null
   outputTokens: number | null
   totalTokens: number | null
+  /** 命中缓存的输入 token：是 inputTokens 的**子集**，不是额外量，也不计入 totalTokens。 */
+  cachedTokens: number | null
+  /** 模型自报耗时（毫秒）；与 modelMs 之差即网络/排队开销。 */
+  modelReportedMs: number | null
 }
 
 // 契约固定 { total, rows }，与通用 PageResult 的 pageNum/pageSize/list 命名不同（同 MpPageResult
@@ -255,6 +261,10 @@ export interface AgentCallStatsSegment {
   /** token 消耗（仅 MODEL 段有值，缺失为 null）。 */
   inputTokens: number | null
   outputTokens: number | null
+  /** 命中缓存的输入 token（inputTokens 的子集，仅 MODEL 段）。 */
+  cachedTokens: number | null
+  /** 模型自报耗时（毫秒，仅 MODEL 段）。 */
+  modelReportedMs: number | null
   success: boolean
   errorMsg: string | null
 }
@@ -277,6 +287,12 @@ export interface AgentCallStatsSummary {
   /** 总 token 消耗 / 平均每次 token 消耗。 */
   totalTokens: number
   avgTotalTokens: number
+  /** 总输入 token（缓存命中率的分母）。 */
+  inputTokens: number
+  /** 总命中缓存的输入 token（inputTokens 的子集，各家通常按 1/10 计价）。 */
+  cachedTokens: number
+  /** 缓存命中率 = cachedTokens / inputTokens，后端算好下发，前端不重复推导口径。 */
+  cacheHitRate: number
 }
 
 /** 趋势图单个时间桶。 */

--- a/customer-admin-web/src/views/system/AgentCallStats.vue
+++ b/customer-admin-web/src/views/system/AgentCallStats.vue
@@ -148,6 +148,9 @@ const SUMMARY_CARDS = [
   { key: 'totalCalls', label: '总调用数', unit: '次' },
   { key: 'totalTokens', label: '总 Token 消耗', unit: 'token' },
   { key: 'avgTotalTokens', label: '平均 Token/次', unit: 'token' },
+  // 缓存命中率单列一张卡：它是判断 prompt 缓存有没有真生效的唯一直接信号，
+  // 长期为 0 说明系统提示词/历史每次都在变，那笔本可省下的钱一直在白花
+  { key: 'cacheHitRate', label: '缓存命中率', unit: 'percent' },
   { key: 'avgDurationMs', label: '平均耗时', unit: 'ms' },
   { key: 'maxDurationMs', label: '最大耗时', unit: 'ms' },
   { key: 'avgModelMs', label: '大模型平均耗时', unit: 'ms' },
@@ -165,6 +168,7 @@ function summaryDisplay(card: (typeof SUMMARY_CARDS)[number]): string {
   const value = summaryValue(card.key)
   if (card.unit === 'ms') return formatDuration(value)
   if (card.unit === 'token') return formatTokens(Math.round(value))
+  if (card.unit === 'percent') return `${(value * 100).toFixed(1)}%`
   return String(value)
 }
 
@@ -396,6 +400,7 @@ onMounted(() => {
               <template #content>
                 <div>输入：{{ formatTokens(row.inputTokens) }}</div>
                 <div>输出：{{ formatTokens(row.outputTokens) }}</div>
+                <div>其中命中缓存：{{ formatTokens(row.cachedTokens) }}</div>
               </template>
               <span>{{ formatTokens(row.totalTokens) }}</span>
             </el-tooltip>
@@ -458,7 +463,19 @@ onMounted(() => {
             <el-descriptions-item label="总耗时" :span="2">{{ formatDuration(detail.durationMs) }}</el-descriptions-item>
             <el-descriptions-item label="输入 Token">{{ formatTokens(detail.inputTokens) }}</el-descriptions-item>
             <el-descriptions-item label="输出 Token">{{ formatTokens(detail.outputTokens) }}</el-descriptions-item>
-            <el-descriptions-item label="总 Token" :span="2">{{ formatTokens(detail.totalTokens) }}</el-descriptions-item>
+            <el-descriptions-item label="总 Token">{{ formatTokens(detail.totalTokens) }}</el-descriptions-item>
+            <el-descriptions-item label="命中缓存 Token">
+              {{ formatTokens(detail.cachedTokens) }}
+              <span v-if="detail.cachedTokens != null && detail.inputTokens" class="muted">
+                （占输入 {{ ((detail.cachedTokens / detail.inputTokens) * 100).toFixed(1) }}%）
+              </span>
+            </el-descriptions-item>
+            <el-descriptions-item label="模型自报耗时" :span="2">
+              {{ detail.modelReportedMs == null ? '—' : formatDuration(detail.modelReportedMs) }}
+              <span v-if="detail.modelReportedMs != null" class="muted">
+                （与实测大模型耗时之差 {{ formatDuration(Math.max(0, detail.modelMs - detail.modelReportedMs)) }} = 网络/排队开销）
+              </span>
+            </el-descriptions-item>
           </el-descriptions>
 
           <div class="detail-block">

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallCollector.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallCollector.java
@@ -33,14 +33,17 @@ public class AgentCallCollector {
      * @param segStartNano 分段开始的 {@code System.nanoTime()}（用于高精度算耗时）
      * @param success      是否成功
      * @param errorMsg     失败原因
-     * @param inputTokens  输入 token（仅 MODEL 段有值，缺失传 null）
-     * @param outputTokens 输出 token（仅 MODEL 段有值，缺失传 null）
+     * @param inputTokens     输入 token（仅 MODEL 段有值，缺失传 null）
+     * @param outputTokens    输出 token（仅 MODEL 段有值，缺失传 null）
+     * @param cachedTokens    命中缓存的输入 token（inputTokens 的子集，缺失传 null）
+     * @param modelReportedMs 模型自报耗时（毫秒，缺失传 null）
      */
     public void addSegment(AgentCallKind kind, String name, long segStartMs, long segStartNano,
-                           boolean success, String errorMsg, Long inputTokens, Long outputTokens) {
+                           boolean success, String errorMsg, Long inputTokens, Long outputTokens,
+                           Long cachedTokens, Long modelReportedMs) {
         long durationMs = Math.max(0L, (System.nanoTime() - segStartNano) / 1_000_000L);
         segments.add(new AgentCallSegment(seq.incrementAndGet(), kind, name, segStartMs, durationMs,
-            success, errorMsg, inputTokens, outputTokens));
+            success, errorMsg, inputTokens, outputTokens, cachedTokens, modelReportedMs));
     }
 
     /** 设置最终回答（可被后续 AGENT_RESULT 覆盖为最新全文）。 */
@@ -81,6 +84,10 @@ public class AgentCallCollector {
         // 与 admin 审计模块 totalUsage 的空判语义一致）
         Long inputTokens = null;
         Long outputTokens = null;
+        // cachedTokens 是 inputTokens 的子集（命中 prompt 缓存的那部分），不参与 totalTokens 计算，
+        // 否则会把缓存量重复计一遍；它单独留存是为了成本核算（缓存读通常只按 1/10 计价）与命中率观测
+        Long cachedTokens = null;
+        Long modelReportedMs = null;
         for (AgentCallSegment s : snapshot) {
             switch (s.kind()) {
                 case MODEL -> modelMs += s.durationMs();
@@ -94,6 +101,12 @@ public class AgentCallCollector {
             if (s.outputTokens() != null) {
                 outputTokens = (outputTokens == null ? 0L : outputTokens) + s.outputTokens();
             }
+            if (s.cachedTokens() != null) {
+                cachedTokens = (cachedTokens == null ? 0L : cachedTokens) + s.cachedTokens();
+            }
+            if (s.modelReportedMs() != null) {
+                modelReportedMs = (modelReportedMs == null ? 0L : modelReportedMs) + s.modelReportedMs();
+            }
         }
         Long totalTokens = (inputTokens == null && outputTokens == null) ? null
             : (inputTokens == null ? 0L : inputTokens) + (outputTokens == null ? 0L : outputTokens);
@@ -101,6 +114,6 @@ public class AgentCallCollector {
         return new AgentCallRecord(0L, requestId, userId, username, agentCode, agentName, sessionId,
             sessionType, question, answer, startTimeMs, endTimeMs, durationMs,
             modelMs, toolMs, mcpMs, skillMs, snapshot.size(), inputTokens, outputTokens, totalTokens,
-            success, errorMsg, snapshot);
+            cachedTokens, modelReportedMs, success, errorMsg, snapshot);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogSummary.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallLogSummary.java
@@ -12,14 +12,27 @@ package com.richard.fyoung.customerwork.calllog;
  * @param avgSkillMs    平均 SKILL 段耗时（毫秒）
  * @param totalTokens   总 token 消耗（符合条件的记录 total_tokens 求和）
  * @param avgTotalTokens 平均每次 token 消耗
+ * @param inputTokens   总输入 token（算缓存命中率的分母）
+ * @param cachedTokens  总命中缓存的输入 token（<b>inputTokens 的子集</b>，各家通常按 1/10 计价）
  * @author owlzhangfq@gmail.com
  */
 public record AgentCallLogSummary(long totalCount, double avgDurationMs, long maxDurationMs,
                                   double avgModelMs, double avgToolMs, double avgMcpMs,
-                                  double avgSkillMs, long totalTokens, double avgTotalTokens) {
+                                  double avgSkillMs, long totalTokens, double avgTotalTokens,
+                                  long inputTokens, long cachedTokens) {
 
     /** 空结果（无数据时返回，避免 null）。 */
     public static AgentCallLogSummary empty() {
-        return new AgentCallLogSummary(0L, 0d, 0L, 0d, 0d, 0d, 0d, 0L, 0d);
+        return new AgentCallLogSummary(0L, 0d, 0L, 0d, 0d, 0d, 0d, 0L, 0d, 0L, 0L);
+    }
+
+    /**
+     * 缓存命中率（{@code cachedTokens / inputTokens}）；无输入 token 时返回 0。
+     *
+     * <p>这是判断 prompt 缓存有没有真生效的唯一直接信号：命中率长期为 0，说明系统提示词或历史消息
+     * 每次都在变，缓存根本没建立起来——那笔本可省下的钱一直在白花。</p>
+     */
+    public double cacheHitRate() {
+        return inputTokens == 0L ? 0d : (double) cachedTokens / (double) inputTokens;
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecord.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallRecord.java
@@ -33,6 +33,8 @@ import java.util.List;
  * @param inputTokens  请求级输入 token 合计（缺失为 null）
  * @param outputTokens 请求级输出 token 合计（缺失为 null）
  * @param totalTokens  请求级总 token 合计（缺失为 null）
+ * @param cachedTokens 请求级命中缓存的输入 token 合计（<b>inputTokens 的子集，不计入 totalTokens</b>，缺失为 null）
+ * @param modelReportedMs 各 MODEL 段模型自报耗时之和（毫秒，缺失为 null）
  * @param success      整次调用是否成功
  * @param errorMsg     失败原因（成功时为 null）
  * @param segments     分段明细（按 seq 升序）
@@ -44,6 +46,7 @@ public record AgentCallRecord(long id, String requestId, String userId, String u
                               long startTimeMs, long endTimeMs, long durationMs,
                               long modelMs, long toolMs, long mcpMs, long skillMs,
                               int segmentCount, Long inputTokens, Long outputTokens, Long totalTokens,
+                              Long cachedTokens, Long modelReportedMs,
                               boolean success, String errorMsg,
                               List<AgentCallSegment> segments) {
 
@@ -52,6 +55,19 @@ public record AgentCallRecord(long id, String requestId, String userId, String u
         return new AgentCallRecord(assignedId, requestId, userId, username, agentCode, agentName,
             sessionId, sessionType, question, answer, startTimeMs, endTimeMs, durationMs,
             modelMs, toolMs, mcpMs, skillMs, segmentCount, inputTokens, outputTokens, totalTokens,
-            success, errorMsg, segments);
+            cachedTokens, modelReportedMs, success, errorMsg, segments);
+    }
+
+    /**
+     * 缓存命中率（{@code cachedTokens / inputTokens}）；无输入 token 或未采到缓存量时返回 null。
+     *
+     * <p>放在领域对象上而不是让每个展示端各算一遍：命中率是"缓存有没有真生效"的唯一直接信号，
+     * 分子分母的口径（缓存量是输入的子集）一旦在某处理解错，算出来的数就会误导决策。</p>
+     */
+    public Double cacheHitRate() {
+        if (cachedTokens == null || inputTokens == null || inputTokens == 0L) {
+            return null;
+        }
+        return (double) cachedTokens / (double) inputTokens;
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSegment.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallSegment.java
@@ -7,21 +7,30 @@ package com.richard.fyoung.customerwork.calllog;
  * {@link ToolKindRegistry} 归为 TOOL/MCP/SKILL）。{@code seq} 为该次调用内的分段序号（从 1 起，
  * 按结算顺序自增）；{@code startTimeMs} 为分段开始的墙上时钟（毫秒），{@code durationMs} 为分段耗时。</p>
  *
- * <p>{@code inputTokens}/{@code outputTokens} 仅 MODEL 段有值（取自框架 {@code ModelCallEndEvent}
- * 携带的 {@code ChatUsage}，与 admin 审计模块同源同口径）；工具段及 usage 缺失时为 {@code null}。</p>
+ * <p>token 与模型自报耗时仅 MODEL 段有值（取自框架 {@code ModelCallEndEvent} 携带的 {@code ChatUsage}，
+ * 与 admin 审计模块同源同口径）；工具段及 usage 缺失时为 {@code null}。</p>
  *
- * @param seq          调用内分段序号（从 1 起）
- * @param kind         分段类别
- * @param name         分段名称（模型名 / 工具名）
- * @param startTimeMs  分段开始时间戳（毫秒）
- * @param durationMs   分段耗时（毫秒）
- * @param success      是否成功
- * @param errorMsg     失败原因（成功时为 null）
- * @param inputTokens  输入 token（仅 MODEL 段，缺失为 null）
- * @param outputTokens 输出 token（仅 MODEL 段，缺失为 null）
+ * <p><b>{@code cachedTokens} 是 {@code inputTokens} 的子集，不是额外量</b>——命中 prompt 缓存的那部分
+ * 输入 token。各家计价通常只按 1/10 左右收，不单独留存就没法做准确的成本核算，也看不出缓存到底有没有生效。</p>
+ *
+ * <p><b>{@code modelReportedMs} 是模型自报的本次调用耗时</b>（{@code ChatUsage.time}，秒 → 毫秒），
+ * 与本段实测的 {@code durationMs} 是两个口径：两者之差就是网络与排队开销，能把"模型慢"和"链路慢"分开。</p>
+ *
+ * @param seq             调用内分段序号（从 1 起）
+ * @param kind            分段类别
+ * @param name            分段名称（模型名 / 工具名）
+ * @param startTimeMs     分段开始时间戳（毫秒）
+ * @param durationMs      分段耗时（毫秒，本地实测）
+ * @param success         是否成功
+ * @param errorMsg        失败原因（成功时为 null）
+ * @param inputTokens     输入 token（仅 MODEL 段，缺失为 null）
+ * @param outputTokens    输出 token（仅 MODEL 段，缺失为 null）
+ * @param cachedTokens    命中缓存的输入 token（inputTokens 的子集，仅 MODEL 段，缺失为 null）
+ * @param modelReportedMs 模型自报耗时（毫秒，仅 MODEL 段，缺失为 null）
  * @author owlzhangfq@gmail.com
  */
 public record AgentCallSegment(int seq, AgentCallKind kind, String name, long startTimeMs,
                                long durationMs, boolean success, String errorMsg,
-                               Long inputTokens, Long outputTokens) {
+                               Long inputTokens, Long outputTokens,
+                               Long cachedTokens, Long modelReportedMs) {
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
@@ -223,13 +223,20 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
                             AtomicReference<ChatUsage> usageRef) {
         Long inputTokens = null;
         Long outputTokens = null;
+        Long cachedTokens = null;
+        Long modelReportedMs = null;
         ChatUsage usage = usageRef == null ? null : usageRef.get();
         if (usage != null) {
             inputTokens = (long) usage.getInputTokens();
             outputTokens = (long) usage.getOutputTokens();
+            // 缓存量与模型自报耗时：框架早就给了，此前一直丢弃——前者是成本核算的前提（缓存读通常按
+            // 1/10 计价），后者与本段实测耗时相减即网络/排队开销，能把"模型慢"和"链路慢"分开
+            cachedTokens = (long) usage.getCachedTokens();
+            modelReportedMs = Math.round(usage.getTime() * 1000d);
         }
         try {
-            collector.addSegment(kind, name, startMs, startNano, success, errorMsg, inputTokens, outputTokens);
+            collector.addSegment(kind, name, startMs, startNano, success, errorMsg,
+                inputTokens, outputTokens, cachedTokens, modelReportedMs);
         } catch (Exception e) {
             log.error("agent call segment collect failed, code={}, kind={}, name={}",
                 "CALLLOG-SEGMENT-FAIL", kind, name, e);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStore.java
@@ -72,6 +72,8 @@ public class InMemoryAgentCallLogStore implements AgentCallLogStore {
         // token 汇总：null 视为 0（与 SQL SUM/AVG 忽略 NULL 的口径略有差异——内存实现仅测试/演示用，
         // 生产走 MybatisAgentCallLogStore，此处保持简单一致即可）
         long totalTokens = list.stream().mapToLong(r -> r.totalTokens() == null ? 0L : r.totalTokens()).sum();
+        long inputTokens = list.stream().mapToLong(r -> r.inputTokens() == null ? 0L : r.inputTokens()).sum();
+        long cachedTokens = list.stream().mapToLong(r -> r.cachedTokens() == null ? 0L : r.cachedTokens()).sum();
         return new AgentCallLogSummary(
             total,
             list.stream().mapToLong(AgentCallRecord::durationMs).average().orElse(0d),
@@ -81,7 +83,9 @@ public class InMemoryAgentCallLogStore implements AgentCallLogStore {
             list.stream().mapToLong(AgentCallRecord::mcpMs).average().orElse(0d),
             list.stream().mapToLong(AgentCallRecord::skillMs).average().orElse(0d),
             totalTokens,
-            (double) totalTokens / total);
+            (double) totalTokens / total,
+            inputTokens,
+            cachedTokens);
     }
 
     @Override

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStore.java
@@ -116,7 +116,9 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
                 toDouble(do1.getAvgMcpMs()),
                 toDouble(do1.getAvgSkillMs()),
                 do1.getTotalTokens() == null ? 0L : do1.getTotalTokens(),
-                toDouble(do1.getAvgTotalTokens()));
+                toDouble(do1.getAvgTotalTokens()),
+                do1.getInputTokens() == null ? 0L : do1.getInputTokens(),
+                do1.getCachedTokens() == null ? 0L : do1.getCachedTokens());
         } catch (Exception e) {
             log.error("agent call log summary failed, code={}", "CALLLOG-SUMMARY-FAIL", e);
             return AgentCallLogSummary.empty();
@@ -172,6 +174,8 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
         d.setInputTokens(r.inputTokens());
         d.setOutputTokens(r.outputTokens());
         d.setTotalTokens(r.totalTokens());
+        d.setCachedTokens(r.cachedTokens());
+        d.setModelReportedMs(r.modelReportedMs());
         d.setSuccess(r.success());
         d.setErrorMsg(r.errorMsg());
         return d;
@@ -187,6 +191,8 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
         d.setDurationMs(s.durationMs());
         d.setInputTokens(s.inputTokens());
         d.setOutputTokens(s.outputTokens());
+        d.setCachedTokens(s.cachedTokens());
+        d.setModelReportedMs(s.modelReportedMs());
         d.setSuccess(s.success());
         d.setErrorMsg(s.errorMsg());
         return d;
@@ -208,6 +214,7 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
             d.getSkillMs() == null ? 0L : d.getSkillMs(),
             d.getSegmentCount() == null ? 0 : d.getSegmentCount(),
             d.getInputTokens(), d.getOutputTokens(), d.getTotalTokens(),
+            d.getCachedTokens(), d.getModelReportedMs(),
             d.getSuccess() != null && d.getSuccess(), d.getErrorMsg(), List.of());
     }
 
@@ -220,7 +227,8 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
             d.getDurationMs() == null ? 0L : d.getDurationMs(),
             d.getSuccess() != null && d.getSuccess(),
             d.getErrorMsg(),
-            d.getInputTokens(), d.getOutputTokens());
+            d.getInputTokens(), d.getOutputTokens(),
+            d.getCachedTokens(), d.getModelReportedMs());
     }
 
     private double toDouble(BigDecimal value) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallLogDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallLogDO.java
@@ -40,6 +40,10 @@ public class AgentCallLogDO {
     private Long inputTokens;
     private Long outputTokens;
     private Long totalTokens;
+    /** 命中缓存的输入 token（inputTokens 的子集，不计入 totalTokens）。 */
+    private Long cachedTokens;
+    /** 各 MODEL 段模型自报耗时之和（毫秒），与实测 modelMs 之差即网络/排队开销。 */
+    private Long modelReportedMs;
     private Boolean success;
     private String errorMsg;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSegmentDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSegmentDO.java
@@ -27,6 +27,10 @@ public class AgentCallSegmentDO {
     private Long durationMs;
     private Long inputTokens;
     private Long outputTokens;
+    /** 命中缓存的输入 token（inputTokens 的子集，仅 MODEL 段）。 */
+    private Long cachedTokens;
+    /** 模型自报耗时（毫秒，仅 MODEL 段）。 */
+    private Long modelReportedMs;
     private Boolean success;
     private String errorMsg;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSummaryDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/entity/AgentCallSummaryDO.java
@@ -20,4 +20,8 @@ public class AgentCallSummaryDO {
     private BigDecimal avgSkillMs;
     private Long totalTokens;
     private BigDecimal avgTotalTokens;
+    /** 命中缓存的输入 token 合计（inputTokens 的子集）。 */
+    private Long cachedTokens;
+    /** 输入 token 合计——与 cachedTokens 配对才能算缓存命中率，单独给缓存量没有意义。 */
+    private Long inputTokens;
 }

--- a/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallLogMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallLogMapper.xml
@@ -19,7 +19,8 @@
     <select id="findPage" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallLogDO">
         SELECT id, request_id, user_id, username, agent_code, agent_name, session_id, session_type,
                question, answer, start_time, end_time, duration_ms, model_ms, tool_ms, mcp_ms,
-               skill_ms, segment_count, input_tokens, output_tokens, total_tokens, success, error_msg
+               skill_ms, segment_count, input_tokens, output_tokens, total_tokens,
+               cached_tokens, model_reported_ms, success, error_msg
         FROM cw_agent_call_log
         <include refid="whereClause"/>
         ORDER BY id DESC

--- a/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallSegmentMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/AgentCallSegmentMapper.xml
@@ -6,6 +6,7 @@
     <!-- 按主记录 id 查全部分段，seq 升序。 -->
     <select id="findByCallLogId" resultType="com.richard.fyoung.customerwork.calllog.entity.AgentCallSegmentDO">
         SELECT id, call_log_id, seq, kind, name, start_time, duration_ms, input_tokens, output_tokens,
+               cached_tokens, model_reported_ms,
                success, error_msg
         FROM cw_agent_call_segment
         WHERE call_log_id = #{callLogId}

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -185,6 +185,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
     `input_tokens`   BIGINT DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）',
     `output_tokens`  BIGINT DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）',
     `total_tokens`   BIGINT DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）',
+    `cached_tokens`  BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）',
+    `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
@@ -206,10 +208,21 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
     `input_tokens`   BIGINT DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）',
     `output_tokens`  BIGINT DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）',
+    `cached_tokens`  BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（仅MODEL段）',
+    `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用分段明细';
+
+-- token 统计补列（2026-07-28）：CREATE TABLE IF NOT EXISTS 对已存在的表不加列，
+-- 旧库存量表需手工执行下列 ALTER 补列（MySQL 无 ADD COLUMN IF NOT EXISTS，重复执行报 Duplicate column 可忽略）：
+-- ALTER TABLE `cw_agent_call_log`
+--   ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）' AFTER `total_tokens`,
+--   ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销' AFTER `cached_tokens`;
+-- ALTER TABLE `cw_agent_call_segment`
+--   ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（仅MODEL段）' AFTER `output_tokens`,
+--   ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）' AFTER `cached_tokens`;
 
 -- 对话附件表（MybatisAttachmentStore）：上传附件落盘 + 落库，解析文本可追溯。
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallCollectorTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/AgentCallCollectorTest.java
@@ -18,10 +18,10 @@ class AgentCallCollectorTest {
         AgentCallCollector collector = new AgentCallCollector();
         long now = System.currentTimeMillis();
         long nano = System.nanoTime();
-        collector.addSegment(AgentCallKind.MODEL, "qwen-max", now, nano, true, null, 120L, 30L);
-        collector.addSegment(AgentCallKind.TOOL, "queryOrder", now, nano, true, null, null, null);
-        collector.addSegment(AgentCallKind.MCP, "mcp_weather", now, nano, true, null, null, null);
-        collector.addSegment(AgentCallKind.SKILL, "skill_pdf", now, nano, false, "boom", null, null);
+        collector.addSegment(AgentCallKind.MODEL, "qwen-max", now, nano, true, null, 120L, 30L, 80L, 25L);
+        collector.addSegment(AgentCallKind.TOOL, "queryOrder", now, nano, true, null, null, null, null, null);
+        collector.addSegment(AgentCallKind.MCP, "mcp_weather", now, nano, true, null, null, null, null, null);
+        collector.addSegment(AgentCallKind.SKILL, "skill_pdf", now, nano, false, "boom", null, null, null, null);
         collector.setAnswer("最终回答");
 
         AgentCallRecord record = collector.toRecord("req-1", "tenantA", "userA", "agentA",
@@ -37,9 +37,13 @@ class AgentCallCollectorTest {
         assertEquals(120L, record.inputTokens(), "请求级输入 token = MODEL 段之和");
         assertEquals(30L, record.outputTokens(), "请求级输出 token = MODEL 段之和");
         assertEquals(150L, record.totalTokens(), "请求级总 token = 输入 + 输出");
+        assertEquals(80L, record.cachedTokens(), "请求级缓存 token = MODEL 段之和");
+        assertEquals(25L, record.modelReportedMs(), "模型自报耗时 = MODEL 段之和");
         assertEquals(120L, record.segments().get(0).inputTokens(), "MODEL 段输入 token");
         assertEquals(30L, record.segments().get(0).outputTokens(), "MODEL 段输出 token");
+        assertEquals(80L, record.segments().get(0).cachedTokens(), "MODEL 段缓存 token");
         assertNull(record.segments().get(1).inputTokens(), "工具段无 token");
+        assertNull(record.segments().get(1).cachedTokens(), "工具段无缓存 token");
         // 每类各一段，各段耗时 >=0，四类互不串味
         assertTrue(record.modelMs() >= 0 && record.toolMs() >= 0
             && record.mcpMs() >= 0 && record.skillMs() >= 0);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/CacheHitRateTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/CacheHitRateTest.java
@@ -1,0 +1,56 @@
+package com.richard.fyoung.customerwork.calllog;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 缓存命中率口径单测。
+ *
+ * <p>这个口径最容易错在一个地方：{@code cachedTokens} 是 {@code inputTokens} 的<b>子集</b>，
+ * 不是与输入并列的额外量。分母用错（比如拿 totalTokens）算出来的命中率会系统性偏低，
+ * 进而得出"缓存没生效"的错误结论。故把它固定在领域对象上并用测试锁住。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class CacheHitRateTest {
+
+    private AgentCallRecord recordWith(Long inputTokens, Long cachedTokens) {
+        return new AgentCallRecord(1L, "req", "u", "user", "agent", "客服", "sess",
+            AgentCallSessionType.CHAT, "问", "答", 0L, 100L, 100L, 60L, 0L, 0L, 0L, 1,
+            inputTokens, 50L, inputTokens == null ? null : inputTokens + 50L,
+            cachedTokens, 55L, true, null, java.util.List.of());
+    }
+
+    @Test
+    void record_cacheHitRate_shouldDivideByInputNotTotal() {
+        // 输入 1000、缓存 800、输出 50（总 1050）：命中率必须是 800/1000 而不是 800/1050
+        AgentCallRecord record = recordWith(1000L, 800L);
+
+        assertEquals(0.8d, record.cacheHitRate(), 1e-9, "分母是输入总量，缓存量是它的子集");
+    }
+
+    @Test
+    void record_cacheHitRate_shouldBeNullWhenNotCollected() {
+        assertNull(recordWith(1000L, null).cacheHitRate(), "未采到缓存量时不能当作 0——那是两回事");
+        assertNull(recordWith(null, 800L).cacheHitRate(), "没有输入量就没有分母");
+    }
+
+    @Test
+    void record_cacheHitRate_shouldBeNullWhenInputIsZero() {
+        assertNull(recordWith(0L, 0L).cacheHitRate(), "输入为 0 时不做除法");
+    }
+
+    @Test
+    void summary_cacheHitRate_shouldComputeFromAggregates() {
+        AgentCallLogSummary summary = new AgentCallLogSummary(
+            10L, 100d, 200L, 60d, 10d, 5d, 5d, 10500L, 1050d, 10000L, 8000L);
+
+        assertEquals(0.8d, summary.cacheHitRate(), 1e-9);
+    }
+
+    @Test
+    void summary_cacheHitRate_shouldBeZeroWhenNoInput() {
+        assertEquals(0d, AgentCallLogSummary.empty().cacheHitRate(), 1e-9);
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/InMemoryAgentCallLogStoreTest.java
@@ -29,7 +29,7 @@ class InMemoryAgentCallLogStoreTest {
         return new AgentCallRecord(0L, "req-" + startMs, "u-" + username, username, agentCode,
             "客服Agent", "sess-1", AgentCallSessionType.CHAT, "问题", "回答",
             startMs, startMs + durationMs, durationMs, modelMs, toolMs, 0L, 0L,
-            segments.size(), 10L, 5L, 15L, true, null, segments);
+            segments.size(), 10L, 5L, 15L, 4L, 8L, true, null, segments);
     }
 
     @Test
@@ -70,8 +70,8 @@ class InMemoryAgentCallLogStoreTest {
     @Test
     void findSegmentsAndDelete_shouldWork() {
         List<AgentCallSegment> segs = List.of(
-            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", 1000L, 30L, true, null, 100L, 20L),
-            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", 1030L, 20L, true, null, null, null));
+            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", 1000L, 30L, true, null, 100L, 20L, 60L, 18L),
+            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", 1030L, 20L, true, null, null, null, null, null));
         AgentCallRecord saved = store.save(record("alice", "A", 1000L, 50L, 30L, 20L, segs));
 
         List<AgentCallSegment> loaded = store.findSegments(saved.id());

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/calllog/MybatisAgentCallLogStoreTest.java
@@ -63,12 +63,12 @@ class MybatisAgentCallLogStoreTest {
 
     private AgentCallRecord newRecord(String username, String agentCode, long startMs) {
         List<AgentCallSegment> segs = List.of(
-            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", startMs, 30L, true, null, 100L, 20L),
-            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", startMs + 30, 20L, true, null, null, null),
-            new AgentCallSegment(3, AgentCallKind.MCP, "mcp_weather", startMs + 50, 10L, false, "boom", null, null));
+            new AgentCallSegment(1, AgentCallKind.MODEL, "qwen-max", startMs, 30L, true, null, 100L, 20L, 60L, 18L),
+            new AgentCallSegment(2, AgentCallKind.TOOL, "queryOrder", startMs + 30, 20L, true, null, null, null, null, null),
+            new AgentCallSegment(3, AgentCallKind.MCP, "mcp_weather", startMs + 50, 10L, false, "boom", null, null, null, null));
         return new AgentCallRecord(0L, "req-" + UUID.randomUUID(), "u-" + username, username, agentCode,
             "客服Agent", "sess-" + UUID.randomUUID(), AgentCallSessionType.CHAT, "问题", "回答",
-            startMs, startMs + 60, 60L, 30L, 20L, 10L, 0L, segs.size(), 100L, 20L, 120L, true, null, segs);
+            startMs, startMs + 60, 60L, 30L, 20L, 10L, 0L, segs.size(), 100L, 20L, 120L, 60L, 18L, true, null, segs);
     }
 
     @Test

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -815,6 +815,27 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/contentguard/hit-log/{page,stats}` | 敏感词命中看板（明细分页 + 动作/方向分布 + Top 命中词 + 时间趋势，只读，权限点 `sensitive-hit-log:view`） |
 | `/swagger-ui/index.html` | 接口文档 |
 
+**调用统计的 token 口径（V43 起补齐缓存量）**：框架 `ChatUsage` 一共只给四个原始量——
+`inputTokens` / `outputTokens` / `cachedTokens` / `time`（`totalTokens` 是派生的 input+output），
+没有 reasoning tokens、没有价格信息。此前只落了前两个和 total，**缓存量与模型自报耗时采到了却被丢弃**，
+现已补全（`cw_agent_call_log` / `cw_agent_call_segment` 加 `cached_tokens`、`model_reported_ms`；
+`ai_coding_audit_log` 加 `cached_tokens`）。
+
+> ⚠️ **`cachedTokens` 是 `inputTokens` 的子集，不是额外量，也不计入 `totalTokens`**。这是最容易算错的地方：
+> 命中率的分母必须是 `inputTokens`（用 `totalTokens` 会系统性偏低，进而误判"缓存没生效"）。
+> 口径固定在 `AgentCallRecord#cacheHitRate()` / `AgentCallLogSummary#cacheHitRate()`，后端算好下发，
+> 前端不重复推导。
+>
+> 为什么值得单独存：缓存读各家通常只按 1/10 左右计价，不留这个量就无法准确核算成本；
+> 命中率长期为 0 则说明系统提示词或历史每次都在变，缓存根本没建立起来——那笔本可省下的钱一直在白花。
+>
+> `model_reported_ms` 是模型自报耗时（`ChatUsage.time` 秒 → 毫秒），与本地实测的 `model_ms` 之差
+> 即网络/排队开销，能把"模型慢"和"链路慢"分开。
+>
+> **旧库要手工补列**：这两张 `cw_` 表由 `SchemaInitializer` 的 `CREATE TABLE IF NOT EXISTS` 建，
+> 对已存在的表不加列，ALTER 语句附在 `customer-work-schema.sql` 对应建表段之后（注释形式）。
+> admin 侧走 Flyway V43 自动执行。
+
 **内容风控（V42 起）**：三个页面挂一级菜单「内容风控」。要点是**数据不在 admin 库**——敏感词词库
 （`cw_sensitive_word`）、限流规则（`cw_rate_limit_rule`）、命中日志（`cw_sensitive_word_hit_log`）都在客服端库
 `agent_scope_customer_work`，admin 经 `ContentGuardGatewayProvider` 惰性跨库读写（照 `AppAgentCallStatsGatewayProvider`

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -248,6 +248,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
     `input_tokens`   BIGINT DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）',
     `output_tokens`  BIGINT DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）',
     `total_tokens`   BIGINT DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）',
+    `cached_tokens`  BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）',
+    `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '整次调用是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
@@ -269,10 +271,21 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `duration_ms`    BIGINT NOT NULL DEFAULT 0 COMMENT '分段耗时（毫秒）',
     `input_tokens`   BIGINT DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）',
     `output_tokens`  BIGINT DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）',
+    `cached_tokens`  BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（仅MODEL段）',
+    `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
     INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- token 统计补列（2026-07-28）：CREATE TABLE IF NOT EXISTS 对已存在的表不加列，
+-- 旧库存量表需手工执行下列 ALTER 补列（MySQL 无 ADD COLUMN IF NOT EXISTS，重复执行报 Duplicate column 可忽略）：
+-- ALTER TABLE `cw_agent_call_log`
+--   ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）' AFTER `total_tokens`,
+--   ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销' AFTER `cached_tokens`;
+-- ALTER TABLE `cw_agent_call_segment`
+--   ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL COMMENT '命中缓存的输入token（仅MODEL段）' AFTER `output_tokens`,
+--   ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）' AFTER `cached_tokens`;
 
 -- 对话附件表（cw_chat_attachment）：上传附件落盘 + 落库，解析文本可追溯（MybatisAttachmentStore）。
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (

--- a/mysql/02-customer-admin/43-V43__audit_cached_tokens.sql
+++ b/mysql/02-customer-admin/43-V43__audit_cached_tokens.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- AI 编码审计日志补 cached_tokens（Flyway V43，仅本地/测试 profile 自动执行，生产手工同步）
+-- =============================================================================
+-- 框架 ChatUsage 一直返回 cachedTokens（命中 prompt 缓存的输入 token），但 AiCodingAuditService#applyUsage
+-- 此前只取了 input/output/total 三个字段——采到了、算过了、直接扔掉。
+--
+-- 为什么这个字段值得单独存：cachedTokens 是 input_tokens 的**子集**（不是额外量），各家计价通常只按
+-- 1/10 左右收。不留它就有两个后果：一是成本核算永远偏高（把缓存命中的部分按全价算），二是看不出
+-- prompt 缓存到底有没有生效——命中率长期为 0 说明系统提示词或历史每次都在变，那笔本可省下的钱一直在白花。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `ai_coding_audit_log`
+    ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL
+        COMMENT '命中缓存的输入token（input_tokens的子集，不计入total_tokens）' AFTER `total_tokens`;

--- a/mysql/02-customer-admin/44-V44__agent_call_stats_cached_tokens.sql
+++ b/mysql/02-customer-admin/44-V44__agent_call_stats_cached_tokens.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- admin 库的调用统计两表补 cached_tokens / model_reported_ms（Flyway V44，生产手工同步）
+-- =============================================================================
+-- 补 V43 的漏：cw_agent_call_log / cw_agent_call_segment 这两张表**两个库各有一份**——
+-- 客服端库 agent_scope_customer_work（8080 客服链路写入）与 admin 库 customer_admin
+-- （V38/V39 建，后台工作区对话写入）。AgentCallStatsService 按 source 参数路由：
+-- ADMIN 查 admin 库、APP 查客服端库，而**默认值是 ADMIN**。
+--
+-- V43 只补了客服端库那份（走 schema.sql 的手工 ALTER），admin 库这份没动，
+-- 于是后台"调用统计"页一打开就报 Unknown column 'cached_tokens'。
+--
+-- 教训记在这里：cw_ 前缀的同名表凡是同时存在于两个库的，加列必须两边都改——
+-- 客服端库走 customer-work-schema.sql 的注释式 ALTER（SchemaInitializer 不会加列），
+-- admin 库走 Flyway 迁移。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故本文件首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响）。
+-- =============================================================================
+
+SET NAMES utf8mb4;
+
+ALTER TABLE `cw_agent_call_log`
+    ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL
+        COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）' AFTER `total_tokens`,
+    ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL
+        COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销' AFTER `cached_tokens`;
+
+ALTER TABLE `cw_agent_call_segment`
+    ADD COLUMN `cached_tokens` BIGINT DEFAULT NULL
+        COMMENT '命中缓存的输入token（仅MODEL段）' AFTER `output_tokens`,
+    ADD COLUMN `model_reported_ms` BIGINT DEFAULT NULL
+        COMMENT '模型自报耗时（毫秒，仅MODEL段）' AFTER `cached_tokens`;


### PR DESCRIPTION
接 #63（已合并）的后续：那个 PR 做的是内容风控，这个补的是 **token 统计里一直被丢弃的两个量**。

## 背景

框架 `io.agentscope.core.model.ChatUsage` 一共只给四个原始量：

| 字段 | 此前 |
|---|---|
| `inputTokens` / `outputTokens` | 已落库 |
| `totalTokens` | 已落库（派生 = input + output） |
| **`cachedTokens`** | **采到了、算过了、直接扔掉** |
| **`time`**（模型自报耗时） | **同上** |

`ChatService#totalUsage` 明明累加了 `getCachedTokens()` 和 `getTime()`，`AiCodingAuditService#applyUsage` 却只取三个字段。框架层面再没有别的了（没有 reasoning tokens、没有价格信息），所以能补的就是这两个。

## 为什么这两个值得补

**`cachedTokens`**：命中 prompt 缓存的输入 token，各家计价通常只按 1/10 左右收。不留它有两个后果——成本核算永远偏高（把缓存命中的部分按全价算）；**缓存命中率无从观测**，而命中率长期为 0 恰恰说明系统提示词或历史每次都在变、缓存根本没建立起来，那笔本可省下的钱一直在白花。

**`ChatUsage.time`**：模型自报耗时，与本地实测的 `model_ms` 相减即网络/排队开销，能把"模型慢"和"链路慢"分开。

## 改动范围（采集链 → 展示）

- **starter 采集**：`AgentCallSegment` / `AgentCallRecord` 两个 record 加 `cachedTokens` / `modelReportedMs`，`AgentCallCollector` 汇总，`AgentCallTimingMiddleware` 从 `ChatUsage` 取值
- **starter 持久**：两个 DO + 两个 Mapper XML + schema 两份（starter 与 `mysql/01` 副本）
- **admin 读侧**：ext XML 补列与 `SUM` 聚合、四个 VO、Service 映射；`ai_coding_audit_log` 走 **V43**
- **admin 库补列**：**V44**——见下方"踩的坑"
- **前端**：汇总卡片加「缓存命中率」，列表 Token 悬浮加命中缓存量，详情加缓存占比 +「模型自报耗时 / 网络排队开销」对照

## 两个刻意的决定

**1. `cachedTokens` 不计入 `totalTokens`。** 它是 `inputTokens` 的**子集**，加进去等于把缓存量重复计一遍。同理命中率的分母必须是 `inputTokens`——用 `totalTokens` 会系统性偏低，进而误判"缓存没生效"。口径固定在 `AgentCallRecord#cacheHitRate()` / `AgentCallLogSummary#cacheHitRate()`，后端算好下发，前端不重复推导，`CacheHitRateTest` 5 个用例锁死。

**2. 旧库补列分两套机制**（这里踩了坑，见下）。

## 踩的坑：两张 cw_ 表在两个库各有一份

`cw_agent_call_log` / `cw_agent_call_segment` 同时存在于：

- 客服端库 `agent_scope_customer_work`（8080 客服链路写入，`SchemaInitializer` 建）
- admin 库 `customer_admin`（后台工作区对话写入，V38/V39 建）

`AgentCallStatsService` 按 `source` 参数路由，**默认值是 ADMIN**。第一版只补了客服端库那份，后台"调用统计"页一打开就 `Unknown column 'cached_tokens'`——V44 就是补这个漏。

两侧补列机制还不一样：客服端库走 `customer-work-schema.sql` 里的**注释式 ALTER**（`SchemaInitializer` 只跑 `CREATE TABLE IF NOT EXISTS`，对已存在的表不加列），admin 库走 Flyway。实测确认**全库只有这两张表是双库同名的**，补完两边列数一致（26/26、13/13），无同类隐患遗留。

## 测试

新增 `CacheHitRateTest` 5 例（分母口径、未采集与 0 的区分、汇总口径），`AgentCallCollectorTest` 补缓存量与自报耗时断言。全仓回归 **starter 740 + app 78 + channel 65 + admin 776 + gateway 1 全绿**（排除本机 MinIO/Redis 两个环境门控测试）。前端 `vue-tsc -b && vite build` 通过。

## 部署注意

- admin 库：**V43 + V44 由 Flyway 自动执行**，重启即可
- 客服端库：**需手工 ALTER**，语句以注释形式附在 `customer-work-schema.sql` 对应建表段之后（照 `cw_handoff_ticket` 先例）
- 存量数据的新列为 NULL，与"用了 0 token"可区分

🤖 Generated with [Claude Code](https://claude.com/claude-code)