### PR TITLE
feat(admin): 登录态持久化到 Redis，服务重启不再强制重新登录

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
 
       - name: Build and test (with coverage)
         run: mvn -B test
+        env:
+          # 上面给 CI 的 Redis 设了 requirepass 123456，而 admin 侧的 Redis 密码走
+          # ADMIN_REDIS_PASSWORD（默认空）。不注入这一项，登录态持久化的门控集成测试
+          # （SaTokenRedisPersistenceIntegrationTest）会因鉴权失败自动跳过——不红，但也就白跑了。
+          ADMIN_REDIS_PASSWORD: "123456"
         # 说明：
         # - Redis/MySQL/Nacos 服务容器在线，相关集成测试真实执行（探测可达性后运行）
         # - 百炼集成测试默认跳过（未设置 RUN_BAILIAN_IT）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 | `customer-work-starter` | 可复用智能体基础设施（模型/记忆/RAG/工具SPI/中间件/调度等），`@AutoConfiguration` 自动装配 |
 | `customer-work-app-server` | 可运行客服示例（端口 8080） |
 | `customer-channel` | 多渠道接入演示模块（官方五套前端能力接入：admin/chat-completions/AG-UI/Studio/Channel，端口 8081），非主链路必需 |
-| `customer-admin-server` | 后台管理系统后端（Spring MVC + MyBatis-Plus + Sa-Token，端口 8082，独立库 `customer_admin`） |
+| `customer-admin-server` | 后台管理系统后端（Spring MVC + MyBatis-Plus + Sa-Token，端口 8082，独立库 `customer_admin`；**登录态存 Redis**，Redis 不可达则登录 fail-closed，见 `AdminSaTokenDaoConfig`） |
 | `customer-admin-web` | 后台管理前端（Vue3+TS+Vite+Element Plus，**非 Maven 模块**，端口 5174） |
 | `customer-work-app` | 智能客服用户端 H5（Vue3+TS+Vite+Vant4，**非 Maven 模块**，端口 5175，proxy → 8080） |
 
@@ -31,8 +31,9 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **813** + admin-server **805** + app 78 + customer-channel 65 + gateway 1
-  （2026-07-29 feature/cert-pem-export 全量实测，starter 已按下方规则排除 2 个环境门控测试；
+- 测试基线：starter **813** + admin-server **807** + app 78 + customer-channel 65 + gateway 1
+  （admin-server 2026-08-03 feature/admin-session-redis 实测 807；其余为 2026-07-29
+  feature/cert-pem-export 全量实测，starter 已按下方规则排除 2 个环境门控测试；
   PR #68 修掉多构造器缺 @Autowired 后 `ApplicationContextTest` 已恢复，不再需要额外排除）。
   门控集成测试依赖：PaddleOCR serving(localhost:8868)、MinIO(localhost:9000)，不可达自动跳过。
   外部依赖门控测试：MySQL(root/root)、Redis(密码 123456)、Nacos(nacos/nacos:8848)，不可达自动跳过。

--- a/customer-admin-server/pom.xml
+++ b/customer-admin-server/pom.xml
@@ -132,6 +132,21 @@
             <version>3.52.0</version>
         </dependency>
 
