### PR TITLE
refactor(admin): ChatService 迁到 streamEvents，删掉四份增量去重状态

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/a2a/AdminAgentRunner.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/a2a/AdminAgentRunner.java
@@ -91,7 +91,16 @@ public class AdminAgentRunner implements AgentRunner {
 
     /**
      * {@code stream(List, StreamOptions, RuntimeContext)} 只声明在 {@link ReActAgent}/{@link HarnessAgent}
-     * 上而不在 {@code Agent} 接口上，因此这里按运行时类型分派——与 {@code ChatService#streamEvents} 同款处理。
+     * 上而不在 {@code Agent} 接口上，因此这里按运行时类型分派。
+     *
+     * <p><b>为什么这里还在用已标记 {@code forRemoval} 的 {@code stream(...)}</b>（对话链路的
+     * {@code ChatService} 已迁到 {@code streamEvents(...)}，本处刻意没跟）：{@link AgentRunner#stream}
+     * 的返回类型被框架写死为 {@code Flux<}{@link Event}{@code >}，就是那个废弃类型本身；框架自带的参考
+     * 实现 {@code BaseReActAgentRunner} 也仍在调 {@code agent.stream(msgs)}——A2A 这一层框架自己都没迁。
+     * 若本方法改用 {@code streamEvents(...)}，拿到 {@code AgentEvent} 后还得手工 {@code new Event(...)}
+     * 喂回接口，废弃 API 的暴露面一点没减少，反而要自行复刻 {@code AgentScopeAgentExecutor} 依赖的
+     * {@code isLast}/{@code messageId} 去重语义（它靠这两个字段判重与拼装回包），平白引入一层易错的
+     * 翻译。等框架把 A2A 层迁到细粒度事件后再跟进。</p>
      */
     private Flux<Event> streamEvents(Agent agent, List<Msg> msgs, RuntimeContext ctx) {
         StreamOptions options = StreamOptions.builder()

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatStreamChunk.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/dto/ChatStreamChunk.java
@@ -10,16 +10,16 @@ import org.slf4j.LoggerFactory;
  * 代码块渲染），其余类型走 {@code node:<kind小写>} 事件，前端据此把执行轨迹渲染成
  * 开始思考 → 调用大模型/调用 Skill/调用 MCP → 结束思考 这样的时间线，而不是一整段纯文本。
  *
- * <p><b>子 Agent 归属标识</b>：当片段来自 harness spawn 出来的子 Agent（其全量事件经
- * {@code SubagentEventBus} 直推父 sink）时，{@code source}/{@code subagentName} 非空，前端据此把
- * 子 Agent 的执行轨迹渲染进独立的可折叠卡片/分组，而不是和父 Agent 主流程混在一起；来自父 Agent
- * 自身的片段两者均为 {@code null}（{@code io.agentscope.core.agent.EventSource == null}）。</p>
+ * <p><b>子 Agent 归属标识</b>：当片段来自 harness spawn 出来的子 Agent（其细粒度事件由框架的
+ * {@code AgentEventEmitter} 转发进父流并打上来源标记）时，{@code source}/{@code subagentName} 非空，
+ * 前端据此把子 Agent 的执行轨迹渲染进独立的可折叠卡片/分组，而不是和父 Agent 主流程混在一起；
+ * 来自父 Agent 自身的片段两者均为 {@code null}（{@code AgentEvent#getSource() == null}）。</p>
  *
  * @param kind         节点类型
  * @param text         该节点携带的文本（增量思考内容/工具名提示/工具返回结果/正文增量/子 Agent 名称）
- * @param source       子 Agent 的调用链路径（{@code EventSource.getPath()}，如 {@code "main/doc-writer"}），
+ * @param source       子 Agent 的调用链路径（{@code AgentEvent#getSource()}，如 {@code "main/doc-writer"}），
  *                     {@code null} 表示来自父 Agent 自身
- * @param subagentName 子 Agent 展示名（{@code EventSource.getAgentName()}，为空回退 {@code getAgentId()}），
+ * @param subagentName 子 Agent 展示名（取 {@code source} 路径末段，即子 Agent 的 agentId），
  *                     {@code null} 表示来自父 Agent 自身
  * @author owlzhangfq@gmail.com
  */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -15,17 +15,20 @@ import com.richard.fyoung.customeradmin.workspace.vibecoding.service.PlanConfirm
 import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
-import io.agentscope.core.agent.Event;
-import io.agentscope.core.agent.EventSource;
-import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.RuntimeContext;
-import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
-import io.agentscope.core.message.ThinkingBlock;
-import io.agentscope.core.message.ToolResultBlock;
-import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatUsage;
 import io.agentscope.harness.agent.HarnessAgent;
 import org.slf4j.Logger;
@@ -39,23 +42,22 @@ import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordStreamGuard;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * 工作区对话服务：从 {@link AgentInstanceCache} 取（或惰性构建）智能体实例，流式对话。
  *
- * <p>与 {@code CustomerServiceService#chatStream} 同一套"类型化事件流 -&gt; 提取增量文本"手法
- * （见 io.agentscope.core.agent.StreamOptions 用法），区别仅在于 Agent 实例来源：那边是启动期
- * 固定装配的单例，这里是按 agentCode 动态取的缓存实例，且底层可能是 ReActAgent 也可能是
- * HarnessAgent（{@link Agent} 接口统一了 {@code stream(...)} 签名，调用方无感知）。</p>
+ * <p>与 {@code CustomerServiceService#chatStream} 同一套"细粒度事件流 -&gt; 展示片段"手法
+ * （框架 {@code streamEvents(msgs, ctx)}），区别仅在于 Agent 实例来源：那边是启动期固定装配的
+ * 单例，这里是按 agentCode 动态取的缓存实例，且底层可能是 ReActAgent 也可能是 HarnessAgent
+ * （两者各自声明 {@code streamEvents}，本类按运行时类型分派，见 {@link #streamEvents}）。</p>
  *
  * <p>一轮流式对话正常结束（含内部异常被兜底成 {@link #FALLBACK_REPLY} 后正常结束的情形）后，主动调用
  * {@link ChatHistoryCache#evict} 让该智能体的历史会话列表缓存与本次会话的消息缓存立即失效——写路径本身
@@ -68,10 +70,12 @@ public class ChatService {
 
     private static final Logger log = LoggerFactory.getLogger(ChatService.class);
     private static final String FALLBACK_REPLY = "抱歉，我暂时无法处理这个请求，请稍后重试。";
-    /** 父 Agent 自身事件在 per-source 状态表里的 key（{@code EventSource == null}）。 */
+    /** 父 Agent 自身事件在 per-source 状态表里的 key（{@code AgentEvent#getSource() == null}）。 */
     private static final String MAIN_AGENT_SOURCE_KEY = "";
-    /** 子 Agent 的 {@code EventSource} 既无 path 也无 agentId 时的兜底 key，避免与父 Agent 的 "" 撞车。 */
-    private static final String SUBAGENT_FALLBACK_KEY = "subagent";
+    /** "调用大模型"节点的展示文案。 */
+    private static final String MODEL_CALL_TEXT = "调用大模型";
+    /** 子 Agent 调用链 path 的分隔符（框架 {@code AgentSpawnTool#buildSourcePath} 的约定：父会话/子 agentId）。 */
+    private static final String SOURCE_PATH_SEPARATOR = "/";
 
     private final AgentInstanceCache agentInstanceCache;
     private final AdminAgentInstanceFactory agentInstanceFactory;
@@ -214,8 +218,10 @@ public class ChatService {
      * token 用量汇总后回调一次 {@code usageTotalObserver}——供 VibeCoding 审计记录 token 数（需求文档 §5.3）。
      * 本轮无任何用量信息（框架/模型未返回 usage）时回调 {@code null}。
      *
-     * <p>聚合方式：框架把 usage 挂在事件消息（{@link Msg#getUsage()}）上，同一条消息的增量事件
-     * 会重复携带（后到覆盖先到），不同消息各算一次——按 messageId 去重后求和，两种语义都兼容。</p>
+     * <p>聚合方式：细粒度事件流里每次模型调用结束都会带一条 {@link ModelCallEndEvent}，其
+     * {@code usage} 就是这一次调用的用量，{@code replyId} 每次调用各不相同——按 replyId 去重后求和
+     * 即本轮全部模型调用（含子 Agent 的）的合计。比旧路径"从事件消息上捞 {@code Msg#getUsage()}
+     * 再按 messageId 去重"更贴合语义：那条路上增量事件与最终结果消息携带的口径并不统一。</p>
      *
      * <p><b>执行模式与 Plan 确认闭环</b>：订阅时把 {@code mode}（解析为 {@link ExecutionMode}）登记进
      * {@link ExecutionModeRegistry}（键 {@code agentCode:sessionId}），供 {@code ExecutionModeMiddleware}
@@ -253,38 +259,38 @@ public class ChatService {
         }
         ToolSourceInfo toolSource = agentInstanceFactory.toolSourceFor(agentCode);
 
-        // 除了 REASONING/AGENT_RESULT，还订阅 TOOL_RESULT——不然模型调用 MCP 工具等待结果的这段时间
-        // （可能好几秒）前端界面上什么都不会动，看起来像"卡住了"。includeActingChunk 让耗时较长的
-        // 工具也能流式吐中间结果，而不是等它彻底跑完才一次性出现。
-        StreamOptions options = StreamOptions.builder()
-            .eventTypes(EventType.REASONING, EventType.TOOL_RESULT, EventType.AGENT_RESULT)
-            .incremental(true)
-            .includeReasoningChunk(true) // 关键：让 REASONING 事件把思考内容也流出来
-            .includeActingChunk(true)
-            .build();
-
-        // 增量去重状态（最近提示过的工具名 / 是否已通过 REASONING 流出正文 / 上一段 reasoning 与 answer
-        // 全量文本 / 本轮 ReAct 迭代是否已标过"调用大模型"）都收拢进 {@link StreamState}，并按事件来源
-        // （父 Agent 用 "" / 子 Agent 用其调用链 path）各存一份：harness spawn 出的子 Agent 事件会经
-        // SubagentEventBus 与父 Agent 事件交错推到同一个 sink，若父子共用一份去重状态，累积型 provider
-        // 的前缀判断会互相污染（父的全量文本被子的全量文本"顶掉"，反之亦然）。每次 chatStream 各建一份，
-        // 不跨请求共享。
+        // 跨事件的拼装状态（工具结果分片累积 / 子 Agent 正文累积 / 是否已流式过正文）收拢进
+        // {@link StreamState}，并按事件来源（父 Agent 用 "" / 子 Agent 用其调用链 path）各存一份：
+        // harness spawn 出的子 Agent 事件会与父 Agent 事件交错推到同一条流上（框架给子事件打了
+        // {@code AgentEvent#getSource()} 标记），父子共用一份状态会把两股文本互相串进对方的缓冲区。
+        // 每次 chatStream 各建一份，不跨请求共享。
         Map<String, StreamState> stateBySource = new ConcurrentHashMap<>();
 
-        // Flux.defer 包一层：像 HarnessAgent.stream(...) 在沙箱资源获取失败时（如 docker 容器创建
-        // 超时）是同步抛异常，不是发出错误信号——不包 defer 的话，streamEvents(...) 这行方法调用本身
+        // 本轮各次模型调用的用量，流终止时汇总回调一次（完成/取消各有入口，正常只会命中其一）
+        Map<String, ChatUsage> usageByModelCall = new ConcurrentHashMap<>();
+        AtomicBoolean usageObserved = new AtomicBoolean(false);
+        Runnable observeUsage = () -> {
+            if (usageObserved.compareAndSet(false, true)) {
+                usageTotalObserver.accept(totalUsage(usageByModelCall));
+            }
+        };
+        // 出站敏感词过滤：每次请求一份独立的 guard 集合（有状态，跨请求复用会串内容）。
+        // 挂在接入层而不是中间件里的理由见 SensitiveWordStreamGuard 类注释（guard 的滑动缓冲是
+        // 每流一份的有状态对象，与 Agent 级共享的中间件 Bean 生命周期不符）。
+        Map<String, SensitiveWordStreamGuard> outboundGuards = new ConcurrentHashMap<>();
+
+        // Flux.defer 包一层：像 HarnessAgent 在沙箱资源获取失败时（如 docker 容器创建超时）是
+        // 同步抛异常，不是发出错误信号——不包 defer 的话，streamEvents(...) 这行方法调用本身
         // 就会直接向外抛，导致整个 chatStream(...) 方法体同步抛出，下面的 .onErrorResume(...) 根本
         // 没机会接管。届时 Spring MVC 的 SSE 响应式适配器可能已经提交了响应头，连接就会挂起不报错
         // 也不关闭，前端永远卡在"生成中..."。defer 把方法调用推迟到订阅时执行，任何同步异常都会被
         // Reactor 自动转成 Flux.error(...)，从而能被 onErrorResume 正常捕获、优雅降级成兜底话术。
-        Map<String, ChatUsage> usageByMessage = new ConcurrentHashMap<>();
-        // 出站敏感词过滤：每次请求一份独立的 guard 集合（有状态，跨请求复用会串内容）。
-        // 挂在这里而不是中间件里——agent.stream(...) 走 StreamingHook 旁路绕开了中间件链，
-        // 中间件只看得到最后那条 AGENT_RESULT，而它在 toMainChunks 里因"已流式过"被丢弃，
-        // 只改中间件的话出站过滤在流式链路上完全落空。详见 SensitiveWordStreamGuard 类注释。
-        Map<String, SensitiveWordStreamGuard> outboundGuards = new ConcurrentHashMap<>();
-        Flux<ChatStreamChunk> body = Flux.defer(() -> streamEvents(agent, List.of(userMsg), options, ctx))
-            .doOnNext(event -> collectUsage(usageByMessage, event))
+        Flux<ChatStreamChunk> body = Flux.defer(() -> streamEvents(agent, List.of(userMsg), ctx))
+            // 旧的 stream(...) 在 AgentBase#createEventStream 末尾自带 publishOn(boundedElastic)，
+            // streamEvents 没有：不切走的话下面的事件拼装、敏感词过滤与 SSE 写出全跑在模型 IO 线程上，
+            // 拖慢框架侧读取模型 chunk 的速度。
+            .publishOn(Schedulers.boundedElastic())
+            .doOnNext(event -> collectUsage(usageByModelCall, event))
             .concatMap(event -> Flux.fromIterable(toChunks(event, toolSource, stateBySource)))
             .concatMap(chunk -> guardChunk(chunk, outboundGuards))
             .concatWith(Flux.defer(() -> flushGuards(outboundGuards)));
@@ -304,7 +310,12 @@ public class ChatService {
                 // 同步失败只记日志不打断流（见 AgentMemorySyncService 的兜底约定）
                 memorySyncService.persistIfChanged(agentCode, agentInstanceFactory.resolveWorkspace(agentCode));
             })
-            .doFinally(signal -> usageTotalObserver.accept(totalUsage(usageByMessage)));
+            // 用量回调必须在终止信号"向下游传播之前"执行，故用 peek 语义的 doOnComplete/doOnCancel
+            // 而不是 doFinally：Reactor 的 doFinally 是先把 onComplete 传给下游、回调最后才跑，下游
+            // （{@code VibeCodingService} 落审计的那个 doFinally）会抢在本回调之前读到还没写入的用量。
+            // 上面的 onErrorResume 已把异常兜底成正常完成，错误路径同样走 onComplete。
+            .doOnComplete(observeUsage)
+            .doOnCancel(observeUsage);
 
         // 执行模式登记 + Plan 确认通道：与 RuntimeContext 一致地归一 sessionId，保证中间件按同一键读到模式、
         // 定位到同一通道。Flux.using 在订阅时（早于 Agent 产出任何事件）打开通道并把 plan/plan_result 事件
@@ -321,24 +332,23 @@ public class ChatService {
             .doFinally(signal -> executionModeRegistry.remove(agentCode, safeSession));
     }
 
-    /** 收集事件消息上的模型用量：同一 messageId 后到覆盖先到（增量事件重复携带累计值的场景）。 */
-    private void collectUsage(Map<String, ChatUsage> usageByMessage, Event event) {
-        Msg msg = event.getMessage();
-        if (msg != null && msg.getUsage() != null && msg.getId() != null) {
-            usageByMessage.put(msg.getId(), msg.getUsage());
+    /** 收集单次模型调用的用量：按 {@code replyId} 存一份（同一 replyId 只会来一条 MODEL_CALL_END）。 */
+    private void collectUsage(Map<String, ChatUsage> usageByModelCall, AgentEvent event) {
+        if (event instanceof ModelCallEndEvent modelCallEnd && modelCallEnd.getUsage() != null) {
+            usageByModelCall.put(modelCallEnd.getReplyId(), modelCallEnd.getUsage());
         }
     }
 
-    /** 汇总本轮全部消息的用量；一条都没有时返回 null（区分"确实没有用量信息"与"用了 0 token"）。 */
-    private ChatUsage totalUsage(Map<String, ChatUsage> usageByMessage) {
-        if (usageByMessage.isEmpty()) {
+    /** 汇总本轮全部模型调用的用量；一条都没有时返回 null（区分"确实没有用量信息"与"用了 0 token"）。 */
+    private ChatUsage totalUsage(Map<String, ChatUsage> usageByModelCall) {
+        if (usageByModelCall.isEmpty()) {
             return null;
         }
         int inputTokens = 0;
         int outputTokens = 0;
         int cachedTokens = 0;
         double time = 0;
-        for (ChatUsage usage : usageByMessage.values()) {
+        for (ChatUsage usage : usageByModelCall.values()) {
             inputTokens += usage.getInputTokens();
             outputTokens += usage.getOutputTokens();
             cachedTokens += usage.getCachedTokens();
@@ -347,42 +357,6 @@ public class ChatService {
         return new ChatUsage(inputTokens, outputTokens, cachedTokens, time);
     }
 
-    /**
-     * 从一个事件拆出 0~N 个展示片段。
-     *
-     *  提问： AgentScope 框架层为什么能产生 ThinkingBlock
-     * 项目里用的是 AgentScope 2.0.0-RC4（在 customer-admin-server/pom.xml 里引入依赖）。框架内部实现大致是：
-     * ReActAgent / HarnessAgent 在调用大模型时，会解析模型返回的 reasoning_content（或等效字段）。
-     * 对于支持推理的模型（如 OpenAI o1/o3、DeepSeek-R1、QwQ 等），模型 API 返回里通常有独立的 reasoning 字段。
-     * AgentScope 把这部分单独封装成 io.agentscope.core.message.ThinkingBlock，和普通 TextBlock 区分开。
-     * 当调用 agent.stream(...) 并设置 includeReasoningChunk(true) 时，框架会通过 EventType.REASONING 事件把这些 ThinkingBlock 增量流出来。
-     * <p><b>坑（本方法存在的核心原因）</b>：{@link EventType#AGENT_RESULT} 官方文档写明
-     * "Streaming: Not applicable"——它是对话结束时一次性吐出的完整最终文本，不是增量。而真正
-     * 会逐字增量流式生成的可见回答文本，其实是通过 {@link EventType#REASONING} 事件里的
-     * {@link TextBlock} 内容送出来的（同一条消息 id 下会触发多次事件）；{@link ThinkingBlock}
-     * 内容才是真正的"内部思考过程"。早期实现把 REASONING 事件的一切内容统统归进"思考过程"
-     * 折叠区，导致真正的可见回答文本被错误地也塞进了折叠区、用户只能通过一次性到达的
-     * {@code AGENT_RESULT} 看到最终答案——外在表现就是"思考过程能看到增量，但最终结果一次性蹦出来"。
-     * 现在按内容块类型正确分流：{@link ThinkingBlock} → 思考过程；{@link TextBlock} → 正文
-     * （增量追加）；{@code AGENT_RESULT} 只在本轮从没通过 REASONING 流出过正文时才当兜底用一次
-     * （避免同一段最终答案先增量出现一遍、结束时又整段重复一遍）。</p>
-     *
-     * <p>TOOL_RESULT 消息装的是 {@link ToolResultBlock}（不在 {@code getTextContent()} 覆盖范围内），
-     * 取工具名 + 输出文本拼成一行过程提示。</p>
-     *
-     * <p><b>坑</b>：{@code incremental(true)} 下框架按原始流式增量吐 {@link ToolUseBlock}，尚未做
-     * 跨分片的聚合——同一个工具调用会被拆成好几个片段各触发一个事件，且早期片段的 {@code name} 常是
-     * 框架内部占位符（{@code "__fragment__"}/{@code "__pending__"}/任何 {@code "__"} 前缀，真正做
-     * 聚合的 {@code ToolCallsAccumulator} 是框架内部类，这层拿不到聚合后的结果）。用
-     * {@code lastAnnouncedTool} 记录"最近一次已经提示过的工具名"，同名只提示一次；工具真正返回
-     * （TOOL_RESULT）后清空，下次再调用（哪怕是同一个工具）会重新提示一次。</p>
-     *
-     * <p><b>节点化时间线</b>：{@code modelCallAnnounced} 标记"本轮 ReAct 迭代是否已经发过一条
-     * {@link ChatNodeKind#MODEL_CALL}"——TOOL_RESULT 到达后重置为 false，因为工具返回后模型必然
-     * 会被重新调用一轮做下一步推理/总结，这样"调用大模型"节点数就等于模型实际被调用的次数。
-     * {@code toolSource} 用于把 {@code ToolUseBlock} 按来源分类成
-     * {@link ChatNodeKind#TOOL_SKILL}/{@link ChatNodeKind#TOOL_MCP}/{@link ChatNodeKind#TOOL_BUILTIN}。</p>
-     */
     /**
      * 对 ANSWER 片段做出站敏感词过滤；其余节点（思考、工具调用等）原样透传。
      *
@@ -430,89 +404,106 @@ public class ChatService {
         return new SensitiveWordStreamGuard(sensitiveWordFilter, outboundSafeReply);
     }
 
-    private List<ChatStreamChunk> toChunks(Event event, ToolSourceInfo toolSource,
+    /**
+     * 从一个框架事件拆出 0~N 个展示片段。
+     *
+     * <p><b>为什么用 {@code streamEvents} 而不是 {@code stream(msgs, options, ctx)}</b>：后者已标记
+     * {@code forRemoval}，且它把"增量"和"汇总"混在同一个 {@code EventType.REASONING} 里靠
+     * {@code isLast} 区分，消费侧必须自己按"新值是否以旧值为前缀"猜哪段是净增量；细粒度事件流把两者
+     * 拆成了不同事件类型（{@code TEXT_BLOCK_DELTA} 是真增量，{@code AGENT_RESULT} 才是汇总），
+     * 那套前缀猜测连同 {@code lastReasoningText}/{@code lastAnswerText}/{@code lastAnnouncedTool}/
+     * {@code modelCallAnnounced} 四份去重状态一并删掉了。</p>
+     *
+     * <p><b>事件 → 节点映射</b>（父 Agent 与子 Agent 共用同一张表，差异见 {@link #toSubagentChunks}）：
+     * <ul>
+     *   <li>{@code MODEL_CALL_START} → {@link ChatNodeKind#MODEL_CALL}：框架每次真正调模型发一条，
+     *       节点数天然等于模型被调用的次数，不用再自己数迭代；</li>
+     *   <li>{@code THINKING_BLOCK_DELTA} → {@link ChatNodeKind#THINKING}（内部思考过程）；</li>
+     *   <li>{@code TEXT_BLOCK_DELTA} → {@link ChatNodeKind#ANSWER}（可见回答正文增量）；</li>
+     *   <li>{@code TOOL_CALL_START} → TOOL_SKILL/TOOL_MCP/TOOL_BUILTIN：框架已按 toolCallId 去重、
+     *       且过滤掉了 {@code "__"} 前缀的内部占位名，这层不用再管分片重复；</li>
+     *   <li>{@code TOOL_RESULT_TEXT_DELTA} 累积 → {@code TOOL_RESULT_END} 时吐一条
+     *       {@link ChatNodeKind#TOOL_RESULT}：流式工具的分片与非流式工具的整段结果，框架都走这一对
+     *       事件，累积后一次性成文，{@code TestReportParser} 拿到的是完整输出；</li>
+     *   <li>{@code AGENT_RESULT} → 仅当本轮一个正文增量都没出现过（非流式 provider）时补一次全文。</li>
+     * </ul>
+     * 其余事件类型（block start/end、{@code TOOL_CALL_DELTA}、{@code HINT_BLOCK} 等）不进展示轨迹，
+     * 直接忽略。</p>
+     */
+    private List<ChatStreamChunk> toChunks(AgentEvent event, ToolSourceInfo toolSource,
                                              Map<String, StreamState> stateBySource) {
-        Msg msg = event.getMessage();
-        if (msg == null) {
-            return List.of();
-        }
-        EventSource source = event.getSource();
+        String source = event.getSource();
         if (source == null) {
-            // 父 Agent 自身事件：行为与改造前逐字节等价（走 "" 这一份状态），前端拿到的 chunk 依旧
-            // source/subagentName 均为 null。
+            // 父 Agent 自身事件：前端拿到的 chunk 依旧 source/subagentName 均为 null。
             StreamState state = stateBySource.computeIfAbsent(MAIN_AGENT_SOURCE_KEY, k -> new StreamState());
-            return toMainChunks(event, msg, toolSource, state);
+            return toMainChunks(event, toolSource, state);
         }
-        return toSubagentChunks(event, msg, source, stateBySource);
+        return toSubagentChunks(event, source, stateBySource);
     }
 
-    /**
-     * 父 Agent 事件 → 展示片段（原 {@code toChunks} 逻辑原样迁入，只是去重状态从方法局部变量收拢进
-     * per-source 的 {@link StreamState}）。REASONING 里 {@link ThinkingBlock} 是真正的思考过程，
-     * {@link TextBlock} 是正在增量生成的可见回答正文，两者可能同时出现在同一条消息里，都要各自送出。
-     * 本轮迭代第一次收到任何 REASONING 内容（思考/正文/工具调用）先补一条"调用大模型"节点。
-     */
-    private List<ChatStreamChunk> toMainChunks(Event event, Msg msg, ToolSourceInfo toolSource, StreamState state) {
-        if (event.getType() == EventType.TOOL_RESULT) {
-            state.lastAnnouncedTool.set(null);
-            state.modelCallAnnounced.set(false);
-            return msg.getContentBlocks(ToolResultBlock.class).stream()
-                .map(block -> new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, describeToolResult(block)))
-                .collect(Collectors.toList());
+    /** 父 Agent 事件 → 展示片段，映射规则见 {@link #toChunks}。 */
+    private List<ChatStreamChunk> toMainChunks(AgentEvent event, ToolSourceInfo toolSource, StreamState state) {
+        if (event instanceof ModelCallStartEvent) {
+            return List.of(new ChatStreamChunk(ChatNodeKind.MODEL_CALL, MODEL_CALL_TEXT));
         }
-
-        if (event.getType() == EventType.AGENT_RESULT) {
-            if (state.answerStreamed.get()) {
+        if (event instanceof ThinkingBlockDeltaEvent thinking) {
+            return StringUtils.hasText(thinking.getDelta())
+                ? List.of(new ChatStreamChunk(ChatNodeKind.THINKING, thinking.getDelta()))
+                : List.of();
+        }
+        if (event instanceof TextBlockDeltaEvent text) {
+            if (!StringUtils.hasText(text.getDelta())) {
                 return List.of();
             }
-            String text = msg.getTextContent();
+            state.answerStreamed.set(true);
+            return List.of(new ChatStreamChunk(ChatNodeKind.ANSWER, text.getDelta()));
+        }
+        if (event instanceof ToolCallStartEvent toolCall) {
+            return StringUtils.hasText(toolCall.getToolCallName())
+                ? List.of(new ChatStreamChunk(classifyToolSource(toolSource, toolCall.getToolCallName()),
+                    describeToolCall(toolCall.getToolCallName())))
+                : List.of();
+        }
+        if (event instanceof ToolResultTextDeltaEvent toolResultDelta) {
+            state.appendToolResult(toolResultDelta.getToolCallId(), toolResultDelta.getDelta());
+            return List.of();
+        }
+        if (event instanceof ToolResultEndEvent toolResultEnd) {
+            return List.of(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT,
+                describeToolResult(toolResultEnd.getToolCallName(), state.takeToolResult(toolResultEnd.getToolCallId()))));
+        }
+        if (event instanceof AgentResultEvent agentResult) {
+            // 非流式 provider 兜底：一个正文增量都没出过时，用最终结果补一次全文，避免空回复。
+            // 已经逐字流出过就丢弃，否则同一段答案会先增量出现一遍、结束时又整段重复一遍。
+            if (state.answerStreamed.get() || agentResult.getResult() == null) {
+                return List.of();
+            }
+            String text = agentResult.getResult().getTextContent();
             return StringUtils.hasText(text) ? List.of(new ChatStreamChunk(ChatNodeKind.ANSWER, text)) : List.of();
         }
-
-        List<ChatStreamChunk> chunks = new ArrayList<>();
-        for (ThinkingBlock block : msg.getContentBlocks(ThinkingBlock.class)) {
-            String delta = extractDelta(state.lastReasoningText, block.getThinking());
-            if (StringUtils.hasText(delta)) {
-                addModelCallIfNew(chunks, state, null, null);
-                chunks.add(new ChatStreamChunk(ChatNodeKind.THINKING, delta));
-            }
-        }
-        String answerDelta = extractDelta(state.lastAnswerText, msg.getTextContent());
-        if (StringUtils.hasText(answerDelta)) {
-            state.answerStreamed.set(true);
-            addModelCallIfNew(chunks, state, null, null);
-            chunks.add(new ChatStreamChunk(ChatNodeKind.ANSWER, answerDelta));
-        }
-        List<ChatStreamChunk> toolChunks = msg.getContentBlocks(ToolUseBlock.class).stream()
-            .map(ToolUseBlock::getName)
-            .filter(name -> StringUtils.hasText(name) && !name.startsWith("__"))
-            .filter(name -> !name.equals(state.lastAnnouncedTool.getAndSet(name)))
-            .map(name -> new ChatStreamChunk(classifyToolSource(toolSource, name), "「" + name + "」"))
-            .collect(Collectors.toList());
-        if (!toolChunks.isEmpty()) {
-            addModelCallIfNew(chunks, state, null, null);
-            chunks.addAll(toolChunks);
-        }
-        return chunks;
+        return List.of();
     }
 
     /**
-     * 子 Agent 事件 → 展示片段。harness spawn 出的子 Agent 用 {@code StreamOptions.defaults()}
-     * （全量事件类型）经 {@code SubagentEventBus} 直推父 sink，绕过父流的 eventTypes 过滤，因此这里
-     * 可能收到父流本不会出现的类型，只认 REASONING/TOOL_RESULT/AGENT_RESULT，其余（HINT/SUMMARY 等）
-     * 直接忽略容错。片段统一带 {@code source}（调用链 path）与 {@code subagentName}（展示名），前端据此
-     * 归入独立卡片。
+     * 子 Agent 事件 → 展示片段。harness spawn 出的子 Agent，其细粒度事件由框架的
+     * {@code AgentEventEmitter} 转发进父流并打上 {@code AgentEvent#getSource()}（调用链 path），与父
+     * Agent 的事件交错到达；片段统一带 {@code source} 与 {@code subagentName}，前端据此归入独立卡片。
      *
-     * <p>与父 Agent 的差异：① 该 source 首次出现时先补一条 {@link ChatNodeKind#SUBAGENT_START}；
-     * ② {@code AGENT_RESULT} 走 {@link ChatNodeKind#SUBAGENT_RESULT}（子 Agent 的最终文本），绝不
-     * 走父 Agent 的 ANSWER/answerStreamed 链路；③ 工具一律归 {@link ChatNodeKind#TOOL_BUILTIN}
-     * （子 Agent 的工具不在父的 {@link ToolSourceInfo} 里，不为此额外查询）；④ 不补"调用大模型"节点，
-     * 只复用需求约定的 THINKING/ANSWER/TOOL_BUILTIN/TOOL_RESULT。</p>
+     * <p>与父 Agent 的差异：① 该 source 首次出现时先补一条 {@link ChatNodeKind#SUBAGENT_START}
+     * （框架在 spawn 点补的 {@code AGENT_START} 一定是该 source 的首个事件）；② 工具一律归
+     * {@link ChatNodeKind#TOOL_BUILTIN}（子 Agent 的工具不在父的 {@link ToolSourceInfo} 里，不为此
+     * 额外查询）；③ 不补"调用大模型"节点，只复用需求约定的 THINKING/ANSWER/TOOL_BUILTIN/TOOL_RESULT；
+     * ④ {@link ChatNodeKind#SUBAGENT_RESULT} 由 {@code AGENT_END} 触发、内容取本股流累积的正文。</p>
+     *
+     * <p><b>为什么 SUBAGENT_RESULT 不再取 {@code AGENT_RESULT}</b>：新路径上子 Agent 是被
+     * {@code AgentSpawnTool} 以 {@code call()} 驱动的，它自己的 {@code AgentResultEvent} 在子流内部
+     * 就被 {@code callInternal} 取走当返回值了，到不了父流；父流能看到的只有工具侧补发的
+     * {@code AGENT_START}/{@code AGENT_END} 与中间的细粒度事件。故改为在 {@code AGENT_END} 处用累积
+     * 正文补一条收尾节点，前端协议（{@link ChatNodeKind}/{@link ChatStreamChunk}）不变。</p>
      */
-    private List<ChatStreamChunk> toSubagentChunks(Event event, Msg msg, EventSource source,
+    private List<ChatStreamChunk> toSubagentChunks(AgentEvent event, String sourceKey,
                                                      Map<String, StreamState> stateBySource) {
-        String sourceKey = resolveSourceKey(source);
-        String subagentName = resolveSubagentName(source);
+        String subagentName = resolveSubagentName(sourceKey);
         boolean firstAppearance = !stateBySource.containsKey(sourceKey);
         StreamState state = stateBySource.computeIfAbsent(sourceKey, k -> new StreamState());
 
@@ -523,94 +514,40 @@ public class ChatService {
             chunks.add(new ChatStreamChunk(ChatNodeKind.SUBAGENT_START, subagentName, sourceKey, subagentName));
         }
 
-        EventType type = event.getType();
-        if (type == EventType.TOOL_RESULT) {
-            state.lastAnnouncedTool.set(null);
-            for (ToolResultBlock block : msg.getContentBlocks(ToolResultBlock.class)) {
-                chunks.add(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT, describeToolResult(block), sourceKey, subagentName));
+        if (event instanceof ThinkingBlockDeltaEvent thinking && StringUtils.hasText(thinking.getDelta())) {
+            chunks.add(new ChatStreamChunk(ChatNodeKind.THINKING, thinking.getDelta(), sourceKey, subagentName));
+        } else if (event instanceof TextBlockDeltaEvent text && StringUtils.hasText(text.getDelta())) {
+            state.appendAnswer(text.getDelta());
+            chunks.add(new ChatStreamChunk(ChatNodeKind.ANSWER, text.getDelta(), sourceKey, subagentName));
+        } else if (event instanceof ToolCallStartEvent toolCall && StringUtils.hasText(toolCall.getToolCallName())) {
+            chunks.add(new ChatStreamChunk(ChatNodeKind.TOOL_BUILTIN,
+                describeToolCall(toolCall.getToolCallName()), sourceKey, subagentName));
+        } else if (event instanceof ToolResultTextDeltaEvent toolResultDelta) {
+            state.appendToolResult(toolResultDelta.getToolCallId(), toolResultDelta.getDelta());
+        } else if (event instanceof ToolResultEndEvent toolResultEnd) {
+            chunks.add(new ChatStreamChunk(ChatNodeKind.TOOL_RESULT,
+                describeToolResult(toolResultEnd.getToolCallName(), state.takeToolResult(toolResultEnd.getToolCallId())),
+                sourceKey, subagentName));
+        } else if (event instanceof AgentEndEvent) {
+            String answer = state.takeAnswer();
+            if (StringUtils.hasText(answer)) {
+                chunks.add(new ChatStreamChunk(ChatNodeKind.SUBAGENT_RESULT, answer, sourceKey, subagentName));
             }
-            return chunks;
+            log.info("[chat] subagent stream finished: path={} name={}", sourceKey, subagentName);
         }
-        if (type == EventType.AGENT_RESULT) {
-            String text = msg.getTextContent();
-            if (StringUtils.hasText(text)) {
-                chunks.add(new ChatStreamChunk(ChatNodeKind.SUBAGENT_RESULT, text, sourceKey, subagentName));
-                log.info("[chat] subagent stream finished: path={} name={}", sourceKey, subagentName);
-            }
-            return chunks;
-        }
-        if (type == EventType.REASONING) {
-            for (ThinkingBlock block : msg.getContentBlocks(ThinkingBlock.class)) {
-                String delta = extractDelta(state.lastReasoningText, block.getThinking());
-                if (StringUtils.hasText(delta)) {
-                    chunks.add(new ChatStreamChunk(ChatNodeKind.THINKING, delta, sourceKey, subagentName));
-                }
-            }
-            String answerDelta = extractDelta(state.lastAnswerText, msg.getTextContent());
-            if (StringUtils.hasText(answerDelta)) {
-                chunks.add(new ChatStreamChunk(ChatNodeKind.ANSWER, answerDelta, sourceKey, subagentName));
-            }
-            msg.getContentBlocks(ToolUseBlock.class).stream()
-                .map(ToolUseBlock::getName)
-                .filter(name -> StringUtils.hasText(name) && !name.startsWith("__"))
-                .filter(name -> !name.equals(state.lastAnnouncedTool.getAndSet(name)))
-                .forEach(name -> chunks.add(new ChatStreamChunk(ChatNodeKind.TOOL_BUILTIN, "「" + name + "」", sourceKey, subagentName)));
-            return chunks;
-        }
-        // 其它未知事件类型（HINT/SUMMARY/ALL 等）：直接忽略，只保留可能已补的 SUBAGENT_START。
+        // 其它事件类型（AGENT_START、block start/end 等）：不进展示轨迹，只保留可能已补的 SUBAGENT_START。
         return chunks;
     }
 
-    /** 子 Agent 的状态表 key：优先用调用链 path，其次 agentId，都空时用兜底 key（不会与父 Agent 的 "" 撞车）。 */
-    private String resolveSourceKey(EventSource source) {
-        if (StringUtils.hasText(source.getPath())) {
-            return source.getPath();
-        }
-        if (StringUtils.hasText(source.getAgentId())) {
-            return source.getAgentId();
-        }
-        return SUBAGENT_FALLBACK_KEY;
-    }
-
-    /** 子 Agent 展示名：优先 {@code getAgentName()}，为空回退 {@code getAgentId()}，再空回退 path。 */
-    private String resolveSubagentName(EventSource source) {
-        if (StringUtils.hasText(source.getAgentName())) {
-            return source.getAgentName();
-        }
-        if (StringUtils.hasText(source.getAgentId())) {
-            return source.getAgentId();
-        }
-        return source.getPath();
-    }
-
     /**
-     * 提取本次内容相对上次的净增量。框架/模型对"增量"的语义不完全一致——有的 provider 每次给的是
-     * 真正独立的分片（delta），有的给的是"从头到现在"的累积全量文本（实测复现于某些 DeepSeek 风格
-     * 推理模型的 reasoning_content）；不区分对待、原样转发再让前端 {@code +=} 拼接，遇到累积型
-     * provider 就会把重叠部分重复拼接一遍，界面上看到同一句话连续出现两次。用"新值是否以旧值为
-     * 前缀"识别累积型场景，命中则只发净增量部分（旧值本身也涵盖了"两次内容完全相同、这次没有
-     * 新增"的去重场景，此时截出空串直接不发）；不构成前缀关系（真正的独立分片，或模型侧发生了
-     * 非累积性的改写）则原样发一遍，保底不丢内容。
+     * 子 Agent 展示名：新路径上框架只给一个 path 字符串（{@code 父会话id/子agentId}），取末段即子
+     * agentId。旧路径的 {@code EventSource#getAgentName()}（更友好的展示名）在细粒度事件上不存在，
+     * 这是本次迁移已知的展示降级——path 无分隔符时整串回退。
      */
-    private String extractDelta(AtomicReference<String> lastFull, String currentFull) {
-        if (!StringUtils.hasText(currentFull)) {
-            return "";
-        }
-        String previous = lastFull.getAndSet(currentFull);
-        if (!StringUtils.hasText(previous) || !currentFull.startsWith(previous)) {
-            return currentFull;
-        }
-        return currentFull.substring(previous.length());
-    }
-
-    /**
-     * 本轮迭代还没标过"调用大模型"就补一条，只在真正产出内容（思考/正文/工具调用）的那一刻才补，
-     * 避免空跑一轮也占一个节点。仅父 Agent 主流程调用（{@code source}/{@code subagentName} 传 null）。
-     */
-    private void addModelCallIfNew(List<ChatStreamChunk> chunks, StreamState state, String source, String subagentName) {
-        if (!state.modelCallAnnounced.getAndSet(true)) {
-            chunks.add(new ChatStreamChunk(ChatNodeKind.MODEL_CALL, "调用大模型", source, subagentName));
-        }
+    private String resolveSubagentName(String sourceKey) {
+        int separator = sourceKey.lastIndexOf(SOURCE_PATH_SEPARATOR);
+        String lastSegment = separator < 0 ? sourceKey : sourceKey.substring(separator + SOURCE_PATH_SEPARATOR.length());
+        return StringUtils.hasText(lastSegment) ? lastSegment : sourceKey;
     }
 
     private ChatNodeKind classifyToolSource(ToolSourceInfo toolSource, String toolName) {
@@ -623,27 +560,31 @@ public class ChatService {
         return ChatNodeKind.TOOL_BUILTIN;
     }
 
-    private String describeToolResult(ToolResultBlock block) {
-        String output = block.getOutput().stream()
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining("\n"));
-        return "工具「" + block.getName() + "」返回：" + (StringUtils.hasText(output) ? output : "(无文本结果)");
+    /** 工具调用提示文案。 */
+    private String describeToolCall(String toolName) {
+        return "「" + toolName + "」";
     }
 
     /**
-     * {@code stream(List, StreamOptions, RuntimeContext)} 只直接声明在 {@link ReActAgent}/
-     * {@link HarnessAgent} 各自的类上（2.0.0-RC4 未收敛进共享的 {@code Agent} 接口），
-     * 故按运行时具体类型分派——{@link AdminAgentInstanceFactory#build} 只会产出这两种之一。
+     * 工具返回结果的展示文案。格式与改造前逐字节一致——{@code TestReportParser} 靠
+     * {@code 工具「execute」返回：} 这个前缀识别沙箱命令执行结果，改格式会静默打断 VibeCoding 的
+     * test_report 产出。
      */
-    private Flux<Event> streamEvents(Agent agent, List<Msg> msgs, StreamOptions options, RuntimeContext ctx) {
+    private String describeToolResult(String toolName, String output) {
+        return "工具「" + toolName + "」返回：" + (StringUtils.hasText(output) ? output : "(无文本结果)");
+    }
+
+    /**
+     * {@code streamEvents(List, RuntimeContext)} 只直接声明在 {@link ReActAgent}/{@link HarnessAgent}
+     * 各自的类上（2.0.0 未收敛进共享的 {@code Agent} 接口），故按运行时具体类型分派——
+     * {@link AdminAgentInstanceFactory#build} 只会产出这两种之一。
+     */
+    private Flux<AgentEvent> streamEvents(Agent agent, List<Msg> msgs, RuntimeContext ctx) {
         if (agent instanceof ReActAgent reActAgent) {
-            return reActAgent.stream(msgs, options, ctx);
+            return reActAgent.streamEvents(msgs, ctx);
         }
         if (agent instanceof HarnessAgent harnessAgent) {
-            return harnessAgent.stream(msgs, options, ctx);
+            return harnessAgent.streamEvents(msgs, ctx);
         }
         throw new IllegalStateException("unsupported agent runtime type: " + agent.getClass());
     }
@@ -657,17 +598,46 @@ public class ChatService {
     }
 
     /**
-     * 单一事件来源（父 Agent 或某个子 Agent）在本轮对话内的增量去重状态。父子交错推流时各持一份，
-     * 互不污染（见 {@link #chatStream} 里 {@code stateBySource} 的说明）。字段语义同改造前的方法局部
-     * 变量：最近提示过的工具名 / 是否已通过 REASONING 流出正文 / 上一段 reasoning 与 answer 全量文本
-     * / 本轮迭代是否已标过"调用大模型"。沿用 {@code Atomic*} 类型是为了让 {@link #extractDelta}
-     * 等既有 helper 的 {@code getAndSet} 语义原样复用，主流程行为与改造前逐字节等价。
+     * 单一事件来源（父 Agent 或某个子 Agent）在本轮对话内的跨事件拼装状态。父子交错推流时各持一份，
+     * 互不污染（见 {@link #chatStream} 里 {@code stateBySource} 的说明）。
+     *
+     * <p>细粒度事件把"增量"和"汇总"拆成了不同事件类型，改造前那四份去重状态（最近提示过的工具名 /
+     * 上一段 reasoning 与 answer 全量文本 / 本轮迭代是否已标过"调用大模型"）全部不再需要，这里只剩
+     * 三样真正跨事件的拼装缓冲。</p>
      */
     private static final class StreamState {
-        private final AtomicReference<String> lastAnnouncedTool = new AtomicReference<>();
-        private final AtomicReference<String> lastReasoningText = new AtomicReference<>();
-        private final AtomicReference<String> lastAnswerText = new AtomicReference<>();
+        /** 本股流是否已经流出过正文增量——决定要不要用 {@code AGENT_RESULT} 补非流式 provider 的全文。 */
         private final AtomicBoolean answerStreamed = new AtomicBoolean(false);
-        private final AtomicBoolean modelCallAnnounced = new AtomicBoolean(false);
+        /** 子 Agent 正文累积，{@code AGENT_END} 时取走拼成 SUBAGENT_RESULT（父 Agent 不用）。 */
+        private final StringBuilder answer = new StringBuilder();
+        /** 工具结果文本累积：toolCallId → 已到达的分片；{@code TOOL_RESULT_END} 时取走。 */
+        private final Map<String, StringBuilder> toolResults = new ConcurrentHashMap<>();
+
+        private void appendAnswer(String delta) {
+            synchronized (answer) {
+                answer.append(delta);
+            }
+        }
+
+        private String takeAnswer() {
+            synchronized (answer) {
+                String text = answer.toString();
+                answer.setLength(0);
+                return text;
+            }
+        }
+
+        private void appendToolResult(String toolCallId, String delta) {
+            if (toolCallId == null || !StringUtils.hasText(delta)) {
+                return;
+            }
+            toolResults.computeIfAbsent(toolCallId, k -> new StringBuilder()).append(delta);
+        }
+
+        /** 取走并清空某次工具调用的累积文本；没有任何分片（如无输出的工具）时返回空串。 */
+        private String takeToolResult(String toolCallId) {
+            StringBuilder buffer = toolCallId == null ? null : toolResults.remove(toolCallId);
+            return buffer == null ? "" : buffer.toString();
+        }
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatServiceTest.java
@@ -9,17 +9,22 @@ import com.richard.fyoung.customeradmin.workspace.runtime.ToolSourceInfo;
 import com.richard.fyoung.customeradmin.workspace.runtime.mode.ExecutionModeRegistry;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.service.PlanConfirmationService;
 import io.agentscope.core.ReActAgent;
-import io.agentscope.core.agent.Event;
-import io.agentscope.core.agent.EventSource;
-import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.RuntimeContext;
-import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
-import io.agentscope.core.message.TextBlock;
-import io.agentscope.core.message.ThinkingBlock;
-import io.agentscope.core.message.ToolResultBlock;
-import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.ToolResultState;
 import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
 import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import io.agentscope.core.model.ChatUsage;
@@ -29,12 +34,12 @@ import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,20 +51,30 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link ChatService} 单测：重点覆盖 {@code toChunks} 的事件分流逻辑——
- * ① REASONING 事件里 {@link ThinkingBlock} 内容归"思考过程"、{@link TextBlock} 内容才是真正在
- *   增量流出的可见回答正文（早期实现混为一谈，导致回答文本被误判成思考过程、只能靠一次性到达的
- *   AGENT_RESULT 看最终答案）；
- * ② AGENT_RESULT 是一次性完整文本，已经通过 REASONING 流出过正文时要丢弃它，避免重复；
- * ③ TOOL_RESULT / 纯工具调用请求的 REASONING 事件——消息体不含 {@link TextBlock}，
- *   {@code Msg#getTextContent()} 直接拿到空字符串，不额外处理的话前端在"决定调用工具"和
- *   "等工具返回"这两段时间会看起来像卡住；
+ * {@link ChatService} 单测：重点覆盖 {@code toChunks} 对框架细粒度事件流（{@code streamEvents}）的分流——
+ * ① {@code THINKING_BLOCK_DELTA} 归"思考过程"、{@code TEXT_BLOCK_DELTA} 才是可见回答正文；
+ * ② {@code AGENT_RESULT} 只在本轮一个正文增量都没出现过时（非流式 provider）当兜底用一次；
+ * ③ {@code TOOL_CALL_START} / {@code TOOL_RESULT_*} 让"决定调用工具"和"等工具返回"这两段时间也有节点，
+ *    否则前端看起来像卡住；工具结果按 toolCallId 累积、在 {@code TOOL_RESULT_END} 一次性成文；
  * ④ 每轮对话固定以 {@link ChatNodeKind#THINKING_START}/{@link ChatNodeKind#THINKING_END} 收尾；
- * ⑤ 每轮 ReAct 迭代第一次产出内容前补一条 {@link ChatNodeKind#MODEL_CALL}，TOOL_RESULT 后重置；
+ * ⑤ {@link ChatNodeKind#MODEL_CALL} 一一对应框架的 {@code MODEL_CALL_START}，节点数即模型被调用次数；
  * ⑥ 工具调用按 {@link ToolSourceInfo} 分类成 SKILL/MCP/内置三种节点类型。
+ *
+ * <p><b>与迁移前的差异</b>：旧的 {@code stream(msgs, options, ctx)} 把增量与整段回放混在同一个
+ * {@code REASONING} 事件里，消费侧得靠"新值是否以旧值为前缀"猜净增量；细粒度事件已经把两者拆成不同
+ * 事件类型，那套猜测连同四份去重状态一起删了，对应的单测也随之改写（见
+ * {@link #chatStream_shouldForwardDeltasVerbatim_withoutPrefixStripping}）。</p>
  * @author owlzhangfq@gmail.com
  */
 class ChatServiceTest {
+
+    /** 同一次模型调用内的事件共用的 replyId（框架每次调模型生成一个）。 */
+    private static final String REPLY_ID = "reply-1";
+    private static final String TOOL_CALL_ID = "call-1";
+    private static final String TOOL_NAME = "OA考勤查询";
+    /** 子 Agent 的来源 path（框架约定：{@code 父会话id/子agentId}）。 */
+    private static final String SUB_SOURCE = "s1/doc-writer";
+    private static final String SUB_NAME = "doc-writer";
 
     private AgentInstanceCache agentInstanceCache;
     private AdminAgentInstanceFactory agentInstanceFactory;
@@ -88,16 +103,25 @@ class ChatServiceTest {
         when(agentInstanceFactory.toolSourceFor(anyString())).thenReturn(ToolSourceInfo.EMPTY);
     }
 
-    private Msg toolUseOnlyMsg() {
-        return Msg.builder().role(MsgRole.ASSISTANT)
-            .content(new ToolUseBlock("call-1", "OA考勤查询", Map.of("date", "today")))
-            .build();
+    // ==================== 事件构造与订阅辅助 ====================
+
+    @SuppressWarnings("unchecked")
+    private void stubEvents(AgentEvent... events) {
+        when(agent.streamEvents(any(List.class), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(events));
     }
 
-    private Msg toolResultMsg(String output) {
-        return Msg.builder().role(MsgRole.TOOL)
-            .content(new ToolResultBlock("call-1", "OA考勤查询", List.of(TextBlock.builder().text(output).build()), null, null))
-            .build();
+    /** 一次工具调用的完整结果事件三连（非流式工具：框架在 END 前把整段输出当作一条 delta 发出）。 */
+    private AgentEvent[] toolResultEvents(String output) {
+        return new AgentEvent[] {
+            new ToolResultStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME),
+            new ToolResultTextDeltaEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, output),
+            new ToolResultEndEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, ToolResultState.SUCCESS)
+        };
+    }
+
+    private AgentEvent sourced(AgentEvent event) {
+        return event.withSource(SUB_SOURCE);
     }
 
     private List<ChatStreamChunk> stream(String message) {
@@ -111,11 +135,11 @@ class ChatServiceTest {
         }
     }
 
+    // ==================== 父 Agent 主链路 ====================
+
     @Test
     void chatStream_shouldAlwaysBracketWithThinkingStartAndEnd() {
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        stubEvents(new AgentResultEvent(assistantMsg("你好")));
 
         List<ChatStreamChunk> chunks = stream("你好");
 
@@ -124,82 +148,86 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_shouldSurfaceToolUseRequest_whenReasoningMessageHasNoText() {
-        Msg toolUseMsg = toolUseOnlyMsg();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.REASONING, toolUseMsg, true)));
+    void chatStream_shouldSurfaceToolCallRequest_soFrontendDoesNotLookStuck() {
+        // 模型决定调工具、还没拿到结果的这段时间必须有节点，否则界面上什么都不动
+        stubEvents(
+            new ModelCallStartEvent(REPLY_ID),
+            new ToolCallStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL,
             ChatNodeKind.TOOL_BUILTIN, ChatNodeKind.THINKING_END);
-        assertTrue(chunks.get(2).text().contains("OA考勤查询"));
+        assertTrue(chunks.get(2).text().contains(TOOL_NAME));
     }
 
     @Test
     void chatStream_shouldSurfaceToolResultText() {
-        Msg resultMsg = toolResultMsg("今日出勤：09:02 打卡");
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.TOOL_RESULT, resultMsg, true)));
+        stubEvents(toolResultEvents("今日出勤：09:02 打卡"));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.TOOL_RESULT, ChatNodeKind.THINKING_END);
-        assertTrue(chunks.get(1).text().contains("今日出勤：09:02 打卡"));
+        assertEquals("工具「" + TOOL_NAME + "」返回：今日出勤：09:02 打卡", chunks.get(1).text());
     }
 
     @Test
-    void chatStream_shouldSuppressPlaceholderFragmentNames_andDedupeRepeatedToolUseChunks() {
-        // 模拟 incremental(true) 下框架按原始分片吐 ToolUseBlock 的真实场景：先来一个占位符片段
-        // （框架内部聚合前的过渡态，名字是 "__fragment__"），再来两个已经解析出真实工具名的重复片段
-        // （同一个工具调用在参数流式拼接过程中触发了多次事件）——前端应该只看到一条提示，不出现
-        // "__fragment__" 这种内部占位符。
-        Msg fragmentMsg = Msg.builder().role(MsgRole.ASSISTANT)
-            .content(new ToolUseBlock(null, "__fragment__", Map.of())).build();
-        Msg toolUseMsg1 = toolUseOnlyMsg();
-        Msg toolUseMsg2 = toolUseOnlyMsg();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, fragmentMsg, false),
-                new Event(EventType.REASONING, toolUseMsg1, false),
-                new Event(EventType.REASONING, toolUseMsg2, false)));
+    void chatStream_shouldConcatToolResultChunks_intoOneNode() {
+        // 流式工具（如沙箱 execute）分多片吐结果：必须累积成一条完整文本再发，
+        // 否则 TestReportParser 只能看到半截输出，解析不出 test_report。
+        stubEvents(
+            new ToolResultStartEvent(REPLY_ID, TOOL_CALL_ID, "execute"),
+            new ToolResultTextDeltaEvent(REPLY_ID, TOOL_CALL_ID, "execute", "Exit code: 0\n"),
+            new ToolResultTextDeltaEvent(REPLY_ID, TOOL_CALL_ID, "execute", "BUILD SUCCESS"),
+            new ToolResultEndEvent(REPLY_ID, TOOL_CALL_ID, "execute", ToolResultState.SUCCESS));
+
+        List<ChatStreamChunk> chunks = stream("跑一下测试");
+
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.TOOL_RESULT, ChatNodeKind.THINKING_END);
+        assertEquals("工具「execute」返回：Exit code: 0\nBUILD SUCCESS", chunks.get(1).text());
+    }
+
+    @Test
+    void chatStream_toolResultWithoutAnyTextDelta_shouldStillEmitNode() {
+        // 工具没有文本输出（只有二进制块或干脆没输出）：仍要发一条节点，不能让前端停在"等工具返回"
+        stubEvents(
+            new ToolResultStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME),
+            new ToolResultEndEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, ToolResultState.SUCCESS));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
-        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL,
-            ChatNodeKind.TOOL_BUILTIN, ChatNodeKind.THINKING_END);
-        assertTrue(chunks.get(2).text().contains("OA考勤查询"));
-        assertTrue(!chunks.get(2).text().contains("__fragment__"));
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.TOOL_RESULT, ChatNodeKind.THINKING_END);
+        assertEquals("工具「" + TOOL_NAME + "」返回：(无文本结果)", chunks.get(1).text());
     }
 
     @Test
-    void chatStream_shouldReAnnounceSameTool_afterPriorToolResultArrived() {
-        // 工具真正返回过一次之后，哪怕紧接着又调用同一个工具，也应该重新提示一次
-        // （不是"这个工具名这辈子只提示一次"，而是"这一轮调用内不重复刷屏"），且要重新记一条
-        // "调用大模型"——工具返回后模型必然会被重新调用一轮。
-        Msg toolUseMsg1 = toolUseOnlyMsg();
-        Msg resultMsg = toolResultMsg("今日出勤：09:02 打卡");
-        Msg toolUseMsg2 = toolUseOnlyMsg();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, toolUseMsg1, false),
-                new Event(EventType.TOOL_RESULT, resultMsg, false),
-                new Event(EventType.REASONING, toolUseMsg2, false)));
+    void chatStream_shouldReAnnounceSameTool_inNextRound_andCountEachModelCall() {
+        // 工具返回后模型必然被再调一轮：MODEL_CALL 节点数 = 模型实际被调用次数；
+        // 同一个工具在新一轮里被再次调用（新的 toolCallId）也要重新提示一次。
+        stubEvents(concat(
+            new AgentEvent[] {
+                new ModelCallStartEvent(REPLY_ID),
+                new ToolCallStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME)
+            },
+            toolResultEvents("今日出勤：09:02 打卡"),
+            new AgentEvent[] {
+                new ModelCallStartEvent("reply-2"),
+                new ToolCallStartEvent("reply-2", "call-2", TOOL_NAME)
+            }));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL, ChatNodeKind.TOOL_BUILTIN,
             ChatNodeKind.TOOL_RESULT, ChatNodeKind.MODEL_CALL, ChatNodeKind.TOOL_BUILTIN, ChatNodeKind.THINKING_END);
-        assertTrue(chunks.get(2).text().contains("OA考勤查询"));
+        assertTrue(chunks.get(2).text().contains(TOOL_NAME));
         assertTrue(chunks.get(3).text().contains("今日出勤：09:02 打卡"));
-        assertTrue(chunks.get(5).text().contains("OA考勤查询"));
+        assertTrue(chunks.get(5).text().contains(TOOL_NAME));
     }
 
     @Test
-    void chatStream_finalAgentResult_shouldBeAnswerKind() {
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你今天已打卡").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+    void chatStream_finalAgentResult_shouldBeAnswerKind_whenNothingStreamed() {
+        // 非流式 provider 兜底：一个正文增量都没出现过时，用最终结果补一次全文
+        stubEvents(new AgentResultEvent(assistantMsg("你今天已打卡")));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
@@ -208,16 +236,12 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_reasoningTextBlock_shouldStreamAsAnswerKind_notThinking() {
-        // EventType.REASONING 官方文档写明支持增量（"同一条消息 id 触发多次事件"），真正逐字流出来的
-        // 可见回答文本走的是这里的 TextBlock，不是 AGENT_RESULT（那个是一次性的完整最终文本）。
-        // 同一轮迭代内第二次产出内容不应该再补一条 MODEL_CALL。
-        Msg delta1 = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好，").build();
-        Msg delta2 = Msg.builder().role(MsgRole.ASSISTANT).textContent("我是智能体").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, delta1, false),
-                new Event(EventType.REASONING, delta2, false)));
+    void chatStream_textBlockDelta_shouldStreamAsAnswerKind_notThinking() {
+        // 逐字流出来的可见回答文本走 TEXT_BLOCK_DELTA，不是 AGENT_RESULT（那是一次性的完整最终文本）
+        stubEvents(
+            new ModelCallStartEvent(REPLY_ID),
+            new TextBlockDeltaEvent(REPLY_ID, "text", "你好，"),
+            new TextBlockDeltaEvent(REPLY_ID, "text", "我是智能体"));
 
         List<ChatStreamChunk> chunks = stream("你好");
 
@@ -228,34 +252,27 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_reasoningThinkingBlock_shouldExtractDelta_whenProviderSendsCumulativeText() {
-        // 复现真实线上问题：某些 DeepSeek 风格推理模型的 reasoning_content 不是"这次新增的分片"，
-        // 而是"从头到现在的累积全量文本"；早期实现原样转发每个值、前端再无脑 += 拼接，导致重叠
-        // 部分被重复拼接一遍（界面上同一句话连续出现两次）。这里第二个值以第一个值为前缀，
-        // 只应该把净增量部分（"Let me check..."）当作 chunk 发出去，不能把第一段再发一遍。
-        Msg cumulative1 = Msg.builder().role(MsgRole.ASSISTANT)
-            .content(ThinkingBlock.builder().thinking("No attendance info found.").build()).build();
-        Msg cumulative2 = Msg.builder().role(MsgRole.ASSISTANT)
-            .content(ThinkingBlock.builder().thinking("No attendance info found.Let me check the code.").build()).build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, cumulative1, false),
-                new Event(EventType.REASONING, cumulative2, false)));
+    void chatStream_shouldForwardDeltasVerbatim_withoutPrefixStripping() {
+        // 迁移前的行为契约变更：旧路径的 REASONING 事件既发增量又发整段回放，消费侧靠"新值以旧值为前缀"
+        // 猜净增量，代价是模型真吐出"abc"→"abcdef"这种前缀关系的<b>独立</b>分片时会被误截。细粒度事件
+        // 的 TEXT_BLOCK_DELTA 定义上就是净增量（框架自己也是 append 累积它来还原全文），这里断言原样透传。
+        stubEvents(
+            new TextBlockDeltaEvent(REPLY_ID, "text", "abc"),
+            new TextBlockDeltaEvent(REPLY_ID, "text", "abcdef"));
 
-        List<ChatStreamChunk> chunks = stream("查一下我的考勤");
+        List<ChatStreamChunk> chunks = stream("你好");
 
-        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL,
-            ChatNodeKind.THINKING, ChatNodeKind.THINKING, ChatNodeKind.THINKING_END);
-        assertEquals("No attendance info found.", chunks.get(2).text());
-        assertEquals("Let me check the code.", chunks.get(3).text());
+        assertKinds(chunks, ChatNodeKind.THINKING_START,
+            ChatNodeKind.ANSWER, ChatNodeKind.ANSWER, ChatNodeKind.THINKING_END);
+        assertEquals("abc", chunks.get(1).text());
+        assertEquals("abcdef", chunks.get(2).text());
     }
 
     @Test
-    void chatStream_reasoningThinkingBlock_shouldStayInThinkingBucket() {
-        Msg thinkingMsg = Msg.builder().role(MsgRole.ASSISTANT)
-            .content(ThinkingBlock.builder().thinking("用户想知道天气，我需要先确认城市").build()).build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.REASONING, thinkingMsg, false)));
+    void chatStream_thinkingBlockDelta_shouldStayInThinkingBucket() {
+        stubEvents(
+            new ModelCallStartEvent(REPLY_ID),
+            new ThinkingBlockDeltaEvent(REPLY_ID, "thinking", "用户想知道天气，我需要先确认城市"));
 
         List<ChatStreamChunk> chunks = stream("今天天气怎么样");
 
@@ -265,54 +282,45 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_agentResult_shouldBeSuppressed_whenAnswerAlreadyStreamedViaReasoning() {
-        // 已经通过 REASONING 增量流出过正文的情况下，结尾的 AGENT_RESULT（完整重复文本）应该被丢弃，
+    void chatStream_agentResult_shouldBeSuppressed_whenAnswerAlreadyStreamed() {
+        // 已经逐字流出过正文时，结尾的 AGENT_RESULT（同一段文本的汇总）必须丢弃，
         // 否则前端会先看到逐字流出的答案，结束时又整段重复一遍。
-        Msg delta = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, delta, false),
-                new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        stubEvents(
+            new TextBlockDeltaEvent(REPLY_ID, "text", "你好"),
+            new AgentResultEvent(assistantMsg("你好")));
 
         List<ChatStreamChunk> chunks = stream("你好");
 
-        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL,
-            ChatNodeKind.ANSWER, ChatNodeKind.THINKING_END);
-        assertEquals("你好", chunks.get(2).text());
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.ANSWER, ChatNodeKind.THINKING_END);
+        assertEquals("你好", chunks.get(1).text());
     }
 
     @Test
     void chatStream_shouldClassifyToolCall_bySkillSource() {
         when(agentInstanceFactory.toolSourceFor("coder"))
-            .thenReturn(new ToolSourceInfo(Set.of("OA考勤查询"), Set.of()));
-        Msg toolUseMsg = toolUseOnlyMsg();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.REASONING, toolUseMsg, true)));
+            .thenReturn(new ToolSourceInfo(Set.of(TOOL_NAME), Set.of()));
+        stubEvents(new ToolCallStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
-        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL,
-            ChatNodeKind.TOOL_SKILL, ChatNodeKind.THINKING_END);
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.TOOL_SKILL, ChatNodeKind.THINKING_END);
     }
 
     @Test
     void chatStream_shouldClassifyToolCall_byMcpSource() {
         when(agentInstanceFactory.toolSourceFor("coder"))
-            .thenReturn(new ToolSourceInfo(Set.of(), Set.of("OA考勤查询")));
-        Msg toolUseMsg = toolUseOnlyMsg();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.REASONING, toolUseMsg, true)));
+            .thenReturn(new ToolSourceInfo(Set.of(), Set.of(TOOL_NAME)));
+        stubEvents(new ToolCallStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
-        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.MODEL_CALL,
-            ChatNodeKind.TOOL_MCP, ChatNodeKind.THINKING_END);
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.TOOL_MCP, ChatNodeKind.THINKING_END);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void chatStream_onError_shouldStillEmitThinkingEnd_beforeFallbackAnswer() {
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+        when(agent.streamEvents(any(List.class), any(RuntimeContext.class)))
             .thenReturn(Flux.error(new RuntimeException("model down")));
 
         List<ChatStreamChunk> chunks = stream("你好");
@@ -321,13 +329,12 @@ class ChatServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void chatStream_shouldFallBackGracefully_whenAgentStreamThrowsSynchronously() {
-        // 复现真实场景：HarnessAgent.stream(...) 在沙箱资源获取失败时（如 docker 容器创建超时）是
-        // 方法调用本身同步抛异常，不是返回一个 error Flux。如果 streamEvents(...) 没有包 Flux.defer，
-        // 这个异常会在 chatStream(...) 方法体执行期间直接向外抛，onErrorResume 完全没机会接管，
-        // 前端会收不到任何 SSE 事件（连接挂起）。用 thenThrow（而非 thenReturn(Flux.error(...))）
-        // 模拟这种"同步抛"场景，断言依然能拿到完整的兜底话术，而不是让异常直接冒穿。
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+        // 复现真实场景：HarnessAgent 在沙箱资源获取失败时（如 docker 容器创建超时）是方法调用本身
+        // 同步抛异常，不是返回一个 error Flux。如果没包 Flux.defer，这个异常会在 chatStream(...) 方法体
+        // 执行期间直接向外抛，onErrorResume 完全没机会接管，前端会收不到任何 SSE 事件（连接挂起）。
+        when(agent.streamEvents(any(List.class), any(RuntimeContext.class)))
             .thenThrow(new RuntimeException("docker run timed out for image: maven:3.9-eclipse-temurin-17"));
 
         List<ChatStreamChunk> chunks = stream("写一个 Fibonacci.java");
@@ -340,9 +347,7 @@ class ChatServiceTest {
     @Test
     void chatStream_withAttachmentIds_shouldBindToMessage_inRequestThread() {
         // attachmentIds 非空 → 请求线程同步段（订阅前）调 bindToMessage：sessionId 用归一值，messageId 为本条用户消息 id。
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("已收到附件").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        stubEvents(new AgentResultEvent(assistantMsg("已收到附件")));
         List<String> ids = List.of("att-1", "att-2");
 
         chatService.chatStreamWithAttachments("coder", "s1", "看下这个附件", null, null, ids).collectList().block();
@@ -353,9 +358,7 @@ class ChatServiceTest {
     @Test
     void chatStream_emptySession_shouldBindWithDefaultSession() {
         // sessionId 空 → 归一成 "default"，与历史读取/Plan 通道口径一致。
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("ok").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        stubEvents(new AgentResultEvent(assistantMsg("ok")));
         List<String> ids = List.of("att-1");
 
         chatService.chatStreamWithAttachments("coder", "", "看下这个附件", null, null, ids).collectList().block();
@@ -365,34 +368,19 @@ class ChatServiceTest {
 
     @Test
     void chatStream_withoutAttachmentIds_shouldNotBind() {
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        stubEvents(new AgentResultEvent(assistantMsg("你好")));
 
         stream("你好");
 
         verify(chatAttachmentService, never()).bindToMessage(anyString(), anyString(), anyString(), any());
     }
 
-    // ===== 子 Agent 事件流透传（harness spawn 出的子 Agent 经 SubagentEventBus 直推父 sink）=====
-
-    /** 构造一个直接子级（depth=1）的 EventSource：path=main/doc-writer，展示名 DocWriter。 */
-    private EventSource subSource() {
-        return EventSource.builder()
-            .path("main/doc-writer").agentId("doc-writer").agentName("DocWriter").depth(1).build();
-    }
-
-    private Msg thinkingMsg(String thinking) {
-        return Msg.builder().role(MsgRole.ASSISTANT)
-            .content(ThinkingBlock.builder().thinking(thinking).build()).build();
-    }
+    // ===== 子 Agent 事件流透传（harness spawn 出的子 Agent，事件由框架打上 source 后并入父流）=====
 
     @Test
     void chatStream_mainChunks_shouldCarryNullSourceAndSubagentName() {
         // 回归：source=null 的父 Agent 事件，产出 chunk 的 source/subagentName 必须为 null（前端据此判定"非子 Agent"）。
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你今天已打卡").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+        stubEvents(new AgentResultEvent(assistantMsg("你今天已打卡")));
 
         List<ChatStreamChunk> chunks = stream("查一下我的考勤");
 
@@ -404,24 +392,24 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_subagentReasoningAndToolResult_shouldStampSource_andPrependSubagentStart() {
-        // 带 source 的 REASONING（思考）+ TOOL_RESULT：首事件前补一条 SUBAGENT_START，
-        // 后续 chunk 均带 source（调用链 path）与 subagentName（展示名）。
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, thinkingMsg("分析文档结构"), false, subSource()),
-                new Event(EventType.TOOL_RESULT, toolResultMsg("已生成大纲"), false, subSource())));
+    void chatStream_subagentEvents_shouldStampSource_andPrependSubagentStart() {
+        // 框架在 spawn 点补的带 source 的 AGENT_START 是该子 Agent 的首个事件 → 补一条 SUBAGENT_START；
+        // 后续 chunk 均带 source（调用链 path）与 subagentName（path 末段 = 子 agentId）。
+        stubEvents(
+            sourced(new AgentStartEvent("sub-session", null, SUB_NAME)),
+            sourced(new ThinkingBlockDeltaEvent(REPLY_ID, "thinking", "分析文档结构")),
+            sourced(new ToolResultStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME)),
+            sourced(new ToolResultTextDeltaEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, "已生成大纲")),
+            sourced(new ToolResultEndEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, ToolResultState.SUCCESS)));
 
         List<ChatStreamChunk> chunks = stream("帮我写文档");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.SUBAGENT_START,
             ChatNodeKind.THINKING, ChatNodeKind.TOOL_RESULT, ChatNodeKind.THINKING_END);
-        // SUBAGENT_START 文本为展示名
-        assertEquals("DocWriter", chunks.get(1).text());
-        // 子 Agent 片段带 source/subagentName
+        assertEquals(SUB_NAME, chunks.get(1).text(), "SUBAGENT_START 文本为子 Agent 展示名");
         for (int i = 1; i <= 3; i++) {
-            assertEquals("main/doc-writer", chunks.get(i).source(), "第 " + i + " 个 chunk source 不符，实际=" + chunks);
-            assertEquals("DocWriter", chunks.get(i).subagentName());
+            assertEquals(SUB_SOURCE, chunks.get(i).source(), "第 " + i + " 个 chunk source 不符，实际=" + chunks);
+            assertEquals(SUB_NAME, chunks.get(i).subagentName());
         }
         assertTrue(chunks.get(2).text().contains("分析文档结构"));
         assertTrue(chunks.get(3).text().contains("已生成大纲"));
@@ -431,60 +419,71 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_subagentAgentResult_shouldBeSubagentResultKind_notAnswer() {
-        // 带 source 的 AGENT_RESULT → SUBAGENT_RESULT（子 Agent 最终文本），绝不走父 Agent 的 ANSWER 链路。
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("文档已生成完毕").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true, subSource())));
+    void chatStream_subagentAgentEnd_shouldEmitSubagentResult_withAccumulatedAnswer() {
+        // 子 Agent 的 AgentResultEvent 在子流内部就被 callInternal 取走了、到不了父流，
+        // 故 SUBAGENT_RESULT 改由带 source 的 AGENT_END 触发，内容取本股流累积的正文增量。
+        stubEvents(
+            sourced(new AgentStartEvent("sub-session", null, SUB_NAME)),
+            sourced(new TextBlockDeltaEvent(REPLY_ID, "text", "文档已")),
+            sourced(new TextBlockDeltaEvent(REPLY_ID, "text", "生成完毕")),
+            sourced(new AgentEndEvent(null)));
 
         List<ChatStreamChunk> chunks = stream("帮我写文档");
 
         assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.SUBAGENT_START,
-            ChatNodeKind.SUBAGENT_RESULT, ChatNodeKind.THINKING_END);
-        assertEquals("文档已生成完毕", chunks.get(2).text());
-        assertEquals("main/doc-writer", chunks.get(2).source());
-        assertEquals("DocWriter", chunks.get(2).subagentName());
+            ChatNodeKind.ANSWER, ChatNodeKind.ANSWER, ChatNodeKind.SUBAGENT_RESULT, ChatNodeKind.THINKING_END);
+        assertEquals("文档已生成完毕", chunks.get(4).text());
+        assertEquals(SUB_SOURCE, chunks.get(4).source());
+        assertEquals(SUB_NAME, chunks.get(4).subagentName());
     }
 
     @Test
-    void chatStream_interleavedParentAndChild_shouldDedupeDeltaIndependently() {
-        // 父子交错推流：两边都是累积型全量文本（后值以前值为前缀）。若父子共用一份去重状态，
-        // 父的第二次全量会被子的全量"顶掉"、前缀判断失效，导致重复内容整段重发。这里断言父子各自
-        // 只发出净增量（父 A→B、子 X→Y），证明 per-source 状态隔离生效。
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, thinkingMsg("A"), false),
-                new Event(EventType.REASONING, thinkingMsg("X"), false, subSource()),
-                new Event(EventType.REASONING, thinkingMsg("AB"), false),
-                new Event(EventType.REASONING, thinkingMsg("XY"), false, subSource())));
+    void chatStream_subagentAnswer_shouldNotSuppressParentAgentResult() {
+        // 子 Agent 流出的正文不能把父 Agent 的"是否已流式过正文"标记染上：父侧一个增量都没有时，
+        // 结尾的 AGENT_RESULT 仍要作为兜底全文发出去，否则用户看不到父 Agent 的最终回答。
+        stubEvents(
+            sourced(new AgentStartEvent("sub-session", null, SUB_NAME)),
+            sourced(new TextBlockDeltaEvent(REPLY_ID, "text", "子结论")),
+            sourced(new AgentEndEvent(null)),
+            new AgentResultEvent(assistantMsg("父Agent收尾")));
+
+        List<ChatStreamChunk> chunks = stream("帮我写文档");
+
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.SUBAGENT_START, ChatNodeKind.ANSWER,
+            ChatNodeKind.SUBAGENT_RESULT, ChatNodeKind.ANSWER, ChatNodeKind.THINKING_END);
+        assertEquals("父Agent收尾", chunks.get(4).text());
+        assertNull(chunks.get(4).source());
+    }
+
+    @Test
+    void chatStream_interleavedParentAndChild_shouldBufferToolResultsIndependently() {
+        // 父子交错推流且工具调用 id 相同（两个 Agent 各自的 toolCallId 空间独立、完全可能撞号）：
+        // 若父子共用一份缓冲，两股工具输出会被拼进同一个 StringBuilder。这里断言各自成文。
+        stubEvents(
+            new ToolResultStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME),
+            sourced(new ToolResultStartEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME)),
+            new ToolResultTextDeltaEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, "父结果"),
+            sourced(new ToolResultTextDeltaEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, "子结果")),
+            new ToolResultEndEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, ToolResultState.SUCCESS),
+            sourced(new ToolResultEndEvent(REPLY_ID, TOOL_CALL_ID, TOOL_NAME, ToolResultState.SUCCESS)));
 
         List<ChatStreamChunk> chunks = stream("你好");
 
