### PR TITLE
feat(dict): 新增数据字典管理（starter Store SPI + admin 跨库 CRUD + useDict 接入）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,11 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **778** + admin-server **786**（2026-07-29 feature/agent-hardening-batch 实测，
-  starter 已按下方规则排除 2 个环境门控测试）；app 78 + customer-channel 65 + gateway 1
-  （沿用 2026-07-28 内容风控分支实测值，本次未重跑）。
+- 测试基线：starter **786** + admin-server **795** + app 78 + customer-channel 65 + gateway 1
+  （2026-07-29 feature/dict-management 全量实测，starter 已按下方规则排除 2 个环境门控测试）。
+  **另需排除 `ApplicationContextTest`**：main 基线上 `IndirectInjectionGuardMiddleware`（@Component + 两个
+  构造器且都无 @Autowired）让 app-server 整个 Spring 上下文起不来，PR #65 引入、当时未重跑该模块，
+  与后续分支无关；修掉后这条排除即可去掉。
   门控集成测试依赖：PaddleOCR serving(localhost:8868)、MinIO(localhost:9000)，不可达自动跳过。
   外部依赖门控测试：MySQL(root/root)、Redis(密码 123456)、Nacos(nacos/nacos:8848)，不可达自动跳过。
 - **本机跑全量要排除 2 个环境门控测试**（当前 MinIO 的 9000 被 kb-rag 栈占、Redis 无密码，共 4 个用例必挂；

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictGatewayFactory.java
@@ -1,0 +1,48 @@
+package com.richard.fyoung.customeradmin.dict.config;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.richard.fyoung.customeradmin.dict.jdbc.DictGateway;
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * 为客服端库数据源装配一套字典门面（{@link DictGateway}）。
+ *
+ * <p>手法与 {@code ContentGuardGatewayFactory} 一致：现场构建<b>专用</b> {@link SqlSessionFactory}
+ * （不暴露为 Spring Bean，免得 MP 自动装配的主 {@code SqlSessionFactory} 退避）。两个 Mapper 都是
+ * 无 XML 的纯 {@code BaseMapper}，直接 {@code addMapper} 注册接口即可，无需加载任何 Mapper XML。</p>
+ * @author owlzhangfq@gmail.com
+ */
+final class DictGatewayFactory {
+
+    private DictGatewayFactory() {
+    }
+
+    /** 按数据源装配一套门面。工厂构建阶段不连库，首次查询时才真正取连接。 */
+    static DictGateway build(DataSource dataSource) {
+        try {
+            MybatisConfiguration configuration = new MybatisConfiguration();
+            // 列名下划线、DO 字段驼峰，必须开启映射（created_at_ms -> createdAtMs）
+            configuration.setMapUnderscoreToCamelCase(true);
+            configuration.addMapper(DictTypeMapper.class);
+            configuration.addMapper(DictItemMapper.class);
+
+            MybatisSqlSessionFactoryBean factoryBean = new MybatisSqlSessionFactoryBean();
+            factoryBean.setDataSource(dataSource);
+            factoryBean.setConfiguration(configuration);
+            factoryBean.afterPropertiesSet();
+            SqlSessionFactory factory = factoryBean.getObject();
+            SqlSessionTemplate template = new SqlSessionTemplate(factory);
+            return new DictGateway(
+                template.getMapper(DictTypeMapper.class),
+                template.getMapper(DictItemMapper.class));
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to build dict gateway", e);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictGatewayProvider.java
@@ -1,0 +1,112 @@
+package com.richard.fyoung.customeradmin.dict.config;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.dict.jdbc.DictGateway;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+
+/**
+ * 客服端库字典门面的惰性提供者（照 {@code ContentGuardGatewayProvider}）。
+ *
+ * <p><b>惰性 + 容错</b>：连接池与门面在首次 {@link #get()} 时才构建并做一次连通性探测，库不可达则抛
+ * {@link ResultCode#CUSTOMER_WORK_UNAVAILABLE} 业务异常，<b>绝不在 admin 启动期触碰该库</b>。
+ * 构建成功后缓存复用（双重检查）；构建失败不缓存，下次 {@link #get()} 重试。</p>
+ *
+ * <p>连接池<b>可写</b>：字典管理页是这份数据唯一的维护入口，写是它的本职。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+@EnableConfigurationProperties(DictProperties.class)
+public class DictGatewayProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(DictGatewayProvider.class);
+
+    private static final String POOL_NAME = "dict-pool";
+    private static final int MAX_POOL_SIZE = 2;
+    private static final int MIN_IDLE = 0;
+    private static final long CONNECTION_TIMEOUT_MS = 5000L;
+    private static final String DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
+
+    private final DictProperties properties;
+
+    private volatile DictGateway cachedGateway;
+    private volatile HikariDataSource dataSource;
+
+    public DictGatewayProvider(DictProperties properties) {
+        this.properties = properties;
+    }
+
+    /** 取门面（惰性构建 + 探测 + 缓存）；库不可达抛明确业务异常。 */
+    public DictGateway get() {
+        DictGateway gateway = cachedGateway;
+        if (gateway != null) {
+            return gateway;
+        }
+        synchronized (this) {
+            if (cachedGateway != null) {
+                return cachedGateway;
+            }
+            HikariDataSource ds = buildAndProbeDataSource();
+            DictGateway built = DictGatewayFactory.build(ds);
+            this.dataSource = ds;
+            this.cachedGateway = built;
+            log.info("dict datasource ready, url={}", properties.jdbcUrl());
+            return built;
+        }
+    }
+
+    /** 构建连接池并探测连通性；任何失败关闭半开池并抛 {@link ResultCode#CUSTOMER_WORK_UNAVAILABLE}。 */
+    private HikariDataSource buildAndProbeDataSource() {
+        HikariDataSource ds = null;
+        try {
+            HikariConfig config = new HikariConfig();
+            config.setPoolName(POOL_NAME);
+            config.setDriverClassName(DRIVER_CLASS);
+            config.setJdbcUrl(properties.jdbcUrl());
+            config.setUsername(properties.getUsername());
+            config.setPassword(properties.getPassword());
+            config.setMaximumPoolSize(MAX_POOL_SIZE);
+            config.setMinimumIdle(MIN_IDLE);
+            config.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
+            // 惰性：构造连接池本身不因不可达而抛（探测放在下方显式 getConnection，失败信息更明确可控）
+            config.setInitializationFailTimeout(-1L);
+            ds = new HikariDataSource(config);
+            try (Connection ignored = ds.getConnection()) {
+                log.info("dict datasource probe ok");
+            }
+            return ds;
+        } catch (Exception e) {
+            if (ds != null) {
+                ds.close();
+            }
+            log.error("dict datasource unavailable, code={}, url={}",
+                "DICT-DS-UNAVAILABLE", properties.jdbcUrl(), e);
+            throw new BizException(ResultCode.CUSTOMER_WORK_UNAVAILABLE,
+                "客服端库不可达（字典数据存放于此）：" + rootMessage(e));
+        }
+    }
+
+    private String rootMessage(Throwable e) {
+        Throwable cause = e;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+    }
+
+    @PreDestroy
+    public void close() {
+        if (dataSource != null) {
+            dataSource.close();
+            log.info("dict datasource closed");
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictProperties.java
@@ -1,0 +1,39 @@
+package com.richard.fyoung.customeradmin.dict.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 字典数据源连接参数：{@code admin.dict.*}。
+ *
+ * <p>字典两表（{@code cw_dict_type} / {@code cw_dict_item}）在<b>客服端库</b>（{@code agent_scope_customer_work}）
+ * ——客服端运行时经 {@code DictStore}（store-mode=jdbc）读取的就是这两张表，后台只是这份数据的维护端。
+ * 照内容风控先例单一数据真源、不做双写同步。该库不可达不影响 admin 启动（数据源惰性构建，
+ * 见 {@link DictGatewayProvider}）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@ConfigurationProperties(prefix = "admin.dict")
+public class DictProperties {
+
+    /** 数据库主机。 */
+    private String host = "localhost";
+
+    /** 数据库端口。 */
+    private int port = 3306;
+
+    /** 库名。 */
+    private String database = "agent_scope_customer_work";
+
+    /** 用户名。 */
+    private String username = "root";
+
+    /** 密码。 */
+    private String password = "root";
+
+    /** 拼装 JDBC URL（与 admin 主库同款连接参数）。 */
+    public String jdbcUrl() {
+        return "jdbc:mysql://" + host + ":" + port + "/" + database
+            + "?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true";
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/controller/DictController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/controller/DictController.java
@@ -1,0 +1,115 @@
+package com.richard.fyoung.customeradmin.dict.controller;
+
+import cn.dev33.satoken.annotation.SaCheckLogin;
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.dict.dto.DictItemSaveRequest;
+import com.richard.fyoung.customeradmin.dict.dto.DictItemVO;
+import com.richard.fyoung.customeradmin.dict.dto.DictOptionVO;
+import com.richard.fyoung.customeradmin.dict.dto.DictTypeSaveRequest;
+import com.richard.fyoung.customeradmin.dict.dto.DictTypeVO;
+import com.richard.fyoung.customeradmin.dict.service.DictService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 字典管理：类型 + 字典项两级 CRUD，及消费端下拉选项查询。
+ *
+ * <p>管理接口按 {@code dict:*} 权限点控制；{@code /options/*} 是各业务页面下拉的消费入口，
+ * 仅要求登录（能进后台的人即可读字典选项，与菜单权限解耦——否则每接一个页面都要给角色补授权）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/dict")
+public class DictController {
+
+    private final DictService dictService;
+
+    public DictController(DictService dictService) {
+        this.dictService = dictService;
+    }
+
+    // ---------- 字典类型 ----------
+
+    @SaCheckPermission("dict:view")
+    @GetMapping("/types")
+    public Result<List<DictTypeVO>> listTypes() {
+        return Result.success(dictService.listTypes());
+    }
+
+    @SaCheckPermission("dict:add")
+    @OperationLog(operation = "新增字典类型", target = "cw_dict_type")
+    @PostMapping("/types")
+    public Result<Void> createType(@Valid @RequestBody DictTypeSaveRequest request) {
+        dictService.createType(request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("dict:edit")
+    @OperationLog(operation = "编辑字典类型", target = "cw_dict_type")
+    @PutMapping("/types/{id}")
+    public Result<Void> updateType(@PathVariable Long id, @Valid @RequestBody DictTypeSaveRequest request) {
+        dictService.updateType(id, request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("dict:delete")
+    @OperationLog(operation = "删除字典类型", target = "cw_dict_type")
+    @DeleteMapping("/types/{id}")
+    public Result<Void> deleteType(@PathVariable Long id) {
+        dictService.deleteType(id);
+        return Result.success();
+    }
+
+    // ---------- 字典项 ----------
+
+    @SaCheckPermission("dict:view")
+    @GetMapping("/items")
+    public Result<List<DictItemVO>> listItems(@RequestParam String dictType) {
+        return Result.success(dictService.listItems(dictType));
+    }
+
+    @SaCheckPermission("dict:add")
+    @OperationLog(operation = "新增字典项", target = "cw_dict_item")
+    @PostMapping("/items")
+    public Result<Void> createItem(@RequestParam String dictType, @Valid @RequestBody DictItemSaveRequest request) {
+        dictService.createItem(dictType, request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("dict:edit")
+    @OperationLog(operation = "编辑字典项", target = "cw_dict_item")
+    @PutMapping("/items/{id}")
+    public Result<Void> updateItem(@PathVariable Long id, @Valid @RequestBody DictItemSaveRequest request) {
+        dictService.updateItem(id, request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("dict:delete")
+    @OperationLog(operation = "删除字典项", target = "cw_dict_item")
+    @DeleteMapping("/items/{id}")
+    public Result<Void> deleteItem(@PathVariable Long id) {
+        dictService.deleteItem(id);
+        return Result.success();
+    }
+
+    // ---------- 消费端 ----------
+
+    /** 业务页面下拉选项：仅启用项；类型停用/不存在返回空列表（前端按无字典配置降级到硬编码兜底）。 */
+    @SaCheckLogin
+    @GetMapping("/options/{dictType}")
+    public Result<List<DictOptionVO>> options(@PathVariable String dictType) {
+        return Result.success(dictService.options(dictType));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictItemSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictItemSaveRequest.java
@@ -1,0 +1,33 @@
+package com.richard.fyoung.customeradmin.dict.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 字典项新增/编辑请求。所属 {@code dictType} 由路径/查询参数携带，编辑时不允许挪类型。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DictItemSaveRequest {
+
+    /** 字典项键（业务值，同一类型下唯一）。 */
+    @NotBlank(message = "字典项键不能为空")
+    @Size(max = 128, message = "字典项键最长 128 字符")
+    private String itemKey;
+
+    /** 字典项标签（展示文案）。 */
+    @NotBlank(message = "字典项标签不能为空")
+    @Size(max = 128, message = "字典项标签最长 128 字符")
+    private String itemLabel;
+
+    /** 排序号，越小越靠前（缺省 0）。 */
+    private Integer sort;
+
+    /** 是否启用（缺省 true）。 */
+    private Boolean enabled;
+
+    /** 备注说明。 */
+    @Size(max = 255, message = "备注最长 255 字符")
+    private String remark;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictItemVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictItemVO.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customeradmin.dict.dto;
+
+import lombok.Data;
+
+/**
+ * 字典项视图对象。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DictItemVO {
+
+    private Long id;
+
+    /** 所属字典类型编码。 */
+    private String dictType;
+
+    /** 字典项键（业务值）。 */
+    private String itemKey;
+
+    /** 字典项标签（展示文案）。 */
+    private String itemLabel;
+
+    /** 排序号，越小越靠前。 */
+    private Integer sort;
+
+    /** 是否启用。 */
+    private Boolean enabled;
+
+    /** 备注说明。 */
+    private String remark;
+
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictOptionVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictOptionVO.java
@@ -1,0 +1,19 @@
+package com.richard.fyoung.customeradmin.dict.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * 字典下拉选项（消费端视图，仅启用项）：前端 {@code useDict} 通用 hook 消费的最小结构。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@AllArgsConstructor
+public class DictOptionVO {
+
+    /** 选项值（字典项键）。 */
+    private String value;
+
+    /** 选项文案（字典项标签）。 */
+    private String label;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictTypeSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictTypeSaveRequest.java
@@ -1,0 +1,31 @@
+package com.richard.fyoung.customeradmin.dict.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 字典类型新增/编辑请求。编辑时 {@code dictType} 不允许变更（作为字典项的外链键，改编码等于换类型）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DictTypeSaveRequest {
+
+    /** 字典类型编码：小写字母/数字/下划线，2-64 位（如 order_status）。 */
+    @NotBlank(message = "字典类型编码不能为空")
+    @Pattern(regexp = "^[a-z][a-z0-9_]{1,63}$", message = "类型编码须为小写字母开头的小写字母/数字/下划线，2-64 位")
+    private String dictType;
+
+    /** 类型名称（展示用）。 */
+    @NotBlank(message = "类型名称不能为空")
+    @Size(max = 64, message = "类型名称最长 64 字符")
+    private String typeName;
+
+    /** 备注说明。 */
+    @Size(max = 255, message = "备注最长 255 字符")
+    private String remark;
+
+    /** 是否启用（缺省 true）。 */
+    private Boolean enabled;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictTypeVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/dto/DictTypeVO.java
@@ -1,0 +1,31 @@
+package com.richard.fyoung.customeradmin.dict.dto;
+
+import lombok.Data;
+
+/**
+ * 字典类型视图对象。{@code itemCount} 为该类型下字典项数量（含停用），供列表页展示与删除前提示。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DictTypeVO {
+
+    private Long id;
+
+    /** 字典类型编码（唯一，如 order_status）。 */
+    private String dictType;
+
+    /** 类型名称（展示用）。 */
+    private String typeName;
+
+    /** 备注说明。 */
+    private String remark;
+
+    /** 是否启用。 */
+    private Boolean enabled;
+
+    /** 该类型下字典项数量（含停用）。 */
+    private Long itemCount;
+
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/jdbc/DictGateway.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/jdbc/DictGateway.java
@@ -1,0 +1,14 @@
+package com.richard.fyoung.customeradmin.dict.jdbc;
+
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
+
+/**
+ * 字典数据门面：把客服端库上的两套 Mapper 打包成一个对象传递。
+ *
+ * <p>直接复用 starter 的 {@code BaseMapper}（同两张表、同一套列，没有理由重造）；字典数据量小
+ * （每类几条到几十条），全量取回内存筛选即可，不需要 admin 侧的分页/聚合 ext Mapper。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record DictGateway(DictTypeMapper typeMapper, DictItemMapper itemMapper) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/service/DictService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/service/DictService.java
@@ -1,0 +1,250 @@
+package com.richard.fyoung.customeradmin.dict.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.dict.config.DictGatewayProvider;
+import com.richard.fyoung.customeradmin.dict.dto.DictItemSaveRequest;
+import com.richard.fyoung.customeradmin.dict.dto.DictItemVO;
+import com.richard.fyoung.customeradmin.dict.dto.DictOptionVO;
+import com.richard.fyoung.customeradmin.dict.dto.DictTypeSaveRequest;
+import com.richard.fyoung.customeradmin.dict.dto.DictTypeVO;
+import com.richard.fyoung.customeradmin.dict.jdbc.DictGateway;
+import com.richard.fyoung.customerwork.dict.entity.DictItemEntity;
+import com.richard.fyoung.customerwork.dict.entity.DictTypeEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 字典管理：类型 + 字典项两级 CRUD，及消费端下拉选项查询。
+ *
+ * <p><b>全量取回、不做分页 SQL，是刻意的</b>：字典本来就是"就几条数据、不值当建表"的场景，
+ * 单类型几条到几十条、类型总数也就几十个；真涨到需要分页的量级，说明这数据不该进字典。</p>
+ *
+ * <p>写的是客服端库 {@code cw_dict_type} / {@code cw_dict_item}（单一数据真源），客服端
+ * {@code DictStore}（store-mode=jdbc）读同两张表，改动即时可见，无缓存同步问题。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class DictService {
+
+    private final DictGatewayProvider gatewayProvider;
+
+    public DictService(DictGatewayProvider gatewayProvider) {
+        this.gatewayProvider = gatewayProvider;
+    }
+
+    // ---------- 字典类型 ----------
+
+    /** 全部字典类型（含停用，编码升序），附各类型的字典项数量。 */
+    public List<DictTypeVO> listTypes() {
+        DictGateway gateway = gatewayProvider.get();
+        List<DictTypeEntity> rows = gateway.typeMapper()
+            .selectList(new QueryWrapper<DictTypeEntity>().orderByAsc("dict_type"));
+        List<DictTypeVO> result = new ArrayList<>(rows.size());
+        for (DictTypeEntity row : rows) {
+            DictTypeVO vo = toTypeVO(row);
+            vo.setItemCount(gateway.itemMapper().selectCount(
+                new QueryWrapper<DictItemEntity>().eq("dict_type", row.getDictType())));
+            result.add(vo);
+        }
+        return result;
+    }
+
+    /** 新增类型；编码唯一冲突抛 {@link ResultCode#RESOURCE_DUPLICATE}。 */
+    public void createType(DictTypeSaveRequest request) {
+        DictGateway gateway = gatewayProvider.get();
+        Long exists = gateway.typeMapper().selectCount(
+            new QueryWrapper<DictTypeEntity>().eq("dict_type", request.getDictType()));
+        if (exists != null && exists > 0) {
+            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "字典类型已存在: " + request.getDictType());
+        }
+        long now = System.currentTimeMillis();
+        DictTypeEntity row = new DictTypeEntity();
+        row.setDictType(request.getDictType());
+        row.setTypeName(request.getTypeName());
+        row.setRemark(request.getRemark());
+        row.setEnabled(request.getEnabled() == null || request.getEnabled());
+        row.setCreatedAtMs(now);
+        row.setUpdatedAtMs(now);
+        gateway.typeMapper().insert(row);
+    }
+
+    /** 编辑类型（名称/备注/启停）；类型编码不允许变更。 */
+    public void updateType(Long id, DictTypeSaveRequest request) {
+        DictGateway gateway = gatewayProvider.get();
+        DictTypeEntity row = requireType(gateway, id);
+        if (!row.getDictType().equals(request.getDictType())) {
+            throw new BizException(ResultCode.PARAM_INVALID, "字典类型编码不允许变更: " + row.getDictType());
+        }
+        row.setTypeName(request.getTypeName());
+        row.setRemark(request.getRemark());
+        if (request.getEnabled() != null) {
+            row.setEnabled(request.getEnabled());
+        }
+        row.setUpdatedAtMs(System.currentTimeMillis());
+        gateway.typeMapper().updateById(row);
+    }
+
+    /** 删除类型；仍有字典项时拒绝（先清空项，避免留下孤儿项）。 */
+    public void deleteType(Long id) {
+        DictGateway gateway = gatewayProvider.get();
+        DictTypeEntity row = requireType(gateway, id);
+        Long itemCount = gateway.itemMapper().selectCount(
+            new QueryWrapper<DictItemEntity>().eq("dict_type", row.getDictType()));
+        if (itemCount != null && itemCount > 0) {
+            throw new BizException(ResultCode.RESOURCE_IN_USE,
+                "该类型下仍有 " + itemCount + " 个字典项，请先删除字典项");
+        }
+        gateway.typeMapper().deleteById(id);
+    }
+
+    // ---------- 字典项 ----------
+
+    /** 某类型下全部字典项（含停用，sort 升序）。 */
+    public List<DictItemVO> listItems(String dictType) {
+        requireText(dictType);
+        List<DictItemEntity> rows = gatewayProvider.get().itemMapper().selectList(
+            new QueryWrapper<DictItemEntity>().eq("dict_type", dictType).orderByAsc("sort", "id"));
+        List<DictItemVO> result = new ArrayList<>(rows.size());
+        for (DictItemEntity row : rows) {
+            result.add(toItemVO(row));
+        }
+        return result;
+    }
+
+    /** 新增字典项；同类型下键唯一冲突抛 {@link ResultCode#RESOURCE_DUPLICATE}。 */
+    public void createItem(String dictType, DictItemSaveRequest request) {
+        requireText(dictType);
+        DictGateway gateway = gatewayProvider.get();
+        requireTypeByCode(gateway, dictType);
+        Long exists = gateway.itemMapper().selectCount(new QueryWrapper<DictItemEntity>()
+            .eq("dict_type", dictType).eq("item_key", request.getItemKey()));
+        if (exists != null && exists > 0) {
+            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "字典项已存在: " + request.getItemKey());
+        }
+        long now = System.currentTimeMillis();
+        DictItemEntity row = new DictItemEntity();
+        row.setDictType(dictType);
+        row.setItemKey(request.getItemKey());
+        row.setItemLabel(request.getItemLabel());
+        row.setSort(request.getSort() == null ? 0 : request.getSort());
+        row.setEnabled(request.getEnabled() == null || request.getEnabled());
+        row.setRemark(request.getRemark());
+        row.setCreatedAtMs(now);
+        row.setUpdatedAtMs(now);
+        gateway.itemMapper().insert(row);
+    }
+
+    /** 编辑字典项（键/文案/排序/启停/备注）；不允许挪类型。改键时校验同类型下唯一。 */
+    public void updateItem(Long id, DictItemSaveRequest request) {
+        DictGateway gateway = gatewayProvider.get();
+        DictItemEntity row = requireItem(gateway, id);
+        if (!row.getItemKey().equals(request.getItemKey())) {
+            Long exists = gateway.itemMapper().selectCount(new QueryWrapper<DictItemEntity>()
+                .eq("dict_type", row.getDictType()).eq("item_key", request.getItemKey()));
+            if (exists != null && exists > 0) {
+                throw new BizException(ResultCode.RESOURCE_DUPLICATE, "字典项已存在: " + request.getItemKey());
+            }
+        }
+        row.setItemKey(request.getItemKey());
+        row.setItemLabel(request.getItemLabel());
+        if (request.getSort() != null) {
+            row.setSort(request.getSort());
+        }
+        if (request.getEnabled() != null) {
+            row.setEnabled(request.getEnabled());
+        }
+        row.setRemark(request.getRemark());
+        row.setUpdatedAtMs(System.currentTimeMillis());
+        gateway.itemMapper().updateById(row);
+    }
+
+    /** 删除字典项。 */
+    public void deleteItem(Long id) {
+        DictGateway gateway = gatewayProvider.get();
+        requireItem(gateway, id);
+        gateway.itemMapper().deleteById(id);
+    }
+
+    // ---------- 消费端 ----------
+
+    /** 某类型下启用项的下拉选项（sort 升序）；类型停用或不存在返回空列表（消费端按无字典配置降级）。 */
+    public List<DictOptionVO> options(String dictType) {
+        requireText(dictType);
+        DictGateway gateway = gatewayProvider.get();
+        Long enabledType = gateway.typeMapper().selectCount(new QueryWrapper<DictTypeEntity>()
+            .eq("dict_type", dictType).eq("enabled", true));
+        if (enabledType == null || enabledType == 0) {
+            return List.of();
+        }
+        List<DictItemEntity> rows = gateway.itemMapper().selectList(new QueryWrapper<DictItemEntity>()
+            .eq("dict_type", dictType).eq("enabled", true).orderByAsc("sort", "id"));
+        List<DictOptionVO> result = new ArrayList<>(rows.size());
+        for (DictItemEntity row : rows) {
+            result.add(new DictOptionVO(row.getItemKey(), row.getItemLabel()));
+        }
+        return result;
+    }
+
+    // ---------- 私有辅助 ----------
+
+    private DictTypeEntity requireType(DictGateway gateway, Long id) {
+        DictTypeEntity row = gateway.typeMapper().selectById(id);
+        if (row == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "字典类型不存在: " + id);
+        }
+        return row;
+    }
+
+    private void requireTypeByCode(DictGateway gateway, String dictType) {
+        Long exists = gateway.typeMapper().selectCount(
+            new QueryWrapper<DictTypeEntity>().eq("dict_type", dictType));
+        if (exists == null || exists == 0) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "字典类型不存在: " + dictType);
+        }
+    }
+
+    private DictItemEntity requireItem(DictGateway gateway, Long id) {
+        DictItemEntity row = gateway.itemMapper().selectById(id);
+        if (row == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "字典项不存在: " + id);
+        }
+        return row;
+    }
+
+    private void requireText(String dictType) {
+        if (!StringUtils.hasText(dictType)) {
+            throw new BizException(ResultCode.PARAM_MISSING, "缺少字典类型编码");
+        }
+    }
+
+    private DictTypeVO toTypeVO(DictTypeEntity row) {
+        DictTypeVO vo = new DictTypeVO();
+        vo.setId(row.getId());
+        vo.setDictType(row.getDictType());
+        vo.setTypeName(row.getTypeName());
+        vo.setRemark(row.getRemark());
+        vo.setEnabled(row.getEnabled());
+        vo.setCreatedAtMs(row.getCreatedAtMs());
+        vo.setUpdatedAtMs(row.getUpdatedAtMs());
+        return vo;
+    }
+
+    private DictItemVO toItemVO(DictItemEntity row) {
+        DictItemVO vo = new DictItemVO();
+        vo.setId(row.getId());
+        vo.setDictType(row.getDictType());
+        vo.setItemKey(row.getItemKey());
+        vo.setItemLabel(row.getItemLabel());
+        vo.setSort(row.getSort());
+        vo.setEnabled(row.getEnabled());
+        vo.setRemark(row.getRemark());
+        vo.setCreatedAtMs(row.getCreatedAtMs());
+        vo.setUpdatedAtMs(row.getUpdatedAtMs());
+        return vo;
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V46__dict_management.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V46__dict_management.sql
@@ -1,0 +1,17 @@
+-- 字典管理菜单权限（Flyway V46）。
+--
+-- 字典数据两表（cw_dict_type / cw_dict_item）在客服端库（agent_scope_customer_work），由 starter 的
+-- SchemaInitializer 建表并种子，本迁移只登记 admin 侧菜单与按钮权限点——照内容风控（V42）的先例：
+-- admin 直连客服端库维护（DictGatewayProvider 惰性数据源），单一数据真源、不做双写同步。
+-- 无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接返回全部权限点。
+
+-- 二级菜单：字典管理（挂系统管理 id=1 下，排在轮播图管理 sort=7 之后）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (216, 1, '字典管理', 'dict:view', 1, '/system/dict', 'Collection', 'library', 8);
+
+-- 三级：按钮/接口权限点（type=2）。类型与字典项共用同一组权限点——
+-- 它们是同一能力（维护一份字典）的两级视图，不是两个独立的能力边界。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (217, 216, '新增字典', 'dict:add', 2, 1),
+    (218, 216, '编辑字典', 'dict:edit', 2, 2),
+    (219, 216, '删除字典', 'dict:delete', 2, 3);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/dict/service/DictServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/dict/service/DictServiceTest.java
@@ -1,0 +1,160 @@
+package com.richard.fyoung.customeradmin.dict.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.dict.config.DictGatewayProvider;
+import com.richard.fyoung.customeradmin.dict.dto.DictItemSaveRequest;
+import com.richard.fyoung.customeradmin.dict.dto.DictOptionVO;
+import com.richard.fyoung.customeradmin.dict.dto.DictTypeSaveRequest;
+import com.richard.fyoung.customeradmin.dict.jdbc.DictGateway;
+import com.richard.fyoung.customerwork.dict.entity.DictItemEntity;
+import com.richard.fyoung.customerwork.dict.entity.DictTypeEntity;
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link DictService} 单测：类型编码判重/不可变更、有项类型禁删、字典项同类型判重、
+ * 停用类型的 options 返回空、缺参 fast fail。
+ * @author owlzhangfq@gmail.com
+ */
+class DictServiceTest {
+
+    private DictTypeMapper typeMapper;
+    private DictItemMapper itemMapper;
+    private DictService service;
+
+    @BeforeEach
+    void setUp() {
+        typeMapper = mock(DictTypeMapper.class);
+        itemMapper = mock(DictItemMapper.class);
+        DictGatewayProvider provider = mock(DictGatewayProvider.class);
+        when(provider.get()).thenReturn(new DictGateway(typeMapper, itemMapper));
+        service = new DictService(provider);
+    }
+
+    private DictTypeSaveRequest typeRequest(String code, String name) {
+        DictTypeSaveRequest request = new DictTypeSaveRequest();
+        request.setDictType(code);
+        request.setTypeName(name);
+        return request;
+    }
+
+    private DictItemSaveRequest itemRequest(String key, String label) {
+        DictItemSaveRequest request = new DictItemSaveRequest();
+        request.setItemKey(key);
+        request.setItemLabel(label);
+        return request;
+    }
+
+    private DictTypeEntity typeRow(long id, String code, boolean enabled) {
+        DictTypeEntity row = new DictTypeEntity();
+        row.setId(id);
+        row.setDictType(code);
+        row.setTypeName("名称");
+        row.setEnabled(enabled);
+        return row;
+    }
+
+    @Test
+    void createType_shouldRejectDuplicateCode() {
+        when(typeMapper.selectCount(any())).thenReturn(1L);
+
+        BizException e = assertThrows(BizException.class, () -> service.createType(typeRequest("order_status", "订单状态")));
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, e.getResultCode());
+        verify(typeMapper, never()).insert(any(DictTypeEntity.class));
+    }
+
+    @Test
+    void createType_shouldDefaultEnabled_andStampTimestamps() {
+        when(typeMapper.selectCount(any())).thenReturn(0L);
+
+        service.createType(typeRequest("order_status", "订单状态"));
+
+        ArgumentCaptor<DictTypeEntity> captor = ArgumentCaptor.forClass(DictTypeEntity.class);
+        verify(typeMapper).insert(captor.capture());
+        assertTrue(captor.getValue().getEnabled(), "缺省应启用");
+        assertTrue(captor.getValue().getCreatedAtMs() > 0);
+    }
+
+    @Test
+    void updateType_shouldRejectCodeChange() {
+        when(typeMapper.selectById(1L)).thenReturn(typeRow(1L, "order_status", true));
+
+        BizException e = assertThrows(BizException.class, () -> service.updateType(1L, typeRequest("other_code", "订单状态")));
+        assertEquals(ResultCode.PARAM_INVALID, e.getResultCode());
+    }
+
+    @Test
+    void deleteType_shouldRejectWhenItemsExist() {
+        when(typeMapper.selectById(1L)).thenReturn(typeRow(1L, "order_status", true));
+        when(itemMapper.selectCount(any())).thenReturn(3L);
+
+        BizException e = assertThrows(BizException.class, () -> service.deleteType(1L));
+        assertEquals(ResultCode.RESOURCE_IN_USE, e.getResultCode());
+        verify(typeMapper, never()).deleteById(1L);
+    }
+
+    @Test
+    void createItem_shouldRejectDuplicateKeyInSameType() {
+        // 第一次 selectCount 校验类型存在，第二次校验键唯一
+        when(typeMapper.selectCount(any())).thenReturn(1L);
+        when(itemMapper.selectCount(any())).thenReturn(1L);
+
+        BizException e = assertThrows(BizException.class, () -> service.createItem("order_status", itemRequest("待支付", "待支付")));
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, e.getResultCode());
+        verify(itemMapper, never()).insert(any(DictItemEntity.class));
+    }
+
+    @Test
+    void createItem_shouldRejectUnknownType() {
+        when(typeMapper.selectCount(any())).thenReturn(0L);
+
+        BizException e = assertThrows(BizException.class, () -> service.createItem("no_such", itemRequest("k", "v")));
+        assertEquals(ResultCode.RESOURCE_NOT_FOUND, e.getResultCode());
+    }
+
+    @Test
+    void options_shouldReturnEmpty_whenTypeDisabledOrMissing() {
+        when(typeMapper.selectCount(any())).thenReturn(0L);
+
+        assertTrue(service.options("order_status").isEmpty(), "停用/不存在的类型应返回空列表");
+        verify(itemMapper, never()).selectList(any());
+    }
+
+    @Test
+    void options_shouldReturnEnabledItems_asValueLabelPairs() {
+        when(typeMapper.selectCount(any())).thenReturn(1L);
+        DictItemEntity item = new DictItemEntity();
+        item.setDictType("order_status");
+        item.setItemKey("待支付");
+        item.setItemLabel("待支付");
+        item.setSort(1);
+        item.setEnabled(true);
+        when(itemMapper.selectList(any())).thenReturn(List.of(item));
+
+        List<DictOptionVO> options = service.options("order_status");
+        assertEquals(1, options.size());
+        assertEquals("待支付", options.get(0).getValue());
+        assertEquals("待支付", options.get(0).getLabel());
+    }
+
+    @Test
+    void listItems_shouldFastFailOnBlankType() {
+        BizException e = assertThrows(BizException.class, () -> service.listItems("  "));
+        assertEquals(ResultCode.PARAM_MISSING, e.getResultCode());
+    }
+}

--- a/customer-admin-web/src/api/dict.ts
+++ b/customer-admin-web/src/api/dict.ts
@@ -1,0 +1,91 @@
+import { request } from './request'
+
+// 字典管理 API，与 admin-server /api/dict/** 契约对应。
+// 字典数据落在客服端库 cw_dict_type / cw_dict_item（单一数据真源），admin 直连维护。
+
+export interface DictTypeVO {
+  id: number
+  dictType: string
+  typeName: string
+  remark: string | null
+  enabled: boolean
+  itemCount: number
+  createdAtMs: number | null
+  updatedAtMs: number | null
+}
+
+export interface DictTypeSaveRequest {
+  dictType: string
+  typeName: string
+  remark?: string | null
+  enabled?: boolean
+}
+
+export interface DictItemVO {
+  id: number
+  dictType: string
+  itemKey: string
+  itemLabel: string
+  sort: number
+  enabled: boolean
+  remark: string | null
+  createdAtMs: number | null
+  updatedAtMs: number | null
+}
+
+export interface DictItemSaveRequest {
+  itemKey: string
+  itemLabel: string
+  sort?: number
+  enabled?: boolean
+  remark?: string | null
+}
+
+/** 消费端下拉选项（仅启用项）。 */
+export interface DictOption {
+  value: string
+  label: string
+}
+
+// ---------- 字典类型 ----------
+
+export function listDictTypes() {
+  return request<DictTypeVO[]>({ url: '/dict/types', method: 'get' })
+}
+
+export function createDictType(data: DictTypeSaveRequest) {
+  return request<void>({ url: '/dict/types', method: 'post', data })
+}
+
+export function updateDictType(id: number, data: DictTypeSaveRequest) {
+  return request<void>({ url: `/dict/types/${id}`, method: 'put', data })
+}
+
+export function deleteDictType(id: number) {
+  return request<void>({ url: `/dict/types/${id}`, method: 'delete' })
+}
+
+// ---------- 字典项 ----------
+
+export function listDictItems(dictType: string) {
+  return request<DictItemVO[]>({ url: '/dict/items', method: 'get', params: { dictType } })
+}
+
+export function createDictItem(dictType: string, data: DictItemSaveRequest) {
+  return request<void>({ url: '/dict/items', method: 'post', params: { dictType }, data })
+}
+
+export function updateDictItem(id: number, data: DictItemSaveRequest) {
+  return request<void>({ url: `/dict/items/${id}`, method: 'put', data })
+}
+
+export function deleteDictItem(id: number) {
+  return request<void>({ url: `/dict/items/${id}`, method: 'delete' })
+}
+
+// ---------- 消费端 ----------
+
+/** 业务页面下拉选项：仅启用项；类型停用/不存在返回空数组（调用方自带硬编码兜底）。 */
+export function fetchDictOptions(dictType: string) {
+  return request<DictOption[]>({ url: `/dict/options/${dictType}`, method: 'get' })
+}

--- a/customer-admin-web/src/composables/useDict.ts
+++ b/customer-admin-web/src/composables/useDict.ts
@@ -1,0 +1,32 @@
+import { ref, type Ref } from 'vue'
+import { fetchDictOptions, type DictOption } from '@/api/dict'
+
+/**
+ * 通用字典下拉 hook：按字典类型编码取启用选项，供各业务页面替代硬编码下拉。
+ *
+ * - 模块级缓存：同一类型整个 SPA 生命周期内只请求一次（字典是低频变更数据，改完刷新页面即可）。
+ * - 硬编码兜底：接口失败或类型未配置（空数组）时保留 fallback——字典是展示增强，不能因为
+ *   客服端库不可达就让业务页面的筛选框变成空白。
+ */
+const optionsCache = new Map<string, Promise<DictOption[]>>()
+
+export function useDict(dictType: string, fallback: DictOption[] = []): { options: Ref<DictOption[]> } {
+  const options = ref<DictOption[]>(fallback)
+
+  let pending = optionsCache.get(dictType)
+  if (!pending) {
+    pending = fetchDictOptions(dictType).catch(() => {
+      // 失败不缓存成功值：从缓存剔除，下一个使用方重试
+      optionsCache.delete(dictType)
+      return [] as DictOption[]
+    })
+    optionsCache.set(dictType, pending)
+  }
+  pending.then((list) => {
+    if (list.length > 0) {
+      options.value = list
+    }
+  })
+
+  return { options }
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -14,6 +14,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/menu': () => import('@/views/system/MenuManage.vue'),
   '/system/devtools': () => import('@/views/system/DevToolboxView.vue'),
   '/system/login-image': () => import('@/views/system/LoginImageManage.vue'),
+  '/system/dict': () => import('@/views/system/DictManage.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),

--- a/customer-admin-web/src/views/system/DictManage.vue
+++ b/customer-admin-web/src/views/system/DictManage.vue
@@ -1,0 +1,408 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import type { FormInstance, FormRules } from 'element-plus'
+import {
+  createDictItem,
+  createDictType,
+  deleteDictItem,
+  deleteDictType,
+  listDictItems,
+  listDictTypes,
+  updateDictItem,
+  updateDictType,
+  type DictItemSaveRequest,
+  type DictItemVO,
+  type DictTypeSaveRequest,
+  type DictTypeVO,
+} from '@/api/dict'
+
+// ---------- 类型列表（左侧） ----------
+
+const typeLoading = ref(false)
+const types = ref<DictTypeVO[]>([])
+const typeKeyword = ref('')
+const activeType = ref<DictTypeVO | null>(null)
+
+function filteredTypes(): DictTypeVO[] {
+  const kw = typeKeyword.value.trim().toLowerCase()
+  if (!kw) return types.value
+  return types.value.filter(
+    (t) => t.dictType.toLowerCase().includes(kw) || t.typeName.toLowerCase().includes(kw),
+  )
+}
+
+async function loadTypes(keepActive = true) {
+  typeLoading.value = true
+  try {
+    types.value = await listDictTypes()
+    if (keepActive && activeType.value) {
+      activeType.value = types.value.find((t) => t.id === activeType.value?.id) ?? types.value[0] ?? null
+    } else {
+      activeType.value = types.value[0] ?? null
+    }
+    await loadItems()
+  } finally {
+    typeLoading.value = false
+  }
+}
+
+async function selectType(row: DictTypeVO) {
+  activeType.value = row
+  await loadItems()
+}
+
+// ---------- 类型编辑弹窗 ----------
+
+const typeDialogVisible = ref(false)
+const typeDialogMode = ref<'create' | 'edit'>('create')
+const typeFormRef = ref<FormInstance>()
+const editingTypeId = ref<number | null>(null)
+const typeForm = reactive<DictTypeSaveRequest>({ dictType: '', typeName: '', remark: '', enabled: true })
+
+const typeRules: FormRules = {
+  dictType: [
+    { required: true, message: '请输入类型编码', trigger: 'blur' },
+    { pattern: /^[a-z][a-z0-9_]{1,63}$/, message: '小写字母开头的小写字母/数字/下划线，2-64 位', trigger: 'blur' },
+  ],
+  typeName: [{ required: true, message: '请输入类型名称', trigger: 'blur' }],
+}
+
+function openCreateType() {
+  typeDialogMode.value = 'create'
+  editingTypeId.value = null
+  Object.assign(typeForm, { dictType: '', typeName: '', remark: '', enabled: true })
+  typeDialogVisible.value = true
+}
+
+function openEditType(row: DictTypeVO) {
+  typeDialogMode.value = 'edit'
+  editingTypeId.value = row.id
+  Object.assign(typeForm, {
+    dictType: row.dictType, typeName: row.typeName, remark: row.remark ?? '', enabled: row.enabled,
+  })
+  typeDialogVisible.value = true
+}
+
+async function submitType() {
+  await typeFormRef.value?.validate()
+  if (typeDialogMode.value === 'create') {
+    await createDictType({ ...typeForm })
+    ElMessage.success('类型已创建')
+  } else if (editingTypeId.value != null) {
+    await updateDictType(editingTypeId.value, { ...typeForm })
+    ElMessage.success('类型已更新')
+  }
+  typeDialogVisible.value = false
+  await loadTypes()
+}
+
+async function handleDeleteType(row: DictTypeVO) {
+  await ElMessageBox.confirm(
+    `确认删除字典类型「${row.typeName}」（${row.dictType}）？该类型下仍有字典项时将被拒绝。`,
+    '删除确认', { type: 'warning' },
+  )
+  await deleteDictType(row.id)
+  ElMessage.success('类型已删除')
+  if (activeType.value?.id === row.id) {
+    activeType.value = null
+  }
+  await loadTypes(false)
+}
+
+// ---------- 字典项（右侧） ----------
+
+const itemLoading = ref(false)
+const items = ref<DictItemVO[]>([])
+
+async function loadItems() {
+  if (!activeType.value) {
+    items.value = []
+    return
+  }
+  itemLoading.value = true
+  try {
+    items.value = await listDictItems(activeType.value.dictType)
+  } finally {
+    itemLoading.value = false
+  }
+}
+
+// ---------- 字典项编辑弹窗 ----------
+
+const itemDialogVisible = ref(false)
+const itemDialogMode = ref<'create' | 'edit'>('create')
+const itemFormRef = ref<FormInstance>()
+const editingItemId = ref<number | null>(null)
+const itemForm = reactive<DictItemSaveRequest>({ itemKey: '', itemLabel: '', sort: 0, enabled: true, remark: '' })
+
+const itemRules: FormRules = {
+  itemKey: [{ required: true, message: '请输入字典项键（业务值）', trigger: 'blur' }],
+  itemLabel: [{ required: true, message: '请输入字典项标签（展示文案）', trigger: 'blur' }],
+}
+
+function openCreateItem() {
+  itemDialogMode.value = 'create'
+  editingItemId.value = null
+  const nextSort = items.value.length > 0 ? Math.max(...items.value.map((i) => i.sort)) + 1 : 1
+  Object.assign(itemForm, { itemKey: '', itemLabel: '', sort: nextSort, enabled: true, remark: '' })
+  itemDialogVisible.value = true
+}
+
+function openEditItem(row: DictItemVO) {
+  itemDialogMode.value = 'edit'
+  editingItemId.value = row.id
+  Object.assign(itemForm, {
+    itemKey: row.itemKey, itemLabel: row.itemLabel, sort: row.sort, enabled: row.enabled, remark: row.remark ?? '',
+  })
+  itemDialogVisible.value = true
+}
+
+async function submitItem() {
+  await itemFormRef.value?.validate()
+  if (itemDialogMode.value === 'create') {
+    if (!activeType.value) return
+    await createDictItem(activeType.value.dictType, { ...itemForm })
+    ElMessage.success('字典项已创建')
+  } else if (editingItemId.value != null) {
+    await updateDictItem(editingItemId.value, { ...itemForm })
+    ElMessage.success('字典项已更新')
+  }
+  itemDialogVisible.value = false
+  await loadItems()
+  await refreshTypeCounts()
+}
+
+async function toggleItem(row: DictItemVO) {
+  await updateDictItem(row.id, {
+    itemKey: row.itemKey, itemLabel: row.itemLabel, sort: row.sort, enabled: !row.enabled, remark: row.remark,
+  })
+  ElMessage.success(row.enabled ? '已停用' : '已启用')
+  await loadItems()
+}
+
+async function handleDeleteItem(row: DictItemVO) {
+  await ElMessageBox.confirm(`确认删除字典项「${row.itemLabel}」（${row.itemKey}）？`, '删除确认', { type: 'warning' })
+  await deleteDictItem(row.id)
+  ElMessage.success('字典项已删除')
+  await loadItems()
+  await refreshTypeCounts()
+}
+
+/** 项增删后仅刷新左侧计数，不打断当前选中态。 */
+async function refreshTypeCounts() {
+  types.value = await listDictTypes()
+  if (activeType.value) {
+    activeType.value = types.value.find((t) => t.id === activeType.value?.id) ?? activeType.value
+  }
+}
+
+function formatTime(ms: number | null): string {
+  return ms ? new Date(ms).toLocaleString('zh-CN') : '-'
+}
+
+onMounted(loadTypes)
+</script>
+
+<template>
+  <div class="page">
+    <el-alert type="info" :closable="false" show-icon class="notice">
+      字典解决"就几条枚举数据、不值当建表"的场景：新增一类下拉/标签数据时在此配置即可，业务页面经
+      <code>useDict('类型编码')</code> 读取。数据存客服端库（cw_dict_type / cw_dict_item），客服端
+      <code>customer-work.dict.store-mode=jdbc</code> 时读同一份数据。
+    </el-alert>
+
+    <div class="layout">
+      <!-- 左：字典类型 -->
+      <el-card class="type-panel">
+        <template #header>
+          <div class="panel-header">
+            <span>字典类型</span>
+            <el-button v-permission="'dict:add'" type="primary" size="small" @click="openCreateType">新增类型</el-button>
+          </div>
+        </template>
+        <el-input v-model="typeKeyword" placeholder="按编码或名称过滤" clearable class="type-filter" />
+        <el-table
+          v-loading="typeLoading"
+          :data="filteredTypes()"
+          highlight-current-row
+          :row-class-name="({ row }) => (row.id === activeType?.id ? 'active-row' : '')"
+          @row-click="selectType"
+        >
+          <el-table-column label="类型" min-width="140">
+            <template #default="{ row }">
+              <div class="type-cell">
+                <span class="type-name">{{ row.typeName }}</span>
+                <span class="type-code">{{ row.dictType }}</span>
+              </div>
+            </template>
+          </el-table-column>
+          <el-table-column label="项数" width="60" align="center">
+            <template #default="{ row }">{{ row.itemCount }}</template>
+          </el-table-column>
+          <el-table-column label="状态" width="70" align="center">
+            <template #default="{ row }">
+              <el-tag :type="row.enabled ? 'success' : 'info'" size="small">{{ row.enabled ? '启用' : '停用' }}</el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="操作" width="110" align="center">
+            <template #default="{ row }">
+              <el-button v-permission="'dict:edit'" link type="primary" size="small" @click.stop="openEditType(row)">编辑</el-button>
+              <el-button v-permission="'dict:delete'" link type="danger" size="small" @click.stop="handleDeleteType(row)">删除</el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+
+      <!-- 右：字典项 -->
+      <el-card class="item-panel">
+        <template #header>
+          <div class="panel-header">
+            <span>
+              字典项
+              <template v-if="activeType">
+                · {{ activeType.typeName }}（<code>{{ activeType.dictType }}</code>）
+              </template>
+            </span>
+            <el-button
+              v-permission="'dict:add'"
+              type="primary"
+              size="small"
+              :disabled="!activeType"
+              @click="openCreateItem"
+            >新增字典项</el-button>
+          </div>
+        </template>
+        <el-empty v-if="!activeType" description="左侧选择一个字典类型" />
+        <el-table v-else v-loading="itemLoading" :data="items">
+          <el-table-column prop="sort" label="排序" width="70" align="center" />
+          <el-table-column prop="itemKey" label="键（业务值）" min-width="140" show-overflow-tooltip />
+          <el-table-column prop="itemLabel" label="标签（展示文案）" min-width="140" show-overflow-tooltip />
+          <el-table-column label="状态" width="80" align="center">
+            <template #default="{ row }">
+              <el-tag :type="row.enabled ? 'success' : 'info'" size="small">{{ row.enabled ? '启用' : '停用' }}</el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column prop="remark" label="备注" min-width="120" show-overflow-tooltip />
+          <el-table-column label="更新时间" width="170">
+            <template #default="{ row }">{{ formatTime(row.updatedAtMs) }}</template>
+          </el-table-column>
+          <el-table-column label="操作" width="160" fixed="right">
+            <template #default="{ row }">
+              <el-button v-permission="'dict:edit'" link type="primary" @click="openEditItem(row)">编辑</el-button>
+              <el-button v-permission="'dict:edit'" link type="primary" @click="toggleItem(row)">
+                {{ row.enabled ? '停用' : '启用' }}
+              </el-button>
+              <el-button v-permission="'dict:delete'" link type="danger" @click="handleDeleteItem(row)">删除</el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+    </div>
+
+    <!-- 类型弹窗 -->
+    <el-dialog
+      v-model="typeDialogVisible"
+      :title="typeDialogMode === 'create' ? '新增字典类型' : '编辑字典类型'"
+      width="480px"
+    >
+      <el-form ref="typeFormRef" :model="typeForm" :rules="typeRules" label-width="90px">
+        <el-form-item label="类型编码" prop="dictType">
+          <el-input v-model="typeForm.dictType" :disabled="typeDialogMode === 'edit'" placeholder="如 order_status" />
+        </el-form-item>
+        <el-form-item label="类型名称" prop="typeName">
+          <el-input v-model="typeForm.typeName" placeholder="如 订单状态" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="typeForm.remark" type="textarea" :rows="2" maxlength="255" />
+        </el-form-item>
+        <el-form-item label="启用">
+          <el-switch v-model="typeForm.enabled" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="typeDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submitType">确定</el-button>
+      </template>
+    </el-dialog>
+
+    <!-- 字典项弹窗 -->
+    <el-dialog
+      v-model="itemDialogVisible"
+      :title="itemDialogMode === 'create' ? '新增字典项' : '编辑字典项'"
+      width="480px"
+    >
+      <el-form ref="itemFormRef" :model="itemForm" :rules="itemRules" label-width="110px">
+        <el-form-item label="键（业务值）" prop="itemKey">
+          <el-input v-model="itemForm.itemKey" placeholder="参与业务匹配的值" />
+        </el-form-item>
+        <el-form-item label="标签（文案）" prop="itemLabel">
+          <el-input v-model="itemForm.itemLabel" placeholder="下拉/标签展示的文案" />
+        </el-form-item>
+        <el-form-item label="排序">
+          <el-input-number v-model="itemForm.sort" :min="0" :max="9999" />
+        </el-form-item>
+        <el-form-item label="启用">
+          <el-switch v-model="itemForm.enabled" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="itemForm.remark" type="textarea" :rows="2" maxlength="255" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="itemDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submitItem">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.notice {
+  margin-bottom: 12px;
+}
+
+.layout {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.type-panel {
+  width: 420px;
+  flex-shrink: 0;
+}
+
+.item-panel {
+  flex: 1;
+  min-width: 0;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.type-filter {
+  margin-bottom: 8px;
+}
+
+.type-cell {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.type-name {
+  font-weight: 500;
+}
+
+.type-code {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+:deep(.active-row) {
+  background: var(--el-color-primary-light-9);
+}
+</style>

--- a/customer-admin-web/src/views/ticket/UserOrderManage.vue
+++ b/customer-admin-web/src/views/ticket/UserOrderManage.vue
@@ -3,6 +3,14 @@ import { reactive, ref } from 'vue'
 import type { FormInstance } from 'element-plus'
 import { cancelOrder, getOrderDetail, modifyOrderAddress, pageOrders } from '@/api/user-order'
 import { ORDER_STATUS_OPTIONS, ORDER_STATUS_TAG_TYPE, type OrderDetailVO, type OrderPageQuery, type OrderVO } from '@/types/order'
+import { useDict } from '@/composables/useDict'
+
+// 状态筛选项走字典（类型编码 order_status，后台"系统管理→字典管理"维护）；
+// 字典未配置或接口失败时回落到本地硬编码 ORDER_STATUS_OPTIONS，页面不受影响。
+const { options: orderStatusOptions } = useDict(
+  'order_status',
+  ORDER_STATUS_OPTIONS.map((s) => ({ value: s, label: s })),
+)
 
 const loading = ref(false)
 const list = ref<OrderVO[]>([])
@@ -117,7 +125,7 @@ async function handleCancelSubmit() {
         <el-input v-model="query.username" placeholder="用户名" clearable style="width: 140px" @keyup.enter="handleSearch" />
         <el-input v-model="query.orderId" placeholder="订单号" clearable style="width: 160px" @keyup.enter="handleSearch" />
         <el-select v-model="query.status" placeholder="状态" clearable style="width: 140px" @change="handleSearch">
-          <el-option v-for="status in ORDER_STATUS_OPTIONS" :key="status" :value="status" :label="status" />
+          <el-option v-for="opt in orderStatusOptions" :key="opt.value" :value="opt.value" :label="opt.label" />
         </el-select>
         <el-button v-permission="'user-order:view'" type="primary" @click="handleSearch">查询</el-button>
       </div>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -551,6 +551,9 @@ public class CustomerWorkProperties {
     /** 用户反馈（消息级点赞/点踩）存储配置。 */
     private final Feedback feedback = new Feedback();
 
+    /** 数据字典（少量枚举型键值数据，免建表）存储配置。 */
+    private final Dict dict = new Dict();
+
     /** 智能客服工单配置（存储 + 转人工关键词 + SLA 阈值与自动流转）。 */
     private final Ticket ticket = new Ticket();
 
@@ -767,6 +770,18 @@ public class CustomerWorkProperties {
     @Data
     public static class Feedback {
         /** 存储模式：memory（进程内，默认，仅单实例场景适用）| jdbc（跨实例共享）。 */
+        private String storeMode = "memory";
+    }
+
+    /**
+     * 数据字典存储配置。
+     *
+     * <p>决定 {@code DictStore} 的实现：memory 模式仅进程内演示种子；jdbc 模式读客服端库
+     * {@code cw_dict_type} / {@code cw_dict_item}（后台字典管理页维护的即这两张表）。</p>
+     */
+    @Data
+    public static class Dict {
+        /** 存储模式：memory（进程内种子，默认）| jdbc（读客服端库字典表）。 */
         private String storeMode = "memory";
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/PersistenceJdbcCondition.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/PersistenceJdbcCondition.java
@@ -26,6 +26,7 @@ public class PersistenceJdbcCondition implements Condition {
         "customer-work.dialog.store-mode",
         "customer-work.human-handoff.store-mode",
         "customer-work.feedback.store-mode",
+        "customer-work.dict.store-mode",
         "customer-work.user-auth.store-mode",
         "customer-work.chat-log.store-mode",
         "customer-work.call-log.store-mode",

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictConfig.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customerwork.dict;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 字典存储配置。
+ *
+ * <p>按 {@code customer-work.dict.store-mode} 选择实现：默认 {@code memory}（进程内种子，离线可测）；
+ * {@code jdbc} 落地为 {@link MybatisDictStore}（复用 {@code CustomerWorkPersistenceConfig} 的独立持久化
+ * 环境）。Mapper 用 {@link ObjectProvider} 惰性获取，仅 jdbc 分支取用。
+ * 下游声明自己的 {@link DictStore} Bean 即可整体覆盖。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class DictConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(DictConfig.class);
+
+    private static final String STORE_MODE_JDBC = "jdbc";
+
+    @Bean
+    @ConditionalOnMissingBean(DictStore.class)
+    public DictStore dictStore(CustomerWorkProperties properties,
+                               ObjectProvider<DictTypeMapper> typeMapperProvider,
+                               ObjectProvider<DictItemMapper> itemMapperProvider) {
+        String mode = properties.getDict().getStoreMode();
+        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+            log.info("dict store: jdbc (MyBatis-Plus 实现, tables=cw_dict_type/cw_dict_item)");
+            return new MybatisDictStore(typeMapperProvider.getObject(), itemMapperProvider.getObject());
+        }
+        log.info("dict store: memory (进程内种子，重启不保留，生产建议 store-mode=jdbc)");
+        return new InMemoryDictStore();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictItem.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictItem.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customerwork.dict;
+
+/**
+ * 字典项领域对象：某个字典类型下的一条键值（key 参与业务匹配，label 供展示）。
+ *
+ * <p>key 与 label 允许相同（如订单状态直接用中文文案作值）；sort 越小越靠前。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record DictItem(Long id, String dictType, String itemKey, String itemLabel,
+                       int sort, boolean enabled, String remark) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictStore.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.dict;
+
+import java.util.List;
+
+/**
+ * 字典存储 SPI（持久化扩展点，运行时只读）。
+ *
+ * <p>默认 {@link InMemoryDictStore}（进程内、带演示种子，离线可测）；生产可切
+ * {@link MybatisDictStore}（{@code customer-work.dict.store-mode=jdbc}，落 {@code cw_dict_type} /
+ * {@code cw_dict_item} 两表），或下游声明同类型 Bean 覆盖。</p>
+ *
+ * <p><b>职责边界</b>：本 SPI 只承担客服端运行时的读取；字典的增删改由后台管理系统直连客服端库
+ * 的同两张表完成（照内容风控先例，单一数据真源、不做双写同步）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface DictStore {
+
+    /** 全部启用的字典类型（sort 无关，按 dict_type 排序）。 */
+    List<DictType> listEnabledTypes();
+
+    /** 某类型下全部启用的字典项（按 sort 升序）；类型不存在或未配置返回空列表。 */
+    List<DictItem> findEnabledItems(String dictType);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictType.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/DictType.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customerwork.dict;
+
+/**
+ * 字典类型领域对象：一组字典项的命名空间（如 order_status = 订单状态）。
+ *
+ * <p>字典解决的是"就几条枚举数据、不值当单独建表"的场景：新增一类下拉/标签数据时，
+ * 在后台字典管理里配一个类型 + 若干项即可，不再新建表与 CRUD。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record DictType(String dictType, String typeName, String remark, boolean enabled) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/InMemoryDictStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/InMemoryDictStore.java
@@ -1,0 +1,47 @@
+package com.richard.fyoung.customerwork.dict;
+
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 进程内字典存储（默认实现，离线可测）。
+ *
+ * <p>种子与 {@code customer-work-schema.sql} 中 {@code cw_dict_type} / {@code cw_dict_item}
+ * 的演示种子保持一致（order_status 订单状态七态），保证 memory / jdbc 两种模式下
+ * 消费方看到同一份演示数据。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemoryDictStore implements DictStore {
+
+    private final List<DictType> types;
+    private final List<DictItem> items;
+
+    public InMemoryDictStore() {
+        this.types = List.of(new DictType("order_status", "订单状态", "用户订单状态筛选项（与后端返回的中文文案一致）", true));
+        List<DictItem> seeds = new ArrayList<>();
+        String[] statuses = {"待支付", "已支付", "待发货", "已发货", "已签收", "已取消", "已退款"};
+        for (int i = 0; i < statuses.length; i++) {
+            seeds.add(new DictItem((long) (i + 1), "order_status", statuses[i], statuses[i], i + 1, true, null));
+        }
+        this.items = List.copyOf(seeds);
+    }
+
+    @Override
+    public List<DictType> listEnabledTypes() {
+        return types;
+    }
+
+    @Override
+    public List<DictItem> findEnabledItems(String dictType) {
+        if (!StringUtils.hasText(dictType)) {
+            return List.of();
+        }
+        return items.stream()
+            .filter(item -> dictType.equals(item.dictType()))
+            .sorted(Comparator.comparingInt(DictItem::sort))
+            .toList();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/MybatisDictStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/MybatisDictStore.java
@@ -1,0 +1,76 @@
+package com.richard.fyoung.customerwork.dict;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.richard.fyoung.customerwork.dict.entity.DictItemEntity;
+import com.richard.fyoung.customerwork.dict.entity.DictTypeEntity;
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
+import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * MyBatis-Plus 字典存储（生产实现：{@code customer-work.dict.store-mode=jdbc} 时装配）。
+ *
+ * <p>读 {@code cw_dict_type} / {@code cw_dict_item} 两表（客服端库唯一真源，后台管理系统直连维护）。
+ * 字典是展示型数据、非核心链路：读取失败只记 error 并返回空列表，不阻断主流程（同 Feedback 先例）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisDictStore implements DictStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MybatisDictStore.class);
+
+    private final DictTypeMapper typeMapper;
+    private final DictItemMapper itemMapper;
+
+    public MybatisDictStore(DictTypeMapper typeMapper, DictItemMapper itemMapper) {
+        this.typeMapper = typeMapper;
+        this.itemMapper = itemMapper;
+    }
+
+    @Override
+    public List<DictType> listEnabledTypes() {
+        try {
+            QueryWrapper<DictTypeEntity> wrapper = new QueryWrapper<DictTypeEntity>()
+                .eq("enabled", true)
+                .orderByAsc("dict_type");
+            List<DictTypeEntity> rows = typeMapper.selectList(wrapper);
+            List<DictType> result = new ArrayList<>(rows.size());
+            for (DictTypeEntity row : rows) {
+                result.add(new DictType(row.getDictType(), row.getTypeName(), row.getRemark(),
+                    Boolean.TRUE.equals(row.getEnabled())));
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("[MybatisDictStore] listEnabledTypes failed, errorCode={}", "DICT-STORE-LISTTYPES-FAIL", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public List<DictItem> findEnabledItems(String dictType) {
+        if (!StringUtils.hasText(dictType)) {
+            return List.of();
+        }
+        try {
+            QueryWrapper<DictItemEntity> wrapper = new QueryWrapper<DictItemEntity>()
+                .eq("dict_type", dictType)
+                .eq("enabled", true)
+                .orderByAsc("sort", "id");
+            List<DictItemEntity> rows = itemMapper.selectList(wrapper);
+            List<DictItem> result = new ArrayList<>(rows.size());
+            for (DictItemEntity row : rows) {
+                result.add(new DictItem(row.getId(), row.getDictType(), row.getItemKey(), row.getItemLabel(),
+                    row.getSort() == null ? 0 : row.getSort(), Boolean.TRUE.equals(row.getEnabled()), row.getRemark()));
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("[MybatisDictStore] findEnabledItems failed, errorCode={}, dictType={}",
+                "DICT-STORE-FINDITEMS-FAIL", dictType, e);
+            return List.of();
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/entity/DictItemEntity.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/entity/DictItemEntity.java
@@ -1,0 +1,41 @@
+package com.richard.fyoung.customerwork.dict.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 字典项持久化对象（贫血数据袋）：与 {@code cw_dict_item} 表一一映射。
+ * {@code (dict_type, item_key)} 唯一。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_dict_item")
+public class DictItemEntity {
+
+    /** 自增主键。 */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    /** 所属字典类型编码。 */
+    private String dictType;
+
+    /** 字典项键（业务值）。 */
+    private String itemKey;
+
+    /** 字典项标签（展示文案）。 */
+    private String itemLabel;
+
+    /** 排序号，越小越靠前。 */
+    private Integer sort;
+
+    /** 是否启用（1 启用 / 0 停用）。 */
+    private Boolean enabled;
+
+    /** 备注说明。 */
+    private String remark;
+
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/entity/DictTypeEntity.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/entity/DictTypeEntity.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customerwork.dict.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 字典类型持久化对象（贫血数据袋）：与 {@code cw_dict_type} 表一一映射。
+ * 驼峰字段由 MyBatis-Plus 下划线映射自动对应下划线列。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_dict_type")
+public class DictTypeEntity {
+
+    /** 自增主键。 */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    /** 字典类型编码（唯一，如 order_status）。 */
+    private String dictType;
+
+    /** 类型名称（展示用，如 订单状态）。 */
+    private String typeName;
+
+    /** 备注说明。 */
+    private String remark;
+
+    /** 是否启用（1 启用 / 0 停用）。 */
+    private Boolean enabled;
+
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/mapper/DictItemMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/mapper/DictItemMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customerwork.dict.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.dict.entity.DictItemEntity;
+
+/**
+ * 字典项 Mapper：单表 CRUD 全部由 {@link BaseMapper} 覆盖，无自定义 SQL、无 XML。
+ * @author owlzhangfq@gmail.com
+ */
+public interface DictItemMapper extends BaseMapper<DictItemEntity> {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/mapper/DictTypeMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dict/mapper/DictTypeMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customerwork.dict.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.dict.entity.DictTypeEntity;
+
+/**
+ * 字典类型 Mapper：单表 CRUD 全部由 {@link BaseMapper} 覆盖，无自定义 SQL、无 XML。
+ * @author owlzhangfq@gmail.com
+ */
+public interface DictTypeMapper extends BaseMapper<DictTypeEntity> {
+}

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -441,3 +441,43 @@ INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current
 ('SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
 ('SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
 ('SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);
+
+-- 数据字典（DictStore / cw_dict_type + cw_dict_item）：少量枚举型键值数据的统一落点，免于逐个建表。
+-- 后台管理系统"字典管理"页直连维护这两张表（单一数据真源，照内容风控先例不做双写同步）。
+CREATE TABLE IF NOT EXISTS `cw_dict_type` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `dict_type`      VARCHAR(64) NOT NULL COMMENT '字典类型编码（如 order_status）',
+    `type_name`      VARCHAR(64) NOT NULL COMMENT '类型名称（展示用）',
+    `remark`         VARCHAR(255) COMMENT '备注说明',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_dict_type` (`dict_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典类型表';
+
+CREATE TABLE IF NOT EXISTS `cw_dict_item` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `dict_type`      VARCHAR(64) NOT NULL COMMENT '所属字典类型编码',
+    `item_key`       VARCHAR(128) NOT NULL COMMENT '字典项键（业务值）',
+    `item_label`     VARCHAR(128) NOT NULL COMMENT '字典项标签（展示文案）',
+    `sort`           INT NOT NULL DEFAULT 0 COMMENT '排序号，越小越靠前',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `remark`         VARCHAR(255) COMMENT '备注说明',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_dict_item` (`dict_type`, `item_key`),
+    KEY `idx_dict_item_type` (`dict_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典项表';
+
+-- 演示种子：订单状态（与 InMemoryDictStore 种子、后台订单页硬编码文案一致）。
+INSERT IGNORE INTO `cw_dict_type` (`dict_type`, `type_name`, `remark`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('order_status', '订单状态', '用户订单状态筛选项（与后端返回的中文文案一致）', 1, 1779235200000, 1779235200000);
+
+INSERT IGNORE INTO `cw_dict_item` (`dict_type`, `item_key`, `item_label`, `sort`, `enabled`, `remark`, `created_at_ms`, `updated_at_ms`) VALUES
+('order_status', '待支付', '待支付', 1, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已支付', '已支付', 2, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '待发货', '待发货', 3, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已发货', '已发货', 4, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/dict/DictConfigTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/dict/DictConfigTest.java
@@ -1,0 +1,31 @@
+package com.richard.fyoung.customerwork.dict;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * 字典存储装配选择单测（离线，无需 MySQL）：默认 memory 模式选中 {@link InMemoryDictStore}。
+ *
+ * <p>{@code store-mode=jdbc} 分支的装配验证见 {@link MybatisDictStoreTest}（需真实 MySQL，本类不覆盖）。
+ * memory 分支不取用 Mapper，故两个 provider 传 {@code null}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class DictConfigTest {
+
+    @Test
+    void dictStore_shouldSelectInMemory_byDefault() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        DictStore store = new DictConfig().dictStore(props, null, null);
+        assertInstanceOf(InMemoryDictStore.class, store);
+    }
+
+    @Test
+    void dictStore_shouldSelectInMemory_whenStoreModeExplicitlyMemory() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getDict().setStoreMode("memory");
+        DictStore store = new DictConfig().dictStore(props, null, null);
+        assertInstanceOf(InMemoryDictStore.class, store);
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/dict/InMemoryDictStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/dict/InMemoryDictStoreTest.java
@@ -1,0 +1,41 @@
+package com.richard.fyoung.customerwork.dict;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 进程内字典存储单测（离线）：验证演示种子与查询语义（排序 / 未知类型 / 空入参）。
+ * @author owlzhangfq@gmail.com
+ */
+class InMemoryDictStoreTest {
+
+    private final InMemoryDictStore store = new InMemoryDictStore();
+
+    @Test
+    void listEnabledTypes_shouldContainOrderStatusSeed() {
+        List<DictType> types = store.listEnabledTypes();
+        assertTrue(types.stream().anyMatch(t -> "order_status".equals(t.dictType())), "演示种子应包含 order_status 类型");
+    }
+
+    @Test
+    void findEnabledItems_shouldReturnOrderStatusSeeds_inSortOrder() {
+        List<DictItem> items = store.findEnabledItems("order_status");
+        assertEquals(7, items.size(), "订单状态种子应为七态");
+        assertEquals("待支付", items.get(0).itemKey());
+        assertEquals("已退款", items.get(6).itemKey());
+        for (int i = 1; i < items.size(); i++) {
+            assertTrue(items.get(i - 1).sort() <= items.get(i).sort(), "字典项应按 sort 升序");
+        }
+    }
+
+    @Test
+    void findEnabledItems_shouldReturnEmpty_forUnknownOrBlankType() {
+        assertTrue(store.findEnabledItems("no_such_type").isEmpty());
+        assertTrue(store.findEnabledItems("  ").isEmpty());
+        assertTrue(store.findEnabledItems(null).isEmpty());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/dict/MybatisDictStoreTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/dict/MybatisDictStoreTest.java
@@ -1,0 +1,159 @@
+package com.richard.fyoung.customerwork.dict;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.dict.entity.DictItemEntity;
+import com.richard.fyoung.customerwork.dict.entity.DictTypeEntity;
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
+import com.richard.fyoung.customerwork.support.MybatisTestSupport;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * MyBatis-Plus 字典存储测试（对接本机 MySQL：localhost:3306，root/root，
+ * 库 agent_scope_customer_work，表 cw_dict_type / cw_dict_item 由 {@link MybatisTestSupport#ensureSchema} 建好）。
+ *
+ * <p>MySQL 不可达时自动跳过（assumeTrue）；MySQL 在线的机器上真实执行写入-读取往返，
+ * 验证 {@link MybatisDictStore} 的启用过滤与排序语义。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class MybatisDictStoreTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 3306;
+
+    private HikariDataSource dataSource;
+    private DictTypeMapper typeMapper;
+    private DictItemMapper itemMapper;
+    private MybatisDictStore store;
+
+    @BeforeEach
+    void setUp() {
+        assumeTrue(reachable(HOST, PORT), "MySQL 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+
+        dataSource = MybatisTestSupport.mysqlDataSource("test-dict-pool");
+        MybatisTestSupport.ensureSchema(dataSource);
+        typeMapper = MybatisTestSupport.mapper(dataSource, DictTypeMapper.class);
+        itemMapper = MybatisTestSupport.mapper(dataSource, DictItemMapper.class);
+        store = new MybatisDictStore(typeMapper, itemMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    private static boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    void findEnabledItems_shouldFilterDisabled_andSortAsc() {
+        String dictType = "it_dict_" + UUID.randomUUID().toString().substring(0, 8);
+        long now = System.currentTimeMillis();
+        try {
+            insertType(dictType, now);
+            insertItem(dictType, "k2", "标签2", 2, true, now);
+            insertItem(dictType, "k1", "标签1", 1, true, now);
+            insertItem(dictType, "k3", "停用项", 3, false, now);
+
+            List<DictItem> items = store.findEnabledItems(dictType);
+            assertEquals(2, items.size(), "停用项不应返回");
+            assertEquals("k1", items.get(0).itemKey(), "应按 sort 升序");
+            assertEquals("k2", items.get(1).itemKey());
+
+            List<DictType> types = store.listEnabledTypes();
+            assertTrue(types.stream().anyMatch(t -> dictType.equals(t.dictType())), "启用类型应可列出");
+        } finally {
+            cleanup(dictType);
+        }
+    }
+
+    @Test
+    void findEnabledItems_shouldReturnEmpty_forUnknownType() {
+        assertTrue(store.findEnabledItems("no_such_type_" + UUID.randomUUID()).isEmpty());
+    }
+
+    @Test
+    void dictConfig_shouldSelectMybatisStore_whenStoreModeIsJdbc() {
+        CustomerWorkProperties props = new CustomerWorkProperties();
+        props.getDict().setStoreMode("jdbc");
+
+        DictStore selected = new DictConfig().dictStore(props,
+            singletonProvider(typeMapper), singletonProvider(itemMapper));
+        assertInstanceOf(MybatisDictStore.class, selected, "store-mode=jdbc 应装配 MybatisDictStore");
+    }
+
+    private void insertType(String dictType, long now) {
+        DictTypeEntity type = new DictTypeEntity();
+        type.setDictType(dictType);
+        type.setTypeName("集成测试类型");
+        type.setEnabled(true);
+        type.setCreatedAtMs(now);
+        type.setUpdatedAtMs(now);
+        typeMapper.insert(type);
+    }
+
+    private void insertItem(String dictType, String key, String label, int sort, boolean enabled, long now) {
+        DictItemEntity item = new DictItemEntity();
+        item.setDictType(dictType);
+        item.setItemKey(key);
+        item.setItemLabel(label);
+        item.setSort(sort);
+        item.setEnabled(enabled);
+        item.setCreatedAtMs(now);
+        item.setUpdatedAtMs(now);
+        itemMapper.insert(item);
+    }
+
+    private void cleanup(String dictType) {
+        itemMapper.delete(new QueryWrapper<DictItemEntity>().eq("dict_type", dictType));
+        typeMapper.delete(new QueryWrapper<DictTypeEntity>().eq("dict_type", dictType));
+    }
+
+    /** 最小 {@link ObjectProvider}：仅 {@code getObject()} 返回给定 Bean，供 Config 单测在无 Spring 容器下取 Mapper。 */
+    private static <T> ObjectProvider<T> singletonProvider(T bean) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject() {
+                return bean;
+            }
+
+            @Override
+            public T getObject(Object... args) {
+                return bean;
+            }
+
+            @Override
+            public T getIfAvailable() {
+                return bean;
+            }
+
+            @Override
+            public T getIfUnique() {
+                return bean;
+            }
+        };
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/support/MybatisTestSupport.java
@@ -12,6 +12,8 @@ import com.richard.fyoung.customerwork.calllog.mapper.AgentCallLogMapper;
 import com.richard.fyoung.customerwork.calllog.mapper.AgentCallSegmentMapper;
 import com.richard.fyoung.customerwork.chatlog.mapper.ChatMessageMapper;
 import com.richard.fyoung.customerwork.dialog.mapper.DialogStageMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictItemMapper;
+import com.richard.fyoung.customerwork.dict.mapper.DictTypeMapper;
 import com.richard.fyoung.customerwork.feedback.mapper.FeedbackMapper;
 import com.richard.fyoung.customerwork.handoff.mapper.HandoffMapper;
 import com.richard.fyoung.customerwork.observability.mapper.AuditLogMapper;
@@ -62,7 +64,8 @@ public final class MybatisTestSupport {
         RefundMapper.class, InvoiceRequestMapper.class, MemberMapper.class, MemberAccountLogMapper.class,
         ComplaintMapper.class, KnowledgeMapper.class, ChatAttachmentMapper.class,
         SensitiveWordMapper.class, SeatAgentMapper.class,
-        AgentCallLogMapper.class, AgentCallSegmentMapper.class
+        AgentCallLogMapper.class, AgentCallSegmentMapper.class,
+        DictTypeMapper.class, DictItemMapper.class
     };
 
     private MybatisTestSupport() {

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -814,6 +814,8 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/contentguard/sensitive-word/**` | 敏感词词库管理（CRUD/启停/批量导入导出/枚举下拉，权限点 `sensitive-word:*`），见 §6.14.2 |
 | `/api/contentguard/rate-limit-rule/**` | 限流规则管理（CRUD/启停/枚举下拉，权限点 `rate-limit-rule:*`），见 §6.14.1 |
 | `/api/contentguard/hit-log/{page,stats}` | 敏感词命中看板（明细分页 + 动作/方向分布 + Top 命中词 + 时间趋势，只读，权限点 `sensitive-hit-log:view`） |
+| `/api/dict/{types,items}` | 字典管理（类型 + 字典项两级 CRUD，权限点 `dict:*`），见「数据字典」小节 |
+| `GET /api/dict/options/{dictType}` | 字典下拉选项（仅启用项，只要求登录不校验权限点，前端 `useDict` 消费） |
 | `/swagger-ui/index.html` | 接口文档 |
 
 **调用统计的 token 口径（V43 起补齐缓存量）**：框架 `ChatUsage` 一共只给四个原始量——
@@ -862,6 +864,34 @@ admin.content-guard:
 > fail-closed（拦截一切）——这是敏感词的既定语义。`SensitiveWordRefreshTask` 随后按间隔重试，库恢复即自动
 > 脱离，无需重启 admin。该任务自带守护线程定时器而非 `@Scheduled`：admin 至今没开 `@EnableScheduling`，
 > 为一个词表刷新去打开全局调度会把容器里所有 `@Scheduled` Bean 一并激活，影响面远大于收益。
+
+**数据字典（V46 起）**：系统管理 → 字典管理，解决"就几条枚举数据、不值当单独建表"的场景。
+两级结构：字典类型（`cw_dict_type`，如 `order_status`）+ 字典项（`cw_dict_item`，键 + 展示标签 + 排序 + 启停）。
+
+数据同样**不在 admin 库**——两表落客服端库 `agent_scope_customer_work`，admin 经 `DictGatewayProvider`
+惰性跨库读写（手法同上面的内容风控），客服端 starter 侧由 `DictStore` SPI 读同一份数据
+（`customer-work.dict.store-mode=jdbc` 时装配 `MybatisDictStore`，默认 `memory` 用进程内演示种子）。
+建表与种子走 `SchemaInitializer`，不需要 Flyway；Flyway V46 只登记 admin 侧菜单与权限点。
+
+```yaml
+admin.dict:                      # admin 侧跨库连接参数（默认本机 3306 / agent_scope_customer_work）
+  host: localhost
+  port: 3306
+  database: agent_scope_customer_work
+
+customer-work:
+  dict:
+    store-mode: memory           # memory（进程内种子，默认）| jdbc（读客服端库字典表）
+```
+
+前端消费走 `useDict(dictType, fallback)`（`customer-admin-web/src/composables/useDict.ts`）：
+模块级缓存，同一类型整个 SPA 生命周期只请求一次；**接口失败或类型未配置时保留调用方传入的硬编码
+fallback**——字典是展示增强，不能因为客服端库不可达就让业务页面的筛选框变空白。首个接入示范是
+用户订单管理页的状态筛选（`order_status`，fallback 为 `ORDER_STATUS_OPTIONS`）。
+
+> 什么该进字典、什么不该：**纯展示型选项**（订单状态文案、渠道来源、分类标签）适合；
+> **后端有逻辑依赖的状态机枚举**（工单 7 态、审批态）不适合——那些枚举改一个值就要动代码分支，
+> 放进字典只会制造"库里改了但代码不认"的假象。
 
 生产建表由 DBA 参照 **[mysql/02-customer-admin/](../mysql/02-customer-admin/)**（V1~V20 有序副本）手工执行（与 `mysql/01-agent-scope-customer-work/customer-work-schema.sql`
 客服主业务库物理隔离，独立数据库 `customer_admin`），与仓库既有"生产不自动建表"约定一致。

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -513,3 +513,43 @@ INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current
 --   ADD COLUMN `priority` VARCHAR(16) NULL COMMENT '优先级 LOW/MEDIUM/HIGH/URGENT（LLM 分类，可空）',
 --   ADD COLUMN `emotion` VARCHAR(32) NULL COMMENT '用户情绪（LLM 分类，可空）',
 --   ADD COLUMN `suggested_assignees` TEXT NULL COMMENT '推荐坐席列表 JSON（HITL 推荐，可空）';
+
+-- 数据字典（DictStore / cw_dict_type + cw_dict_item）：少量枚举型键值数据的统一落点，免于逐个建表。
+-- 后台管理系统"字典管理"页直连维护这两张表（单一数据真源，照内容风控先例不做双写同步）。
+CREATE TABLE IF NOT EXISTS `cw_dict_type` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `dict_type`      VARCHAR(64) NOT NULL COMMENT '字典类型编码（如 order_status）',
+    `type_name`      VARCHAR(64) NOT NULL COMMENT '类型名称（展示用）',
+    `remark`         VARCHAR(255) COMMENT '备注说明',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_dict_type` (`dict_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典类型表';
+
+CREATE TABLE IF NOT EXISTS `cw_dict_item` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `dict_type`      VARCHAR(64) NOT NULL COMMENT '所属字典类型编码',
+    `item_key`       VARCHAR(128) NOT NULL COMMENT '字典项键（业务值）',
+    `item_label`     VARCHAR(128) NOT NULL COMMENT '字典项标签（展示文案）',
+    `sort`           INT NOT NULL DEFAULT 0 COMMENT '排序号，越小越靠前',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `remark`         VARCHAR(255) COMMENT '备注说明',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_dict_item` (`dict_type`, `item_key`),
+    KEY `idx_dict_item_type` (`dict_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典项表';
+
+-- 演示种子：订单状态（与 InMemoryDictStore 种子、后台订单页硬编码文案一致）。
+INSERT IGNORE INTO `cw_dict_type` (`dict_type`, `type_name`, `remark`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('order_status', '订单状态', '用户订单状态筛选项（与后端返回的中文文案一致）', 1, 1779235200000, 1779235200000);
+
+INSERT IGNORE INTO `cw_dict_item` (`dict_type`, `item_key`, `item_label`, `sort`, `enabled`, `remark`, `created_at_ms`, `updated_at_ms`) VALUES
+('order_status', '待支付', '待支付', 1, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已支付', '已支付', 2, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '待发货', '待发货', 3, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已发货', '已发货', 4, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
+('order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);

--- a/mysql/02-customer-admin/46-V46__dict_management.sql
+++ b/mysql/02-customer-admin/46-V46__dict_management.sql
@@ -1,0 +1,17 @@
+-- 字典管理菜单权限（Flyway V46）。
+--
+-- 字典数据两表（cw_dict_type / cw_dict_item）在客服端库（agent_scope_customer_work），由 starter 的
+-- SchemaInitializer 建表并种子，本迁移只登记 admin 侧菜单与按钮权限点——照内容风控（V42）的先例：
+-- admin 直连客服端库维护（DictGatewayProvider 惰性数据源），单一数据真源、不做双写同步。
+-- 无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接返回全部权限点。
+
+-- 二级菜单：字典管理（挂系统管理 id=1 下，排在轮播图管理 sort=7 之后）。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (216, 1, '字典管理', 'dict:view', 1, '/system/dict', 'Collection', 'library', 8);
+
+-- 三级：按钮/接口权限点（type=2）。类型与字典项共用同一组权限点——
+-- 它们是同一能力（维护一份字典）的两级视图，不是两个独立的能力边界。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (217, 216, '新增字典', 'dict:add', 2, 1),
+    (218, 216, '编辑字典', 'dict:edit', 2, 2),
+    (219, 216, '删除字典', 'dict:delete', 2, 3);


### PR DESCRIPTION
## 需求

系统管理里新增字典管理页，解决「就几条枚举数据、不值当单独建表」的场景；并把现有硬编码下拉做一处示范改造。

## 做了什么

**customer-work-starter**（通用能力下沉）
- 新增 `dict` 域：`DictStore` SPI + `InMemoryDictStore`（默认，带演示种子）+ `MybatisDictStore` + `@ConditionalOnMissingBean`，第 9 次套用既有 Store SPI 模式
- 两表 `cw_dict_type` / `cw_dict_item` 走 `SchemaInitializer` 建表与种子（`customer-work-schema.sql` 与 `mysql/01-*` 副本同步）
- 配置键 `customer-work.dict.store-mode`（memory 默认 / jdbc），已登记进 `PersistenceJdbcCondition`

**customer-admin-server**
- `DictGatewayProvider` 惰性跨库读写客服端库（照内容风控 `ContentGuardGatewayProvider` 先例：首次访问才建池并探测，库不可达抛 `CUSTOMER_WORK_UNAVAILABLE`，绝不在启动期触碰）
- 类型 + 字典项两级 CRUD（`/api/dict/types`、`/api/dict/items`）+ 消费端 `/api/dict/options/{dictType}`
- Flyway V46 只登记菜单与权限点（`dict:view/add/edit/delete`，id 216-219），表由 starter 建

**customer-admin-web**
- 系统管理 → 字典管理页（左侧类型、右侧字典项）
- 通用 `useDict(dictType, fallback)` hook：模块级缓存 + 硬编码 fallback
- 示范接入：用户订单管理页状态筛选改走 `order_status` 字典

## 关键决策

- **数据落客服端库而非 admin 库**：客服端运行时经 `DictStore`(store-mode=jdbc) 读同一份，双写副本必然出现「后台改了、客服端不认」的不一致
- **useDict 保留硬编码 fallback**：字典是展示增强，不能因客服端库不可达就让业务页面筛选框变空白
- **改造范围限于纯展示型选项**：状态机枚举（工单 7 态等）后端有逻辑依赖，进字典只会制造「库里改了但代码不认」的假象，刻意不动

## 测试

全量实测 `BUILD SUCCESS`：starter **786**（778+8）、admin-server **795**（786+9）、app 78、channel 65、gateway 1。

⚠️ 跑全量需额外排除 `ApplicationContextTest`：main 基线上 `IndirectInjectionGuardMiddleware`（`@Component` + 两个构造器且都无 `@Autowired`）让 app-server 整个 Spring 上下文起不来，PR #65 引入且当时未重跑该模块，**与本 PR 无关**，已在 CLAUDE.md 记录、另行修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)