+        <!-- 登录态持久化：Sa-Token 默认 DAO 把 token 存 JVM 内存，服务一重启全部用户被踢下线。
+             换成官方 Redis 插件（SaTokenDaoRedisJackson，由 AdminSaTokenDaoConfig 显式装配），
+             传递引入 spring-boot-starter-data-redis 提供 RedisConnectionFactory（Lettuce，惰性连接，
+             连接参数见 application.yml 的 spring.data.redis.*，与 admin.redis.* 取同一批环境变量）。
+
+             没有选同系列的 sa-token-redisson-jackson（本可复用已有的 RedissonClient）：它的
+             init() 里 new spring-data-redis 的 GenericJackson2JsonRedisSerializer 再反射偷其私有
+             mapper 字段，照样离不开 spring-data-redis，还额外多一层依赖 spring-data-redis 私有
+             字段名的隐式耦合——同样的传递依赖代价，不如走官方主线这条被验证最多的路。 -->
+        <dependency>
+            <groupId>cn.dev33</groupId>
+            <artifactId>sa-token-redis-jackson</artifactId>
+            <version>${sa-token.version}</version>
+        </dependency>
+
         <!-- SQL 查询结果导出 xlsx（SqlQueryController#export）。项目原本无 POI，EasyExcel 传递
              引入 poi/poi-ooxml 4.1.2；选本地仓库已存在的稳定版 3.3.2，避免额外下载/版本冲突。 -->
         <!-- SQL 查询结果导出 xlsx。easyexcel 必须用 4.x（基于 POI 5.x）：starter 经

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminSaTokenDaoConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminSaTokenDaoConfig.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customeradmin.config;
+
+import cn.dev33.satoken.dao.SaTokenDao;
+import cn.dev33.satoken.dao.SaTokenDaoRedisJackson;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Sa-Token 登录态存储装配：把 token / SaSession 从 JVM 内存换到 Redis。
+ *
+ * <p>Sa-Token 默认的 {@code SaTokenDaoDefaultImpl} 把登录态放在进程内的 Map 里，服务一重启
+ * 全部用户被踢下线（"重启后必须重新登录"就是这么来的），多实例部署时各实例也互不认对方签发的
+ * token。改存 Redis 后登录态与进程解耦：重启不掉线、可水平扩容，过期交给 Redis 的 TTL
+ * （有效期见 {@code sa-token.timeout}，默认 24 小时绝对过期，不按活跃续期）。</p>
+ *
+ * <p>{@link RedisConnectionFactory} 来自 spring-boot-starter-data-redis 的自动装配（Lettuce，
+ * 惰性连接，参数取 {@code spring.data.redis.*}，与 {@link AdminRedisConfig}/
+ * {@link AdminDistributedLockConfig} 用的 {@code admin.redis.*} 指向同一个 Redis 实例、同一批
+ * 环境变量）。插件自带的自动装配已在 {@code application.yml} 的
+ * {@code spring.autoconfigure.exclude} 里关掉，改由这里显式装配，为的是留出
+ * {@code admin.sa-token.redis-persistent} 这个开关。</p>
+ *
+ * <p>注意语义变化：登录态改由 Redis 承载后，Redis 不可达时鉴权是 <b>fail-closed</b> 的
+ * （校验登录态直接抛异常 → 请求失败），这正是登录态该有的安全语义，与 {@code ChatHistoryCache}
+ * 那种"连不上就退化直读 MySQL"的缓存旁路刻意相反。真出故障时把开关置 false 可临时退回内存态，
+ * 代价是重启即全员掉线、多实例互不认 token。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Configuration
+public class AdminSaTokenDaoConfig {
+
+    /**
+     * 登录态持久化 DAO。开关关闭时不注册本 Bean，Sa-Token 自动回退其内置的内存实现。
+     */
+    @Bean
+    @ConditionalOnProperty(name = "admin.sa-token.redis-persistent", havingValue = "true", matchIfMissing = true)
+    public SaTokenDao saTokenDao(RedisConnectionFactory redisConnectionFactory) {
+        SaTokenDaoRedisJackson dao = new SaTokenDaoRedisJackson();
+        // 插件把连接工厂的注入点设计成 init 方法（自动装配时由 @Autowired 触发），这里手动装配
+        // 必须显式调一次，否则内部两个 RedisTemplate 为 null，要到第一次鉴权才 NPE。
+        dao.init(redisConnectionFactory);
+        log.info("Sa-Token login state persisted to Redis, restart will not kick users out");
+        return dao;
+    }
+}

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
     # （与 customer-channel 同一手法：不依赖 starter 的自动装配 Bean，需要的能力在本模块的 Config 类里显式 new）
     exclude:
       - com.richard.fyoung.customerwork.autoconfigure.CustomerWorkAutoConfiguration
