### PR TITLE
fix(starter): 修复多构造器缺 @Autowired 导致的上下文启动失败与静默降级

### DIFF
--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/approval/PendingApprovalService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/approval/PendingApprovalService.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.approval;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,7 +42,13 @@ public class PendingApprovalService {
     private final AtomicReference<Consumer<ApprovalRequest>> onApprove = new AtomicReference<>(r -> { });
     private final AtomicReference<Consumer<ApprovalRequest>> onDeny = new AtomicReference<>(r -> { });
 
-    /** Spring 注入构造：使用自动装配的 ApprovalStore Bean。 */
+    /**
+     * Spring 注入构造：使用自动装配的 ApprovalStore Bean。
+     *
+     * <p>必须标 {@code @Autowired}：本类同时存在无参构造，Spring 对「多构造器 + 存在无参 + 无
+     * {@code @Autowired}」会回退到无参构造 → 永远用内存实现、审批单重启即丢。</p>
+     */
+    @Autowired
     public PendingApprovalService(ApprovalStore store) {
         this.store = store;
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dialog/DialogStageService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/dialog/DialogStageService.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.dialog;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -22,7 +23,13 @@ public class DialogStageService {
 
     private final DialogStageStore store;
 
-    /** Spring 注入构造：使用自动装配的 DialogStageStore Bean。 */
+    /**
+     * Spring 注入构造：使用自动装配的 DialogStageStore Bean。
+     *
+     * <p>必须标 {@code @Autowired}：本类同时存在无参构造，Spring 对「多构造器 + 存在无参 + 无
+     * {@code @Autowired}」会回退到无参构造 → 永远用内存实现、配置的落库 Store 空转。</p>
+     */
+    @Autowired
     public DialogStageService(DialogStageStore store) {
         this.store = store;
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/middleware/IndirectInjectionGuardMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/middleware/IndirectInjectionGuardMiddleware.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -83,7 +84,14 @@ public class IndirectInjectionGuardMiddleware implements MiddlewareBase {
     /** 可为 null：未接入 Micrometer 时观测降级为仅日志。 */
     private final MeterRegistry meterRegistry;
 
-    /** Spring 装配构造：客服端（starter 自动装配生效）走这条。 */
+    /**
+     * Spring 装配构造：客服端（starter 自动装配生效）走这条。
+     *
+     * <p>必须标 {@code @Autowired}：本类同时存在下面那个直接参数构造，Spring 对「多 public 构造器 +
+     * 无 {@code @Autowired}」无法判定候选，会回退去找无参构造 → 直接 {@code NoSuchMethodException}
+     * 让整个上下文起不来。显式标注让容器选中本构造。</p>
+     */
+    @Autowired
     public IndirectInjectionGuardMiddleware(CustomerWorkProperties properties,
                                             ObjectProvider<MeterRegistry> meterRegistryProvider) {
         this(properties.getHooks().getIndirectInjectionGuard().isEnabled(),

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/ModelCostCircuitBreaker.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/ModelCostCircuitBreaker.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerwork.observability;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -41,6 +42,14 @@ public class ModelCostCircuitBreaker {
     private final AtomicLong currentHourTokens = new AtomicLong(0);
     private volatile long currentHourTimestamp = currentHour();
 
+    /**
+     * Spring 注入构造：读取 {@code model.cost-control.*} 配置。
+     *
+     * <p>必须标 {@code @Autowired}：本类同时存在无参构造，Spring 对「多构造器 + 存在无参 + 无
+     * {@code @Autowired}」会回退到无参构造 → 熔断器永远处于禁用态、
+     * {@code model.cost-control.enabled=true} 空转。</p>
+     */
+    @Autowired
     public ModelCostCircuitBreaker(CustomerWorkProperties properties) {
         this.enabled = properties.getModel().getCostControl().isEnabled();
         this.maxTokensPerMinute = properties.getModel().getCostControl().getMaxTokensPerMinute();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/slotfilling/SlotFillingService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/slotfilling/SlotFillingService.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.slotfilling;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -30,7 +31,13 @@ public class SlotFillingService {
 
     private final SlotFillingStore store;
 
-    /** Spring 注入构造。 */
+    /**
+     * Spring 注入构造。
+     *
+     * <p>必须标 {@code @Autowired}：本类同时存在无参构造，Spring 对「多构造器 + 存在无参 + 无
+     * {@code @Autowired}」会回退到无参构造 → 永远用内存实现、配置的落库 Store 空转。</p>
+     */
+    @Autowired
     public SlotFillingService(SlotFillingStore store) {
         this.store = store;
     }


### PR DESCRIPTION
## 问题

PR #65 引入的 `IndirectInjectionGuardMiddleware` 标了 `@Component`，但类里有两个 public 构造器且都没有 `@Autowired`。Spring 无法判定注入候选，回退去找无参构造器 → `NoSuchMethodException`。

影响面不止测试：**customer-work-app-server（8080 智能客服示例）整个 Spring 上下文起不来**，`ApplicationContextTest` 只是最先暴露它的地方。PR #65 合入时未重跑 app-server 模块测试，所以没被发现。

## 顺带修掉的 4 个同类漏网之鱼

排查 starter 全量 `@Component`/`@Service` + 多构造器的类，又找到 4 个。它们的第二个构造器是**无参**的，所以 Spring 回退时不报错，而是静默选中无参构造——故障比上面那个更隐蔽：

| 类 | 静默后果 |
|---|---|
| `DialogStageService` | 永远走 `InMemoryDialogStageStore`，Config 里按 store-mode 装配的落库 Store Bean 空转 |
| `SlotFillingService` | 同上 |
| `PendingApprovalService` | 同上，审批单重启即丢 |
| `ModelCostCircuitBreaker` | 永远 `enabled=false`，`model.cost-control.enabled=true` 空转 |

这不是新猜测：`HandoffService:48-50` 早前踩过同一个坑，注释里已写明成因（"多构造器 + 存在无参 + 无 `@Autowired` 会回退到无参构造 → 永远用内存实现、`store-mode=jdbc` 空转"）。本次按同样方式修齐，并在每个构造器上补了说明成因的注释，避免再犯。

三个 Store 的默认 Bean 均由各自 Config 声明（含 jdbc 分支），加 `@Autowired` 后能正常注入；默认内存分支行为不变。

## 验证

```
mvn -pl customer-work-starter,customer-work-app-server test -Djacoco.skip=true \
  -Dtest='!MinioAttachmentFileStorageIntegrationTest,!RedisSessionPersistenceTest'
```

- starter **778** 通过（skip 2 个环境门控测试：MinIO 9000 被 kb-rag 栈占、Redis 无密码）
- app-server **78** 通过，含 `ApplicationContextTest`
- BUILD SUCCESS，与基线一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)