### PR TITLE
feat(admin-web): 智能体列表新增知识库列

### DIFF
--- a/customer-admin-web/src/views/aiconfig/AgentManage.vue
+++ b/customer-admin-web/src/views/aiconfig/AgentManage.vue
@@ -346,6 +346,13 @@ onMounted(() => {
             <span v-if="!row.backupModelNames?.length" style="color: #909399">-</span>
           </template>
         </el-table-column>
+        <!-- 知识库名称由后端 AgentVO.knowledgeBaseNames 直接回填，前端不再二次查询 -->
+        <el-table-column label="知识库" width="200">
+          <template #default="{ row }">
+            <el-tag v-for="k in row.knowledgeBaseNames" :key="k" type="success" style="margin: 2px">{{ k }}</el-tag>
+            <span v-if="!row.knowledgeBaseNames?.length" style="color: #909399">-</span>
+          </template>
+        </el-table-column>
         <el-table-column label="能力" width="260">
           <template #default="{ row }">
             <el-tag v-for="c in row.capabilities" :key="c" style="margin: 2px">{{ capabilityLabel(c) }}</el-tag>


### PR DESCRIPTION
## 背景
智能体管理列表页没有展示已绑定的 RAG 知识库，只能进编辑弹窗才看得到。

## 改动
- `AgentManage.vue` 列表在「备用模型」与「能力」之间新增「知识库」列，用 tag 展示绑定的知识库名称，未绑定显示 `-`。

后端 `AgentVO.knowledgeBaseNames` 早已回填（`AgentService#fillKnowledgeBases` 批量查名，无 N+1），前端类型 `api.ts` 也已声明，本次只补渲染，**不涉及接口、SQL、迁移脚本变更**。

## 验证
- `npx vue-tsc --noEmit` 通过
- `npm run build` 通过
- 库中现存绑定数据：`java-assistant` → 「易卡知识库」，该行应显示对应 tag