-        assertKinds(chunks, ChatNodeKind.THINKING_START,
-            ChatNodeKind.MODEL_CALL, ChatNodeKind.THINKING,  // 父：MODEL_CALL + THINKING("A")
-            ChatNodeKind.SUBAGENT_START, ChatNodeKind.THINKING, // 子：SUBAGENT_START + THINKING("X")
-            ChatNodeKind.THINKING,                            // 父：THINKING("B")，无新 MODEL_CALL
-            ChatNodeKind.THINKING,                            // 子：THINKING("Y")
-            ChatNodeKind.THINKING_END);
-        assertEquals("A", chunks.get(2).text());
+        assertKinds(chunks, ChatNodeKind.THINKING_START, ChatNodeKind.SUBAGENT_START,
+            ChatNodeKind.TOOL_RESULT, ChatNodeKind.TOOL_RESULT, ChatNodeKind.THINKING_END);
+        assertEquals("工具「" + TOOL_NAME + "」返回：父结果", chunks.get(2).text());
         assertNull(chunks.get(2).source());
-        assertEquals("X", chunks.get(4).text());
-        assertEquals("main/doc-writer", chunks.get(4).source());
-        assertEquals("B", chunks.get(5).text());
-        assertNull(chunks.get(5).source());
-        assertEquals("Y", chunks.get(6).text());
-        assertEquals("main/doc-writer", chunks.get(6).source());
+        assertEquals("工具「" + TOOL_NAME + "」返回：子结果", chunks.get(3).text());
+        assertEquals(SUB_SOURCE, chunks.get(3).source());
     }
 
     @Test
