### PR TITLE
fix(admin): MCP 发布链路兼容 mcpServers 包装格式配置

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
@@ -59,6 +59,7 @@ public class CustomerWorkConfigPublisher {
     private static final String MCP_TYPE_HTTP = "http";
     private static final String MCP_TYPE_SSE = "sse";
     private static final String TRANSPORT_STREAMABLE_HTTP = "streamable-http";
+    private static final String MCP_SERVERS_WRAPPER_KEY = "mcpServers";
 
     private final AiChannelBindingMapper channelBindingMapper;
     private final AiAgentMapper agentMapper;
@@ -315,13 +316,20 @@ public class CustomerWorkConfigPublisher {
         return null;
     }
 
-    /** 解析 ai_mcp.config JSON 的 url 与 headers（与 AdminMcpFactory 的取值方式一致）。 */
+    /**
+     * 解析 ai_mcp.config JSON 的 url 与 headers（与 AdminMcpFactory 的取值方式一致）：
+     * 同样兼容 Claude Desktop / Cursor 风格的 {@code {"mcpServers": {...}}} 包装格式——调试面板与真实
+     * 注册路径都认这层包装，发布链路不解包会导致 url 取空、该 MCP 被静默跳过。
+     *
+     * <p>TODO(sink-common-to-starter 合入后)：改为复用 starter 的
+     * {@code com.richard.fyoung.customerwork.tool.mcp.McpClientFactory#parseSpec}，删除本地解包实现。</p>
+     */
     private void fillUrlAndHeaders(CustomerWorkRuntimeConfig.McpServer server, String config) {
         if (!StringUtils.hasText(config)) {
             return;
         }
         try {
-            JsonNode node = objectMapper.readTree(config);
+            JsonNode node = unwrapMcpServers(objectMapper.readTree(config));
             server.setUrl(node.path("url").asText(null));
             JsonNode headersNode = node.path("headers");
             if (headersNode.isObject() && !headersNode.isEmpty()) {
@@ -330,6 +338,19 @@ public class CustomerWorkConfigPublisher {
         } catch (Exception e) {
             log.error("parse mcp config failed, code={}, mcpName={}", "RUNTIME-PUBLISH-MCP-PARSE-FAIL", server.getName(), e);
         }
+    }
+
+    /**
+     * 与 {@code AdminMcpFactory#unwrapMcpServers} 同语义：外层带 {@code mcpServers} 包装时取里面唯一
+     * 一个 server 条目的配置对象（服务名以 {@code ai_mcp.mcp_name} 为准，不读 wrapper 里的 key）；
+     * 没有包装时按原样返回，两种格式都认。
+     */
+    private JsonNode unwrapMcpServers(JsonNode node) {
+        JsonNode servers = node.path(MCP_SERVERS_WRAPPER_KEY);
+        if (servers.isObject() && servers.size() > 0) {
+            return servers.elements().next();
+        }
+        return node;
     }
 
     private String serialize(CustomerWorkRuntimeConfig payload) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisherTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisherTest.java
@@ -129,6 +129,35 @@ class CustomerWorkConfigPublisherTest {
     }
 
     @Test
+    void assembleUnwrapsMcpServersWrapperConfig() {
+        CustomerWorkConfigPublisher publisher = publisher(true);
+        AiModelConfig primary = model(100L, "openai", "gpt-4o", "CIPHER_PRIMARY");
+        when(backupModelMapper.selectList(any())).thenReturn(List.of());
+
+        // Claude Desktop / Cursor 风格：外层包一层 mcpServers（调试面板可用，发布链路曾解不出 url 被静默跳过）
+        AiAgentMcp rel = new AiAgentMcp();
+        rel.setAgentId(1L);
+        rel.setMcpId(11L);
+        when(agentMcpMapper.selectList(any())).thenReturn(List.of(rel));
+        AiMcp mcp = new AiMcp();
+        mcp.setId(11L);
+        mcp.setMcpName("amap");
+        mcp.setMcpType("http");
+        mcp.setStatus(1);
+        mcp.setConfig("{\"mcpServers\":{\"amap-maps\":{\"url\":\"https://mcp.amap.com/mcp\","
+            + "\"headers\":{\"Authorization\":\"Bearer y\"}}}}");
+        when(mcpMapper.selectBatchIds(any())).thenReturn(List.of(mcp));
+
+        CustomerWorkRuntimeConfig cfg = publisher.assemble(agent(), primary);
+
+        assertEquals(1, cfg.getMcpServers().size(), "包装格式的 MCP 不应被静默跳过");
+        assertEquals("amap", cfg.getMcpServers().get(0).getName(), "名称以 ai_mcp.mcp_name 为准，不读 wrapper 的 key");
+        assertEquals("https://mcp.amap.com/mcp", cfg.getMcpServers().get(0).getUrl());
+        assertEquals("streamable-http", cfg.getMcpServers().get(0).getTransport());
+        assertEquals("Bearer y", cfg.getMcpServers().get(0).getHeaders().get("Authorization"));
+    }
+
+    @Test
     void republishBlockedWhenConnectivityProbeFails() {
         CustomerWorkConfigPublisher publisher = publisher(true);
         AiChannelBinding binding = new AiChannelBinding();


### PR DESCRIPTION
## 问题

`CustomerWorkConfigPublisher#fillUrlAndHeaders` 自己 `readTree` 解析 `ai_mcp.config` 取 url/headers，不认 Claude Desktop / Cursor 风格的 `{"mcpServers": {"任意名字": {实际配置}}}` 包装格式。

后果：按包装格式录入的 MCP，在后台调试面板一切正常（`AdminMcpFactory#unwrapMcpServers` 能解包），但发布到 8080 客服端时 url 取空、整个 MCP 被 `StringUtils.hasText(url)` 静默过滤掉——同一份配置两条链路行为不一致，且无任何报错。

## 修复

`fillUrlAndHeaders` 先做与 `AdminMcpFactory#unwrapMcpServers` 逐字同语义的解包再取 url/headers，两种格式都认；服务名仍以 `ai_mcp.mcp_name` 为准，不读 wrapper 里的 key。

**与 feature/sink-common-to-starter 的关系**：原计划直接复用 starter 下沉后的 `McpClientFactory#parseSpec`，但该分支目前尚未提交/合入（分支指针仍在 main），无法 stack。本 PR 采用零冲突的本地同语义解包（sink 分支未改动本文件），并在代码内留 TODO：sink 合入后把这段切换为 `parseSpec` 统一解析、删除本地实现。

## 测试

- 新增 `assembleUnwrapsMcpServersWrapperConfig`：包装格式（http 型 + headers）发布输出正确、不再被静默跳过；既有 `assembleBuildsPayloadWithCipherFallbackAndMcp` 继续覆盖非包装格式。
- admin-server 全量：**808 通过（基线 807 + 新增 1），0 失败**。