+      # Sa-Token 的 Redis DAO 插件自带自动装配（无条件生效、无开关）。这里排除掉，改由
+      # AdminSaTokenDaoConfig 按 admin.sa-token.redis-persistent 开关显式装配：Redis 故障时
+      # 运维可关成内存态先把后台救回来（代价是重启需重登），不必改代码重新发版。
+      - cn.dev33.satoken.dao.SaTokenDaoRedisJackson
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${ADMIN_MYSQL_URL:jdbc:mysql://localhost:3306/customer_admin?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true}
@@ -36,6 +40,15 @@ spring:
     # 报 "No value provided for placeholder: ${now}" 直接中断迁移。本项目迁移脚本不使用
     # Flyway 占位符功能，全局关闭即可。
     placeholder-replacement: false
+  data:
+    redis:
+      # Sa-Token 登录态存储用（AdminSaTokenDaoConfig 注入这里自动装配出的 RedisConnectionFactory）。
+      # 与下面 admin.redis.* 是同一个 Redis 实例、同一批环境变量——两套配置项是因为一边由
+      # Spring Boot 自动装配（Lettuce）、一边是本模块手写的 Jedis/Redisson，改地址只需改环境变量。
+      host: ${ADMIN_REDIS_HOST:localhost}
+      port: ${ADMIN_REDIS_PORT:6379}
+      password: ${ADMIN_REDIS_PASSWORD:}
+      timeout: 3000ms
 
 
 mybatis-plus:
@@ -51,7 +64,9 @@ mybatis-plus:
 # Sa-Token 认证配置
 sa-token:
   token-name: Authorization      # 请求头 / 参数名
-  timeout: 7200                  # 登录态有效期（秒），2 小时
+  # 登录态有效期（秒），默认 24 小时。登录态存在 Redis（见 admin.sa-token.redis-persistent），
+  # 服务重启不丢，这个 24 小时是"从登录那一刻算起的绝对时长"，与进程生命周期无关。
+  timeout: ${ADMIN_SATOKEN_TIMEOUT_SECONDS:86400}
   activity-timeout: -1           # 按最后活跃时间续期：-1 表示不限（依赖 timeout 硬过期）
   is-concurrent: true            # 允许同一账号多端登录
   is-share: true                 # 多端共用一个 token
@@ -61,8 +76,13 @@ sa-token:
 # AES 加密密钥：AES-256 需 32 字节明文密钥（不入库不硬编码，本地开发用固定测试值，生产由运维走 Secret 管理下发）
 admin:
   aes-secret-key: ${ADMIN_AES_SECRET_KEY:0123456789abcdef0123456789abcdef}
-  # 登录“记住我”勾选后登录态有效期（秒），默认 7 天；不勾选时沿用 sa-token.timeout（2 小时）全局配置
+  # 登录“记住我”勾选后登录态有效期（秒），默认 7 天；不勾选时沿用 sa-token.timeout（24 小时）全局配置
   remember-me-timeout-seconds: ${ADMIN_REMEMBER_ME_TIMEOUT_SECONDS:604800}
+  sa-token:
+    # 登录态是否持久化到 Redis（见 AdminSaTokenDaoConfig）。默认 true：token 存 Redis，
+    # 服务重启/多实例部署都不掉线。设为 false 回退 Sa-Token 内置的 JVM 内存 DAO——
+    # 仅在 Redis 故障需要临时把后台救回来时用，代价是重启即全员掉线、多实例互不认 token。
+    redis-persistent: ${ADMIN_SATOKEN_REDIS_PERSISTENT:true}
   open-api:
     # 开放 API（/api/open/**）访问令牌，供 customer-channel 等外部模块通过请求头 X-Open-Api-Token 调用。
     # 无默认值：未配置时所有开放 API 一律 401（见 OpenApiAuthInterceptor），不留“空 token 放行”后门。

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/AdminSaTokenDaoConfigTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/AdminSaTokenDaoConfigTest.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customeradmin.config;
+
+import cn.dev33.satoken.dao.SaTokenDao;
+import cn.dev33.satoken.dao.SaTokenDaoRedisJackson;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * {@link AdminSaTokenDaoConfig} 单测：手动装配必须替插件把 {@code init} 调掉。
+ *
+ * <p>这一层防的是"忘了调 init"这类只在运行期第一次鉴权才炸的空指针——插件把连接工厂的注入点
+ * 设计成 {@code @Autowired} 方法，脱离自动装配后没人替我们调。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class AdminSaTokenDaoConfigTest {
+
+    @Test
+    void saTokenDao_shouldBeRedisBackedAndInitialized() {
+        RedisConnectionFactory connectionFactory = Mockito.mock(RedisConnectionFactory.class);
+
+        SaTokenDao dao = new AdminSaTokenDaoConfig().saTokenDao(connectionFactory);
+
+        SaTokenDaoRedisJackson redisDao = assertInstanceOf(SaTokenDaoRedisJackson.class, dao);
+        // init 成功的可观测标志：两个 RedisTemplate 建好且绑到传入的连接工厂上
+        assertNotNull(redisDao.stringRedisTemplate);
+        assertNotNull(redisDao.objectRedisTemplate);
+        assertSame(connectionFactory, redisDao.stringRedisTemplate.getConnectionFactory());
+        assertSame(connectionFactory, redisDao.objectRedisTemplate.getConnectionFactory());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/SaTokenRedisPersistenceIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/SaTokenRedisPersistenceIntegrationTest.java
@@ -1,0 +1,119 @@
+package com.richard.fyoung.customeradmin.config;
+
+import cn.dev33.satoken.dao.SaTokenDao;
+import cn.dev33.satoken.session.SaSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * 登录态 Redis 持久化门控集成测试：验证"服务重启后登录态还在"这件事本身。
+ *
+ * <p>用两个互相独立的 {@link SaTokenDao} 实例模拟重启前后的两个进程——第一个写入，第二个（全新的
+ * 连接工厂 + 全新的 DAO，等价于新起的 JVM）能读到同一份数据，就证明登录态不再依附于进程内存。
+ * 顺带验证 TTL 真落到了 Redis 上，以及 {@link SaSession}（token session 里存了 username）能
+ * 跨实例正确反序列化——这是从内存 DAO 换到 Redis 后唯一新增的失败面。</p>
+ *
+ * <p>Redis 不可达或需要鉴权而本机未提供密码时自动跳过（同仓库既有门控约定），
+ * 地址/密码取 {@code ADMIN_REDIS_HOST}/{@code ADMIN_REDIS_PORT}/{@code ADMIN_REDIS_PASSWORD}，
+ * 与运行期用的是同一批环境变量。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class SaTokenRedisPersistenceIntegrationTest {
+
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 6379;
+    private static final int PROBE_TIMEOUT_MILLIS = 800;
+    /** 与 application.yml 的 sa-token.timeout 默认值一致：24 小时 */
+    private static final long TIMEOUT_SECONDS = 86400L;
+
+    @Test
+    void loginState_shouldSurviveProcessRestart() {
+        String host = envOrDefault("ADMIN_REDIS_HOST", DEFAULT_HOST);
+        int port = Integer.parseInt(envOrDefault("ADMIN_REDIS_PORT", String.valueOf(DEFAULT_PORT)));
+        assumeTrue(reachable(host, port), "Redis 不可达（" + host + ":" + port + "），跳过该集成测试");
+
+        String key = "satoken-it:" + UUID.randomUUID();
+        String sessionId = "satoken-it-session:" + UUID.randomUUID();
+
+        LettuceConnectionFactory writerFactory = connectionFactory(host, port);
+        SaTokenDao writer = new AdminSaTokenDaoConfig().saTokenDao(writerFactory);
+        try {
+            assumeTrue(pingable(writer, key), "Redis 需要鉴权但未提供 ADMIN_REDIS_PASSWORD，跳过该集成测试");
+
+            writer.set(key, "10001", TIMEOUT_SECONDS);
+            SaSession session = new SaSession(sessionId);
+            session.set("username", "admin");
+            writer.setObject(sessionId, session, TIMEOUT_SECONDS);
+        } finally {
+            writerFactory.destroy();
+        }
+
+        // 这里等价于"服务重启"：连接工厂与 DAO 全部换新，进程内不残留任何登录态
+        LettuceConnectionFactory readerFactory = connectionFactory(host, port);
+        SaTokenDao reader = new AdminSaTokenDaoConfig().saTokenDao(readerFactory);
+        try {
+            assertEquals("10001", reader.get(key));
+            // TTL 由 Redis 兜底：允许写入到读取之间的秒级损耗，只断言仍在 24 小时量级
+            long timeout = reader.getTimeout(key);
+            assertTrue(timeout > TIMEOUT_SECONDS - 60 && timeout <= TIMEOUT_SECONDS,
+                "TTL 应仍在 24 小时量级，实际 " + timeout);
+
+            SaSession restored = (SaSession) reader.getObject(sessionId);
+            assertNotNull(restored, "SaSession 跨实例反序列化失败");
+            assertEquals("admin", restored.getString("username"));
+
+            reader.delete(key);
+            reader.deleteObject(sessionId);
+            assertNull(reader.get(key));
+        } finally {
+            readerFactory.destroy();
+        }
+    }
+
+    /** 写一次并读回，借此把 NOAUTH 这类鉴权失败暴露出来（连得上端口不等于能用） */
+    private boolean pingable(SaTokenDao dao, String key) {
+        try {
+            dao.set(key + ":probe", "1", 10);
+            dao.delete(key + ":probe");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private LettuceConnectionFactory connectionFactory(String host, int port) {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        String password = System.getenv("ADMIN_REDIS_PASSWORD");
+        if (password != null && !password.isBlank()) {
+            config.setPassword(password);
+        }
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    private String envOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), PROBE_TIMEOUT_MILLIS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -1057,6 +1057,22 @@ Key 前缀 `admin:chat:sessions:{agentCode}` / `admin:chat:messages:{agentCode}:
 `localhost:6379` 无密码）。新增 `ChatHistoryCacheTest`（6：命中/未命中/写入回填/失效/Redis 不可达两种
 场景不抛异常）。
 
+**后台登录态 Redis 持久化**：Sa-Token 默认的 `SaTokenDaoDefaultImpl` 把 token 与 `SaSession` 放在进程内
+的 Map 里，服务一重启全部用户被踢下线（前端 token 存 localStorage 并没丢，是后端认不出来了），多实例
+部署时各实例也互不认对方签发的 token。改用官方 `sa-token-redis-jackson`（`SaTokenDaoRedisJackson`），
+由 `AdminSaTokenDaoConfig` 显式装配——插件自带的自动装配在 `spring.autoconfigure.exclude` 里关掉，为的是
+留出 `admin.sa-token.redis-persistent`（`ADMIN_SATOKEN_REDIS_PERSISTENT`，默认 `true`）这个应急开关：
+Redis 故障时置 `false` 可临时退回内存态先把后台救回来，不必改代码发版。有效期 `sa-token.timeout`
+（`ADMIN_SATOKEN_TIMEOUT_SECONDS`）默认 **86400 秒 = 24 小时绝对过期**（`activity-timeout: -1`，不按活跃
+续期），勾选"记住我"仍走 `admin.remember-me-timeout-seconds`（默认 7 天）。连接工厂是
+spring-boot-starter-data-redis 自动装配的 Lettuce（`spring.data.redis.*`，与 `admin.redis.*` 取同一批
+环境变量、指向同一个 Redis 实例；两套配置项是因为一边自动装配、一边是本模块手写的 Jedis/Redisson）。
+**语义上要注意**：登录态改由 Redis 承载后 Redis 不可达是 fail-closed（鉴权直接失败），与上面
+`ChatHistoryCache` "连不上就回源 MySQL" 的缓存旁路刻意相反——登录态就该这么定。新增
+`AdminSaTokenDaoConfigTest`（1：手动装配必须替插件调掉 `init`，否则首次鉴权才 NPE）与门控集成测试
+`SaTokenRedisPersistenceIntegrationTest`（1：两个独立 DAO 实例模拟重启前后的两个进程，验证写入方存的
+token/`SaSession` 能被全新实例读到、TTL 真落到 Redis 上；Redis 不可达或需鉴权而未提供密码时自动跳过）。
+
 ### 6.22 用户工单系统（终端用户端 ↔ AI ↔ 人工坐席全链路）
 
 在既有"AI 客服 + 人机切换"能力之上，补齐了**面向真实终端用户的完整工单闭环**：用户注册登录后开会话与

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -152,6 +152,19 @@
 | `CW_AGENT_WS_SECRET` | 坐席 HMAC 凭证密钥,**必须与 8080 同值**(`admin.customer-work.agent-secret` 读取此 env);不一致则坐席全链路 401 |
 | `admin.customer-work.base-url` / `ws-url` | 指向 8080 的 HTTP 与 WebSocket 地址(默认 `http://localhost:8080` / `ws://localhost:8080/ws/agent`);生产改为 8080 实际内网/公网地址,`ws-url` 供浏览器直连,须走公网可达地址 |
 
+#### 后台登录态持久化(Sa-Token + Redis)
+
+后台登录态存 Redis(`AdminSaTokenDaoConfig`),**服务重启/滚动发布不会把在线用户踢下线**,多实例部署也天然共享同一份登录态。Redis 对 8082 因此从"可选的读缓存"升级为**登录必须依赖**:Redis 不可达时鉴权 fail-closed(请求 401),这是登录态该有的安全语义(与历史对话读缓存"连不上就回源 MySQL"刻意相反)。
+
+| 环境变量 / 配置 | 默认 | 说明 |
+|---|---|---|
+| `ADMIN_REDIS_HOST` / `ADMIN_REDIS_PORT` / `ADMIN_REDIS_PASSWORD` | `localhost` / `6379` / 空 | 登录态存储 Redis(同一实例同时供历史对话读缓存、分布式锁复用);生产必填且必须配密码 |
+| `ADMIN_SATOKEN_TIMEOUT_SECONDS`(`sa-token.timeout`) | `86400` | 登录态有效期(秒),默认 24 小时。**绝对过期**(`activity-timeout: -1`,不按活跃续期),从登录那一刻算起,与进程生命周期无关 |
+| `ADMIN_REMEMBER_ME_TIMEOUT_SECONDS` | `604800` | 登录时勾选"记住我"的有效期(秒),默认 7 天;不勾选走上面的 24 小时 |
+| `ADMIN_SATOKEN_REDIS_PERSISTENT` | `true` | 应急开关。置 `false` 退回 Sa-Token 内存 DAO——**仅在 Redis 故障需要先把后台救回来时用**,代价是重启即全员掉线、多实例互不认 token |
+
+> 多实例部署注意:各实例必须指向**同一个** Redis,否则各签各的 token,负载均衡轮到另一台就 401。
+
 #### VibeCoding 沙箱 / Plan Mode HITL(`admin.sandbox.*`,AI 编码助手用)
 
 | 环境变量 / 配置 | 默认 | 说明 |

--- a/scripts/run-admin-server-dev.sh
+++ b/scripts/run-admin-server-dev.sh
@@ -7,5 +7,8 @@ export ADMIN_AES_SECRET_KEY=01234567890123456789012345678901
 # 未改过 xxl.job.accessToken 配置，故这里保持同值；调度中心侧改了 token 后这里要同步改。
 export ADMIN_XXL_JOB_ENABLED=true
 export ADMIN_XXL_JOB_ACCESS_TOKEN=default_token
+# 登录态存 Redis（服务重启不掉线，见 AdminSaTokenDaoConfig）：本机 redis 容器是 localhost:6379
+# 无密码，与默认值一致故无需显式 export；换地址/加密码用 ADMIN_REDIS_HOST/PORT/PASSWORD 覆盖。
+# 注意 Redis 起不来时后台登录会直接失败（fail-closed），应急可 export ADMIN_SATOKEN_REDIS_PERSISTENT=false。
 cd "$(dirname "$0")/../customer-admin-server"
 exec mvn spring-boot:run -Dspring-boot.run.profiles=dev -q


### PR DESCRIPTION
## 问题

admin-server 每次重启，所有人都要重新登录。

根因是 Sa-Token 用的还是默认的 `SaTokenDaoDefaultImpl`——token 和 `SaSession` 都放在进程内的 Map 里，进程一没就全没了（前端 token 存的是 localStorage，并没丢，是后端认不出来了）。同一个原因下，多实例部署时各实例也互不认对方签发的 token，负载均衡轮到另一台就 401。

另外 `sa-token.timeout` 只有 2 小时。

## 改动

- 引入官方 `sa-token-redis-jackson`，登录态改存 Redis，由 `AdminSaTokenDaoConfig` **显式装配**（插件自带的自动装配在 `spring.autoconfigure.exclude` 里关掉）——这么绕一下是为了留出 `admin.sa-token.redis-persistent`（`ADMIN_SATOKEN_REDIS_PERSISTENT`，默认 `true`）应急开关：Redis 故障时置 `false` 可临时退回内存态先把后台救回来，不必改代码发版。
- `sa-token.timeout` 7200 → **86400（24 小时）**，可用 `ADMIN_SATOKEN_TIMEOUT_SECONDS` 覆盖；`activity-timeout` 保持 `-1`，即从登录那一刻起算的**绝对过期**，不按活跃续期。勾选"记住我"仍走 `admin.remember-me-timeout-seconds`（7 天）。
- `spring.data.redis.*` 与既有 `admin.redis.*` 取**同一批环境变量**、指向同一个 Redis 实例（两套配置项是因为一边由 Spring Boot 自动装配 Lettuce、一边是本模块手写的 Jedis/Redisson）。
- CI 的 test 步骤注入 `ADMIN_REDIS_PASSWORD=123456`（CI 的 Redis 设了 requirepass），否则新增的门控集成测试会因鉴权失败静默跳过、白跑。

### 为什么不用 sa-token-redisson-jackson

本模块已经有一个 `RedissonClient`（`AdminDistributedLockConfig`），同系列的 redisson 版插件看起来能直接复用、零新增传递依赖。实际不行：它 `init()` 里 `new` 了 spring-data-redis 的 `GenericJackson2JsonRedisSerializer` 再**反射偷其私有 `mapper` 字段**，照样离不开 `spring-data-redis`，还额外多一层对私有字段名的隐式耦合（spring-data-redis 换版本就可能炸）。同样的传递依赖代价，走官方主线这条被验证最多的路。

依赖树实测：`spring-data-redis 3.2.5`（与 Spring Boot 版本一致），lettuce 仍是 agentscope 传递的 `6.3.2.RELEASE`（正是 spring-data-redis 3.2.5 官方管理的版本），无版本冲突。

## 需要留意的语义变化

登录态改由 Redis 承载后，**Redis 不可达时鉴权是 fail-closed 的**（请求直接失败），与 `ChatHistoryCache` 那种"连不上就退化回源 MySQL"的缓存旁路刻意相反——登录态就该这么定。部署上 Redis 对 8082 因此从"可选的读缓存"升级为**登录必须依赖**，部署手册已相应更新。

## 验证

- `customer-admin-server` 全量测试 **805 → 807**，全绿（新增装配单测 1 + 跨进程门控集成测试 1）。
- 本机另起 8092 实例实测端到端：
  1. 往 Redis 预置一个该进程从未签发过的 token → `/api/auth/me` 返回 200（无 token 时正常 401）；
  2. `kill` 进程、确认端口释放后重启 → 同一 token 仍然有效，TTL 正常倒计时。

🤖 Generated with [Claude Code](https://claude.com/claude-code)