-    void chatStream_subagentUnknownEventType_shouldBeIgnored_afterSubagentStart() {
-        // 子 Agent 全量事件绕过父流过滤，可能出现父流本不会有的类型（如 SUMMARY）——应被忽略不抛异常，
-        // 仅保留首次出现补的 SUBAGENT_START；随后真正的 REASONING 正常产出。
-        Msg summaryMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("到达最大迭代").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.SUMMARY, summaryMsg, true, subSource()),
-                new Event(EventType.REASONING, thinkingMsg("继续分析"), false, subSource())));
+    void chatStream_subagentUnrelatedEventType_shouldBeIgnored_afterSubagentStart() {
+        // 子 Agent 的细粒度事件里有大量不进展示轨迹的类型（block start/end、TOOL_CALL_DELTA 等）——
+        // 应被忽略不抛异常，仅保留首次出现补的 SUBAGENT_START；随后真正的思考增量正常产出。
+        stubEvents(
+            sourced(new ModelCallEndEvent(REPLY_ID, new ChatUsage(1, 1, 0.0))),
+            sourced(new ThinkingBlockDeltaEvent(REPLY_ID, "thinking", "继续分析")));
 
         List<ChatStreamChunk> chunks = stream("帮我写文档");
 
@@ -496,20 +495,13 @@ class ChatServiceTest {
     // ===== 模型用量聚合（审计需求 §5.3：token 数）=====
 
     @Test
-    void chatStream_shouldAggregateUsageAcrossMessages_andDedupeByMessageId() {
-        // 同一 messageId 的增量事件重复携带 usage（后到为累计值，应覆盖而非累加），
-        // 不同 messageId 各算一次——总量 = msg-1 最终值(10+20) + msg-2(5+7)
-        Msg first = Msg.builder().id("msg-1").role(MsgRole.ASSISTANT).textContent("part")
-            .usage(new ChatUsage(3, 4, 0.1)).build();
-        Msg firstFinal = Msg.builder().id("msg-1").role(MsgRole.ASSISTANT).textContent("part2")
-            .usage(new ChatUsage(10, 20, 0.2)).build();
-        Msg second = Msg.builder().id("msg-2").role(MsgRole.ASSISTANT).textContent("done")
-            .usage(new ChatUsage(5, 7, 0.1)).build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(
-                new Event(EventType.REASONING, first, false),
-                new Event(EventType.REASONING, firstFinal, false),
-                new Event(EventType.AGENT_RESULT, second, true)));
+    void chatStream_shouldAggregateUsageAcrossModelCalls() {
+        // 每次模型调用结束各带一条 MODEL_CALL_END，replyId 不同 → 各算一次；
+        // 子 Agent 的模型调用同样计入（它也是本轮真实消耗的 token）。
+        stubEvents(
+            new ModelCallEndEvent(REPLY_ID, new ChatUsage(10, 20, 0.2)),
+            sourced(new ModelCallEndEvent("reply-sub", new ChatUsage(5, 7, 0.1))),
+            new AgentResultEvent(assistantMsg("done")));
 
         AtomicReference<ChatUsage> observed = new AtomicReference<>();
         chatService.chatStream("coder", "s1", "你好", observed::set).collectList().block();
@@ -520,10 +512,40 @@ class ChatServiceTest {
     }
 
     @Test
-    void chatStream_shouldObserveNullUsage_whenNoMessageCarriesUsage() {
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("你好").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
+    void chatStream_shouldDedupeUsage_bySameModelCallReplyId() {
+        // 同一次模型调用只会来一条 MODEL_CALL_END；即便重复到达也按 replyId 覆盖而非累加。
+        stubEvents(
+            new ModelCallEndEvent(REPLY_ID, new ChatUsage(3, 4, 0.1)),
+            new ModelCallEndEvent(REPLY_ID, new ChatUsage(10, 20, 0.2)));
+
+        AtomicReference<ChatUsage> observed = new AtomicReference<>();
+        chatService.chatStream("coder", "s1", "你好", observed::set).collectList().block();
+
+        assertEquals(10, observed.get().getInputTokens());
+        assertEquals(20, observed.get().getOutputTokens());
+    }
+
+    @Test
+    void chatStream_usageObserver_shouldFireBeforeDownstreamTerminalCallback() {
+        // VibeCodingService 在本流的<b>下游</b>用 doFinally 读 usageTotal 落审计。Reactor 的 doFinally
+        // 语义是"先把终止信号传给下游、回调最后才跑"，用量回调若也挂 doFinally，下游必然读到 null；
+        // 迁移加的 publishOn 还会把这个顺序问题跨线程放大（连 block() 都可能先返回）。
+        // 这里模拟下游消费者，钉住"上游先写、下游后读"这条契约。
+        stubEvents(new ModelCallEndEvent(REPLY_ID, new ChatUsage(10, 20, 0.2)));
+
+        AtomicReference<ChatUsage> usageTotal = new AtomicReference<>();
+        AtomicReference<ChatUsage> seenByDownstream = new AtomicReference<>();
+        chatService.chatStream("coder", "s1", "你好", usageTotal::set)
+            .doFinally(signal -> seenByDownstream.set(usageTotal.get()))
+            .collectList().block();
+
+        assertNotNull(seenByDownstream.get(), "下游的终止回调必须已经能读到本轮用量汇总");
+        assertEquals(10, seenByDownstream.get().getInputTokens());
+    }
+
+    @Test
+    void chatStream_shouldObserveNullUsage_whenNoModelCallCarriesUsage() {
+        stubEvents(new AgentResultEvent(assistantMsg("你好")));
 
         AtomicReference<ChatUsage> observed = new AtomicReference<>(new ChatUsage(1, 1, 0));
         chatService.chatStream("coder", "s1", "你好", observed::set).collectList().block();
@@ -537,14 +559,8 @@ class ChatServiceTest {
     @SuppressWarnings("unchecked")
     private String capturedUserText() {
         ArgumentCaptor<List<Msg>> captor = ArgumentCaptor.forClass(List.class);
-        verify(agent).stream(captor.capture(), any(StreamOptions.class), any(RuntimeContext.class));
+        verify(agent).streamEvents(captor.capture(), any(RuntimeContext.class));
         return captor.getValue().get(0).getTextContent();
-    }
-
-    private void stubEmptyStream() {
-        Msg finalMsg = Msg.builder().role(MsgRole.ASSISTANT).textContent("好的").build();
-        when(agent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
-            .thenReturn(Flux.just(new Event(EventType.AGENT_RESULT, finalMsg, true)));
     }
 
     /**
@@ -554,7 +570,7 @@ class ChatServiceTest {
      */
     @Test
     void chatStream_shouldSendRawUserTextToAgent_withoutAnyInjection() {
-        stubEmptyStream();
+        stubEvents(new AgentResultEvent(assistantMsg("好的")));
 
         chatService.chatStream("coder", "s1", "公积金怎么提取").collectList().block();
 
@@ -567,7 +583,7 @@ class ChatServiceTest {
     /** VibeCoding 链路同理：送进 Agent 的仍是"路径指引 + 提问"原文，不得被检索结果污染。 */
     @Test
     void chatStream_shouldNotAlterVibeCodingDirectiveText() {
-        stubEmptyStream();
+        stubEvents(new AgentResultEvent(assistantMsg("好的")));
         String directivePrefixed = "[VibeCoding指引-local] 本次对话的会话目录为: sessions/s1/\n\n写一个冒泡排序";
         AgentCallMeta callMeta = new AgentCallMeta("req-1", "admin", "coder", "编码助手",
             AgentCallSessionType.VIBE_CODING, "写一个冒泡排序");
@@ -575,5 +591,25 @@ class ChatServiceTest {
         chatService.chatStream("coder", "s1", directivePrefixed, null, callMeta).collectList().block();
 
         assertEquals(directivePrefixed, capturedUserText());
+    }
+
+    // ==================== 小工具 ====================
+
+    private Msg assistantMsg(String text) {
+        return Msg.builder().role(MsgRole.ASSISTANT).textContent(text).build();
+    }
+
+    private AgentEvent[] concat(AgentEvent[]... groups) {
+        int size = 0;
+        for (AgentEvent[] group : groups) {
+            size += group.length;
+        }
+        AgentEvent[] merged = new AgentEvent[size];
+        int offset = 0;
+        for (AgentEvent[] group : groups) {
+            System.arraycopy(group, 0, merged, offset, group.length);
+            offset += group.length;
+        }
+        return merged;
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SubagentEventForwardingTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SubagentEventForwardingTest.java
@@ -2,11 +2,11 @@ package com.richard.fyoung.customeradmin.workspace.runtime;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
-import io.agentscope.core.agent.Event;
-import io.agentscope.core.agent.EventSource;
-import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.RuntimeContext;
-import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -45,24 +45,42 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 确定性验证探针：harness spawn 出的子 Agent 事件，是否原生透传到父 HarnessAgent 的
- * v1 {@code stream(msgs, StreamOptions, RuntimeContext)} 订阅方——即框架 open issue #1954
- * "父子上下文不传递" 是否命中本项目链路。
+ * {@code streamEvents(msgs, RuntimeContext)} 订阅方——即框架 open issue #1954 "父子上下文不传递"
+ * 是否命中本项目链路。
  *
- * <p>链路事实（已核实）：父 Agent 走 v1 {@code stream()} 时，框架在 {@code AgentBase.createEventStream}
- * 里把 {@code SubagentEventBus} 装进 Reactor Context；harness 的 {@code AgentSpawnTool} 在 spawn 点若能
- * 从 Context 拿到 bus，就把子 Agent 事件（携带 {@link EventSource}）直推父 sink。#1954 的风险 =
- * Reactor Context 传播断裂，导致 spawn 点拿不到 bus、子事件到不了父流。</p>
+ * <p><b>链路事实（读 agentscope-core / agentscope-harness 源码核实）</b>：框架对两条流式路径的子事件
+ * 转发机制<b>不同</b>，{@code AgentSpawnTool#execLocalSync} 按 Reactor Context 里有什么分三条路：
+ * <ol>
+ *   <li>{@code streamEvents()} 路径（<b>本项目 {@code ChatService} 现在走的</b>）：
+ *       {@code ReActAgent#buildAgentStream} 把 {@code AgentEventEmitter.CONTEXT_KEY} 装进 Context，
+ *       spawn 点取到它后，用一个"打 source 标记"的包装 emitter 塞进子 Agent 的
+ *       {@code AgentEventEmitter.FORWARDING_CONTEXT_KEY}，于是子 Agent 的每条细粒度事件都带着
+ *       {@code AgentEvent#getSource()}（{@code 父会话id/子agentId}）流进父流；spawn 点还额外补一对
+ *       同样带 source 的 {@code AGENT_START}/{@code AGENT_END} 圈出子 Agent 的执行区间。</li>
+ *   <li>{@code stream()} 路径（已废弃）：{@code AgentBase#createEventStream} 装的是
+ *       {@code SubagentEventBus}，走另一套带 {@code EventSource} 的转发。{@code buildAgentStream} 里
+ *       有 {@code isSubagentBusPath} 分支，正是为了在该路径下<b>故意不装</b> {@code CONTEXT_KEY}，
+ *       避免子事件被路由进父流内部 sink 后又被 {@code callInternal} 过滤掉。</li>
+ *   <li>无流式上下文：纯 {@code call()}，不转发。</li>
+ * </ol>
+ *
+ * <p><b>迁移带来的契约变化（本测试断言的重点）</b>：新路径上子 Agent 是被 spawn 工具以 {@code call()}
+ * 驱动的，它自己的 {@code AgentResultEvent} 在子流内部就被 {@code callInternal} 取走当返回值了，
+ * <b>到不了父流</b>——旧路径能收到子 Agent 的 {@code AGENT_RESULT} 事件，新路径收不到。子 Agent 的最终
+ * 回答改为经 {@code TEXT_BLOCK_DELTA} 逐字到达，收尾信号是带 source 的 {@code AGENT_END}。
+ * {@code ChatService#toSubagentChunks} 的 SUBAGENT_RESULT 就是据此重建的。</p>
  *
  * <p>本测试用脚本化假 {@link Model} 驱动整条链路，纯内存、可重复、不依赖 MySQL/Redis/网络/真实 LLM：
  * <ul>
  *   <li>父 Model 第一轮产出一次 {@code agent_spawn} 工具调用（同步 spawn 子 Agent），第二轮产出纯文本收尾；</li>
  *   <li>子 Model 直接产出一段纯文本回答（一轮内收敛）。</li>
  * </ul>
- * 订阅父 {@code stream(...)} 收集全部事件后，用两个独立 {@code @Test} 明确区分三种结局：
+ * 订阅父 {@code streamEvents(...)} 收集全部事件后，用两个独立 {@code @Test} 明确区分三种结局：
  * <ol>
- *   <li><b>①透传正常</b>：存在 {@code getSource()!=null} 的事件，且子 Agent 的 path 含 doc-writer、有子 AGENT_RESULT；</li>
- *   <li><b>②spawn 发生但事件无 source/未到达</b>：子 Model 被调用过（spawn 执行了），但父流拿不到带 source 的事件
- *       → 命中 #1954，用 {@link Assumptions} 标记为"框架不支持"（跳过、非红），并打印全部事件诊断；</li>
+ *   <li><b>①透传正常</b>：存在 {@code getSource()!=null} 的事件，且 source 含 doc-writer、子 Agent 的
+ *       回答文本经带 source 的 {@code TEXT_BLOCK_DELTA} 到达、并有带 source 的 {@code AGENT_END} 收尾；</li>
+ *   <li><b>②spawn 发生但事件无 source/未到达</b>：子 Model 被调用过（spawn 执行了），但父流拿不到带 source
+ *       的事件 → 命中 #1954，用 {@link Assumptions} 标记为"框架不支持"（跳过、非红），并打印全部事件诊断；</li>
  *   <li><b>③spawn 根本没发生</b>：子 Model 从未被调用（工具没被触发）→ 装配问题（工具名/参数 schema 不对），
  *       断言直接红，提示修测试而非下结论。</li>
  * </ol>
@@ -73,7 +91,7 @@ class SubagentEventForwardingTest {
 
     private static final Logger log = LoggerFactory.getLogger(SubagentEventForwardingTest.class);
 
-    /** 子 Agent 注册名（= spawn 时的 agent_id，也应出现在子事件的调用链 path 里）。 */
+    /** 子 Agent 注册名（= spawn 时的 agent_id，也应出现在子事件的 source 路径里）。 */
     private static final String SUBAGENT_ID = "doc-writer";
     /** harness 注册的子 Agent spawn 工具名（javap 反汇编 SubagentsMiddleware 常量池核实）。 */
     private static final String SPAWN_TOOL_NAME = "agent_spawn";
@@ -99,33 +117,46 @@ class SubagentEventForwardingTest {
 
     @Test
     void subagentEvents_shouldForwardToParentStream_orDiagnoseFrameworkGap() {
-        List<Event> events = runParentStream();
+        List<AgentEvent> events = runParentStream();
 
         // 全量事件诊断日志（无论结局如何都打印，作为证据）
         logEventTrace(events);
 
         boolean spawnExecuted = childModelCalls.get() > 0;
-        boolean anySourced = events.stream().anyMatch(e -> e.getSource() != null);
+        List<AgentEvent> sourced = events.stream()
+            .filter(e -> e.getSource() != null).collect(Collectors.toList());
 
-        if (anySourced) {
+        if (!sourced.isEmpty()) {
             // ===== 结局①：透传正常 =====
-            // 核心断言 (a)：存在 source != null 的事件（子 Agent 事件被透传到父流）
-            List<Event> sourced = events.stream().filter(e -> e.getSource() != null).collect(Collectors.toList());
             log.info("[probe] OUTCOME_1 forwarding works: sourcedEventCount={}", sourced.size());
 
-            // 断言 (b)：source.getPath() 含子 Agent id，且存在子 Agent 的 AGENT_RESULT 事件
+            // 断言 (a)：子事件的 source 路径含子 Agent id
             boolean pathHasSubagent = sourced.stream()
-                .map(Event::getSource).map(EventSource::getPath)
-                .anyMatch(p -> p != null && p.contains(SUBAGENT_ID));
+                .map(AgentEvent::getSource)
+                .anyMatch(p -> p.contains(SUBAGENT_ID));
             assertTrue(pathHasSubagent,
-                "透传发生但子事件 path 未含 '" + SUBAGENT_ID + "'，实际 paths="
-                    + sourced.stream().map(e -> e.getSource().getPath()).collect(Collectors.toList()));
+                "透传发生但子事件 source 未含 '" + SUBAGENT_ID + "'，实际 sources="
+                    + sourced.stream().map(AgentEvent::getSource).distinct().collect(Collectors.toList()));
 
-            boolean hasChildAgentResult = sourced.stream()
-                .anyMatch(e -> e.getType() == EventType.AGENT_RESULT);
-            assertTrue(hasChildAgentResult,
-                "透传发生但未捕获子 Agent 的 AGENT_RESULT 事件，实际带 source 的事件类型="
-                    + sourced.stream().map(e -> e.getType().name()).collect(Collectors.toList()));
+            // 断言 (b)：spawn 点补的 AGENT_START / AGENT_END 圈出了子 Agent 的执行区间——
+            // ChatService 的 SUBAGENT_START / SUBAGENT_RESULT 两个展示节点就挂在这一对事件上
+            assertTrue(sourced.stream().anyMatch(e -> e instanceof AgentStartEvent),
+                "未捕获带 source 的 AGENT_START（SUBAGENT_START 节点的触发点），实际带 source 的事件="
+                    + describeTypes(sourced));
+            assertTrue(sourced.stream().anyMatch(e -> e instanceof AgentEndEvent),
+                "未捕获带 source 的 AGENT_END（SUBAGENT_RESULT 节点的触发点），实际带 source 的事件="
+                    + describeTypes(sourced));
+
+            // 断言 (c)：子 Agent 的回答文本经带 source 的 TEXT_BLOCK_DELTA 到达。
+            // 这是新旧路径最实质的差别：旧的 stream() 路径能收到子 Agent 的 AGENT_RESULT 整段文本，
+            // streamEvents 路径收不到（子流的 AgentResultEvent 被 callInternal 取走了），
+            // 子 Agent 的最终回答只能靠这些增量累积还原。
+            String childText = sourced.stream()
+                .filter(TextBlockDeltaEvent.class::isInstance)
+                .map(e -> ((TextBlockDeltaEvent) e).getDelta())
+                .collect(Collectors.joining());
+            assertTrue(childText.contains(CHILD_ANSWER),
+                "子 Agent 回答未经带 source 的 TEXT_BLOCK_DELTA 到达，累积到的文本=" + childText);
             return;
         }
 
@@ -138,12 +169,30 @@ class SubagentEventForwardingTest {
 
         // ===== 结局②：spawn 执行了但事件无 source/未到达父流（命中 #1954，跳过而非红）=====
         String diagnosis = "结局② 命中框架 open issue #1954：子 Agent 已执行（childModelCalls="
-            + childModelCalls.get() + "），但父流未收到任何带 EventSource 的事件——"
-            + "Reactor Context 中的 SubagentEventBus 未传播到 spawn 点，子事件到不了父 sink。"
-            + " 父流收到的事件类型序列=" + events.stream().map(e -> e.getType().name()).collect(Collectors.toList());
+            + childModelCalls.get() + "），但父流未收到任何带 source 的事件——"
+            + "Reactor Context 中的 AgentEventEmitter 未传播到 spawn 点，子事件到不了父 sink。"
+            + " 父流收到的事件序列=" + describeTypes(events);
         log.info("[probe] OUTCOME_2 framework gap (#1954): {}", diagnosis);
         // Assumptions 中止：标记为"框架不支持"（测试跳过、非失败），与"装配错误(红)"区分开
         Assumptions.abort(diagnosis);
+    }
+
+    /**
+     * 迁移守卫：父 Agent 自身的事件必须 {@code getSource() == null}。
+     * {@code ChatService} 就是靠这一点区分"父 Agent 主流程"与"子 Agent 卡片"的，串了就会把父 Agent
+     * 的正文渲染进子 Agent 的折叠卡片里。
+     */
+    @Test
+    void parentOwnEvents_shouldCarryNullSource() {
+        List<AgentEvent> events = runParentStream();
+
+        String parentText = events.stream()
+            .filter(e -> e.getSource() == null)
+            .filter(TextBlockDeltaEvent.class::isInstance)
+            .map(e -> ((TextBlockDeltaEvent) e).getDelta())
+            .collect(Collectors.joining());
+        assertTrue(parentText.contains(PARENT_FINAL),
+            "父 Agent 自身正文应以 source=null 的 TEXT_BLOCK_DELTA 到达，实际累积=" + parentText);
     }
 
     // ==================== 装配守卫：spawn 工具确实接线进父 Model（区分结局③） ====================
@@ -166,8 +215,8 @@ class SubagentEventForwardingTest {
 
     // ==================== 链路装配 ====================
 
-    /** 构造父 HarnessAgent + 子 Agent，订阅 v1 stream() 并收集全部事件（镜像 ChatService 的生产订阅参数）。 */
-    private List<Event> runParentStream() {
+    /** 构造父 HarnessAgent + 子 Agent，订阅 streamEvents() 并收集全部事件（镜像 ChatService 的生产订阅方式）。 */
+    private List<AgentEvent> runParentStream() {
         childModelCalls.set(0);
         parentToolNamesOffered.clear();
 
@@ -201,18 +250,10 @@ class SubagentEventForwardingTest {
         RuntimeContext ctx = RuntimeContext.builder()
             .userId("probe-user").sessionId("probe-session").build();
 
-        // 镜像 ChatService.chatStream 的生产订阅参数（eventTypes/incremental/includeReasoningChunk/includeActingChunk）
-        StreamOptions options = StreamOptions.builder()
-            .eventTypes(EventType.REASONING, EventType.TOOL_RESULT, EventType.AGENT_RESULT)
-            .incremental(true)
-            .includeReasoningChunk(true)
-            .includeActingChunk(true)
-            .build();
-
         Msg userMsg = Msg.builder().role(MsgRole.USER)
             .textContent("帮我写一份产品文档").build();
 
-        List<Event> events = parent.stream(List.of(userMsg), options, ctx)
+        List<AgentEvent> events = parent.streamEvents(List.of(userMsg), ctx)
             .collectList().block(BLOCK_TIMEOUT);
         return events != null ? events : Collections.emptyList();
     }
@@ -257,8 +298,8 @@ class SubagentEventForwardingTest {
                             ARG_AGENT_ID, SUBAGENT_ID,
                             ARG_TASK, "撰写产品文档大纲",
                             ARG_TIMEOUT_SECONDS, SPAWN_TIMEOUT_SECONDS);
-                        // incremental(true) 流式路径下，框架从 content（原始参数 JSON 字符串）重建工具入参，
-                        // 不读 input map——真实 LLM 的工具调用参数正是以 JSON 字符串分片到达。两者都填。
+                        // 流式路径下框架从 content（原始参数 JSON 字符串）重建工具入参，不读 input map——
+                        // 真实 LLM 的工具调用参数正是以 JSON 字符串分片到达。两者都填。
                         ToolUseBlock spawnCall = new ToolUseBlock(
                             UUID.randomUUID().toString(), toolName, args, toJson(args), null);
                         return Flux.just(response(List.of(spawnCall), "tool_calls"));
@@ -322,14 +363,18 @@ class SubagentEventForwardingTest {
             .build();
     }
 
-    /** 打印收到的全部事件（类型 + source 有无 + path），作为三种结局判定的证据。 */
-    private void logEventTrace(List<Event> events) {
+    /** 事件序列的紧凑描述（类型 + source），作为三种结局判定的证据。 */
+    private List<String> describeTypes(List<AgentEvent> events) {
         List<String> trace = new ArrayList<>();
-        for (Event e : events) {
-            EventSource src = e.getSource();
-            trace.add(e.getType().name() + "(source=" + (src == null ? "null" : src.getPath()) + ")");
+        for (AgentEvent e : events) {
+            trace.add(e.getType().name() + "(source=" + e.getSource() + ")");
         }
+        return trace;
+    }
+
+    /** 打印收到的全部事件，作为三种结局判定的证据。 */
+    private void logEventTrace(List<AgentEvent> events) {
         log.info("[probe] childModelCalls={}, eventTrace={}, parentToolNamesOffered={}",
-            childModelCalls.get(), trace, parentToolNamesOffered);
+            childModelCalls.get(), describeTypes(events), parentToolNamesOffered);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordStreamGuard.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/sensitiveword/SensitiveWordStreamGuard.java
@@ -5,18 +5,22 @@ import java.util.function.Consumer;
 /**
  * 流式输出的敏感词滑动缓冲过滤器：**每个输出流一个实例**，喂增量、吐可放行的文本。
  *
- * <p><b>为什么需要它、为什么不在中间件里做</b>：框架的 {@code AgentBase.stream(msgs, options)}（旧 API）
- * 实为 {@code createEventStream(options, () -> call(msgs))}——中间件链<b>照常执行</b>，但它额外注册的
+ * <p><b>历史成因</b>：框架的 {@code AgentBase.stream(msgs, options)}（旧 API）实为
+ * {@code createEventStream(options, () -> call(msgs))}——中间件链<b>照常执行</b>，但它额外注册的
  * {@code StreamingHook} 是<b>直接从模型输出旁路捕获文本</b>推给 sink 的，中间件对事件流做的任何改写都
  * 落不到这条文本上；两条流只在最后的 {@code AGENT_RESULT} 汇合，而那条事件恰恰被接入层丢弃（避免与
  * 增量重复渲染）。于是"只改中间件"的出站过滤在流式链路上完全落空——命中日志记着"已打码"，用户屏幕上
- * 却是原文。</p>
+ * 却是原文。本类当初就是为绕开这一点而生的。</p>
  *
- * <p>8080 侧（{@code CustomerServiceService}）现已迁到 {@code streamEvents(...)}，用户拿到的就是经过
- * {@code onAgent} 链的那条事件流本身，中间件的改写直接生效，上面这条"技术上做不到"的理由对它已不成立；
- * 但 admin 侧仍在旧 {@code stream(...)} 上，且 guard 的滑动缓冲是<b>每流一份</b>的有状态对象，与 Agent
- * 级共享的中间件 Bean 生命周期不符。因此两侧的流式出口各挂一道 guard 仍是当前做法；等 admin 也迁完，
- * 可再评估统一下沉到中间件。</p>
+ * <p><b>为什么现在仍留在接入层</b>：8080 侧（{@code CustomerServiceService}）与 admin 侧
+ * （{@code ChatService}）<b>都已迁到 {@code streamEvents(...)}</b>，拿到的就是经过 {@code onAgent}
+ * 链的那条事件流本身，上面那条"技术上做不到"的理由已不再成立——下沉到中间件是可行的，而且
+ * {@code MiddlewareBase#onAgent} 每次调用各执行一次并返回一条新 Flux，在方法体里 {@code Flux.defer}
+ * 现建一个本类实例即可，"有状态对象装不进共享 Bean"也不再是障碍。真正拦住下沉的是改造量与风险：
+ * ① 中间件要过滤的是 {@code TextBlockDeltaEvent} 这类<b>不可变事件对象</b>，改文本得逐条重建并搬运
+ * {@code id/createdAt/source/metadata}；② 子 Agent 事件经转发也进同一条流，per-source 分缓冲要在中间件
+ * 里重做一遍；③ BLOCK 的"截断 + 补安全话术"要改成往事件流里插事件。这是一次独立重构（收益是顺带覆盖
+ * 非流式 {@code call()} 路径），不该夹带进迁移里，故两侧的流式出口各挂一道 guard 仍是当前做法。</p>
  *
  * <p><b>滑动缓冲</b>：一个词会被拆进相邻增量（"阿根廷" 可能来自三次推送），逐片匹配必漏。
  * 每片与缓冲区拼接后整体过滤，只放行"确定不再是任何词前缀"的前半段，尾部留

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
@@ -70,12 +70,12 @@ public class CustomerServiceService {
     /**
      * 出站敏感词过滤器；敏感词功能关闭时容器里没有该 Bean，此处为 null，流式链路不做任何过滤。
      *
-     * <p><b>为什么流式过滤在这里而不在中间件</b>：本服务已迁到 {@code streamEvents(...)}，下发的就是经过
-     * {@code onAgent} 链的那条事件流本身，中间件的改写直接生效（旧的 {@code stream(...)} 下中间件虽也执行，
-     * 但文本由 {@code StreamingHook} 旁路捕获、改写落不到用户屏幕上，那个"技术上做不到"的理由已不成立）。
-     * 仍留在这里是因为 guard 有跨片缓冲状态、必须一次订阅一个实例，而中间件是 Agent 级共享 Bean；且 admin
-     * 侧同款过滤还挂在旧路径上，两边统一下沉应作为独立重构，不夹带在本次迁移里——
-     * 详见 {@link SensitiveWordStreamGuard} 类注释。</p>
+     * <p><b>为什么流式过滤在这里而不在中间件</b>：本服务与 admin 侧的 {@code ChatService} 都已迁到
+     * {@code streamEvents(...)}，下发的就是经过 {@code onAgent} 链的那条事件流本身，中间件的改写直接生效
+     * （旧的 {@code stream(...)} 下中间件虽也执行，但文本由 {@code StreamingHook} 旁路捕获、改写落不到
+     * 用户屏幕上，那个"技术上做不到"的理由已不成立）。下沉到中间件现在可行，拦住它的是改造量——事件对象
+     * 不可变、子 Agent 事件同流、BLOCK 要改成插事件，属于独立重构，详见 {@link SensitiveWordStreamGuard}
+     * 类注释。</p>
      */
     private SensitiveWordFilter sensitiveWordFilter;
 


### PR DESCRIPTION
> **Stacked on #74**：base 分支是 `refactor/customer-service-stream-events`，不是 `main`。#74 合入后本 PR 的 base 会自动改指 `main`；届时 diff 只剩 admin 侧改动。之所以不基于 main：本次要订正的 `SensitiveWordStreamGuard` 注释（「admin 侧仍在旧 stream 上」）只存在于 #74 的分支上。

## 做了什么

把 `customer-admin-server` 的对话链路从已标记 `forRemoval` 的 `stream(msgs, options, ctx)` 换成细粒度事件流 `streamEvents(msgs, ctx)`，对齐 #74 的 starter 侧迁移。

事件 → 展示节点映射：

| 框架事件 | ChatNodeKind |
|---|---|
| `MODEL_CALL_START` | `MODEL_CALL`（每次调模型一条，节点数即调用次数） |
| `THINKING_BLOCK_DELTA` | `THINKING` |
| `TEXT_BLOCK_DELTA` | `ANSWER` |
| `TOOL_CALL_START` | `TOOL_SKILL` / `TOOL_MCP` / `TOOL_BUILTIN` |
| `TOOL_RESULT_TEXT_DELTA` 累积 → `TOOL_RESULT_END` | `TOOL_RESULT`（一次成文） |
| `AGENT_RESULT` | 仅非流式 provider 兜底 |
| 带 source 的 `AGENT_START` / `AGENT_END` | `SUBAGENT_START` / `SUBAGENT_RESULT` |

**前端 SSE 协议（`ChatStreamChunk` + `ChatNodeKind`）与 `describeToolResult` 文案格式逐字节不变，`customer-admin-web` 无需改动。**

删掉的四份去重状态：`lastAnnouncedTool` / `lastReasoningText` / `lastAnswerText` / `modelCallAnnounced`。旧路径把增量与整段回放混在同一个 `REASONING` 事件里，消费侧只能靠「新值是否以旧值为前缀」猜净增量；细粒度事件已把两者拆成不同事件类型。

## 三个需要 reviewer 重点看的点

### 1. 必须显式补 `publishOn(boundedElastic)`

旧 `stream()` 在 `AgentBase#createEventStream` 末尾自带这一步，`buildAgentStream` **没有**。不补会让事件拼装、敏感词过滤与 SSE 写出全跑在模型 IO 线程上。#74 已踩过。

### 2. 用量回调 `doFinally` → `doOnComplete`/`doOnCancel`（顺带修了一个既存 bug）

Reactor 的 `doFinally` 语义是**先把终止信号传给下游、回调最后才跑**。下游 `VibeCodingService` 落审计的 `doFinally` 因此会抢在用量写入之前读到 `null`——即 VibeCoding 审计的 token 列一直是空的。加了 `publishOn` 之后这个顺序问题还会跨线程放大（连 `block()` 都可能先返回，本次就是被单测逮住的）。

改成 peek 语义的 `doOnComplete`/`doOnCancel` 即可保证上游先写、下游后读，新增 `chatStream_usageObserver_shouldFireBeforeDownstreamTerminalCallback` 钉住这条契约。

用量来源同时从「事件消息上的 `Msg#getUsage()` 按 messageId 去重」改为 `MODEL_CALL_END` 的 `usage` 按 `replyId` 去重求和，口径更贴合「本轮全部模型调用的合计」。

### 3. 子 Agent 事件转发机制变了（`SubagentEventForwardingTest` 契约随之改写）

`AgentSpawnTool#execLocalSync` 按 Reactor Context 分三条路：
- **`streamEvents()` 路径（本 PR 走的）**：`buildAgentStream` 装 `AgentEventEmitter.CONTEXT_KEY` → spawn 点用「打 source 标记」的包装 emitter 塞进子 Agent 的 `FORWARDING_CONTEXT_KEY`，子 Agent 的每条细粒度事件都带 `AgentEvent#getSource()` 流进父流；spawn 点另补一对带 source 的 `AGENT_START`/`AGENT_END`。
- **`stream()` 路径（旧）**：装的是 `SubagentEventBus`，走另一套带 `EventSource` 的转发。`buildAgentStream` 里的 `isSubagentBusPath` 分支正是为了在该路径下**故意不装** `CONTEXT_KEY`。

**契约变化**：新路径上子 Agent 被以 `call()` 驱动，它自己的 `AgentResultEvent` 在子流内部就被 `callInternal` 取走当返回值了、**到不了父流**。故 `SUBAGENT_RESULT` 改由带 source 的 `AGENT_END` 触发，内容取本股流累积的正文增量。子 Agent 展示名相应从 `EventSource#getAgentName()` 降级为 source path 末段（即 agentId）——细粒度事件上没有 `agentName` 字段。

`SubagentEventForwardingTest` 按新契约重写并**实测通过（结局①，不是跳过）**：带 source 的 `AGENT_START`/`AGENT_END` 存在、子 Agent 回答经带 source 的 `TEXT_BLOCK_DELTA` 到达；另加一条守卫断言父 Agent 自身事件 `getSource()` 为 `null`。

## AdminAgentRunner 刻意未迁

`AgentRunner#stream` 的返回类型被框架写死为 `Flux<Event>`——就是那个废弃类型本身；框架自带的参考实现 `BaseReActAgentRunner` 也仍在调 `agent.stream(msgs)`，**A2A 这一层框架自己都没迁**。改用 `streamEvents` 后仍得手工 `new Event(...)` 喂回接口，废弃 API 暴露面一点没减少，反而要自行复刻 `AgentScopeAgentExecutor` 依赖的 `isLast`/`messageId` 去重语义。已在方法注释里写清，等框架 A2A 层迁完再跟进。

## 出站敏感词 guard 是否下沉到中间件：重新评估结论

订正了 `SensitiveWordStreamGuard` / `CustomerServiceService` 里「admin 侧仍在旧 stream 上」的表述。重新评估后：`MiddlewareBase#onAgent` 每次调用各执行一次并返回新 Flux，**「有状态对象装不进 Agent 级共享 Bean」这条旧理由已不成立**，下沉是可行的（还能顺带覆盖非流式 `call()` 路径）。真正拦住下沉的是改造量：① 事件对象不可变，改文本得逐条重建并搬运 `id/createdAt/source/metadata`；② 子 Agent 事件同流，per-source 分缓冲要在中间件里重做；③ BLOCK 的「截断 + 补安全话术」要改成往事件流里插事件。属于独立重构，不夹带进本次迁移。

## 测试

starter **813** + admin-server **810** + app 78 + channel 65 + gateway 1，全绿。
（本机排除 `MinioAttachmentFileStorageIntegrationTest` / `RedisSessionPersistenceTest` 两个环境门控用例，见 CLAUDE.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)