### PR TITLE
feat(devtools): 工具箱新增证书解析（X.509/CSR/私钥匹配/PFX·JKS）

### DIFF
--- a/customer-admin-server/pom.xml
+++ b/customer-admin-server/pom.xml
@@ -21,6 +21,9 @@
         <!-- SFTP 客户端：JSch 官方已停更，改用社区维护版 mwiede/jsch（同 com.jcraft.jsch 包 API）；
              版本只在本模块声明，不动根 pom。 -->
         <jsch.version>0.2.23</jsch.version>
+        <!-- 证书解析工具：CSR/PEM 私钥解析靠 BouncyCastle（JDK 原生只认 X.509 证书与 PKCS8 未加密私钥）；
+             版本只在本模块声明，不动根 pom。 -->
+        <bouncycastle.version>1.81</bouncycastle.version>
     </properties>
 
     <dependencies>
@@ -34,6 +37,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.18.0</version>
+        </dependency>
+        <!-- 证书解析工具（开发者工具箱）：bcpkix 提供 PKCS10 CSR 与 PEMParser，传递引入 bcprov/bcutil -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <!-- Spring MVC（非 WebFlux）：与 customer-channel 同一手法接入 starter -->
         <dependency>

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/controller/DevToolCertController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/controller/DevToolCertController.java
@@ -1,0 +1,71 @@
+package com.richard.fyoung.customeradmin.system.devtool.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertMatchRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertMatchResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertParseRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertParseResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolKeystoreParseResponse;
+import com.richard.fyoung.customeradmin.system.devtool.service.DevToolCertService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * 开发者工具箱 · 证书解析。权限复用工具箱菜单的 {@code devtools:view}
+ * （能进工具箱页面的人即可使用其中的工具，与其余工具的授权粒度保持一致）。
+ *
+ * <p>所有输入只在请求内存中解析，不落库、不留痕（含私钥与密钥库密码）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/devtools/cert")
+public class DevToolCertController {
+
+    /** 密钥库上传大小上限：1MB（证书库远小于此，超限基本是传错了文件）。 */
+    private static final long MAX_KEYSTORE_BYTES = 1024 * 1024;
+
+    private final DevToolCertService devToolCertService;
+
+    public DevToolCertController(DevToolCertService devToolCertService) {
+        this.devToolCertService = devToolCertService;
+    }
+
+    /** 解析 PEM 文本中的证书/证书链/CSR。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/parse")
+    public Result<DevToolCertParseResponse> parse(@Valid @RequestBody DevToolCertParseRequest request) {
+        return Result.success(devToolCertService.parse(request.getPemContent()));
+    }
+
+    /** 私钥与证书匹配校验。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/match")
+    public Result<DevToolCertMatchResponse> match(@Valid @RequestBody DevToolCertMatchRequest request) {
+        return Result.success(devToolCertService.match(request.getCertPem(), request.getPrivateKeyPem()));
+    }
+
+    /** 解析 PFX/JKS 密钥库（multipart 上传 + 库密码）。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/keystore")
+    public Result<DevToolKeystoreParseResponse> keystore(
+        @RequestParam("file") MultipartFile file,
+        @RequestParam(value = "password", required = false, defaultValue = "") String password) throws IOException {
+        if (file.isEmpty()) {
+            throw new BizException(ResultCode.PARAM_MISSING, "请上传密钥库文件（.pfx/.p12/.jks）");
+        }
+        if (file.getSize() > MAX_KEYSTORE_BYTES) {
+            throw new BizException(ResultCode.PARAM_INVALID, "密钥库文件过大（上限 1MB）");
+        }
+        return Result.success(devToolCertService.parseKeystore(file.getBytes(), password));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertInfo.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertInfo.java
@@ -1,0 +1,61 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 单张 X.509 证书的解析结果视图。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCertInfo {
+
+    /** 使用者（Subject DN）。 */
+    private String subject;
+
+    /** 颁发者（Issuer DN）。 */
+    private String issuer;
+
+    /** 序列号（十六进制）。 */
+    private String serialNumberHex;
+
+    /** X.509 版本（1/2/3）。 */
+    private int version;
+
+    /** 生效时间（毫秒时间戳）。 */
+    private long notBeforeMs;
+
+    /** 过期时间（毫秒时间戳）。 */
+    private long notAfterMs;
+
+    /** 当前是否已过期（或未生效）。 */
+    private boolean expired;
+
+    /** 距过期剩余天数（已过期为负数）。 */
+    private long daysRemaining;
+
+    /** 签名算法（如 SHA256withRSA）。 */
+    private String sigAlgName;
+
+    /** 公钥算法（RSA/EC/Ed25519 等）。 */
+    private String publicKeyAlgorithm;
+
+    /** 公钥长度（bit；无法判定时为 0）。 */
+    private int publicKeyBits;
+
+    /** 是否 CA 证书（BasicConstraints；证书未携带该扩展时为 false）。 */
+    private boolean ca;
+
+    /** 使用者可选名称（SAN，DNS:xx / IP:xx）。 */
+    private List<String> subjectAlternativeNames;
+
+    /** 密钥用法（digitalSignature/keyEncipherment 等）。 */
+    private List<String> keyUsages;
+
+    /** SHA-1 指纹（冒号分隔十六进制）。 */
+    private String sha1Fingerprint;
+
+    /** SHA-256 指纹（冒号分隔十六进制）。 */
+    private String sha256Fingerprint;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertMatchRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertMatchRequest.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 私钥与证书匹配校验请求。私钥仅在内存中参与一次签名-验签探测，不落库不记日志。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCertMatchRequest {
+
+    /** 证书 PEM（取第一段 CERTIFICATE 块）。 */
+    @NotBlank(message = "证书 PEM 不能为空")
+    @Size(max = 256 * 1024, message = "证书内容过大（上限 256KB）")
+    private String certPem;
+
+    /** 私钥 PEM（支持 PKCS#8 / PKCS#1 RSA / SEC1 EC，不支持加密私钥）。 */
+    @NotBlank(message = "私钥 PEM 不能为空")
+    @Size(max = 256 * 1024, message = "私钥内容过大（上限 256KB）")
+    private String privateKeyPem;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertMatchResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertMatchResponse.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * 私钥与证书匹配校验响应。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@AllArgsConstructor
+public class DevToolCertMatchResponse {
+
+    /** 是否配对（私钥签名能被证书公钥验签）。 */
+    private boolean matched;
+
+    /** 证书公钥算法。 */
+    private String publicKeyAlgorithm;
+
+    /** 结论说明。 */
+    private String reason;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertParseRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertParseRequest.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 证书/CSR 解析请求：粘贴任意 PEM 文本（可同时含多张证书与 CSR，按块识别）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCertParseRequest {
+
+    /** PEM 文本（-----BEGIN CERTIFICATE----- / -----BEGIN CERTIFICATE REQUEST----- 块）。 */
+    @NotBlank(message = "PEM 内容不能为空")
+    @Size(max = 256 * 1024, message = "PEM 内容过大（上限 256KB）")
+    private String pemContent;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertParseResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCertParseResponse.java
@@ -1,0 +1,19 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 证书/CSR 解析响应：证书按输入顺序排列（证书链场景第一张通常是叶子证书）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCertParseResponse {
+
+    /** 解析出的证书列表。 */
+    private List<DevToolCertInfo> certificates;
+
+    /** 解析出的 CSR 列表。 */
+    private List<DevToolCsrInfo> csrs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCsrInfo.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCsrInfo.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 证书签名请求（CSR / PKCS#10）的解析结果视图。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCsrInfo {
+
+    /** 申请主题（Subject DN）。 */
+    private String subject;
+
+    /** 公钥算法（RSA/EC 等）。 */
+    private String publicKeyAlgorithm;
+
+    /** 公钥长度（bit；无法判定时为 0）。 */
+    private int publicKeyBits;
+
+    /** 签名算法。 */
+    private String sigAlgName;
+
+    /** 请求扩展里的使用者可选名称（SAN）。 */
+    private List<String> subjectAlternativeNames;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolKeystoreParseResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolKeystoreParseResponse.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 密钥库（PFX/PKCS#12、JKS）解析响应。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolKeystoreParseResponse {
+
+    /** 实际识别出的密钥库类型（PKCS12/JKS）。 */
+    private String keystoreType;
+
+    /** 库内条目。 */
+    private List<Entry> entries;
+
+    /**
+     * 密钥库条目：别名 + 条目类型 + 证书链解析结果。
+     */
+    @Data
+    public static class Entry {
+
+        /** 条目别名。 */
+        private String alias;
+
+        /** 条目类型：PRIVATE_KEY（带私钥）| TRUSTED_CERT（仅证书）。 */
+        private String entryType;
+
+        /** 证书链（叶子在前）。 */
+        private List<DevToolCertInfo> chain;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCertService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCertService.java
@@ -1,0 +1,411 @@
+package com.richard.fyoung.customeradmin.system.devtool.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertInfo;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertMatchResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertParseResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCsrInfo;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolKeystoreParseResponse;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 开发者工具箱 · 证书解析：X.509 证书/证书链、PKCS#10 CSR、私钥-证书匹配校验、PFX/JKS 密钥库。
+ *
+ * <p><b>隐私边界</b>：所有输入只在本次请求的内存中解析，不落库、不写日志（error 日志只记错误码，
+ * 不回显证书/私钥内容）。私钥匹配用"签名-验签探测"而非公钥参数比对——算法无关（RSA/EC/EdDSA 通吃），
+ * 也天然规避了各算法公钥表示的差异。</p>
+ *
+ * <p>JDK 原生只认 X.509 证书与未加密 PKCS#8 私钥，CSR 与 PKCS#1/SEC1 私钥解析靠 BouncyCastle
+ * （PEMParser / PKCS10CertificationRequest）；BC Provider 以实例方式传入，不注册进全局 Security。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class DevToolCertService {
+
+    private static final Logger log = LoggerFactory.getLogger(DevToolCertService.class);
+
+    /** PEM 块通用匹配：BEGIN/END 标签 + Base64 正文。 */
+    private static final Pattern PEM_BLOCK = Pattern.compile(
+        "-----BEGIN ([A-Z0-9 ]+)-----([A-Za-z0-9+/=\\s]+?)-----END \\1-----");
+
+    private static final String BLOCK_CERT = "CERTIFICATE";
+    private static final String BLOCK_CSR = "CERTIFICATE REQUEST";
+    private static final String BLOCK_NEW_CSR = "NEW CERTIFICATE REQUEST";
+
+    /** 签名-验签探测的固定负载（内容无意义，只求两侧一致）。 */
+    private static final byte[] PROBE_PAYLOAD = "customer-work-cert-match-probe".getBytes(StandardCharsets.UTF_8);
+
+    private final BouncyCastleProvider bcProvider = new BouncyCastleProvider();
+
+    // ---------- 证书 / CSR 解析 ----------
+
+    /** 解析 PEM 文本中的全部证书与 CSR 块；一个可识别块都没有则报参数错误。 */
+    public DevToolCertParseResponse parse(String pemContent) {
+        List<DevToolCertInfo> certs = new ArrayList<>();
+        List<DevToolCsrInfo> csrs = new ArrayList<>();
+        Matcher matcher = PEM_BLOCK.matcher(pemContent);
+        while (matcher.find()) {
+            String label = matcher.group(1);
+            byte[] der = decodeBase64Body(matcher.group(2));
+            if (BLOCK_CERT.equals(label)) {
+                certs.add(describeCertificate(parseX509(der)));
+            } else if (BLOCK_CSR.equals(label) || BLOCK_NEW_CSR.equals(label)) {
+                csrs.add(describeCsr(der));
+            }
+            // 其余块类型（私钥等）在解析接口里刻意忽略：私钥只该出现在匹配校验接口
+        }
+        if (certs.isEmpty() && csrs.isEmpty()) {
+            throw new BizException(ResultCode.PARAM_INVALID,
+                "未识别到 CERTIFICATE / CERTIFICATE REQUEST PEM 块，请粘贴 -----BEGIN CERTIFICATE----- 格式内容");
+        }
+        DevToolCertParseResponse response = new DevToolCertParseResponse();
+        response.setCertificates(certs);
+        response.setCsrs(csrs);
+        return response;
+    }
+
+    // ---------- 私钥-证书匹配 ----------
+
+    /** 私钥与证书匹配校验：私钥对固定负载签名，证书公钥验签，验签通过即配对。 */
+    public DevToolCertMatchResponse match(String certPem, String privateKeyPem) {
+        X509Certificate cert = firstCertificate(certPem);
+        PrivateKey privateKey = parsePrivateKey(privateKeyPem);
+        PublicKey publicKey = cert.getPublicKey();
+
+        if (!privateKey.getAlgorithm().equals(publicKey.getAlgorithm())
+            && !isEcAlgorithmFamily(privateKey.getAlgorithm(), publicKey.getAlgorithm())) {
+            return new DevToolCertMatchResponse(false, publicKey.getAlgorithm(),
+                "算法不一致：私钥为 " + privateKey.getAlgorithm() + "，证书公钥为 " + publicKey.getAlgorithm());
+        }
+        try {
+            String sigAlg = probeSignatureAlgorithm(publicKey.getAlgorithm());
+            Signature signer = Signature.getInstance(sigAlg, bcProvider);
+            signer.initSign(privateKey);
+            signer.update(PROBE_PAYLOAD);
+            byte[] signature = signer.sign();
+
+            Signature verifier = Signature.getInstance(sigAlg, bcProvider);
+            verifier.initVerify(publicKey);
+            verifier.update(PROBE_PAYLOAD);
+            boolean matched = verifier.verify(signature);
+            return new DevToolCertMatchResponse(matched, publicKey.getAlgorithm(),
+                matched ? "私钥签名可被证书公钥验签，二者配对" : "私钥签名无法被证书公钥验签，二者不配对");
+        } catch (Exception e) {
+            log.error("cert match probe failed, code={}", "DEVTOOL-CERT-MATCH-FAIL", e);
+            throw new BizException(ResultCode.PARAM_INVALID, "匹配探测失败：" + e.getMessage());
+        }
+    }
+
+    // ---------- 密钥库 ----------
+
+    /** 解析 PFX/JKS 密钥库：按 PKCS12 → JKS 顺序尝试，列出全部条目及其证书链。 */
+    public DevToolKeystoreParseResponse parseKeystore(byte[] data, String password) {
+        char[] pwd = password == null ? new char[0] : password.toCharArray();
+        KeyStore keyStore = null;
+        String loadedType = null;
+        Exception lastError = null;
+        for (String type : new String[] {"PKCS12", "JKS"}) {
+            try {
+                KeyStore candidate = KeyStore.getInstance(type);
+                candidate.load(new ByteArrayInputStream(data), pwd);
+                keyStore = candidate;
+                loadedType = type;
+                break;
+            } catch (Exception e) {
+                lastError = e;
+            }
+        }
+        if (keyStore == null) {
+            throw new BizException(ResultCode.PARAM_INVALID,
+                "密钥库无法打开（已尝试 PKCS12/JKS）：密码错误或文件损坏"
+                    + (lastError == null ? "" : "（" + lastError.getMessage() + "）"));
+        }
+        try {
+            List<DevToolKeystoreParseResponse.Entry> entries = new ArrayList<>();
+            Enumeration<String> aliases = keyStore.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                DevToolKeystoreParseResponse.Entry entry = new DevToolKeystoreParseResponse.Entry();
+                entry.setAlias(alias);
+                List<DevToolCertInfo> chain = new ArrayList<>();
+                if (keyStore.isKeyEntry(alias)) {
+                    entry.setEntryType("PRIVATE_KEY");
+                    Certificate[] certs = keyStore.getCertificateChain(alias);
+                    if (certs != null) {
+                        for (Certificate cert : certs) {
+                            if (cert instanceof X509Certificate x509) {
+                                chain.add(describeCertificate(x509));
+                            }
+                        }
+                    }
+                } else {
+                    entry.setEntryType("TRUSTED_CERT");
+                    Certificate cert = keyStore.getCertificate(alias);
+                    if (cert instanceof X509Certificate x509) {
+                        chain.add(describeCertificate(x509));
+                    }
+                }
+                entry.setChain(chain);
+                entries.add(entry);
+            }
+            DevToolKeystoreParseResponse response = new DevToolKeystoreParseResponse();
+            response.setKeystoreType(loadedType);
+            response.setEntries(entries);
+            return response;
+        } catch (Exception e) {
+            log.error("keystore enumerate failed, code={}", "DEVTOOL-CERT-KEYSTORE-FAIL", e);
+            throw new BizException(ResultCode.PARAM_INVALID, "密钥库条目读取失败：" + e.getMessage());
+        }
+    }
+
+    // ---------- 私有辅助 ----------
+
+    private byte[] decodeBase64Body(String body) {
+        try {
+            return Base64.getMimeDecoder().decode(body);
+        } catch (IllegalArgumentException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "PEM 正文不是合法 Base64");
+        }
+    }
+
+    private X509Certificate parseX509(byte[] der) {
+        try {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            return (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(der));
+        } catch (Exception e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "证书解析失败：" + e.getMessage());
+        }
+    }
+
+    /** 取 PEM 文本中的第一段 CERTIFICATE 块。 */
+    private X509Certificate firstCertificate(String certPem) {
+        Matcher matcher = PEM_BLOCK.matcher(certPem);
+        while (matcher.find()) {
+            if (BLOCK_CERT.equals(matcher.group(1))) {
+                return parseX509(decodeBase64Body(matcher.group(2)));
+            }
+        }
+        throw new BizException(ResultCode.PARAM_INVALID, "未识别到 CERTIFICATE PEM 块");
+    }
+
+    /** 解析私钥 PEM：PEMParser 兼容 PKCS#8 / PKCS#1 RSA / SEC1 EC；加密私钥明确报错。 */
+    private PrivateKey parsePrivateKey(String privateKeyPem) {
+        try (PEMParser parser = new PEMParser(new StringReader(privateKeyPem))) {
+            Object parsed = parser.readObject();
+            if (parsed == null) {
+                throw new BizException(ResultCode.PARAM_INVALID, "未识别到私钥 PEM 块");
+            }
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider(bcProvider);
+            if (parsed instanceof PEMKeyPair keyPair) {
+                // PKCS#1 / SEC1 块通常内嵌公钥段，走 getKeyPair 最完整；缺公钥段时（部分工具导出）
+                // 回落到只解私钥结构，避免 getKeyPair 因 publicKeyInfo 为 null 抛 NPE
+                return keyPair.getPublicKeyInfo() == null
+                    ? converter.getPrivateKey(keyPair.getPrivateKeyInfo())
+                    : converter.getKeyPair(keyPair).getPrivate();
+            }
+            if (parsed instanceof org.bouncycastle.asn1.pkcs.PrivateKeyInfo keyInfo) {
+                return converter.getPrivateKey(keyInfo);
+            }
+            throw new BizException(ResultCode.PARAM_INVALID,
+                "不支持的私钥格式（加密私钥请先解密）：" + parsed.getClass().getSimpleName());
+        } catch (BizException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "私钥解析失败：" + e.getMessage());
+        }
+    }
+
+    /** EC 家族算法名的兼容判断（BC 报 ECDSA，JDK 报 EC）。 */
+    private boolean isEcAlgorithmFamily(String a, String b) {
+        return isEc(a) && isEc(b);
+    }
+
+    private boolean isEc(String algorithm) {
+        return "EC".equals(algorithm) || "ECDSA".equals(algorithm);
+    }
+
+    /** 按公钥算法选择探测用签名算法。 */
+    private String probeSignatureAlgorithm(String publicKeyAlgorithm) {
+        if ("RSA".equals(publicKeyAlgorithm)) {
+            return "SHA256withRSA";
+        }
+        if (isEc(publicKeyAlgorithm)) {
+            return "SHA256withECDSA";
+        }
+        if ("Ed25519".equals(publicKeyAlgorithm) || "EdDSA".equals(publicKeyAlgorithm)) {
+            return "Ed25519";
+        }
+        throw new BizException(ResultCode.PARAM_INVALID, "不支持的公钥算法：" + publicKeyAlgorithm);
+    }
+
+    /** 汇总单张证书的展示信息。 */
+    private DevToolCertInfo describeCertificate(X509Certificate cert) {
+        DevToolCertInfo info = new DevToolCertInfo();
+        info.setSubject(cert.getSubjectX500Principal().getName());
+        info.setIssuer(cert.getIssuerX500Principal().getName());
+        info.setSerialNumberHex(cert.getSerialNumber().toString(16).toUpperCase());
+        info.setVersion(cert.getVersion());
+        info.setNotBeforeMs(cert.getNotBefore().getTime());
+        info.setNotAfterMs(cert.getNotAfter().getTime());
+        Instant now = Instant.now();
+        info.setExpired(now.isAfter(cert.getNotAfter().toInstant()) || now.isBefore(cert.getNotBefore().toInstant()));
+        info.setDaysRemaining(Duration.between(now, cert.getNotAfter().toInstant()).toDays());
+        info.setSigAlgName(cert.getSigAlgName());
+        info.setPublicKeyAlgorithm(cert.getPublicKey().getAlgorithm());
+        info.setPublicKeyBits(publicKeyBits(cert.getPublicKey()));
+        // -1 表示无 BasicConstraints 扩展（非 CA）；>=0 表示 CA 及其路径长度
+        info.setCa(cert.getBasicConstraints() >= 0);
+        info.setSubjectAlternativeNames(readSubjectAlternativeNames(cert));
+        info.setKeyUsages(readKeyUsages(cert));
+        info.setSha1Fingerprint(fingerprint(cert, "SHA-1"));
+        info.setSha256Fingerprint(fingerprint(cert, "SHA-256"));
+        return info;
+    }
+
+    /** 汇总 CSR 的展示信息（含请求扩展里的 SAN）。 */
+    private DevToolCsrInfo describeCsr(byte[] der) {
+        try {
+            JcaPKCS10CertificationRequest csr = new JcaPKCS10CertificationRequest(new PKCS10CertificationRequest(der));
+            csr.setProvider(bcProvider);
+            DevToolCsrInfo info = new DevToolCsrInfo();
+            info.setSubject(csr.getSubject().toString());
+            PublicKey publicKey = csr.getPublicKey();
+            info.setPublicKeyAlgorithm(publicKey.getAlgorithm());
+            info.setPublicKeyBits(publicKeyBits(publicKey));
+            info.setSigAlgName(new org.bouncycastle.operator.DefaultAlgorithmNameFinder()
+                .getAlgorithmName(csr.getSignatureAlgorithm()));
+            info.setSubjectAlternativeNames(readCsrSubjectAlternativeNames(csr));
+            return info;
+        } catch (Exception e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "CSR 解析失败：" + e.getMessage());
+        }
+    }
+
+    private int publicKeyBits(PublicKey publicKey) {
+        if (publicKey instanceof RSAPublicKey rsa) {
+            return rsa.getModulus().bitLength();
+        }
+        if (publicKey instanceof ECPublicKey ec) {
+            return ec.getParams().getCurve().getField().getFieldSize();
+        }
+        return 0;
+    }
+
+    private List<String> readSubjectAlternativeNames(X509Certificate cert) {
+        List<String> result = new ArrayList<>();
+        try {
+            Collection<List<?>> sans = cert.getSubjectAlternativeNames();
+            if (sans == null) {
+                return result;
+            }
+            for (List<?> san : sans) {
+                // [0]=GeneralName 类型编号, [1]=值
+                Integer type = (Integer) san.get(0);
+                result.add(sanTypeName(type) + ":" + san.get(1));
+            }
+        } catch (Exception e) {
+            log.error("read subject alternative names failed, code={}", "DEVTOOL-CERT-SAN-FAIL", e);
+        }
+        return result;
+    }
+
+    /** CSR 请求扩展（extensionRequest 属性）里的 SAN。 */
+    private List<String> readCsrSubjectAlternativeNames(PKCS10CertificationRequest csr) {
+        List<String> result = new ArrayList<>();
+        Attribute[] attributes = csr.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest);
+        for (Attribute attribute : attributes) {
+            Extensions extensions = Extensions.getInstance(attribute.getAttributeValues()[0]);
+            GeneralNames names = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+            if (names == null) {
+                continue;
+            }
+            for (GeneralName name : names.getNames()) {
+                result.add(sanTypeName(name.getTagNo()) + ":" + name.getName());
+            }
+        }
+        return result;
+    }
+
+    private String sanTypeName(int type) {
+        return switch (type) {
+            case GeneralName.dNSName -> "DNS";
+            case GeneralName.iPAddress -> "IP";
+            case GeneralName.rfc822Name -> "EMAIL";
+            case GeneralName.uniformResourceIdentifier -> "URI";
+            default -> "OTHER(" + type + ")";
+        };
+    }
+
+    private List<String> readKeyUsages(X509Certificate cert) {
+        // KeyUsage 位序固定（RFC 5280）
+        String[] names = {"digitalSignature", "nonRepudiation", "keyEncipherment", "dataEncipherment",
+            "keyAgreement", "keyCertSign", "cRLSign", "encipherOnly", "decipherOnly"};
+        List<String> result = new ArrayList<>();
+        boolean[] usage = cert.getKeyUsage();
+        if (usage == null) {
+            return result;
+        }
+        for (int i = 0; i < usage.length && i < names.length; i++) {
+            if (usage[i]) {
+                result.add(names[i]);
+            }
+        }
+        return result;
+    }
+
+    private String fingerprint(X509Certificate cert, String algorithm) {
+        try {
+            byte[] digest = MessageDigest.getInstance(algorithm).digest(cert.getEncoded());
+            StringBuilder sb = new StringBuilder(digest.length * 3);
+            for (byte b : digest) {
+                if (sb.length() > 0) {
+                    sb.append(':');
+                }
+                sb.append(String.format("%02X", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            log.error("cert fingerprint failed, code={}, algorithm={}", "DEVTOOL-CERT-FP-FAIL", algorithm, e);
+            return "";
+        }
+    }
+
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCertServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCertServiceTest.java
@@ -1,0 +1,264 @@
+package com.richard.fyoung.customeradmin.system.devtool.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertInfo;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertMatchResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCertParseResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolKeystoreParseResponse;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DevToolCertService} 单测（全离线）：证书/证书链/CSR 解析、SAN 提取、
+ * 私钥匹配（RSA/EC 正反例）、PKCS12 密钥库枚举、非法输入 fast fail。
+ * 测试材料用 BouncyCastle 现场生成，不依赖外部固定文件。
+ * @author owlzhangfq@gmail.com
+ */
+class DevToolCertServiceTest {
+
+    private static final BouncyCastleProvider BC = new BouncyCastleProvider();
+
+    /** openssl 现场生成的自签 EC 证书（prime256v1，仅测试用，不含任何真实业务身份）。 */
+    private static final String OPENSSL_EC_CERT_PEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIBejCCAR+gAwIBAgIUFcpIIxy3qTLcJS6U/aAD+TestxUwCgYIKoZIzj0EAwIw
+        EjEQMA4GA1UEAwwHZWMudGVzdDAeFw0yNjA3MjkwODQyMDZaFw0yNjA4MjgwODQy
+        MDZaMBIxEDAOBgNVBAMMB2VjLnRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+        AAQ2G7NAgGxzsqB8yJKX71LZw65WTiNqUqtqQvtUMCLHdQPKv8r93X9Q0u+mAfS4
+        6DaElMfGKNC+HACAz8C7JaMRo1MwUTAdBgNVHQ4EFgQUotIrb6QtJz8N30RDQNpw
+        fk/QIZUwHwYDVR0jBBgwFoAUotIrb6QtJz8N30RDQNpwfk/QIZUwDwYDVR0TAQH/
+        BAUwAwEB/zAKBggqhkjOPQQDAgNJADBGAiEAiXk3m+WC/z8jOoYcYvkTmVv0i0D9
+        DbfD8PaiSskPitUCIQDznPdksj09BkliLIjma0Rpp+GPF50VcWniVLMUQ+L+nA==
+        -----END CERTIFICATE-----
+        """;
+
+    /** 与上面证书配对的 openssl SEC1 私钥（仅测试用）。 */
+    private static final String OPENSSL_EC_SEC1_KEY_PEM = """
+        -----BEGIN EC PRIVATE KEY-----
+        MHcCAQEEILmEvcRueU5ts448aMjU+9+A/UGiC4n7IU4y6u/DDndmoAoGCCqGSM49
+        AwEHoUQDQgAENhuzQIBsc7KgfMiSl+9S2cOuVk4jalKrakL7VDAix3UDyr/K/d1/
+        UNLvpgH0uOg2hJTHxijQvhwAgM/AuyWjEQ==
+        -----END EC PRIVATE KEY-----
+        """;
+
+    private static KeyPair rsaKeyPair;
+    private static KeyPair rsaKeyPair2;
+    private static KeyPair ecKeyPair;
+    private static X509Certificate rsaCert;
+    private static X509Certificate ecCert;
+
+    private final DevToolCertService service = new DevToolCertService();
+
+    @BeforeAll
+    static void generateMaterials() throws Exception {
+        KeyPairGenerator rsaGen = KeyPairGenerator.getInstance("RSA");
+        rsaGen.initialize(2048);
+        rsaKeyPair = rsaGen.generateKeyPair();
+        rsaKeyPair2 = rsaGen.generateKeyPair();
+
+        KeyPairGenerator ecGen = KeyPairGenerator.getInstance("EC");
+        ecGen.initialize(256);
+        ecKeyPair = ecGen.generateKeyPair();
+
+        rsaCert = selfSign(rsaKeyPair, "CN=unit-test-rsa.example.com", "SHA256withRSA", true);
+        ecCert = selfSign(ecKeyPair, "CN=unit-test-ec.example.com", "SHA256withECDSA", false);
+    }
+
+    /** 自签证书：SAN 带 DNS + IP，RSA 版附带 CA BasicConstraints。 */
+    private static X509Certificate selfSign(KeyPair keyPair, String dn, String sigAlg, boolean ca) throws Exception {
+        X500Name subject = new X500Name(dn);
+        long now = System.currentTimeMillis();
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+            subject, BigInteger.valueOf(now), new Date(now - 3600_000L),
+            new Date(now + 365L * 24 * 3600_000L), subject, keyPair.getPublic());
+        builder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName[] {
+            new GeneralName(GeneralName.dNSName, "san.example.com"),
+            new GeneralName(GeneralName.iPAddress, "127.0.0.1"),
+        }));
+        if (ca) {
+            builder.addExtension(Extension.basicConstraints, true,
+                new org.bouncycastle.asn1.x509.BasicConstraints(true));
+        }
+        ContentSigner signer = new JcaContentSignerBuilder(sigAlg).setProvider(BC).build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter().setProvider(BC).getCertificate(builder.build(signer));
+    }
+
+    /**
+     * PKCS#8（-----BEGIN PRIVATE KEY-----）格式私钥 PEM。
+     *
+     * <p>手工拼装而不用 {@code JcaPEMWriter}：后者对 EC 私钥会经 MiscPEMGenerator 改写成
+     * <b>缺算法参数</b>的 SEC1 块，那是现实中不存在的残缺形态，会把测试引到假问题上。</p>
+     */
+    private static String pkcs8Pem(KeyPair keyPair) {
+        String body = Base64.getMimeEncoder(64, "\n".getBytes(java.nio.charset.StandardCharsets.US_ASCII))
+            .encodeToString(keyPair.getPrivate().getEncoded());
+        return "-----BEGIN PRIVATE KEY-----\n" + body + "\n-----END PRIVATE KEY-----\n";
+    }
+
+    private static String toPem(Object object) throws Exception {
+        StringWriter writer = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
+            pemWriter.writeObject(object);
+        }
+        return writer.toString();
+    }
+
+    // ---------- 证书解析 ----------
+
+    @Test
+    void parse_shouldDescribeSingleCertificate_withSanAndFingerprints() throws Exception {
+        DevToolCertParseResponse response = service.parse(toPem(rsaCert));
+
+        assertEquals(1, response.getCertificates().size());
+        DevToolCertInfo info = response.getCertificates().get(0);
+        assertTrue(info.getSubject().contains("unit-test-rsa.example.com"));
+        assertEquals("RSA", info.getPublicKeyAlgorithm());
+        assertEquals(2048, info.getPublicKeyBits());
+        assertFalse(info.isExpired());
+        assertTrue(info.isCa(), "RSA 测试证书带 CA BasicConstraints");
+        assertTrue(info.getSubjectAlternativeNames().stream().anyMatch(s -> s.equals("DNS:san.example.com")));
+        assertTrue(info.getSubjectAlternativeNames().stream().anyMatch(s -> s.startsWith("IP:")));
+        assertEquals(32, info.getSha256Fingerprint().split(":").length, "SHA-256 指纹应为 32 组冒号分隔字节");
+        assertEquals(20, info.getSha1Fingerprint().split(":").length, "SHA-1 指纹应为 20 组冒号分隔字节");
+        assertTrue(info.getDaysRemaining() > 300);
+    }
+
+    @Test
+    void parse_shouldDescribeCertChain_inInputOrder() throws Exception {
+        DevToolCertParseResponse response = service.parse(toPem(rsaCert) + "\n" + toPem(ecCert));
+
+        assertEquals(2, response.getCertificates().size());
+        assertTrue(response.getCertificates().get(0).getSubject().contains("rsa"));
+        assertEquals("EC", response.getCertificates().get(1).getPublicKeyAlgorithm());
+        assertEquals(256, response.getCertificates().get(1).getPublicKeyBits());
+        assertFalse(response.getCertificates().get(1).isCa());
+    }
+
+    @Test
+    void parse_shouldDescribeCsr_withSubjectAndKey() throws Exception {
+        PKCS10CertificationRequest csr = new JcaPKCS10CertificationRequestBuilder(
+            new X500Name("CN=csr.example.com,O=UnitTest"), rsaKeyPair.getPublic())
+            .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider(BC).build(rsaKeyPair.getPrivate()));
+
+        DevToolCertParseResponse response = service.parse(toPem(csr));
+
+        assertTrue(response.getCertificates().isEmpty());
+        assertEquals(1, response.getCsrs().size());
+        assertTrue(response.getCsrs().get(0).getSubject().contains("csr.example.com"));
+        assertEquals("RSA", response.getCsrs().get(0).getPublicKeyAlgorithm());
+        assertEquals(2048, response.getCsrs().get(0).getPublicKeyBits());
+    }
+
+    @Test
+    void parse_shouldFastFail_whenNoRecognizableBlock() {
+        BizException e = assertThrows(BizException.class, () -> service.parse("hello world"));
+        assertEquals(ResultCode.PARAM_INVALID, e.getResultCode());
+    }
+
+    // ---------- 私钥匹配 ----------
+
+    @Test
+    void match_shouldPass_forPairedRsaKey() throws Exception {
+        DevToolCertMatchResponse response = service.match(toPem(rsaCert), toPem(rsaKeyPair.getPrivate()));
+        assertTrue(response.isMatched());
+        assertEquals("RSA", response.getPublicKeyAlgorithm());
+    }
+
+    @Test
+    void match_shouldFail_forWrongRsaKey() throws Exception {
+        DevToolCertMatchResponse response = service.match(toPem(rsaCert), toPem(rsaKeyPair2.getPrivate()));
+        assertFalse(response.isMatched());
+    }
+
+    @Test
+    void match_shouldPass_forPairedEcKey() throws Exception {
+        DevToolCertMatchResponse response = service.match(toPem(ecCert), pkcs8Pem(ecKeyPair));
+        assertTrue(response.isMatched());
+    }
+
+    /** openssl 导出的 SEC1（-----BEGIN EC PRIVATE KEY-----）格式也要能解，这是最常见的 EC 私钥形态。 */
+    @Test
+    void match_shouldPass_forOpensslSec1EcKey() {
+        DevToolCertMatchResponse response = service.match(OPENSSL_EC_CERT_PEM, OPENSSL_EC_SEC1_KEY_PEM);
+        assertTrue(response.isMatched(), "openssl SEC1 EC 私钥应能与其自签证书配对");
+    }
+
+    @Test
+    void match_shouldReportAlgorithmMismatch_withoutProbe() throws Exception {
+        DevToolCertMatchResponse response = service.match(toPem(rsaCert), pkcs8Pem(ecKeyPair));
+        assertFalse(response.isMatched());
+        assertTrue(response.getReason().contains("算法不一致"));
+    }
+
+    @Test
+    void match_shouldFastFail_whenPrivateKeyPemInvalid() throws Exception {
+        String certPem = toPem(rsaCert);
+        BizException e = assertThrows(BizException.class, () -> service.match(certPem, "not a key"));
+        assertEquals(ResultCode.PARAM_INVALID, e.getResultCode());
+    }
+
+    // ---------- 密钥库 ----------
+
+    @Test
+    void parseKeystore_shouldListPkcs12Entries_withChain() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("unit-test-key", rsaKeyPair.getPrivate(), "changeit".toCharArray(),
+            new X509Certificate[] {rsaCert});
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        keyStore.store(out, "changeit".toCharArray());
+
+        DevToolKeystoreParseResponse response = service.parseKeystore(out.toByteArray(), "changeit");
+
+        assertEquals("PKCS12", response.getKeystoreType());
+        assertEquals(1, response.getEntries().size());
+        DevToolKeystoreParseResponse.Entry entry = response.getEntries().get(0);
+        assertEquals("unit-test-key", entry.getAlias());
+        assertEquals("PRIVATE_KEY", entry.getEntryType());
+        assertEquals(1, entry.getChain().size());
+        assertTrue(entry.getChain().get(0).getSubject().contains("unit-test-rsa.example.com"));
+    }
+
+    @Test
+    void parseKeystore_shouldFastFail_onWrongPassword() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("k", rsaKeyPair.getPrivate(), "changeit".toCharArray(),
+            new X509Certificate[] {rsaCert});
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        keyStore.store(out, "changeit".toCharArray());
+        byte[] data = out.toByteArray();
+
+        BizException e = assertThrows(BizException.class, () -> service.parseKeystore(data, "wrong"));
+        assertEquals(ResultCode.PARAM_INVALID, e.getResultCode());
+    }
+}

--- a/customer-admin-web/src/api/devtools.ts
+++ b/customer-admin-web/src/api/devtools.ts
@@ -31,3 +31,72 @@ const HTTP_TOOL_TIMEOUT_MS = 45000
 export function sendHttpRequest(data: HttpSendRequest) {
   return request<HttpSendResponse>({ url: '/devtools/http/send', method: 'post', data, timeout: HTTP_TOOL_TIMEOUT_MS })
 }
+
+// ---------- 证书解析 ----------
+
+export interface CertInfo {
+  subject: string
+  issuer: string
+  serialNumberHex: string
+  version: number
+  notBeforeMs: number
+  notAfterMs: number
+  expired: boolean
+  daysRemaining: number
+  sigAlgName: string
+  publicKeyAlgorithm: string
+  publicKeyBits: number
+  ca: boolean
+  subjectAlternativeNames: string[]
+  keyUsages: string[]
+  sha1Fingerprint: string
+  sha256Fingerprint: string
+}
+
+export interface CsrInfo {
+  subject: string
+  publicKeyAlgorithm: string
+  publicKeyBits: number
+  sigAlgName: string
+  subjectAlternativeNames: string[]
+}
+
+export interface CertParseResponse {
+  certificates: CertInfo[]
+  csrs: CsrInfo[]
+}
+
+export interface CertMatchResponse {
+  matched: boolean
+  publicKeyAlgorithm: string
+  reason: string
+}
+
+export interface KeystoreEntry {
+  alias: string
+  entryType: string
+  chain: CertInfo[]
+}
+
+export interface KeystoreParseResponse {
+  keystoreType: string
+  entries: KeystoreEntry[]
+}
+
+/** 解析 PEM 文本中的证书/证书链/CSR（后端 Java 解析，内容不落库）。 */
+export function parseCertPem(pemContent: string) {
+  return request<CertParseResponse>({ url: '/devtools/cert/parse', method: 'post', data: { pemContent } })
+}
+
+/** 私钥与证书匹配校验（私钥仅在后端内存中参与一次签名-验签探测）。 */
+export function matchCertKey(certPem: string, privateKeyPem: string) {
+  return request<CertMatchResponse>({ url: '/devtools/cert/match', method: 'post', data: { certPem, privateKeyPem } })
+}
+
+/** 解析 PFX/PKCS12 或 JKS 密钥库，列出条目与证书链。 */
+export function parseKeystore(file: File, password: string) {
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('password', password)
+  return request<KeystoreParseResponse>({ url: '/devtools/cert/keystore', method: 'post', data: formData })
+}

--- a/customer-admin-web/src/views/system/devtools/CertInfoCard.vue
+++ b/customer-admin-web/src/views/system/devtools/CertInfoCard.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import type { CertInfo } from '@/api/devtools'
+
+// 单张证书的展示卡片：证书解析、密钥库条目链、匹配校验三处复用同一渲染
+defineProps<{ cert: CertInfo; index?: number }>()
+
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleString('zh-CN')
+}
+</script>
+
+<template>
+  <el-card shadow="never" class="cert-card">
+    <template #header>
+      <div class="cert-header">
+        <span class="cert-title">
+          <template v-if="index != null">#{{ index + 1 }} </template>
+          {{ cert.subject }}
+        </span>
+        <span class="cert-tags">
+          <el-tag v-if="cert.ca" type="warning" size="small">CA</el-tag>
+          <el-tag :type="cert.expired ? 'danger' : 'success'" size="small">
+            {{ cert.expired ? '已过期/未生效' : `剩余 ${cert.daysRemaining} 天` }}
+          </el-tag>
+        </span>
+      </div>
+    </template>
+    <el-descriptions :column="2" size="small" border>
+      <el-descriptions-item label="使用者" :span="2">{{ cert.subject }}</el-descriptions-item>
+      <el-descriptions-item label="颁发者" :span="2">{{ cert.issuer }}</el-descriptions-item>
+      <el-descriptions-item label="序列号">{{ cert.serialNumberHex }}</el-descriptions-item>
+      <el-descriptions-item label="版本">V{{ cert.version }}</el-descriptions-item>
+      <el-descriptions-item label="生效时间">{{ formatTime(cert.notBeforeMs) }}</el-descriptions-item>
+      <el-descriptions-item label="过期时间">{{ formatTime(cert.notAfterMs) }}</el-descriptions-item>
+      <el-descriptions-item label="签名算法">{{ cert.sigAlgName }}</el-descriptions-item>
+      <el-descriptions-item label="公钥">
+        {{ cert.publicKeyAlgorithm }}<template v-if="cert.publicKeyBits > 0"> {{ cert.publicKeyBits }} bit</template>
+      </el-descriptions-item>
+      <el-descriptions-item label="SAN" :span="2">
+        <template v-if="cert.subjectAlternativeNames.length > 0">
+          <el-tag v-for="san in cert.subjectAlternativeNames" :key="san" size="small" class="san-tag">{{ san }}</el-tag>
+        </template>
+        <span v-else class="muted">-</span>
+      </el-descriptions-item>
+      <el-descriptions-item label="密钥用法" :span="2">
+        <template v-if="cert.keyUsages.length > 0">
+          <el-tag v-for="usage in cert.keyUsages" :key="usage" type="info" size="small" class="san-tag">{{ usage }}</el-tag>
+        </template>
+        <span v-else class="muted">-</span>
+      </el-descriptions-item>
+      <el-descriptions-item label="SHA-1 指纹" :span="2">
+        <code class="fingerprint">{{ cert.sha1Fingerprint }}</code>
+      </el-descriptions-item>
+      <el-descriptions-item label="SHA-256 指纹" :span="2">
+        <code class="fingerprint">{{ cert.sha256Fingerprint }}</code>
+      </el-descriptions-item>
+    </el-descriptions>
+  </el-card>
+</template>
+
+<style scoped>
+.cert-card {
+  margin-bottom: 12px;
+}
+
+.cert-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.cert-title {
+  font-weight: 500;
+  word-break: break-all;
+}
+
+.cert-tags {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.san-tag {
+  margin-right: 6px;
+  margin-bottom: 4px;
+}
+
+.fingerprint {
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.muted {
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/CertTool.vue
+++ b/customer-admin-web/src/views/system/devtools/CertTool.vue
@@ -1,0 +1,287 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  matchCertKey,
+  parseCertPem,
+  parseKeystore,
+  type CertMatchResponse,
+  type CertParseResponse,
+  type KeystoreParseResponse,
+} from '@/api/devtools'
+import { usePersistedRef } from './composables/useToolStorage'
+import CertInfoCard from './CertInfoCard.vue'
+
+type CertMode = 'parse' | 'match' | 'keystore'
+
+const mode = usePersistedRef<CertMode>('cert:mode', 'parse')
+
+// ---------- 证书 / CSR 解析 ----------
+
+const pemContent = usePersistedRef('cert:pem', '')
+const parsing = ref(false)
+const parseResult = ref<CertParseResponse | null>(null)
+
+async function handleParse() {
+  if (!pemContent.value.trim()) {
+    ElMessage.warning('请先粘贴 PEM 内容')
+    return
+  }
+  parsing.value = true
+  try {
+    parseResult.value = await parseCertPem(pemContent.value)
+  } finally {
+    parsing.value = false
+  }
+}
+
+function clearParse() {
+  pemContent.value = ''
+  parseResult.value = null
+}
+
+// ---------- 私钥匹配校验 ----------
+// 私钥属敏感信息，与 AES 工具的密钥同等对待：用普通 ref，不进 localStorage
+
+const matchCertPem = usePersistedRef('cert:matchCert', '')
+const matchKeyPem = ref('')
+const matching = ref(false)
+const matchResult = ref<CertMatchResponse | null>(null)
+
+async function handleMatch() {
+  if (!matchCertPem.value.trim() || !matchKeyPem.value.trim()) {
+    ElMessage.warning('证书与私钥都要填写')
+    return
+  }
+  matching.value = true
+  try {
+    matchResult.value = await matchCertKey(matchCertPem.value, matchKeyPem.value)
+  } finally {
+    matching.value = false
+  }
+}
+
+function clearMatch() {
+  matchCertPem.value = ''
+  matchKeyPem.value = ''
+  matchResult.value = null
+}
+
+// ---------- 密钥库 ----------
+// 库密码同样不持久化
+
+const keystorePassword = ref('')
+const keystoreFileName = ref('')
+const keystoreLoading = ref(false)
+const keystoreResult = ref<KeystoreParseResponse | null>(null)
+
+async function handleKeystoreUpload(options: { file: File }) {
+  keystoreLoading.value = true
+  keystoreFileName.value = options.file.name
+  try {
+    keystoreResult.value = await parseKeystore(options.file, keystorePassword.value)
+  } finally {
+    keystoreLoading.value = false
+  }
+}
+
+function clearKeystore() {
+  keystorePassword.value = ''
+  keystoreFileName.value = ''
+  keystoreResult.value = null
+}
+</script>
+
+<template>
+  <div class="cert-tool">
+    <el-alert type="info" :closable="false" show-icon class="notice">
+      证书解析在<b>后端 Java</b> 完成（浏览器无 X.509 原生解析能力）。所有输入只在请求内存中解析，
+      不落库、不写日志；私钥与密钥库密码不做本地持久化，刷新页面即清空。
+    </el-alert>
+
+    <el-radio-group v-model="mode" class="mode-switch">
+      <el-radio-button value="parse">证书 / CSR 解析</el-radio-button>
+      <el-radio-button value="match">私钥匹配校验</el-radio-button>
+      <el-radio-button value="keystore">PFX / JKS 密钥库</el-radio-button>
+    </el-radio-group>
+
+    <!-- 证书 / CSR 解析 -->
+    <div v-if="mode === 'parse'">
+      <el-input
+        v-model="pemContent"
+        type="textarea"
+        :rows="10"
+        placeholder="粘贴 -----BEGIN CERTIFICATE----- 证书或证书链，也支持 -----BEGIN CERTIFICATE REQUEST----- (CSR)；可一次粘贴多段"
+      />
+      <div class="actions">
+        <el-button type="primary" :loading="parsing" @click="handleParse">解析</el-button>
+        <el-button @click="clearParse">清空</el-button>
+      </div>
+
+      <template v-if="parseResult">
+        <template v-if="parseResult.certificates.length > 0">
+          <h4 class="section-title">证书（{{ parseResult.certificates.length }}）</h4>
+          <CertInfoCard
+            v-for="(cert, i) in parseResult.certificates"
+            :key="cert.sha256Fingerprint + i"
+            :cert="cert"
+            :index="parseResult.certificates.length > 1 ? i : undefined"
+          />
+        </template>
+        <template v-if="parseResult.csrs.length > 0">
+          <h4 class="section-title">证书签名请求（{{ parseResult.csrs.length }}）</h4>
+          <el-card v-for="(csr, i) in parseResult.csrs" :key="i" shadow="never" class="csr-card">
+            <el-descriptions :column="2" size="small" border>
+              <el-descriptions-item label="申请主题" :span="2">{{ csr.subject }}</el-descriptions-item>
+              <el-descriptions-item label="公钥">
+                {{ csr.publicKeyAlgorithm }}<template v-if="csr.publicKeyBits > 0"> {{ csr.publicKeyBits }} bit</template>
+              </el-descriptions-item>
+              <el-descriptions-item label="签名算法">{{ csr.sigAlgName }}</el-descriptions-item>
+              <el-descriptions-item label="SAN" :span="2">
+                <template v-if="csr.subjectAlternativeNames.length > 0">
+                  <el-tag v-for="san in csr.subjectAlternativeNames" :key="san" size="small" class="san-tag">{{ san }}</el-tag>
+                </template>
+                <span v-else class="muted">-</span>
+              </el-descriptions-item>
+            </el-descriptions>
+          </el-card>
+        </template>
+      </template>
+    </div>
+
+    <!-- 私钥匹配校验 -->
+    <div v-else-if="mode === 'match'">
+      <div class="match-inputs">
+        <div class="match-col">
+          <div class="field-label">证书 PEM</div>
+          <el-input v-model="matchCertPem" type="textarea" :rows="9" placeholder="-----BEGIN CERTIFICATE-----" />
+        </div>
+        <div class="match-col">
+          <div class="field-label">私钥 PEM（不持久化，支持 PKCS#8 / PKCS#1 / SEC1，不支持加密私钥）</div>
+          <el-input v-model="matchKeyPem" type="textarea" :rows="9" placeholder="-----BEGIN PRIVATE KEY----- 或 -----BEGIN RSA/EC PRIVATE KEY-----" />
+        </div>
+      </div>
+      <div class="actions">
+        <el-button type="primary" :loading="matching" @click="handleMatch">校验匹配</el-button>
+        <el-button @click="clearMatch">清空</el-button>
+      </div>
+      <el-result
+        v-if="matchResult"
+        :icon="matchResult.matched ? 'success' : 'error'"
+        :title="matchResult.matched ? '私钥与证书配对' : '私钥与证书不配对'"
+        :sub-title="`${matchResult.reason}（公钥算法：${matchResult.publicKeyAlgorithm}）`"
+      />
+    </div>
+
+    <!-- 密钥库 -->
+    <div v-else>
+      <div class="keystore-form">
+        <el-input
+          v-model="keystorePassword"
+          type="password"
+          show-password
+          placeholder="密钥库密码（不持久化，无密码留空）"
+          style="width: 320px"
+        />
+        <el-upload :show-file-list="false" :http-request="handleKeystoreUpload" accept=".pfx,.p12,.jks,.keystore">
+          <el-button type="primary" :loading="keystoreLoading">选择 .pfx / .p12 / .jks 文件</el-button>
+        </el-upload>
+        <el-button @click="clearKeystore">清空</el-button>
+      </div>
+      <div v-if="keystoreFileName" class="file-hint">已选文件：{{ keystoreFileName }}</div>
+
+      <template v-if="keystoreResult">
+        <h4 class="section-title">
+          密钥库类型：{{ keystoreResult.keystoreType }} · 条目 {{ keystoreResult.entries.length }} 个
+        </h4>
+        <el-collapse>
+          <el-collapse-item v-for="entry in keystoreResult.entries" :key="entry.alias" :name="entry.alias">
+            <template #title>
+              <span class="entry-title">
+                {{ entry.alias }}
+                <el-tag :type="entry.entryType === 'PRIVATE_KEY' ? 'success' : 'info'" size="small">
+                  {{ entry.entryType === 'PRIVATE_KEY' ? '含私钥' : '仅证书' }}
+                </el-tag>
+                <span class="muted">证书链 {{ entry.chain.length }} 张</span>
+              </span>
+            </template>
+            <CertInfoCard
+              v-for="(cert, i) in entry.chain"
+              :key="cert.sha256Fingerprint + i"
+              :cert="cert"
+              :index="entry.chain.length > 1 ? i : undefined"
+            />
+          </el-collapse-item>
+        </el-collapse>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notice {
+  margin-bottom: 12px;
+}
+
+.mode-switch {
+  margin-bottom: 12px;
+}
+
+.actions {
+  margin: 12px 0;
+  display: flex;
+  gap: 8px;
+}
+
+.section-title {
+  margin: 16px 0 8px;
+  font-size: 14px;
+}
+
+.match-inputs {
+  display: flex;
+  gap: 12px;
+}
+
+.match-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.field-label {
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+}
+
+.keystore-form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.file-hint {
+  margin-top: 8px;
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+}
+
+.entry-title {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.csr-card {
+  margin-bottom: 12px;
+}
+
+.san-tag {
+  margin-right: 6px;
+  margin-bottom: 4px;
+}
+
+.muted {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/toolRegistry.ts
+++ b/customer-admin-web/src/views/system/devtools/toolRegistry.ts
@@ -49,6 +49,12 @@ export const devTools: DevTool[] = [
     description: 'GET/POST/PUT/DELETE/PATCH 等，后端代理发送免 CORS',
     component: () => import('./HttpRequestTool.vue'),
   },
+  {
+    key: 'cert',
+    label: '证书解析',
+    description: 'X.509 证书/证书链、CSR、私钥匹配校验、PFX/JKS 密钥库',
+    component: () => import('./CertTool.vue'),
+  },
 ]
 
 export const defaultToolKey = devTools[0].key

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -814,6 +814,8 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/contentguard/sensitive-word/**` | 敏感词词库管理（CRUD/启停/批量导入导出/枚举下拉，权限点 `sensitive-word:*`），见 §6.14.2 |
 | `/api/contentguard/rate-limit-rule/**` | 限流规则管理（CRUD/启停/枚举下拉，权限点 `rate-limit-rule:*`），见 §6.14.1 |
 | `/api/contentguard/hit-log/{page,stats}` | 敏感词命中看板（明细分页 + 动作/方向分布 + Top 命中词 + 时间趋势，只读，权限点 `sensitive-hit-log:view`） |
+| `POST /api/devtools/http/send` | 开发者工具箱 · HTTP 请求后端代理（免 CORS，权限点复用 `devtools:view`） |
+| `/api/devtools/cert/{parse,match,keystore}` | 开发者工具箱 · 证书解析（X.509 证书链 / CSR / 私钥匹配校验 / PFX·JKS 密钥库，权限点复用 `devtools:view`） |
 | `/swagger-ui/index.html` | 接口文档 |
 
 **调用统计的 token 口径（V43 起补齐缓存量）**：框架 `ChatUsage` 一共只给四个原始量——
@@ -862,6 +864,19 @@ admin.content-guard:
 > fail-closed（拦截一切）——这是敏感词的既定语义。`SensitiveWordRefreshTask` 随后按间隔重试，库恢复即自动
 > 脱离，无需重启 admin。该任务自带守护线程定时器而非 `@Scheduled`：admin 至今没开 `@EnableScheduling`，
 > 为一个词表刷新去打开全局调度会把容器里所有 `@Scheduled` Bean 一并激活，影响面远大于收益。
+
+**开发者工具箱 · 证书解析**：系统工具 → 工具箱 → 证书解析。四种模式——PEM 证书/证书链解析、
+CSR（PKCS#10）解析、私钥与证书匹配校验、PFX·PKCS12·JKS 密钥库条目枚举。
+
+放**后端 Java 解析**而不是纯前端：浏览器没有 X.509 解析原生 API，纯前端要自带 ASN.1 解析库且字段覆盖
+远不如 `CertificateFactory` 完整；CSR 与 PKCS#1/SEC1 私钥更是 JDK 原生也不认，靠 BouncyCastle
+（`bcpkix-jdk18on`，版本只在 admin-server 模块声明）。BC Provider 以实例方式传入，不注册进全局 `Security`。
+
+隐私边界：所有输入只在请求内存中解析，**不落库、不写日志**（error 日志只记错误码，不回显证书/私钥内容）；
+私钥与密钥库密码在前端也不做 localStorage 持久化（与 AES 工具的密钥同等对待）。密钥库上传上限 1MB。
+
+> 私钥匹配用**签名-验签探测**而非公钥参数比对：算法无关（RSA/EC/Ed25519 通吃），也天然规避各算法
+> 公钥表示差异。算法本就不一致时直接返回结论，不做无谓探测。
 
 生产建表由 DBA 参照 **[mysql/02-customer-admin/](../mysql/02-customer-admin/)**（V1~V20 有序副本）手工执行（与 `mysql/01-agent-scope-customer-work/customer-work-schema.sql`
 客服主业务库物理隔离，独立数据库 `customer_admin`），与仓库既有"生产不自动建表"约定一致。


### PR DESCRIPTION
## 需求

系统工具里新增证书解析。

## 做了什么

工具箱新增第 7 个工具，四种模式：
- **PEM 证书 / 证书链解析**：主题、颁发者、序列号、有效期与剩余天数、SAN、密钥用法、CA 标记、SHA-1/SHA-256 指纹
- **CSR（PKCS#10）解析**：申请主题、公钥算法与长度、签名算法、请求扩展里的 SAN
- **私钥与证书匹配校验**
- **PFX / PKCS12 / JKS 密钥库**：上传 + 密码，列出条目（含私钥 / 仅证书）与各自证书链

后端 `/api/devtools/cert/{parse,match,keystore}`，权限复用工具箱菜单的 `devtools:view`（与其余工具授权粒度一致，**无新增权限点、无数据库迁移**）。

## 关键决策

- **后端 Java 解析而非纯前端**：浏览器没有 X.509 解析原生 API，纯前端要自带 ASN.1 库且字段覆盖远不如 `CertificateFactory`；CSR 与 PKCS#1/SEC1 私钥 JDK 原生也不认，靠 BouncyCastle（`bcpkix-jdk18on` 1.81，版本只在 admin-server 模块声明，不动根 pom；BC Provider 以实例传入，不注册进全局 `Security`）
- **隐私边界**：输入只在请求内存中解析，不落库、不写日志（error 只记错误码不回显内容）；私钥与密钥库密码前端也不做 localStorage 持久化（与 AES 工具的密钥同等对待）。密钥库上传上限 1MB
- **匹配用签名-验签探测而非公钥参数比对**：算法无关（RSA/EC/Ed25519 通吃），规避各算法公钥表示差异；算法本就不一致时直接返回结论不做无谓探测

## 测试

admin-server 全量 `BUILD SUCCESS`，**798**（786 基线 + 12 例）。测试材料由 BouncyCastle 现场生成，另含一组 openssl 真实 SEC1 EC 私钥用例——正是它暴露了「SEC1 块缺公钥段时 `getKeyPair` 抛 NPE」需要回落解私钥结构。

前端 `vite build` 通过，`CertTool` 已进产物。

> 本 PR 不改 CLAUDE.md 测试基线（与 #66 会在同一行冲突），基线由后合入者统一更新为 admin-server 807。

🤖 Generated with [Claude Code](https://claude.com/claude-code)