### PR TITLE
feat(devtoolbox): 补齐开发者工具箱——两端能力对齐 + cron/JWT/diff/格式互转四项新工具

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,10 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1054** + admin-server **711** + app 78 + customer-channel 65 + gateway 1
-  （2026-08-05 feature/observability-last-mile 实测；admin-server 此前实际基线已是 707，CLAUDE.md 曾记的
+- 测试基线：starter **1136** + admin-server **722** + app 78 + customer-channel 65 + gateway 1
+  （2026-08-06 feature/devtoolbox-expansion 实测，该分支给开发者工具箱补了 cron/JWT/diff/格式互转四项
+  与 AES 两端对齐，starter +82 / admin +11。上一版基线是 2026-08-05 的 starter 1054 + admin 711；
+  admin-server 更早的实际基线已是 707，CLAUDE.md 曾记的
   701 系陈旧数字。starter 已按下方规则排除 2 个环境门控测试。此前 feature/sink-common-to-starter 把 admin
   十项通用能力下沉 starter：核心逻辑测试随迁，故 starter +226 / admin −106，admin 侧只保留薄壳职责测试；
   PR #68 修掉多构造器缺 @Autowired 后 `ApplicationContextTest` 已恢复，不再需要额外排除）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/controller/DevToolCalcController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/controller/DevToolCalcController.java
@@ -1,0 +1,66 @@
+package com.richard.fyoung.customeradmin.system.devtool.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCronExplainRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCronExplainResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolFormatConvertRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolFormatConvertResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolJwtDecodeRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolJwtDecodeResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolTextDiffRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolTextDiffResponse;
+import com.richard.fyoung.customeradmin.system.devtool.service.DevToolCalcService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 开发者工具箱 · 纯计算类工具的统一入口：cron 解析、JWT 解析、文本比对、格式互转。
+ *
+ * <p>这四项与 HTTP 代理（要防 SSRF）、证书解析（走 multipart 且涉及私钥）各有独立的横切关注点不同，
+ * 都是无副作用的纯计算，故合在一个 controller 里，不为每项各建一个只有单个接口的类。</p>
+ *
+ * <p>权限复用工具箱菜单的 {@code devtools:view}，与其余工具的授权粒度保持一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/devtools")
+public class DevToolCalcController {
+
+    private final DevToolCalcService devToolCalcService;
+
+    public DevToolCalcController(DevToolCalcService devToolCalcService) {
+        this.devToolCalcService = devToolCalcService;
+    }
+
+    /** 解析 cron 表达式并推算后续执行时间。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/cron/explain")
+    public Result<DevToolCronExplainResponse> explainCron(@Valid @RequestBody DevToolCronExplainRequest request) {
+        return Result.success(devToolCalcService.explainCron(request));
+    }
+
+    /** 解析 JWT，可选校验 HS* 签名。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/jwt/decode")
+    public Result<DevToolJwtDecodeResponse> decodeJwt(@Valid @RequestBody DevToolJwtDecodeRequest request) {
+        return Result.success(devToolCalcService.decodeJwt(request));
+    }
+
+    /** 行级比对两段文本。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/diff/text")
+    public Result<DevToolTextDiffResponse> diffText(@Valid @RequestBody DevToolTextDiffRequest request) {
+        return Result.success(devToolCalcService.diffText(request));
+    }
+
+    /** JSON / YAML / XML 互转。 */
+    @SaCheckPermission("devtools:view")
+    @PostMapping("/format/convert")
+    public Result<DevToolFormatConvertResponse> convertFormat(@Valid @RequestBody DevToolFormatConvertRequest request) {
+        return Result.success(devToolCalcService.convertFormat(request));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCronExplainRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCronExplainRequest.java
@@ -1,0 +1,29 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * cron 表达式解析请求。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCronExplainRequest {
+
+    /** 6 段 cron（秒 分 时 日 月 周），与 XXL-JOB 调度中心一致。 */
+    @NotBlank(message = "cron 表达式不能为空")
+    @Size(max = 200, message = "cron 表达式过长")
+    private String expression;
+
+    /** 推算的后续执行时间条数，1~20，为空取默认 5。 */
+    @Min(value = 1, message = "推算条数最少 1 条")
+    @Max(value = 20, message = "推算条数最多 20 条")
+    private Integer count;
+
+    /** 时区 ID，为空取 Asia/Shanghai。 */
+    @Size(max = 64, message = "时区 ID 过长")
+    private String timezone;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCronExplainResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolCronExplainResponse.java
@@ -1,0 +1,46 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * cron 表达式解析响应。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolCronExplainResponse {
+
+    /** 归一化后的表达式（多余空白已压缩）。 */
+    private String expression;
+
+    /** 推算所用时区。 */
+    private String timezone;
+
+    /** 逐字段释义。 */
+    private List<Field> fields;
+
+    /** 后续执行时间（yyyy-MM-dd HH:mm:ss）；表达式不会再触发时为空列表。 */
+    private List<String> nextTimes;
+
+    /**
+     * cron 单字段释义。
+     */
+    @Data
+    @AllArgsConstructor
+    public static class Field {
+
+        /** 字段名（秒/分钟/小时/日/月/星期）。 */
+        private String name;
+
+        /** 该字段的原始取值。 */
+        private String value;
+
+        /** 该字段的合法取值范围。 */
+        private String range;
+
+        /** 取值释义。 */
+        private String description;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolFormatConvertRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolFormatConvertRequest.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 结构化数据格式互转请求（JSON / YAML / XML）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolFormatConvertRequest {
+
+    /** 待转换内容。 */
+    @NotBlank(message = "内容不能为空")
+    @Size(max = 512 * 1024, message = "内容过大（上限 512KB）")
+    private String content;
+
+    /** 源格式：json / yaml / xml。 */
+    @NotBlank(message = "源格式不能为空")
+    @Size(max = 16, message = "源格式取值非法")
+    private String sourceFormat;
+
+    /** 目标格式：json / yaml / xml。 */
+    @NotBlank(message = "目标格式不能为空")
+    @Size(max = 16, message = "目标格式取值非法")
+    private String targetFormat;
+
+    /** 转 XML 时的根元素名，为空取 root；其它目标格式忽略。 */
+    @Size(max = 64, message = "根元素名过长")
+    private String rootName;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolFormatConvertResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolFormatConvertResponse.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * 结构化数据格式互转响应。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@AllArgsConstructor
+public class DevToolFormatConvertResponse {
+
+    /** 源格式（小写）。 */
+    private String sourceFormat;
+
+    /** 目标格式（小写）。 */
+    private String targetFormat;
+
+    /** 转换后的内容。 */
+    private String result;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolJwtDecodeRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolJwtDecodeRequest.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * JWT 解析请求。密钥仅用于本次请求内的签名校验，不落库、不写日志。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolJwtDecodeRequest {
+
+    /** JWT 字符串（header.payload.signature）。 */
+    @NotBlank(message = "JWT 不能为空")
+    @Size(max = 64 * 1024, message = "JWT 过长（上限 64KB）")
+    private String token;
+
+    /** 可选，HS256/HS384/HS512 的签名校验密钥；为空则只解码不校验。 */
+    @Size(max = 1024, message = "密钥过长")
+    private String secret;
+
+    /** 密钥的文本编码：utf8(默认)/hex/base64。 */
+    @Size(max = 16, message = "密钥编码取值非法")
+    private String secretEncoding;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolJwtDecodeResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolJwtDecodeResponse.java
@@ -1,0 +1,59 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.Data;
+
+/**
+ * JWT 解析响应。时间类字段均已按 Asia/Shanghai 格式化为 yyyy-MM-dd HH:mm:ss，缺失的声明为 null。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolJwtDecodeResponse {
+
+    /** 签名算法（header.alg）。 */
+    private String algorithm;
+
+    /** 令牌类型（header.typ）。 */
+    private String type;
+
+    /** header 的格式化 JSON。 */
+    private String header;
+
+    /** payload 的格式化 JSON。 */
+    private String payload;
+
+    /** 签发方 iss。 */
+    private String issuer;
+
+    /** 主体 sub。 */
+    private String subject;
+
+    /** 受众 aud（原样 JSON，可能是字符串或数组）。 */
+    private String audience;
+
+    /** 令牌 ID jti。 */
+    private String jwtId;
+
+    /** 签发时间 iat。 */
+    private String issuedAt;
+
+    /** 生效时间 nbf。 */
+    private String notBefore;
+
+    /** 过期时间 exp。 */
+    private String expiresAt;
+
+    /** 是否已过期（无 exp 声明时为 false）。 */
+    private boolean expired;
+
+    /** 是否尚未生效（无 nbf 声明时为 false）。 */
+    private boolean notYetValid;
+
+    /** 距过期的秒数，负数表示已过期；无 exp 声明时为 null。 */
+    private Long secondsRemaining;
+
+    /** 是否是 alg=none 的无签名令牌（签名可被任意伪造）。 */
+    private boolean unsigned;
+
+    /** 签名校验结论：VALID / INVALID / NOT_CHECKED / UNSUPPORTED_ALG。 */
+    private String signatureStatus;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolTextDiffRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolTextDiffRequest.java
@@ -1,0 +1,29 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 文本比对请求。两侧允许空串（表示整段新增或整段删除），但不允许缺字段。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolTextDiffRequest {
+
+    /** 原文本。 */
+    @NotNull(message = "原文本不能缺失")
+    @Size(max = 512 * 1024, message = "原文本过大（上限 512KB）")
+    private String oldText;
+
+    /** 新文本。 */
+    @NotNull(message = "新文本不能缺失")
+    @Size(max = 512 * 1024, message = "新文本过大（上限 512KB）")
+    private String newText;
+
+    /** 是否忽略行首尾空白差异。 */
+    private Boolean ignoreWhitespace;
+
+    /** 是否忽略大小写差异。 */
+    private Boolean ignoreCase;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolTextDiffResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/dto/DevToolTextDiffResponse.java
@@ -1,0 +1,52 @@
+package com.richard.fyoung.customeradmin.system.devtool.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 文本比对响应。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class DevToolTextDiffResponse {
+
+    /** 两段文本是否完全一致（按当前忽略选项判定）。 */
+    private boolean identical;
+
+    /** 新增行数。 */
+    private int addedLines;
+
+    /** 删除行数。 */
+    private int deletedLines;
+
+    /** 结果总行数（截断前）。 */
+    private int totalLines;
+
+    /** 是否因差异过多被截断。 */
+    private boolean truncated;
+
+    /** 逐行结果。 */
+    private List<Line> lines;
+
+    /**
+     * 比对结果中的一行。行号从 1 起；该侧不存在此行时为 -1。
+     */
+    @Data
+    @AllArgsConstructor
+    public static class Line {
+
+        /** 类型：EQUAL / INSERT / DELETE。 */
+        private String type;
+
+        /** 在原文本中的行号，新增行为 -1。 */
+        private int oldLineNo;
+
+        /** 在新文本中的行号，删除行为 -1。 */
+        private int newLineNo;
+
+        /** 行内容（原文，未受忽略选项影响）。 */
+        private String content;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCalcService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCalcService.java
@@ -1,0 +1,126 @@
+package com.richard.fyoung.customeradmin.system.devtool.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCronExplainRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCronExplainResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolFormatConvertRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolFormatConvertResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolJwtDecodeRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolJwtDecodeResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolTextDiffRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolTextDiffResponse;
+import com.richard.fyoung.customerwork.tool.devtool.CronDevToolOps;
+import com.richard.fyoung.customerwork.tool.devtool.DataFormatDevToolOps;
+import com.richard.fyoung.customerwork.tool.devtool.DiffDevToolOps;
+import com.richard.fyoung.customerwork.tool.devtool.JwtDevToolOps;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * 开发者工具箱 · 纯计算类工具（cron 解析 / JWT 解析 / 文本比对 / 格式互转）的页面侧入口。
+ *
+ * <p><b>算法不在本类</b>：四项能力的实现都在 starter 的 Ops（纯函数、无 Spring 依赖），同一份实现
+ * 同时由 {@code devtoolbox} 系统工具的 {@code cron_explain} / {@code jwt_decode} / {@code text_diff} /
+ * {@code data_convert} 暴露给智能体。页面与智能体共用一套逻辑是刻意为之——工具箱早期把 JSON、
+ * 编解码等能力在前端各实现了一遍，结果两侧能力集悄悄分叉（AES 模式互不包含即是一例），这批新工具
+ * 一律只留后端一套。本类只做 DTO 转换与异常翻译。</p>
+ *
+ * <p>cron 尤其不能放到前端算：表达式最终由 XXL-JOB 按 Quartz 6 段语义触发，浏览器端 cron 库多按
+ * Unix 5 段解析，同一串表达式两边给出的"下次执行时间"可能不同，那样的工具会误导排查。</p>
+ *
+ * <p>隐私边界：JWT 与其密钥只在请求内存中解析，不落库、不写日志。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class DevToolCalcService {
+
+    private final CronDevToolOps cronOps = new CronDevToolOps();
+    private final JwtDevToolOps jwtOps = new JwtDevToolOps();
+    private final DiffDevToolOps diffOps = new DiffDevToolOps();
+    private final DataFormatDevToolOps dataFormatOps = new DataFormatDevToolOps();
+
+    /** 解析 cron：校验、逐字段释义、推算后续执行时间。 */
+    public DevToolCronExplainResponse explainCron(DevToolCronExplainRequest request) {
+        CronDevToolOps.CronExplainResult result = call(() ->
+            cronOps.explain(request.getExpression(), request.getCount(), request.getTimezone()));
+
+        List<DevToolCronExplainResponse.Field> fields = new ArrayList<>(result.getFields().size());
+        for (CronDevToolOps.CronFieldDesc desc : result.getFields()) {
+            fields.add(new DevToolCronExplainResponse.Field(
+                desc.getName(), desc.getValue(), desc.getRange(), desc.getDescription()));
+        }
+        DevToolCronExplainResponse response = new DevToolCronExplainResponse();
+        response.setExpression(result.getExpression());
+        response.setTimezone(result.getTimezone());
+        response.setFields(fields);
+        response.setNextTimes(result.getNextTimes());
+        return response;
+    }
+
+    /** 解析 JWT：拆解 header/payload、解读有效期，可选 HS* 验签。 */
+    public DevToolJwtDecodeResponse decodeJwt(DevToolJwtDecodeRequest request) {
+        JwtDevToolOps.JwtDecodeResult result = call(() ->
+            jwtOps.decode(request.getToken(), request.getSecret(), request.getSecretEncoding()));
+
+        DevToolJwtDecodeResponse response = new DevToolJwtDecodeResponse();
+        response.setAlgorithm(result.getAlgorithm());
+        response.setType(result.getType());
+        response.setHeader(result.getHeader());
+        response.setPayload(result.getPayload());
+        response.setIssuer(result.getIssuer());
+        response.setSubject(result.getSubject());
+        response.setAudience(result.getAudience());
+        response.setJwtId(result.getJwtId());
+        response.setIssuedAt(result.getIssuedAt());
+        response.setNotBefore(result.getNotBefore());
+        response.setExpiresAt(result.getExpiresAt());
+        response.setExpired(result.isExpired());
+        response.setNotYetValid(result.isNotYetValid());
+        response.setSecondsRemaining(result.getSecondsRemaining());
+        response.setUnsigned(result.isUnsigned());
+        response.setSignatureStatus(result.getSignatureStatus());
+        return response;
+    }
+
+    /** 行级文本比对。 */
+    public DevToolTextDiffResponse diffText(DevToolTextDiffRequest request) {
+        DiffDevToolOps.DiffResult result = call(() -> diffOps.diff(
+            request.getOldText(), request.getNewText(),
+            request.getIgnoreWhitespace(), request.getIgnoreCase()));
+
+        List<DevToolTextDiffResponse.Line> lines = new ArrayList<>(result.getLines().size());
+        for (DiffDevToolOps.DiffLine line : result.getLines()) {
+            lines.add(new DevToolTextDiffResponse.Line(
+                line.getType(), line.getOldLineNo(), line.getNewLineNo(), line.getContent()));
+        }
+        DevToolTextDiffResponse response = new DevToolTextDiffResponse();
+        response.setIdentical(result.isIdentical());
+        response.setAddedLines(result.getAddedLines());
+        response.setDeletedLines(result.getDeletedLines());
+        response.setTotalLines(result.getTotalLines());
+        response.setTruncated(result.isTruncated());
+        response.setLines(lines);
+        return response;
+    }
+
+    /** JSON / YAML / XML 互转。 */
+    public DevToolFormatConvertResponse convertFormat(DevToolFormatConvertRequest request) {
+        DataFormatDevToolOps.ConvertResult result = call(() -> dataFormatOps.convert(
+            request.getContent(), request.getSourceFormat(), request.getTargetFormat(), request.getRootName()));
+        return new DevToolFormatConvertResponse(
+            result.getSourceFormat(), result.getTargetFormat(), result.getResult());
+    }
+
+    /** Ops 的入参校验一律抛 IllegalArgumentException，在此统一翻译成带原因的业务异常。 */
+    private <T> T call(Supplier<T> action) {
+        try {
+            return action.get();
+        } catch (IllegalArgumentException e) {
+            throw new BizException(ResultCode.PARAM_INVALID, e.getMessage());
+        }
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V48__devtoolbox_more_tools.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V48__devtoolbox_more_tools.sql
@@ -1,0 +1,27 @@
+-- 开发者工具箱系统工具补充一批能力（Flyway V48）。
+--
+-- devtoolbox 这个 @Tool Bean 新增 9 个工具方法，实现全部在 starter 的 Ops 里，与管理台
+-- "开发者工具箱"页面共用同一套逻辑：
+--   hex_encode / hex_decode                                   十六进制编解码（页面早有、智能体侧此前缺）
+--   json_escape / json_unescape / json_unicode_decode         JSON 转义、去转义、Unicode 解码（同上）
+--   cron_explain                                              cron 逐字段释义 + 推算后续执行时间
+--   jwt_decode                                                JWT 解码、有效期判定、HS* 签名校验
+--   text_diff                                                 行级文本比对
+--   data_convert                                              JSON / YAML / XML 互转
+--
+-- 同时 aes_encrypt / aes_decrypt 补齐了 CTR 模式与 padding、密钥/IV 编码、密文输出格式等参数，
+-- 使智能体侧成为页面版能力的严格超集——此前两边模式集合互不包含（页面 CBC/ECB/CTR、智能体
+-- CBC/ECB/GCM），且 IV 与密文编码默认值也不同，同一份密文换一侧就解不开。
+--
+-- 工具目录是代码定义的，本迁移只更新描述文案，让智能体配置页勾选时能看到新能力
+-- （沿用 V15/V27/V47 定的"系统工具目录"范式：无新增/删除，只改描述）。
+--
+-- jwt_decode 的令牌与密钥会进入模型上下文并落进对话历史，约束已写进工具描述（仅在用户明确要求时
+-- 调用、不主动索取密钥），remark 同步标注，供配置智能体的人决策是否勾选。
+
+SET NAMES utf8mb4;
+
+UPDATE `ai_system_tool`
+SET `description` = '开发者常用本地工具集：JSON格式化/压缩/校验/转义/去转义/Unicode解码、时间戳转换、Base64/URL/Hex编解码、哈希(HMAC)、UUID生成、AES加解密(CBC/ECB/CTR/GCM)、正则测试、X.509证书/CSR解析、私钥与证书配对校验、cron表达式解析、JWT解析、文本比对、JSON/YAML/XML互转',
+    `remark`      = '纯本地计算，无外部依赖；注意 cert_match 需传入私钥明文、jwt_decode 可能传入令牌与签名密钥，均会进入模型上下文与对话历史'
+WHERE `tool_code` = 'devtoolbox';

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCalcServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/devtool/service/DevToolCalcServiceTest.java
@@ -1,0 +1,184 @@
+package com.richard.fyoung.customeradmin.system.devtool.service;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCronExplainRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolCronExplainResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolFormatConvertRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolFormatConvertResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolJwtDecodeRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolJwtDecodeResponse;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolTextDiffRequest;
+import com.richard.fyoung.customeradmin.system.devtool.dto.DevToolTextDiffResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DevToolCalcService} 单测。
+ *
+ * <p>本类只负责 <b>VO 转换</b>与<b>异常转换</b>——四项算法本身已下沉到 starter 的
+ * {@code CronDevToolOps} / {@code JwtDevToolOps} / {@code DiffDevToolOps} / {@code DataFormatDevToolOps}，
+ * 其正确性由对应的 Ops 单测覆盖，这里不重复验证，只确认字段没漏映射、
+ * {@link IllegalArgumentException} 被翻译成 {@link ResultCode#PARAM_INVALID} 而非裸穿到 Controller。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class DevToolCalcServiceTest {
+
+    /** jwt.io 公开示例令牌（HS256，密钥 your-256-bit-secret），不含任何真实凭据。 */
+    private static final String SAMPLE_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+        + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    private final DevToolCalcService service = new DevToolCalcService();
+
+    // ---------- cron ----------
+
+    @Test
+    void explainCron_shouldMapAllFields() {
+        DevToolCronExplainRequest request = new DevToolCronExplainRequest();
+        request.setExpression("0 0 2 * * ?");
+        request.setCount(3);
+
+        DevToolCronExplainResponse response = service.explainCron(request);
+        assertEquals("0 0 2 * * ?", response.getExpression());
+        assertEquals("Asia/Shanghai", response.getTimezone());
+        assertEquals(6, response.getFields().size());
+        assertEquals(3, response.getNextTimes().size());
+        DevToolCronExplainResponse.Field first = response.getFields().get(0);
+        assertEquals("秒", first.getName());
+        assertEquals("0", first.getValue());
+        assertNotNull(first.getRange());
+        assertNotNull(first.getDescription());
+    }
+
+    @Test
+    void explainCron_shouldTranslateIllegalArgumentToBizException() {
+        DevToolCronExplainRequest request = new DevToolCronExplainRequest();
+        request.setExpression("0 2 * * *");
+
+        BizException ex = assertThrows(BizException.class, () -> service.explainCron(request));
+        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
+        assertTrue(ex.getMessage().contains("5 段"), "错误原因应透传到页面，实际：" + ex.getMessage());
+    }
+
+    // ---------- JWT ----------
+
+    @Test
+    void decodeJwt_shouldMapAllFields() {
+        DevToolJwtDecodeRequest request = new DevToolJwtDecodeRequest();
+        request.setToken(SAMPLE_TOKEN);
+        request.setSecret("your-256-bit-secret");
+
+        DevToolJwtDecodeResponse response = service.decodeJwt(request);
+        assertEquals("HS256", response.getAlgorithm());
+        assertEquals("JWT", response.getType());
+        assertEquals("1234567890", response.getSubject());
+        assertEquals("VALID", response.getSignatureStatus());
+        assertNotNull(response.getHeader());
+        assertNotNull(response.getPayload());
+        assertEquals("2018-01-18 09:30:22", response.getIssuedAt());
+        assertFalse(response.isExpired());
+        assertFalse(response.isUnsigned());
+    }
+
+    @Test
+    void decodeJwt_shouldReportNotChecked_whenSecretMissing() {
+        DevToolJwtDecodeRequest request = new DevToolJwtDecodeRequest();
+        request.setToken(SAMPLE_TOKEN);
+
+        assertEquals("NOT_CHECKED", service.decodeJwt(request).getSignatureStatus());
+    }
+
+    @Test
+    void decodeJwt_shouldTranslateIllegalArgumentToBizException() {
+        DevToolJwtDecodeRequest request = new DevToolJwtDecodeRequest();
+        request.setToken("not-a-jwt");
+
+        BizException ex = assertThrows(BizException.class, () -> service.decodeJwt(request));
+        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
+    }
+
+    // ---------- 文本比对 ----------
+
+    @Test
+    void diffText_shouldMapLinesAndCounters() {
+        DevToolTextDiffRequest request = new DevToolTextDiffRequest();
+        request.setOldText("a\nb\nc");
+        request.setNewText("a\nB\nc\nd");
+
+        DevToolTextDiffResponse response = service.diffText(request);
+        assertFalse(response.isIdentical());
+        assertEquals(2, response.getAddedLines());
+        assertEquals(1, response.getDeletedLines());
+        assertFalse(response.isTruncated());
+        assertEquals(response.getTotalLines(), response.getLines().size());
+        DevToolTextDiffResponse.Line line = response.getLines().get(0);
+        assertEquals("EQUAL", line.getType());
+        assertEquals(1, line.getOldLineNo());
+        assertEquals(1, line.getNewLineNo());
+        assertEquals("a", line.getContent());
+    }
+
+    @Test
+    void diffText_shouldPassThroughIgnoreOptions() {
+        DevToolTextDiffRequest request = new DevToolTextDiffRequest();
+        request.setOldText("A\n  b");
+        request.setNewText("a\nb");
+        request.setIgnoreCase(true);
+        request.setIgnoreWhitespace(true);
+
+        assertTrue(service.diffText(request).isIdentical(), "两个忽略选项都应透传到 Ops");
+    }
+
+    @Test
+    void diffText_shouldTranslateIllegalArgumentToBizException() {
+        DevToolTextDiffRequest request = new DevToolTextDiffRequest();
+        request.setOldText("x\n".repeat(1501));
+        request.setNewText("y");
+
+        BizException ex = assertThrows(BizException.class, () -> service.diffText(request));
+        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
+    }
+
+    // ---------- 格式互转 ----------
+
+    @Test
+    void convertFormat_shouldMapResult() {
+        DevToolFormatConvertRequest request = new DevToolFormatConvertRequest();
+        request.setContent("{\"a\":1}");
+        request.setSourceFormat("json");
+        request.setTargetFormat("yaml");
+
+        DevToolFormatConvertResponse response = service.convertFormat(request);
+        assertEquals("json", response.getSourceFormat());
+        assertEquals("yaml", response.getTargetFormat());
+        assertTrue(response.getResult().contains("a: 1"));
+    }
+
+    @Test
+    void convertFormat_shouldPassThroughRootName() {
+        DevToolFormatConvertRequest request = new DevToolFormatConvertRequest();
+        request.setContent("{\"a\":1}");
+        request.setSourceFormat("json");
+        request.setTargetFormat("xml");
+        request.setRootName("order");
+
+        assertTrue(service.convertFormat(request).getResult().startsWith("<order>"));
+    }
+
+    @Test
+    void convertFormat_shouldTranslateIllegalArgumentToBizException() {
+        DevToolFormatConvertRequest request = new DevToolFormatConvertRequest();
+        request.setContent("{\"a\":1}");
+        request.setSourceFormat("json");
+        request.setTargetFormat("toml");
+
+        BizException ex = assertThrows(BizException.class, () -> service.convertFormat(request));
+        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
+    }
+}

--- a/customer-admin-web/package-lock.json
+++ b/customer-admin-web/package-lock.json
@@ -17,6 +17,7 @@
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.3.0",
         "pinia": "^2.3.1",
+        "sql-formatter": "^15.8.2",
         "vue": "^3.5.39",
         "vue-router": "^4.6.4"
       },
@@ -934,6 +935,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.2.4.tgz",
@@ -994,6 +1001,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1784,6 +1797,12 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmmirror.com/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
@@ -1813,6 +1832,28 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmmirror.com/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
       }
     },
     "node_modules/normalize-wheel-es": {
@@ -1965,6 +2006,25 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmmirror.com/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
@@ -1977,6 +2037,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmmirror.com/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/rolldown": {
@@ -2027,6 +2096,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.8.2",
+      "resolved": "https://registry.npmmirror.com/sql-formatter/-/sql-formatter-15.8.2.tgz",
+      "integrity": "sha512-kTYRg5FIcvsDtYUG2Qn9pYT6xKwiLJN5TTIvc5Mur6hIg4pSfdpHu8Yyu5bqESLHnVM3mXzD446cb2+uEaKZXg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
     "node_modules/strip-literal": {

--- a/customer-admin-web/package.json
+++ b/customer-admin-web/package.json
@@ -18,6 +18,7 @@
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.3.0",
     "pinia": "^2.3.1",
+    "sql-formatter": "^15.8.2",
     "vue": "^3.5.39",
     "vue-router": "^4.6.4"
   },

--- a/customer-admin-web/src/api/devtools.ts
+++ b/customer-admin-web/src/api/devtools.ts
@@ -127,3 +127,108 @@ export function parseKeystore(file: File, password: string) {
   formData.append('password', password)
   return request<KeystoreParseResponse>({ url: '/devtools/cert/keystore', method: 'post', data: formData })
 }
+
+// ---------- cron / JWT / 文本比对 / 格式互转 ----------
+//
+// 这四项都走后端：算法只在 starter 的 Ops 里实现一份，页面与智能体（devtoolbox 系统工具）共用，
+// 从根上杜绝两端语义分叉。cron 尤其不能放前端算——表达式最终由 XXL-JOB 按 Quartz 6 段语义触发，
+// 浏览器端 cron 库多按 Unix 5 段解析，算出的"下次执行时间"可能与实际调度不符，那样反而误导排查。
+
+export interface CronFieldDesc {
+  name: string
+  value: string
+  range: string
+  description: string
+}
+
+export interface CronExplainResponse {
+  expression: string
+  timezone: string
+  fields: CronFieldDesc[]
+  nextTimes: string[]
+}
+
+/** 解析 cron 表达式：校验、逐字段释义、推算后续执行时间。 */
+export function explainCron(expression: string, count?: number, timezone?: string) {
+  return request<CronExplainResponse>({
+    url: '/devtools/cron/explain',
+    method: 'post',
+    data: { expression, count, timezone },
+  })
+}
+
+export interface JwtDecodeResponse {
+  algorithm: string | null
+  type: string | null
+  header: string
+  payload: string
+  issuer: string | null
+  subject: string | null
+  audience: string | null
+  jwtId: string | null
+  issuedAt: string | null
+  notBefore: string | null
+  expiresAt: string | null
+  expired: boolean
+  notYetValid: boolean
+  secondsRemaining: number | null
+  unsigned: boolean
+  /** VALID / INVALID / NOT_CHECKED(未提供密钥) / UNSUPPORTED_ALG(非 HS* 不验签) */
+  signatureStatus: string
+}
+
+/** 解析 JWT，可选校验 HS* 签名。令牌与密钥仅在后端内存中解析，不落库不写日志。 */
+export function decodeJwt(token: string, secret?: string, secretEncoding?: string) {
+  return request<JwtDecodeResponse>({
+    url: '/devtools/jwt/decode',
+    method: 'post',
+    data: { token, secret, secretEncoding },
+  })
+}
+
+export interface TextDiffLine {
+  /** EQUAL / INSERT / DELETE */
+  type: string
+  /** 原文本行号，新增行为 -1 */
+  oldLineNo: number
+  /** 新文本行号，删除行为 -1 */
+  newLineNo: number
+  content: string
+}
+
+export interface TextDiffResponse {
+  identical: boolean
+  addedLines: number
+  deletedLines: number
+  totalLines: number
+  truncated: boolean
+  lines: TextDiffLine[]
+}
+
+/** 行级比对两段文本。 */
+export function diffText(data: {
+  oldText: string
+  newText: string
+  ignoreWhitespace?: boolean
+  ignoreCase?: boolean
+}) {
+  return request<TextDiffResponse>({ url: '/devtools/diff/text', method: 'post', data })
+}
+
+export type DataFormat = 'json' | 'yaml' | 'xml'
+
+export interface FormatConvertResponse {
+  sourceFormat: string
+  targetFormat: string
+  result: string
+}
+
+/** JSON / YAML / XML 互转。 */
+export function convertFormat(data: {
+  content: string
+  sourceFormat: DataFormat
+  targetFormat: DataFormat
+  rootName?: string
+}) {
+  return request<FormatConvertResponse>({ url: '/devtools/format/convert', method: 'post', data })
+}

--- a/customer-admin-web/src/views/system/devtools/CronTool.vue
+++ b/customer-admin-web/src/views/system/devtools/CronTool.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+// cron 解析：解析与推算一律走后端（starter 的 CronDevToolOps），与 XXL-JOB 的 6 段 Quartz 语义
+// 保持同源。浏览器端 cron 库多按 Unix 5 段解析，若在前端算，页面显示的"下次执行时间"可能与调度
+// 中心实际触发时间不符——排查问题时这种偏差比没有工具更糟。
+import { ref } from 'vue'
+import { explainCron, type CronExplainResponse } from '@/api/devtools'
+import { usePersistedRef } from './composables/useToolStorage'
+import CopyButton from './CopyButton.vue'
+
+const expression = usePersistedRef('cron:expression', '0 0 2 * * ?')
+const count = usePersistedRef('cron:count', 5)
+const timezone = usePersistedRef('cron:timezone', 'Asia/Shanghai')
+
+const loading = ref(false)
+const result = ref<CronExplainResponse | null>(null)
+
+/** 常用表达式，点一下直接填入——多数排查场景就是拿这几个改改。 */
+const presets: { label: string; value: string }[] = [
+  { label: '每分钟', value: '0 * * * * ?' },
+  { label: '每 5 分钟', value: '0 */5 * * * ?' },
+  { label: '每小时整点', value: '0 0 * * * ?' },
+  { label: '每天 02:00', value: '0 0 2 * * ?' },
+  { label: '每周一 09:00', value: '0 0 9 ? * MON' },
+  { label: '每月 1 号 00:00', value: '0 0 0 1 * ?' },
+]
+
+async function handleExplain() {
+  if (!expression.value.trim()) {
+    ElMessage.warning('请先输入 cron 表达式')
+    return
+  }
+  loading.value = true
+  try {
+    result.value = await explainCron(expression.value, count.value, timezone.value)
+  } finally {
+    loading.value = false
+  }
+}
+
+function applyPreset(value: string) {
+  expression.value = value
+  handleExplain()
+}
+</script>
+
+<template>
+  <div class="cron-tool">
+    <el-form label-width="100px" class="param-form">
+      <el-form-item label="cron 表达式">
+        <div class="expression-row">
+          <el-input
+            v-model="expression"
+            placeholder="6 段：秒 分 时 日 月 周，如 0 0 2 * * ?"
+            clearable
+            @keyup.enter="handleExplain"
+          />
+          <el-button type="primary" :loading="loading" @click="handleExplain">解析</el-button>
+        </div>
+        <span class="form-tip">本项目调度中心（XXL-JOB）用 6 段 Quartz 风格；5 段的 Unix cron 需在最前面补一段秒</span>
+      </el-form-item>
+
+      <el-form-item label="常用示例">
+        <div class="presets">
+          <el-tag
+            v-for="preset in presets"
+            :key="preset.value"
+            class="preset-tag"
+            type="info"
+            effect="plain"
+            @click="applyPreset(preset.value)"
+          >
+            {{ preset.label }}
+          </el-tag>
+        </div>
+      </el-form-item>
+
+      <el-form-item label="推算条数">
+        <el-input-number v-model="count" :min="1" :max="20" />
+        <el-select v-model="timezone" class="timezone-select">
+          <el-option label="Asia/Shanghai" value="Asia/Shanghai" />
+          <el-option label="UTC" value="UTC" />
+          <el-option label="America/New_York" value="America/New_York" />
+          <el-option label="Europe/London" value="Europe/London" />
+        </el-select>
+      </el-form-item>
+    </el-form>
+
+    <div v-if="result" class="panes">
+      <div class="pane">
+        <div class="pane-header"><span>字段释义</span></div>
+        <el-table :data="result.fields" size="small" border>
+          <el-table-column prop="name" label="字段" width="80" />
+          <el-table-column prop="value" label="取值" width="110" />
+          <el-table-column prop="description" label="含义" />
+          <el-table-column prop="range" label="合法范围" width="150" />
+        </el-table>
+      </div>
+
+      <div class="pane">
+        <div class="pane-header">
+          <span>后续执行时间（{{ result.timezone }}）</span>
+          <CopyButton :text="result.nextTimes.join('\n')" label="执行时间" />
+        </div>
+        <ul v-if="result.nextTimes.length" class="next-times">
+          <li v-for="(time, index) in result.nextTimes" :key="time + index">
+            <span class="seq">{{ index + 1 }}</span>{{ time }}
+          </li>
+        </ul>
+        <el-alert v-else type="warning" :closable="false" show-icon title="该表达式今后不会再触发（指定的日期已过去）" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cron-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.param-form {
+  max-width: 860px;
+}
+
+.expression-row {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.preset-tag {
+  cursor: pointer;
+}
+
+.timezone-select {
+  width: 200px;
+  margin-left: 12px;
+}
+
+.form-tip {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.6;
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.next-times {
+  margin: 0;
+  padding: 8px 12px;
+  list-style: none;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  background: var(--el-fill-color-lighter);
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+}
+
+.next-times li {
+  padding: 4px 0;
+  color: var(--el-text-color-primary);
+}
+
+.seq {
+  display: inline-block;
+  width: 24px;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/DataConvertTool.vue
+++ b/customer-admin-web/src/views/system/devtools/DataConvertTool.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+// JSON / YAML / XML 互转：走后端（starter 的 DataFormatDevToolOps），与智能体侧 data_convert 同一实现。
+// 后端解析 XML 时已禁用 DTD 与外部实体（防 XXE）。
+import { computed, ref } from 'vue'
+import { convertFormat, type DataFormat } from '@/api/devtools'
+import { usePersistedRef } from './composables/useToolStorage'
+import CopyButton from './CopyButton.vue'
+
+const sourceFormat = usePersistedRef<DataFormat>('convert:sourceFormat', 'json')
+const targetFormat = usePersistedRef<DataFormat>('convert:targetFormat', 'yaml')
+const rootName = usePersistedRef('convert:rootName', 'root')
+const input = usePersistedRef('convert:input', '')
+
+const loading = ref(false)
+const output = ref('')
+
+const needsRootName = computed(() => targetFormat.value === 'xml')
+
+const formatLabels: Record<DataFormat, string> = { json: 'JSON', yaml: 'YAML', xml: 'XML' }
+
+async function handleConvert() {
+  if (!input.value.trim()) {
+    ElMessage.warning('请先输入待转换的内容')
+    return
+  }
+  if (sourceFormat.value === targetFormat.value) {
+    ElMessage.warning('源格式与目标格式相同，无需转换')
+    return
+  }
+  loading.value = true
+  try {
+    const response = await convertFormat({
+      content: input.value,
+      sourceFormat: sourceFormat.value,
+      targetFormat: targetFormat.value,
+      rootName: needsRootName.value ? rootName.value : undefined,
+    })
+    output.value = response.result
+  } finally {
+    loading.value = false
+  }
+}
+
+/** 互换源与目标格式，并把上次的输出接力成新的输入，便于来回转换核对。 */
+function handleSwap() {
+  const from = sourceFormat.value
+  sourceFormat.value = targetFormat.value
+  targetFormat.value = from
+  if (output.value) {
+    input.value = output.value
+    output.value = ''
+  }
+}
+
+function handleClear() {
+  input.value = ''
+  output.value = ''
+}
+</script>
+
+<template>
+  <div class="convert-tool">
+    <el-form label-width="100px" class="param-form" inline>
+      <el-form-item label="源格式">
+        <el-radio-group v-model="sourceFormat">
+          <el-radio-button value="json">JSON</el-radio-button>
+          <el-radio-button value="yaml">YAML</el-radio-button>
+          <el-radio-button value="xml">XML</el-radio-button>
+        </el-radio-group>
+      </el-form-item>
+
+      <el-form-item label="目标格式">
+        <el-radio-group v-model="targetFormat">
+          <el-radio-button value="json">JSON</el-radio-button>
+          <el-radio-button value="yaml">YAML</el-radio-button>
+          <el-radio-button value="xml">XML</el-radio-button>
+        </el-radio-group>
+      </el-form-item>
+
+      <el-form-item v-if="needsRootName" label="XML 根元素">
+        <el-input v-model="rootName" placeholder="root" style="width: 160px" />
+      </el-form-item>
+    </el-form>
+
+    <el-alert type="info" :closable="false" show-icon class="limit-tip">
+      <template #title>
+        已知语义损耗：XML 没有类型系统，转出的 JSON 里数字与布尔都会变成字符串；XML 同名重复子元素只保留最后一个（数组型 XML 请勿依赖本工具）；YAML 多文档只处理第一个。
+      </template>
+    </el-alert>
+
+    <div class="panes">
+      <div class="pane">
+        <div class="pane-header"><span>{{ formatLabels[sourceFormat] }} 输入</span></div>
+        <textarea v-model="input" class="code-textarea" spellcheck="false" placeholder="粘贴待转换的内容…" />
+      </div>
+      <div class="pane">
+        <div class="pane-header">
+          <span>{{ formatLabels[targetFormat] }} 输出</span>
+          <CopyButton :text="output" label="转换结果" />
+        </div>
+        <textarea class="code-textarea" readonly spellcheck="false" :value="output" />
+      </div>
+    </div>
+
+    <div class="actions">
+      <el-button type="primary" :loading="loading" @click="handleConvert">转换</el-button>
+      <el-button @click="handleSwap">互换方向</el-button>
+      <el-button @click="handleClear">清空</el-button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.convert-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.param-form {
+  max-width: 960px;
+}
+
+.limit-tip {
+  line-height: 1.6;
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.code-textarea {
+  min-height: 300px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.code-textarea[readonly] {
+  background: var(--el-fill-color-light);
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/DiffTool.vue
+++ b/customer-admin-web/src/views/system/devtools/DiffTool.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+// 文本比对：LCS 行级 diff 走后端（starter 的 DiffDevToolOps），与智能体侧 text_diff 同一实现。
+import { computed, ref } from 'vue'
+import { diffText, type TextDiffResponse } from '@/api/devtools'
+import { usePersistedRef } from './composables/useToolStorage'
+
+const oldText = usePersistedRef('diff:oldText', '')
+const newText = usePersistedRef('diff:newText', '')
+const ignoreWhitespace = usePersistedRef('diff:ignoreWhitespace', false)
+const ignoreCase = usePersistedRef('diff:ignoreCase', false)
+
+const loading = ref(false)
+const result = ref<TextDiffResponse | null>(null)
+
+/** 只看差异时过滤掉相同行——配置文件比对里相同行往往占绝大多数。 */
+const onlyDifferences = usePersistedRef('diff:onlyDifferences', false)
+
+const displayLines = computed(() => {
+  if (!result.value) return []
+  return onlyDifferences.value
+    ? result.value.lines.filter((line) => line.type !== 'EQUAL')
+    : result.value.lines
+})
+
+const summary = computed(() => {
+  const data = result.value
+  if (!data) return null
+  if (data.identical) {
+    return { type: 'success' as const, text: '两段文本完全一致' }
+  }
+  return { type: 'warning' as const, text: `新增 ${data.addedLines} 行，删除 ${data.deletedLines} 行` }
+})
+
+async function handleDiff() {
+  loading.value = true
+  try {
+    result.value = await diffText({
+      oldText: oldText.value,
+      newText: newText.value,
+      ignoreWhitespace: ignoreWhitespace.value,
+      ignoreCase: ignoreCase.value,
+    })
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleSwap() {
+  const temp = oldText.value
+  oldText.value = newText.value
+  newText.value = temp
+  result.value = null
+}
+
+function handleClear() {
+  oldText.value = ''
+  newText.value = ''
+  result.value = null
+}
+
+function lineMarker(type: string): string {
+  if (type === 'INSERT') return '+'
+  if (type === 'DELETE') return '-'
+  return ' '
+}
+</script>
+
+<template>
+  <div class="diff-tool">
+    <div class="panes">
+      <div class="pane">
+        <div class="pane-header"><span>原文本</span></div>
+        <textarea v-model="oldText" class="code-textarea" spellcheck="false" placeholder="粘贴改动前的内容…" />
+      </div>
+      <div class="pane">
+        <div class="pane-header"><span>新文本</span></div>
+        <textarea v-model="newText" class="code-textarea" spellcheck="false" placeholder="粘贴改动后的内容…" />
+      </div>
+    </div>
+
+    <div class="actions">
+      <el-button type="primary" :loading="loading" @click="handleDiff">比对</el-button>
+      <el-button @click="handleSwap">交换两侧</el-button>
+      <el-button @click="handleClear">清空</el-button>
+      <el-checkbox v-model="ignoreWhitespace">忽略行首尾空白</el-checkbox>
+      <el-checkbox v-model="ignoreCase">忽略大小写</el-checkbox>
+      <el-checkbox v-model="onlyDifferences">只看差异行</el-checkbox>
+    </div>
+
+    <template v-if="result">
+      <el-alert v-if="summary" :type="summary.type" :closable="false" show-icon :title="summary.text" />
+      <el-alert
+        v-if="result.truncated"
+        type="warning"
+        :closable="false"
+        show-icon
+        :title="`差异过多，只展示前 ${result.lines.length} 行（共 ${result.totalLines} 行）`"
+      />
+
+      <div v-if="displayLines.length" class="diff-result">
+        <div
+          v-for="(line, index) in displayLines"
+          :key="index"
+          class="diff-line"
+          :class="`diff-${line.type.toLowerCase()}`"
+        >
+          <span class="line-no">{{ line.oldLineNo > 0 ? line.oldLineNo : '' }}</span>
+          <span class="line-no">{{ line.newLineNo > 0 ? line.newLineNo : '' }}</span>
+          <span class="marker">{{ lineMarker(line.type) }}</span>
+          <span class="content">{{ line.content }}</span>
+        </div>
+      </div>
+      <el-empty v-else-if="onlyDifferences" description="没有差异行" :image-size="80" />
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.diff-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.code-textarea {
+  min-height: 200px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.diff-result {
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 520px;
+  background: var(--el-fill-color-lighter);
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.diff-line {
+  display: flex;
+  align-items: baseline;
+  padding: 0 8px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.line-no {
+  flex: none;
+  width: 44px;
+  text-align: right;
+  padding-right: 8px;
+  color: var(--el-text-color-placeholder);
+  user-select: none;
+}
+
+.marker {
+  flex: none;
+  width: 16px;
+  user-select: none;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+}
+
+.diff-insert {
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
+}
+
+.diff-delete {
+  background: var(--el-color-danger-light-9);
+  color: var(--el-color-danger-dark-2);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/JwtTool.vue
+++ b/customer-admin-web/src/views/system/devtools/JwtTool.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+// JWT 解析：解码与验签走后端（starter 的 JwtDevToolOps），与智能体侧 jwt_decode 同一实现。
+// 令牌与密钥属敏感信息，与 AES 的密钥同等对待——用普通 ref，刷新即清空，不落 localStorage。
+import { computed, ref } from 'vue'
+import { decodeJwt, type JwtDecodeResponse } from '@/api/devtools'
+import CopyButton from './CopyButton.vue'
+
+const token = ref('')
+const secret = ref('')
+const secretEncoding = ref<'utf8' | 'hex' | 'base64'>('utf8')
+
+const loading = ref(false)
+const result = ref<JwtDecodeResponse | null>(null)
+
+/** 签名状态映射成人话与配色，避免用户把"没校验"误读成"校验通过"。 */
+const signatureHint = computed(() => {
+  const status = result.value?.signatureStatus
+  switch (status) {
+    case 'VALID':
+      return { type: 'success' as const, text: '签名校验通过' }
+    case 'INVALID':
+      return { type: 'error' as const, text: '签名校验不通过：密钥不匹配或令牌被篡改' }
+    case 'UNSUPPORTED_ALG':
+      return { type: 'warning' as const, text: `${result.value?.algorithm} 是非对称算法，本工具只能校验 HS256/HS384/HS512，此处仅解码未验签` }
+    default:
+      return { type: 'info' as const, text: '未校验签名（未填写密钥）' }
+  }
+})
+
+const validityHint = computed(() => {
+  const data = result.value
+  if (!data) return null
+  if (data.expired) {
+    return { type: 'error' as const, text: `已过期（${data.expiresAt}）` }
+  }
+  if (data.notYetValid) {
+    return { type: 'warning' as const, text: `尚未生效（${data.notBefore} 之后才可用）` }
+  }
+  if (data.expiresAt) {
+    return { type: 'success' as const, text: `有效，${data.expiresAt} 过期（剩余 ${formatRemaining(data.secondsRemaining)}）` }
+  }
+  return { type: 'info' as const, text: '令牌未声明 exp，不会自行过期' }
+})
+
+function formatRemaining(seconds: number | null): string {
+  if (seconds === null) return '-'
+  const abs = Math.abs(seconds)
+  const days = Math.floor(abs / 86400)
+  const hours = Math.floor((abs % 86400) / 3600)
+  const minutes = Math.floor((abs % 3600) / 60)
+  if (days > 0) return `${days} 天 ${hours} 小时`
+  if (hours > 0) return `${hours} 小时 ${minutes} 分`
+  return `${minutes} 分 ${abs % 60} 秒`
+}
+
+async function handleDecode() {
+  if (!token.value.trim()) {
+    ElMessage.warning('请先粘贴 JWT')
+    return
+  }
+  loading.value = true
+  try {
+    result.value = await decodeJwt(token.value.trim(), secret.value || undefined, secretEncoding.value)
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleClear() {
+  token.value = ''
+  secret.value = ''
+  result.value = null
+}
+</script>
+
+<template>
+  <div class="jwt-tool">
+    <el-alert
+      type="info"
+      :closable="false"
+      show-icon
+      title="令牌与密钥只在本次请求中解析，不落库、不写日志；页面刷新即清空，不会保存到本地。"
+      class="privacy-tip"
+    />
+
+    <div class="pane">
+      <div class="pane-header"><span>JWT</span></div>
+      <textarea v-model="token" class="code-textarea token-input" spellcheck="false" placeholder="粘贴 JWT（header.payload.signature）…" />
+    </div>
+
+    <el-form label-width="100px" class="param-form">
+      <el-form-item label="签名密钥">
+        <div class="key-row">
+          <el-input v-model="secret" placeholder="可选，仅 HS256/HS384/HS512 可校验签名" clearable style="flex: 1" />
+          <el-select v-model="secretEncoding" style="width: 110px">
+            <el-option label="UTF-8" value="utf8" />
+            <el-option label="Hex" value="hex" />
+            <el-option label="Base64" value="base64" />
+          </el-select>
+        </div>
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" :loading="loading" @click="handleDecode">解析</el-button>
+        <el-button @click="handleClear">清空</el-button>
+      </el-form-item>
+    </el-form>
+
+    <template v-if="result">
+      <el-alert v-if="result.unsigned" type="error" :closable="false" show-icon class="status-alert"
+        title="该令牌 alg=none，没有签名保护，内容可被任意伪造，绝不能当作可信凭据" />
+      <el-alert v-if="validityHint" :type="validityHint.type" :closable="false" show-icon class="status-alert" :title="validityHint.text" />
+      <el-alert :type="signatureHint.type" :closable="false" show-icon class="status-alert" :title="signatureHint.text" />
+
+      <el-descriptions :column="3" border size="small" class="claims">
+        <el-descriptions-item label="算法">{{ result.algorithm ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="类型">{{ result.type ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="令牌 ID (jti)">{{ result.jwtId ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="签发方 (iss)">{{ result.issuer ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="主体 (sub)">{{ result.subject ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="受众 (aud)">{{ result.audience ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="签发时间 (iat)">{{ result.issuedAt ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="生效时间 (nbf)">{{ result.notBefore ?? '-' }}</el-descriptions-item>
+        <el-descriptions-item label="过期时间 (exp)">{{ result.expiresAt ?? '-' }}</el-descriptions-item>
+      </el-descriptions>
+
+      <div class="panes">
+        <div class="pane">
+          <div class="pane-header">
+            <span>Header</span>
+            <CopyButton :text="result.header" label="Header" />
+          </div>
+          <textarea class="code-textarea" readonly spellcheck="false" :value="result.header" />
+        </div>
+        <div class="pane">
+          <div class="pane-header">
+            <span>Payload</span>
+            <CopyButton :text="result.payload" label="Payload" />
+          </div>
+          <textarea class="code-textarea" readonly spellcheck="false" :value="result.payload" />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.jwt-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.privacy-tip {
+  margin-bottom: 4px;
+}
+
+.param-form {
+  max-width: 720px;
+}
+
+.key-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.status-alert {
+  margin-bottom: 4px;
+}
+
+.claims {
+  margin: 4px 0 8px;
+}
+
+.panes {
+  display: flex;
+  gap: 16px;
+}
+
+.pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+.code-textarea {
+  min-height: 200px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+}
+
+.token-input {
+  min-height: 110px;
+  word-break: break-all;
+}
+
+.code-textarea:focus {
+  border-color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color);
+}
+
+.code-textarea[readonly] {
+  background: var(--el-fill-color-light);
+}
+</style>

--- a/customer-admin-web/src/views/system/devtools/toolRegistry.ts
+++ b/customer-admin-web/src/views/system/devtools/toolRegistry.ts
@@ -9,8 +9,13 @@ export interface DevTool {
 
 /**
  * 开发者工具箱的工具清单，供左侧导航渲染与搜索过滤，以及右侧按 key 动态加载对应组件。
- * 除 HTTP 请求工具经后端代理发送外，其余工具全部本地计算不调后端接口。
  * 第一项是默认工具（route query 缺失/非法时兜底展示）。
+ *
+ * 工具分两类实现：
+ * - 早期几项（JSON/时间戳/编解码/AES/正则）在浏览器本地算；其中 AES 是刻意保留的——密钥不出浏览器。
+ * - HTTP 代理、证书解析，以及 cron/JWT/文本比对/格式互转，一律走后端接口：算法只在 starter 的 Ops
+ *   里实现一份，与智能体的 devtoolbox 系统工具共用，从根上避免两端语义分叉（前端各实现一套正是
+ *   早期留下的坑，AES 两侧模式集合曾一度互不包含）。
  */
 export const devTools: DevTool[] = [
   {
@@ -54,6 +59,30 @@ export const devTools: DevTool[] = [
     label: '证书解析',
     description: 'X.509 证书/证书链、CSR、私钥匹配校验、PFX/JKS 密钥库',
     component: () => import('./CertTool.vue'),
+  },
+  {
+    key: 'cron',
+    label: 'cron 解析',
+    description: '逐字段释义、推算后续执行时间，与 XXL-JOB 同语义',
+    component: () => import('./CronTool.vue'),
+  },
+  {
+    key: 'jwt',
+    label: 'JWT 解析',
+    description: '解码 header/payload、过期判断、HS* 签名校验',
+    component: () => import('./JwtTool.vue'),
+  },
+  {
+    key: 'diff',
+    label: '文本比对',
+    description: '行级差异高亮，可忽略空白与大小写',
+    component: () => import('./DiffTool.vue'),
+  },
+  {
+    key: 'convert',
+    label: '格式互转',
+    description: 'JSON、YAML、XML 三者任意方向转换',
+    component: () => import('./DataConvertTool.vue'),
   },
 ]
 

--- a/customer-admin-web/src/views/workbench/WorkbenchSqlConsole.vue
+++ b/customer-admin-web/src/views/workbench/WorkbenchSqlConsole.vue
@@ -8,6 +8,7 @@ import {
   listAllSqlDatasources,
 } from '@/api/sql'
 import type { SqlDatasourceVO, SqlQueryResultVO } from '@/types/api'
+import { format, type SqlLanguage } from 'sql-formatter'
 
 const datasources = ref<SqlDatasourceVO[]>([])
 const datasourceId = ref<number>()
@@ -84,6 +85,45 @@ function insertAtCursor(text: string) {
     const pos = start + text.length
     ta.setSelectionRange(pos, pos)
   })
+}
+
+// ===== SQL 格式化 =====
+// 纯前端做（sql-formatter）：这条能力只此一处、没有智能体版本，不存在两端实现漂移的风险；
+// 而 Java 侧没有质量相当的格式化库，硬写一个只会做得更差。
+
+/** jdbcUrl 里的驱动名 → sql-formatter 方言。取不到时回退 MySQL（本项目数据源以 MySQL 为主）。 */
+const SQL_DIALECTS: Record<string, SqlLanguage> = {
+  mysql: 'mysql',
+  mariadb: 'mariadb',
+  postgresql: 'postgresql',
+  sqlite: 'sqlite',
+  sqlserver: 'transactsql',
+  oracle: 'plsql',
+}
+
+const currentDialect = computed<SqlLanguage>(() => {
+  const url = datasources.value.find((item) => item.id === datasourceId.value)?.jdbcUrl ?? ''
+  // jdbc:mysql://host:3306/db → 取 jdbc: 与下一个冒号之间的驱动名
+  const driver = /^jdbc:([a-z0-9]+):/i.exec(url)?.[1]?.toLowerCase()
+  return (driver && SQL_DIALECTS[driver]) || 'mysql'
+})
+
+function formatSql() {
+  if (!sql.value.trim()) {
+    ElMessage.warning('请先输入 SQL')
+    return
+  }
+  try {
+    sql.value = format(sql.value, {
+      language: currentDialect.value,
+      tabWidth: 2,
+      keywordCase: 'upper',
+      linesBetweenQueries: 1,
+    })
+  } catch (e) {
+    // 语法不完整时 sql-formatter 会抛错，保持原文不动并提示，避免把用户写了一半的 SQL 弄乱
+    ElMessage.warning(`SQL 无法解析，未做格式化：${e instanceof Error ? e.message : String(e)}`)
+  }
 }
 
 // ===== 查询 / 导出 =====
@@ -203,6 +243,7 @@ onMounted(loadDatasources)
 
           <div class="toolbar">
             <el-button type="primary" :loading="executing" @click="runQuery">执行（Ctrl+Enter）</el-button>
+            <el-button :disabled="!sql.trim()" @click="formatSql">格式化 SQL</el-button>
             <el-button
               v-permission="'sql-console:export'"
               :loading="exporting"

--- a/customer-work-starter/pom.xml
+++ b/customer-work-starter/pom.xml
@@ -235,6 +235,13 @@
             <artifactId>agentscope-extensions-rag-bailian</artifactId>
         </dependency>
 
+        <!-- 开发者工具箱的 JSON⇄YAML⇄XML 互转（DataFormatDevToolOps）。yaml 版已由 spring-boot 传递进来，
+             xml 版没有，此处显式声明；版本交由 spring-boot-dependencies 管理，避免与 jackson-core 错版。 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+
         <!-- 附件文档解析：Tika（pdf/doc/docx/ppt/pptx/html 文本抽取）。虽已由 rag-simple 传递到 classpath，
              此处显式声明并锁 3.3.0，防上游瘦身导致解析器缺失（poi-ooxml / pdfbox 亦由 rag-simple 传递，不重复声明）。 -->
         <dependency>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOps.java
@@ -22,10 +22,17 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * 编解码与加解密纯函数集：Base64 / URL 编解码、哈希(HMAC)、UUID、AES 加解密。
+ * 编解码与加解密纯函数集：Base64 / URL / Hex 编解码、哈希(HMAC)、UUID、AES 加解密。
  *
  * <p>无 Spring 依赖、无状态，参数非法入口 fast-fail 抛 {@link IllegalArgumentException}。
  * 所有二进制输出统一小写 hex 或 Base64 文本，便于跨系统对齐。</p>
+ *
+ * <p><b>AES 参数集与管理台页面版的对齐</b>：管理台"开发者工具箱 → AES 加解密"页面用 crypto-js
+ * 在浏览器本地算（密钥不出浏览器，刻意不走后端），因此 AES 是整个工具箱里唯一存在两套实现的能力。
+ * 为保证"页面加密的密文智能体一定能解、反之亦然"，本实现刻意做成页面版的<b>严格超集</b>：
+ * 模式覆盖 CBC/ECB/CTR（页面版全集）并额外支持 GCM，填充、密钥/IV 的文本编码、密文输出格式
+ * 也全部与页面版一样可选。唯一不对等的是 GCM——crypto-js 不提供 GCM，页面版解不了智能体产出的
+ * GCM 密文，故 GCM 只适用于两端都在后端的场景。</p>
  *
  * @author owlzhangfq@gmail.com
  */
@@ -43,23 +50,35 @@ public final class CodecDevToolOps {
 
     /** AES 相关常量。 */
     private static final String AES = "AES";
-    private static final String TRANSFORM_CBC = "AES/CBC/PKCS5Padding";
-    private static final String TRANSFORM_ECB = "AES/ECB/PKCS5Padding";
-    private static final String TRANSFORM_GCM = "AES/GCM/NoPadding";
     private static final String MODE_CBC = "CBC";
     private static final String MODE_ECB = "ECB";
     private static final String MODE_GCM = "GCM";
+    private static final String MODE_CTR = "CTR";
+    /** JCE 填充名：AES 场景下 PKCS5Padding 与 PKCS7 等价（块长固定 16）。 */
+    private static final String JCE_PADDING_PKCS7 = "PKCS5Padding";
+    private static final String JCE_PADDING_NONE = "NoPadding";
+    /** 对外的填充取值（与页面版的选项一一对应）。 */
+    private static final String PADDING_PKCS7 = "PKCS7";
+    private static final String PADDING_NONE = "NONE";
     private static final int KEY_LEN_128 = 16;
     private static final int KEY_LEN_192 = 24;
     private static final int KEY_LEN_256 = 32;
-    private static final int CBC_IV_LENGTH = 16;
+    /** 分组模式的 IV 长度即 AES 块长；GCM 用推荐的 12 字节 nonce。 */
+    private static final int BLOCK_IV_LENGTH = 16;
     private static final int GCM_IV_LENGTH = 12;
     private static final int GCM_TAG_BITS = 128;
+    /** AES 块长，NoPadding 时明文长度须为其整数倍。 */
+    private static final int AES_BLOCK_SIZE = 16;
+
+    /** 二进制内容的文本编码（用于密钥/IV 的解析与密文的输出）。 */
+    private static final String ENCODING_UTF8 = "UTF8";
+    private static final String ENCODING_HEX = "HEX";
+    private static final String ENCODING_BASE64 = "BASE64";
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
 
     // ---------------------------------------------------------------------
-    // Base64 / URL
+    // Base64 / URL / Hex
     // ---------------------------------------------------------------------
 
     /** Base64 编码（UTF-8）。允许空串。 */
@@ -92,6 +111,18 @@ public final class CodecDevToolOps {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("URL 解码失败：" + e.getMessage(), e);
         }
+    }
+
+    /** 文本转小写 hex（按 UTF-8 取字节）。允许空串。 */
+    public String hexEncode(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        return toHexLower(text.getBytes(UTF_8));
+    }
+
+    /** hex 转文本（按 UTF-8 解码）。忽略空白字符；长度为奇数或含非 hex 字符均抛出。 */
+    public String hexDecode(String hex) {
+        DevToolArgs.requireNonNull(hex, "hex");
+        return new String(decodeHex(hex, "hex"), UTF_8);
     }
 
     // ---------------------------------------------------------------------
@@ -167,100 +198,98 @@ public final class CodecDevToolOps {
     // ---------------------------------------------------------------------
 
     /**
-     * AES 加密，密文以 Base64 输出。
+     * AES 加密。
      *
      * @param plainText 明文（允许空串）
-     * @param key       密钥，UTF-8 字节长度须为 16/24/32
-     * @param mode      模式 CBC/ECB/GCM，为空默认 CBC
-     * @param iv        IV(Base64)，CBC/GCM 缺省时随机生成并随结果返回；ECB 忽略
-     * @return 加密结果（含 mode、密文 Base64、iv Base64）
+     * @param params    密钥、模式、填充、编码等参数，见 {@link AesParams}
+     * @return 加密结果（含实际生效的模式与填充、密文、IV；密文与 IV 按 outputFormat 编码）
      */
-    public AesResult aesEncrypt(String plainText, String key, String mode, String iv) {
+    public AesResult aesEncrypt(String plainText, AesParams params) {
         DevToolArgs.requireNonNull(plainText, "plainText");
-        byte[] keyBytes = validateKey(key);
-        String normalizedMode = normalizeMode(mode);
+        DevToolArgs.requireNonNull(params, "params");
+        ResolvedAesParams resolved = resolve(params);
+        byte[] plainBytes = plainText.getBytes(UTF_8);
+        if (JCE_PADDING_NONE.equals(resolved.jcePadding) && isBlockMode(resolved.mode)
+            && plainBytes.length % AES_BLOCK_SIZE != 0) {
+            throw new IllegalArgumentException("NoPadding 下明文 UTF-8 字节长度必须是 "
+                + AES_BLOCK_SIZE + " 的整数倍，当前 " + plainBytes.length + " 字节");
+        }
+        byte[] ivBytes = MODE_ECB.equals(resolved.mode)
+            ? null
+            : resolveIvForEncrypt(params.getIv(), resolved.ivEncoding, ivLengthOf(resolved.mode));
         try {
-            switch (normalizedMode) {
-                case MODE_ECB: {
-                    Cipher cipher = Cipher.getInstance(TRANSFORM_ECB);
-                    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, AES));
-                    byte[] out = cipher.doFinal(plainText.getBytes(UTF_8));
-                    return AesResult.builder().mode(normalizedMode).ciphertext(base64(out)).build();
-                }
-                case MODE_GCM: {
-                    byte[] ivBytes = resolveIvForEncrypt(iv, GCM_IV_LENGTH);
-                    Cipher cipher = Cipher.getInstance(TRANSFORM_GCM);
-                    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, AES), new GCMParameterSpec(GCM_TAG_BITS, ivBytes));
-                    byte[] out = cipher.doFinal(plainText.getBytes(UTF_8));
-                    return AesResult.builder().mode(normalizedMode).ciphertext(base64(out)).iv(base64(ivBytes)).build();
-                }
-                case MODE_CBC:
-                default: {
-                    byte[] ivBytes = resolveIvForEncrypt(iv, CBC_IV_LENGTH);
-                    Cipher cipher = Cipher.getInstance(TRANSFORM_CBC);
-                    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, AES), new IvParameterSpec(ivBytes));
-                    byte[] out = cipher.doFinal(plainText.getBytes(UTF_8));
-                    return AesResult.builder().mode(normalizedMode).ciphertext(base64(out)).iv(base64(ivBytes)).build();
-                }
-            }
+            Cipher cipher = Cipher.getInstance(resolved.transform);
+            initCipher(cipher, Cipher.ENCRYPT_MODE, resolved, ivBytes);
+            byte[] out = cipher.doFinal(plainBytes);
+            return AesResult.builder()
+                .mode(resolved.mode)
+                .padding(toExternalPadding(resolved.jcePadding))
+                .outputFormat(resolved.outputFormat.toLowerCase(Locale.ROOT))
+                .ciphertext(encodeBinary(out, resolved.outputFormat))
+                .iv(ivBytes == null ? null : encodeBinary(ivBytes, resolved.ivEncoding))
+                .build();
         } catch (GeneralSecurityException e) {
             throw new IllegalArgumentException("AES 加密失败：" + e.getMessage(), e);
         }
     }
 
     /**
-     * AES 解密，密文为 Base64。
+     * AES 解密。
      *
-     * @param cipherText 密文 Base64
-     * @param key        密钥，UTF-8 字节长度须为 16/24/32
-     * @param mode       模式 CBC/ECB/GCM，为空默认 CBC
-     * @param iv         IV(Base64)，CBC/GCM 必填；ECB 忽略
+     * @param cipherText 密文（按 outputFormat 指定的格式，hex 或 Base64）
+     * @param params     密钥、模式、填充、编码等参数，须与加密时完全一致
      * @return 明文
      */
-    public String aesDecrypt(String cipherText, String key, String mode, String iv) {
+    public String aesDecrypt(String cipherText, AesParams params) {
         DevToolArgs.requireNonBlank(cipherText, "cipherText");
-        byte[] keyBytes = validateKey(key);
-        String normalizedMode = normalizeMode(mode);
-        byte[] cipherBytes;
+        DevToolArgs.requireNonNull(params, "params");
+        ResolvedAesParams resolved = resolve(params);
+        byte[] cipherBytes = decodeBinary(cipherText, resolved.outputFormat, "cipherText");
+        byte[] ivBytes = MODE_ECB.equals(resolved.mode)
+            ? null
+            : requireIvForDecrypt(params.getIv(), resolved.ivEncoding, ivLengthOf(resolved.mode));
         try {
-            cipherBytes = Base64.getDecoder().decode(cipherText.trim());
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("密文必须是合法 Base64：" + e.getMessage(), e);
-        }
-        try {
-            Cipher cipher;
-            switch (normalizedMode) {
-                case MODE_ECB:
-                    cipher = Cipher.getInstance(TRANSFORM_ECB);
-                    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, AES));
-                    break;
-                case MODE_GCM: {
-                    byte[] ivBytes = requireIvForDecrypt(iv, GCM_IV_LENGTH);
-                    cipher = Cipher.getInstance(TRANSFORM_GCM);
-                    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, AES), new GCMParameterSpec(GCM_TAG_BITS, ivBytes));
-                    break;
-                }
-                case MODE_CBC:
-                default: {
-                    byte[] ivBytes = requireIvForDecrypt(iv, CBC_IV_LENGTH);
-                    cipher = Cipher.getInstance(TRANSFORM_CBC);
-                    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, AES), new IvParameterSpec(ivBytes));
-                    break;
-                }
-            }
+            Cipher cipher = Cipher.getInstance(resolved.transform);
+            initCipher(cipher, Cipher.DECRYPT_MODE, resolved, ivBytes);
             return new String(cipher.doFinal(cipherBytes), UTF_8);
         } catch (GeneralSecurityException e) {
-            throw new IllegalArgumentException("AES 解密失败（密钥/IV/模式不匹配或密文损坏）：" + e.getMessage(), e);
+            throw new IllegalArgumentException("AES 解密失败（密钥/IV/模式/填充不匹配或密文损坏）：" + e.getMessage(), e);
         }
     }
 
-    /** 校验并返回密钥字节（UTF-8 长度须 16/24/32）。 */
-    private byte[] validateKey(String key) {
+    /** 按模式装配 Cipher 参数（ECB 无 IV、GCM 走 GCMParameterSpec、其余走 IvParameterSpec）。 */
+    private void initCipher(Cipher cipher, int opmode, ResolvedAesParams resolved, byte[] ivBytes)
+        throws GeneralSecurityException {
+        SecretKeySpec keySpec = new SecretKeySpec(resolved.keyBytes, AES);
+        if (MODE_ECB.equals(resolved.mode)) {
+            cipher.init(opmode, keySpec);
+        } else if (MODE_GCM.equals(resolved.mode)) {
+            cipher.init(opmode, keySpec, new GCMParameterSpec(GCM_TAG_BITS, ivBytes));
+        } else {
+            cipher.init(opmode, keySpec, new IvParameterSpec(ivBytes));
+        }
+    }
+
+    /** 归一化并校验全部 AES 参数，一次算清 transform 与密钥字节。 */
+    private ResolvedAesParams resolve(AesParams params) {
+        ResolvedAesParams resolved = new ResolvedAesParams();
+        resolved.mode = normalizeMode(params.getMode());
+        resolved.jcePadding = resolvePadding(params.getPadding(), resolved.mode);
+        resolved.transform = AES + "/" + resolved.mode + "/" + resolved.jcePadding;
+        resolved.ivEncoding = normalizeEncoding(params.getIvEncoding(), ENCODING_BASE64, "ivEncoding");
+        resolved.outputFormat = normalizeOutputFormat(params.getOutputFormat());
+        resolved.keyBytes = validateKey(params.getKey(),
+            normalizeEncoding(params.getKeyEncoding(), ENCODING_UTF8, "keyEncoding"));
+        return resolved;
+    }
+
+    /** 校验并返回密钥字节（按指定编码解码后长度须 16/24/32）。 */
+    private byte[] validateKey(String key, String encoding) {
         DevToolArgs.requireNonBlank(key, "key");
-        byte[] bytes = key.getBytes(UTF_8);
+        byte[] bytes = decodeBinary(key, encoding, "key");
         if (bytes.length != KEY_LEN_128 && bytes.length != KEY_LEN_192 && bytes.length != KEY_LEN_256) {
-            throw new IllegalArgumentException(
-                "AES 密钥 UTF-8 字节长度必须为 16/24/32，当前 " + bytes.length + " 字节");
+            throw new IllegalArgumentException("AES 密钥按 " + encoding
+                + " 解码后字节长度必须为 16/24/32，当前 " + bytes.length + " 字节");
         }
         return bytes;
     }
@@ -271,46 +300,145 @@ public final class CodecDevToolOps {
             return MODE_CBC;
         }
         String upper = mode.trim().toUpperCase(Locale.ROOT);
-        if (!MODE_CBC.equals(upper) && !MODE_ECB.equals(upper) && !MODE_GCM.equals(upper)) {
-            throw new IllegalArgumentException("mode 仅支持 CBC/ECB/GCM，当前 " + mode);
+        if (!MODE_CBC.equals(upper) && !MODE_ECB.equals(upper) && !MODE_GCM.equals(upper) && !MODE_CTR.equals(upper)) {
+            throw new IllegalArgumentException("mode 仅支持 CBC/ECB/CTR/GCM，当前 " + mode);
         }
         return upper;
     }
 
-    /** 加密取 IV：缺省随机生成，提供则按 Base64 解码并校验长度。 */
-    private byte[] resolveIvForEncrypt(String iv, int expectedLen) {
+    /**
+     * 解析填充方式并与模式做相容性检查。
+     *
+     * <p>缺省时按模式取默认：分组模式(CBC/ECB)默认 PKCS7，流式/认证模式(CTR/GCM)默认无填充。
+     * CTR/GCM 显式指定 PKCS7 属于配置错误，直接 fast-fail 而非静默忽略——静默忽略会让调用方
+     * 以为参数生效了，等到密文对不上时反而更难排查。</p>
+     */
+    private String resolvePadding(String padding, String mode) {
+        boolean blockMode = isBlockMode(mode);
+        if (padding == null || padding.trim().isEmpty()) {
+            return blockMode ? JCE_PADDING_PKCS7 : JCE_PADDING_NONE;
+        }
+        String upper = padding.trim().toUpperCase(Locale.ROOT).replace("PADDING", "").replace("_", "");
+        if (upper.isEmpty() || PADDING_NONE.equals(upper)) {
+            return JCE_PADDING_NONE;
+        }
+        // PKCS5 与 PKCS7 在 AES(块长 16) 下等价，两种写法都收
+        if (PADDING_PKCS7.equals(upper) || "PKCS5".equals(upper)) {
+            if (!blockMode) {
+                throw new IllegalArgumentException(mode + " 是流式/认证加密模式，不使用块填充，padding 只能为 NONE 或留空");
+            }
+            return JCE_PADDING_PKCS7;
+        }
+        throw new IllegalArgumentException("padding 仅支持 PKCS7 或 NONE，当前 " + padding);
+    }
+
+    /** 是否为需要块填充的分组模式。 */
+    private boolean isBlockMode(String mode) {
+        return MODE_CBC.equals(mode) || MODE_ECB.equals(mode);
+    }
+
+    /** JCE 填充名转对外取值。 */
+    private String toExternalPadding(String jcePadding) {
+        return JCE_PADDING_PKCS7.equals(jcePadding) ? PADDING_PKCS7 : PADDING_NONE;
+    }
+
+    /** 各模式的 IV 字节长度（ECB 不使用 IV，不会走到这里）。 */
+    private int ivLengthOf(String mode) {
+        return MODE_GCM.equals(mode) ? GCM_IV_LENGTH : BLOCK_IV_LENGTH;
+    }
+
+    /** 规范化二进制文本编码，为空取默认值。 */
+    private String normalizeEncoding(String encoding, String defaultEncoding, String fieldName) {
+        if (encoding == null || encoding.trim().isEmpty()) {
+            return defaultEncoding;
+        }
+        String upper = encoding.trim().toUpperCase(Locale.ROOT).replace("-", "").replace("_", "");
+        if (!ENCODING_UTF8.equals(upper) && !ENCODING_HEX.equals(upper) && !ENCODING_BASE64.equals(upper)) {
+            throw new IllegalArgumentException(fieldName + " 仅支持 utf8/hex/base64，当前 " + encoding);
+        }
+        return upper;
+    }
+
+    /** 规范化密文输入输出格式，为空默认 base64（密文是二进制，不能按 utf8 呈现）。 */
+    private String normalizeOutputFormat(String outputFormat) {
+        if (outputFormat == null || outputFormat.trim().isEmpty()) {
+            return ENCODING_BASE64;
+        }
+        String upper = outputFormat.trim().toUpperCase(Locale.ROOT);
+        if (!ENCODING_HEX.equals(upper) && !ENCODING_BASE64.equals(upper)) {
+            throw new IllegalArgumentException("outputFormat 仅支持 hex/base64，当前 " + outputFormat);
+        }
+        return upper;
+    }
+
+    /** 按指定编码把文本解析成字节。 */
+    private byte[] decodeBinary(String raw, String encoding, String fieldName) {
+        switch (encoding) {
+            case ENCODING_UTF8:
+                return raw.getBytes(UTF_8);
+            case ENCODING_HEX:
+                return decodeHex(raw, fieldName);
+            case ENCODING_BASE64:
+            default:
+                try {
+                    return Base64.getDecoder().decode(raw.trim());
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(fieldName + " 不是合法的 Base64：" + e.getMessage(), e);
+                }
+        }
+    }
+
+    /** 按指定编码把字节输出成文本（仅 hex/base64；utf8 用于密钥输入，不用于输出）。 */
+    private String encodeBinary(byte[] bytes, String encoding) {
+        return ENCODING_HEX.equals(encoding) ? toHexLower(bytes) : Base64.getEncoder().encodeToString(bytes);
+    }
+
+    /** hex 文本转字节：忽略空白，校验字符集与偶数长度。 */
+    private byte[] decodeHex(String raw, String fieldName) {
+        String cleaned = raw.replaceAll("\\s", "");
+        if (cleaned.isEmpty()) {
+            return new byte[0];
+        }
+        if (!cleaned.matches("[0-9a-fA-F]+")) {
+            throw new IllegalArgumentException(fieldName + " 含非十六进制字符（只允许 0-9、a-f、A-F，空白会被忽略）");
+        }
+        if (cleaned.length() % 2 != 0) {
+            throw new IllegalArgumentException(fieldName + " 的十六进制长度必须是偶数（每两位一个字节），当前 "
+                + cleaned.length() + " 位");
+        }
+        byte[] bytes = new byte[cleaned.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) Integer.parseInt(cleaned.substring(i * 2, i * 2 + 2), 16);
+        }
+        return bytes;
+    }
+
+    /** 加密取 IV：缺省随机生成，提供则按指定编码解码并校验长度。 */
+    private byte[] resolveIvForEncrypt(String iv, String encoding, int expectedLen) {
         if (iv == null || iv.trim().isEmpty()) {
             byte[] generated = new byte[expectedLen];
             new SecureRandom().nextBytes(generated);
             return generated;
         }
-        return decodeIv(iv, expectedLen);
+        return decodeIv(iv, encoding, expectedLen);
     }
 
-    /** 解密取 IV：必填，缺省抛出，提供则按 Base64 解码并校验长度。 */
-    private byte[] requireIvForDecrypt(String iv, int expectedLen) {
+    /** 解密取 IV：必填，缺省抛出，提供则按指定编码解码并校验长度。 */
+    private byte[] requireIvForDecrypt(String iv, String encoding, int expectedLen) {
         if (iv == null || iv.trim().isEmpty()) {
-            throw new IllegalArgumentException("该模式解密必须提供 IV（Base64，" + expectedLen + " 字节）");
+            throw new IllegalArgumentException("该模式解密必须提供 IV（" + expectedLen + " 字节，按 ivEncoding 编码）");
         }
-        return decodeIv(iv, expectedLen);
+        return decodeIv(iv, encoding, expectedLen);
     }
 
-    /** Base64 解码 IV 并校验字节长度。 */
-    private byte[] decodeIv(String iv, int expectedLen) {
-        byte[] decoded;
-        try {
-            decoded = Base64.getDecoder().decode(iv.trim());
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("IV 必须是合法 Base64：" + e.getMessage(), e);
-        }
+    /** 解码 IV 并校验字节长度。 */
+    private byte[] decodeIv(String iv, String encoding, int expectedLen) {
+        byte[] decoded = decodeBinary(iv, encoding, "iv");
         if (decoded.length != expectedLen) {
-            throw new IllegalArgumentException("IV 长度必须为 " + expectedLen + " 字节，当前 " + decoded.length + " 字节");
+            throw new IllegalArgumentException("IV 按 " + encoding + " 解码后长度必须为 " + expectedLen
+                + " 字节，当前 " + decoded.length + " 字节");
         }
         return decoded;
-    }
-
-    private String base64(byte[] bytes) {
-        return Base64.getEncoder().encodeToString(bytes);
     }
 
     /** 字节数组转小写 hex。 */
@@ -324,17 +452,54 @@ public final class CodecDevToolOps {
         return new String(chars);
     }
 
+    /** 归一化后的 AES 参数（内部载体，避免在各方法间反复重算与传一长串参数）。 */
+    private static final class ResolvedAesParams {
+        private String mode;
+        private String jcePadding;
+        private String transform;
+        private byte[] keyBytes;
+        private String ivEncoding;
+        private String outputFormat;
+    }
+
     /**
-     * AES 结果。ECB 模式 iv 为 null。
+     * AES 参数。可选项留空即取默认值，默认值刻意保持本工具早期版本的行为
+     * （CBC + PKCS7 + 密钥 utf8 + IV base64 + 密文 base64），确保既有调用方升级后密文仍对得上。
+     */
+    @Getter
+    @Builder
+    public static class AesParams {
+        /** 密钥（按 keyEncoding 解码后须为 16/24/32 字节）。 */
+        private final String key;
+        /** 密钥的文本编码：utf8(默认)/hex/base64。 */
+        private final String keyEncoding;
+        /** 模式：CBC(默认)/ECB/CTR/GCM。 */
+        private final String mode;
+        /** 填充：PKCS7 / NONE；留空按模式取默认（CBC、ECB 用 PKCS7，CTR、GCM 无填充）。 */
+        private final String padding;
+        /** IV：ECB 不用；加密时留空则随机生成，解密时必填。 */
+        private final String iv;
+        /** IV 的文本编码：utf8/hex/base64(默认)。 */
+        private final String ivEncoding;
+        /** 密文的输入/输出格式：hex / base64(默认)。 */
+        private final String outputFormat;
+    }
+
+    /**
+     * AES 加密结果。ECB 模式 iv 为 null。
      */
     @Getter
     @Builder
     public static class AesResult {
         /** 实际采用的模式。 */
         private final String mode;
-        /** 密文 Base64。 */
+        /** 实际采用的填充（PKCS7 / NONE）。 */
+        private final String padding;
+        /** 密文的编码格式（hex / base64）。 */
+        private final String outputFormat;
+        /** 密文。 */
         private final String ciphertext;
-        /** IV Base64（ECB 时为 null）。 */
+        /** IV（按 ivEncoding 编码；ECB 时为 null）。 */
         private final String iv;
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/CronDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/CronDevToolOps.java
@@ -1,0 +1,222 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.scheduling.support.CronExpression;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Cron 表达式解析纯函数集：校验、逐字段释义、推算后续若干次执行时间。
+ *
+ * <p><b>为什么必须由后端算</b>：本项目的定时任务最终由 XXL-JOB 调度中心按 Quartz 风格的 6 段
+ * cron 触发，而浏览器端 cron 库多按 Unix 5 段语义解析，同一串表达式两边算出的"下次执行时间"
+ * 可能不一致——那样的工具会误导排查。这里统一用 Spring 的 {@link CronExpression}（6 段：
+ * 秒 分 时 日 月 周，与 XXL-JOB 一致）作为唯一真源，页面与智能体都走它。</p>
+ *
+ * <p>无 Spring 容器依赖（只用到 spring-context 的纯工具类）、无状态，参数非法入口 fast-fail。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class CronDevToolOps {
+
+    /** 默认时区：与调度中心、业务库时间口径一致。 */
+    private static final String DEFAULT_ZONE = "Asia/Shanghai";
+
+    /** 推算执行时间的条数：默认与上限。 */
+    private static final int DEFAULT_NEXT_COUNT = 5;
+    private static final int MAX_NEXT_COUNT = 20;
+
+    /** 本工具（及 XXL-JOB）采用的 cron 段数。 */
+    private static final int SUPPORTED_FIELD_COUNT = 6;
+    /** Unix 风格 cron 段数（缺秒段）。 */
+    private static final int UNIX_FIELD_COUNT = 5;
+    /** Quartz 可选带年份的段数。 */
+    private static final int QUARTZ_WITH_YEAR_FIELD_COUNT = 7;
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /** 六个字段的中文名（顺序即 cron 段顺序）。 */
+    private static final String[] FIELD_NAMES = {"秒", "分钟", "小时", "日", "月", "星期"};
+
+    /** 各字段的取值范围说明，用于释义里点明合法区间。 */
+    private static final String[] FIELD_RANGES = {"0-59", "0-59", "0-23", "1-31", "1-12", "0-7(0和7均为周日)"};
+
+    /**
+     * 解析 cron 表达式：校验合法性、逐字段释义、推算后续执行时间。
+     *
+     * @param expression cron 表达式，6 段（秒 分 时 日 月 周）
+     * @param count      推算的执行时间条数，1~20，null 取默认 5
+     * @param timezone   时区 ID，null 取 Asia/Shanghai
+     * @return 解析结果
+     */
+    public CronExplainResult explain(String expression, Integer count, String timezone) {
+        DevToolArgs.requireNonBlank(expression, "expression");
+        int nextCount = resolveCount(count);
+        ZoneId zoneId = resolveZone(timezone);
+        String normalized = expression.trim().replaceAll("\\s+", " ");
+        checkFieldCount(normalized);
+
+        CronExpression cron;
+        try {
+            cron = CronExpression.parse(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("cron 表达式非法：" + e.getMessage(), e);
+        }
+
+        return CronExplainResult.builder()
+            .expression(normalized)
+            .timezone(zoneId.getId())
+            .fields(describeFields(normalized))
+            .nextTimes(computeNextTimes(cron, zoneId, nextCount))
+            .build();
+    }
+
+    /** 段数不符时给出可直接照做的修正建议（这是最高频的输入错误）。 */
+    private void checkFieldCount(String normalized) {
+        int fieldCount = normalized.split(" ").length;
+        if (fieldCount == SUPPORTED_FIELD_COUNT) {
+            return;
+        }
+        if (fieldCount == UNIX_FIELD_COUNT) {
+            throw new IllegalArgumentException("检测到 5 段的 Unix 风格 cron，本项目（XXL-JOB）用 6 段"
+                + "（秒 分 时 日 月 周）：在最前面补一段秒即可，例如 \"0 " + normalized + "\"");
+        }
+        if (fieldCount == QUARTZ_WITH_YEAR_FIELD_COUNT) {
+            throw new IllegalArgumentException("检测到 7 段（末段为年份）的 Quartz cron，本工具与 XXL-JOB "
+                + "只用前 6 段，去掉年份段后重试");
+        }
+        throw new IllegalArgumentException("cron 必须是 6 段（秒 分 时 日 月 周），当前 " + fieldCount + " 段");
+    }
+
+    /** 逐段释义。 */
+    private List<CronFieldDesc> describeFields(String normalized) {
+        String[] parts = normalized.split(" ");
+        List<CronFieldDesc> list = new ArrayList<>(SUPPORTED_FIELD_COUNT);
+        for (int i = 0; i < SUPPORTED_FIELD_COUNT; i++) {
+            list.add(CronFieldDesc.builder()
+                .name(FIELD_NAMES[i])
+                .value(parts[i])
+                .range(FIELD_RANGES[i])
+                .description(describeFieldValue(parts[i], FIELD_NAMES[i]))
+                .build());
+        }
+        return list;
+    }
+
+    /**
+     * 释义单个字段。只做结构化拆解（每个/每隔/枚举/区间/特殊字符），不拼整句自然语言——
+     * 整句描述在多字段组合下极易出错，逐段说明配合下方"后续执行时间"已足够定位问题。
+     */
+    private String describeFieldValue(String value, String fieldName) {
+        if ("*".equals(value)) {
+            return "每" + fieldName;
+        }
+        if ("?".equals(value)) {
+            return "不指定（由另一个日期字段决定）";
+        }
+        if (value.startsWith("*/")) {
+            return "每隔 " + value.substring(2) + " " + fieldName;
+        }
+        if (value.contains("/")) {
+            String[] step = value.split("/", 2);
+            return "从 " + step[0] + " 开始，每隔 " + step[1] + " " + fieldName;
+        }
+        if ("L".equals(value)) {
+            return "最后一" + fieldName;
+        }
+        if (value.endsWith("L")) {
+            return "本月最后一个星期" + value.substring(0, value.length() - 1);
+        }
+        if (value.endsWith("W")) {
+            return "最接近 " + value.substring(0, value.length() - 1) + " 号的工作日";
+        }
+        if (value.contains("#")) {
+            String[] nth = value.split("#", 2);
+            return "本月第 " + nth[1] + " 个星期" + nth[0];
+        }
+        if (value.contains(",")) {
+            return "第 " + value.replace(",", "、") + " " + fieldName;
+        }
+        if (value.contains("-")) {
+            String[] range = value.split("-", 2);
+            return "第 " + range[0] + " 到 " + range[1] + " " + fieldName;
+        }
+        return "第 " + value + " " + fieldName;
+    }
+
+    /** 从当前时刻起推算后续执行时间。表达式永远不会再触发时返回空列表（如指定了已过去的具体日期）。 */
+    private List<String> computeNextTimes(CronExpression cron, ZoneId zoneId, int count) {
+        List<String> times = new ArrayList<>(count);
+        ZonedDateTime cursor = ZonedDateTime.now(zoneId);
+        for (int i = 0; i < count; i++) {
+            ZonedDateTime next = cron.next(cursor);
+            if (next == null) {
+                break;
+            }
+            times.add(next.format(TIME_FORMATTER));
+            cursor = next;
+        }
+        return times;
+    }
+
+    /** 条数取值：null 取默认，越界 fast-fail。 */
+    private int resolveCount(Integer count) {
+        if (count == null) {
+            return DEFAULT_NEXT_COUNT;
+        }
+        if (count < 1 || count > MAX_NEXT_COUNT) {
+            throw new IllegalArgumentException("count 必须在 1~" + MAX_NEXT_COUNT + " 之间，当前 " + count);
+        }
+        return count;
+    }
+
+    /** 时区取值：null/空取默认，非法 ID fast-fail。 */
+    private ZoneId resolveZone(String timezone) {
+        if (timezone == null || timezone.trim().isEmpty()) {
+            return ZoneId.of(DEFAULT_ZONE);
+        }
+        try {
+            return ZoneId.of(timezone.trim());
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException("时区 ID 非法：" + timezone + "，如 Asia/Shanghai、UTC", e);
+        }
+    }
+
+    /**
+     * cron 解析结果。
+     */
+    @Getter
+    @Builder
+    public static class CronExplainResult {
+        /** 归一化后的表达式（多余空白已压缩）。 */
+        private final String expression;
+        /** 推算所用时区。 */
+        private final String timezone;
+        /** 逐字段释义。 */
+        private final List<CronFieldDesc> fields;
+        /** 后续执行时间（yyyy-MM-dd HH:mm:ss）；表达式不会再触发时为空列表。 */
+        private final List<String> nextTimes;
+    }
+
+    /**
+     * cron 单字段释义。
+     */
+    @Getter
+    @Builder
+    public static class CronFieldDesc {
+        /** 字段名（秒/分钟/小时/日/月/星期）。 */
+        private final String name;
+        /** 该字段的原始取值。 */
+        private final String value;
+        /** 该字段的合法取值范围。 */
+        private final String range;
+        /** 取值释义。 */
+        private final String description;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DataFormatDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DataFormatDevToolOps.java
@@ -1,0 +1,173 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 结构化数据格式互转纯函数集：JSON ⇄ YAML ⇄ XML。
+ *
+ * <p>典型用途：对接方给的是 XML 报文、Nacos 配置是 YAML，而排查与录入多以 JSON 为准。三种格式
+ * 统一先解析成 Jackson 树模型再按目标格式输出，因此任意两种之间都能直转。</p>
+ *
+ * <p><b>已知语义损耗</b>（工具描述里同样写明，避免调用方误判）：</p>
+ * <ul>
+ *   <li>XML 无类型系统，转出的 JSON 里数字与布尔都是字符串；</li>
+ *   <li>XML 的同名重复子元素在树模型里只保留最后一个，这类"数组型" XML 请勿依赖本工具转换；</li>
+ *   <li>YAML 多文档（{@code ---} 分隔）只处理第一个文档；</li>
+ *   <li>JSON/YAML 转 XML 需要一个根元素名（默认 root），数组无法直接作为 XML 根。</li>
+ * </ul>
+ *
+ * <p><b>安全</b>：XML 解析显式关闭 DTD 与外部实体，杜绝 XXE（本工具的输入完全来自用户/模型，
+ * 是典型的不可信输入）。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class DataFormatDevToolOps {
+
+    /** 支持的格式。 */
+    private static final String FORMAT_JSON = "JSON";
+    private static final String FORMAT_YAML = "YAML";
+    private static final String FORMAT_XML = "XML";
+    private static final Set<String> SUPPORTED_FORMATS = Set.of(FORMAT_JSON, FORMAT_YAML, FORMAT_XML);
+
+    /** 输入长度上限：512KB，超出多半是传错内容（工具箱面向配置与报文，不是文件转换服务）。 */
+    private static final int MAX_INPUT_LENGTH = 512 * 1024;
+
+    /** JSON/YAML 转 XML 时的默认根元素名。 */
+    private static final String DEFAULT_ROOT_NAME = "root";
+
+    /** XML 根元素名的合法字符（保守取 NCName 子集，避免生成非法 XML）。 */
+    private static final String ROOT_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9_.-]*";
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    /** YAML 输出去掉文档起始符 ---，与主流在线工具的观感一致。 */
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
+        new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+
+    private static final XmlMapper XML_MAPPER = buildSecureXmlMapper();
+
+    /**
+     * 格式互转。
+     *
+     * @param content      待转换内容
+     * @param sourceFormat 源格式：json / yaml / xml
+     * @param targetFormat 目标格式：json / yaml / xml
+     * @param rootName     转 XML 时的根元素名，null 取 root；其它目标格式忽略
+     * @return 转换结果
+     */
+    public ConvertResult convert(String content, String sourceFormat, String targetFormat, String rootName) {
+        DevToolArgs.requireNonBlank(content, "content");
+        if (content.length() > MAX_INPUT_LENGTH) {
+            throw new IllegalArgumentException("内容长度超过上限 " + MAX_INPUT_LENGTH + " 字符，当前 " + content.length());
+        }
+        String source = normalizeFormat(sourceFormat, "sourceFormat");
+        String target = normalizeFormat(targetFormat, "targetFormat");
+
+        JsonNode tree = parse(content, source);
+        return ConvertResult.builder()
+            .sourceFormat(source.toLowerCase(Locale.ROOT))
+            .targetFormat(target.toLowerCase(Locale.ROOT))
+            .result(write(tree, target, rootName))
+            .build();
+    }
+
+    /** 按源格式解析成树模型，解析失败带上格式名与原始原因。 */
+    private JsonNode parse(String content, String format) {
+        try {
+            switch (format) {
+                case FORMAT_YAML:
+                    return YAML_MAPPER.readTree(content);
+                case FORMAT_XML:
+                    return XML_MAPPER.readTree(content);
+                case FORMAT_JSON:
+                default:
+                    return JSON_MAPPER.readTree(content);
+            }
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("按 " + format + " 解析失败：" + e.getOriginalMessage(), e);
+        }
+    }
+
+    /** 按目标格式输出。 */
+    private String write(JsonNode tree, String format, String rootName) {
+        try {
+            switch (format) {
+                case FORMAT_YAML:
+                    return YAML_MAPPER.writeValueAsString(tree);
+                case FORMAT_XML:
+                    return writeXml(tree, rootName);
+                case FORMAT_JSON:
+                default:
+                    return JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(tree);
+            }
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("输出为 " + format + " 失败：" + e.getOriginalMessage(), e);
+        }
+    }
+
+    /** 输出 XML：数组无法作为 XML 根元素，这里显式拦下并说明，避免生成结构诡异的 XML。 */
+    private String writeXml(JsonNode tree, String rootName) throws JsonProcessingException {
+        if (tree.isArray()) {
+            throw new IllegalArgumentException("数组不能直接作为 XML 根元素，请先把数组包进一个对象再转换");
+        }
+        return XML_MAPPER.writer().withRootName(resolveRootName(rootName)).writeValueAsString(tree);
+    }
+
+    /** 根元素名校验：非法字符会生成不合法的 XML，入口直接挡掉。 */
+    private String resolveRootName(String rootName) {
+        if (rootName == null || rootName.trim().isEmpty()) {
+            return DEFAULT_ROOT_NAME;
+        }
+        String trimmed = rootName.trim();
+        if (!trimmed.matches(ROOT_NAME_PATTERN)) {
+            throw new IllegalArgumentException("rootName 不是合法的 XML 元素名（须以字母或下划线开头，"
+                + "后续只能是字母、数字、下划线、点、连字符）：" + rootName);
+        }
+        return trimmed;
+    }
+
+    /** 规范化格式名。 */
+    private String normalizeFormat(String format, String fieldName) {
+        DevToolArgs.requireNonBlank(format, fieldName);
+        String upper = format.trim().toUpperCase(Locale.ROOT);
+        if (!SUPPORTED_FORMATS.contains(upper)) {
+            throw new IllegalArgumentException(fieldName + " 仅支持 json/yaml/xml，当前 " + format);
+        }
+        return upper;
+    }
+
+    /** 构造禁用 DTD 与外部实体的 XmlMapper（防 XXE）。 */
+    private static XmlMapper buildSecureXmlMapper() {
+        XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+        inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        return new XmlMapper(new XmlFactory(inputFactory, XMLOutputFactory.newFactory()));
+    }
+
+    /**
+     * 转换结果。
+     */
+    @Getter
+    @Builder
+    public static class ConvertResult {
+        /** 源格式（小写）。 */
+        private final String sourceFormat;
+        /** 目标格式（小写）。 */
+        private final String targetFormat;
+        /** 转换后的内容。 */
+        private final String result;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxTools.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxTools.java
@@ -12,8 +12,13 @@ import java.util.concurrent.Callable;
 
 /**
  * 开发者工具箱系统工具（system tool {@code devtoolbox}）。给挂载本工具的智能体提供一组开发者常用的
- * 本地计算能力：JSON 格式化/压缩/校验、时间戳转换、Base64/URL 编解码、哈希(HMAC)、UUID 生成、
- * AES 加解密、正则测试、证书解析与私钥匹配校验，均为纯本地计算，不访问外部资源。
+ * 本地计算能力：JSON 格式化/压缩/校验/转义/去转义/Unicode 解码、时间戳转换、Base64/URL/Hex 编解码、
+ * 哈希(HMAC)、UUID 生成、AES 加解密、正则测试、证书解析与私钥匹配校验、cron 解析、JWT 解析、
+ * 文本比对、JSON/YAML/XML 互转，均为纯本地计算，不访问外部资源。
+ *
+ * <p><b>与管理台"开发者工具箱"页面的关系</b>：算法一律实现在同包的 Ops 里，页面与本工具共用，
+ * 不做两套。唯一例外是 AES——页面版为了让密钥不出浏览器而用 crypto-js 本地算，因此
+ * {@link CodecDevToolOps} 刻意做成页面版能力的严格超集，两侧参数填一致时密文互通。</p>
  *
  * <p><b>{@code cert_match} 的授权取舍</b>：该工具需要私钥明文作为参数，意味着私钥会进入模型上下文
  * 并落进对话历史。这是产品上明确接受的代价（用户拍板全开），故在工具描述里写死了使用约束
@@ -53,6 +58,10 @@ public class DevToolboxTools {
     private final CodecDevToolOps codecOps = new CodecDevToolOps();
     private final RegexDevToolOps regexOps = new RegexDevToolOps();
     private final CertDevToolOps certOps = new CertDevToolOps();
+    private final CronDevToolOps cronOps = new CronDevToolOps();
+    private final JwtDevToolOps jwtOps = new JwtDevToolOps();
+    private final DiffDevToolOps diffOps = new DiffDevToolOps();
+    private final DataFormatDevToolOps dataFormatOps = new DataFormatDevToolOps();
 
     // =====================================================================
     // JSON
@@ -79,6 +88,29 @@ public class DevToolboxTools {
     public Mono<String> jsonValidate(
         @ToolParam(name = "json", description = "待校验的JSON字符串") String json) {
         return respond("json_validate", () -> jsonOps.validate(json));
+    }
+
+    @Tool(name = "json_escape", description = "把任意文本转义成可安全嵌入JSON的字符串字面量(结果含外层双引号)。"
+        + "参数 text：原文。用于把一段内容作为值塞进JSON字段前先做转义。返回 result 字段为转义结果。")
+    public Mono<String> jsonEscape(
+        @ToolParam(name = "text", description = "待转义的原文") String text) {
+        return respond("json_escape", () -> wrapResult(jsonOps.escape(text)));
+    }
+
+    @Tool(name = "json_unescape", description = "把转义字符串还原成原文，外层双引号可有可无。参数 text：转义串。"
+        + "最常用于把日志里被转义成一整行的JSON还原成可读内容(再配合 json_format 美化)。"
+        + "返回 result 字段为还原后的原文。")
+    public Mono<String> jsonUnescape(
+        @ToolParam(name = "text", description = "待还原的转义字符串") String text) {
+        return respond("json_unescape", () -> wrapResult(jsonOps.unescape(text)));
+    }
+
+    @Tool(name = "json_unicode_decode", description = "把文本里的Unicode转义序列(形如 \\u4e2d\\u6587)解码成真实字符，"
+        + "其余内容原样保留。参数 text：含该转义序列的文本。用于把日志里被转义的中文还原成可读文字。"
+        + "返回 result 字段为解码结果。")
+    public Mono<String> jsonUnicodeDecode(
+        @ToolParam(name = "text", description = "含 Unicode 转义序列的文本") String text) {
+        return respond("json_unicode_decode", () -> wrapResult(jsonOps.decodeUnicode(text)));
     }
 
     // =====================================================================
@@ -127,6 +159,20 @@ public class DevToolboxTools {
         return respond("url_decode", () -> wrapResult(codecOps.urlDecode(text)));
     }
 
+    @Tool(name = "hex_encode", description = "把文本按UTF-8取字节后转成小写十六进制。参数 text：待编码文本。"
+        + "返回 result 字段为hex字符串。")
+    public Mono<String> hexEncode(
+        @ToolParam(name = "text", description = "待编码文本") String text) {
+        return respond("hex_encode", () -> wrapResult(codecOps.hexEncode(text)));
+    }
+
+    @Tool(name = "hex_decode", description = "把十六进制字符串按UTF-8解码成文本。参数 hex：hex字符串，"
+        + "大小写均可、空白会被忽略，长度须为偶数。返回 result 字段为解码后的文本。")
+    public Mono<String> hexDecode(
+        @ToolParam(name = "hex", description = "待解码的十六进制字符串") String hex) {
+        return respond("hex_decode", () -> wrapResult(codecOps.hexDecode(hex)));
+    }
+
     @Tool(name = "text_hash", description = "计算文本摘要，输出小写hex。参数 algorithm：算法，取值 MD5/SHA-1/SHA-256/SHA-512；"
         + "text：待摘要文本；hmacKey：可选，提供时走对应的HMAC(HmacMD5/HmacSHA1/HmacSHA256/HmacSHA512)。"
         + "返回 result 字段为hex摘要。")
@@ -144,26 +190,58 @@ public class DevToolboxTools {
         return respond("uuid_generate", () -> wrapResult(codecOps.uuid(count == null ? DEFAULT_UUID_COUNT : count)));
     }
 
-    @Tool(name = "aes_encrypt", description = "AES加密，密文以Base64输出。参数 plainText：明文；key：密钥，UTF-8字节长度须为16/24/32；"
-        + "mode：模式 CBC/ECB/GCM，默认CBC；iv：可选Base64编码的IV，CBC/GCM缺省时随机生成并随结果返回，ECB无需IV。"
-        + "返回 mode、ciphertext(Base64)、iv(Base64，ECB时为null)。")
+    @Tool(name = "aes_encrypt", description = "AES加密。参数 plainText：明文；key：密钥(按keyEncoding解码后须为16/24/32字节)；"
+        + "keyEncoding：密钥编码 utf8(默认)/hex/base64；mode：模式 CBC(默认)/ECB/CTR/GCM；"
+        + "padding：填充 PKCS7/NONE，留空时CBC与ECB用PKCS7、CTR与GCM无填充；"
+        + "iv：初始向量，ECB不用、其余缺省时随机生成并随结果返回(CBC/CTR为16字节、GCM为12字节)；"
+        + "ivEncoding：IV编码 utf8/hex/base64(默认)；outputFormat：密文输出格式 hex/base64(默认)。"
+        + "返回 mode、padding、outputFormat、ciphertext、iv。"
+        + "【与管理台页面互通】页面版AES固定用CBC/ECB/CTR，若要解密页面产出的密文，"
+        + "务必把mode、padding、keyEncoding、ivEncoding、outputFormat都填成与页面上一致的值。")
     public Mono<String> aesEncrypt(
         @ToolParam(name = "plainText", description = "待加密明文") String plainText,
-        @ToolParam(name = "key", description = "密钥，UTF-8字节长度16/24/32") String key,
-        @ToolParam(name = "mode", required = false, description = "模式 CBC/ECB/GCM，默认CBC") String mode,
-        @ToolParam(name = "iv", required = false, description = "可选IV(Base64)，缺省随机生成") String iv) {
-        return respond("aes_encrypt", () -> codecOps.aesEncrypt(plainText, key, mode, iv));
+        @ToolParam(name = "key", description = "密钥，按keyEncoding解码后须为16/24/32字节") String key,
+        @ToolParam(name = "keyEncoding", required = false, description = "密钥编码 utf8(默认)/hex/base64") String keyEncoding,
+        @ToolParam(name = "mode", required = false, description = "模式 CBC(默认)/ECB/CTR/GCM") String mode,
+        @ToolParam(name = "padding", required = false, description = "填充 PKCS7/NONE，留空按模式取默认") String padding,
+        @ToolParam(name = "iv", required = false, description = "IV，缺省随机生成；ECB不用") String iv,
+        @ToolParam(name = "ivEncoding", required = false, description = "IV编码 utf8/hex/base64(默认)") String ivEncoding,
+        @ToolParam(name = "outputFormat", required = false, description = "密文输出格式 hex/base64(默认)") String outputFormat) {
+        return respond("aes_encrypt", () -> codecOps.aesEncrypt(plainText,
+            buildAesParams(key, keyEncoding, mode, padding, iv, ivEncoding, outputFormat)));
     }
 
-    @Tool(name = "aes_decrypt", description = "AES解密，密文为Base64。参数 cipherText：Base64密文；key：密钥，UTF-8字节长度须为16/24/32；"
-        + "mode：模式 CBC/ECB/GCM，默认CBC；iv：Base64编码的IV，CBC/GCM必填，须与加密时一致，ECB无需IV。"
-        + "返回 result 字段为解密后的明文。")
+    @Tool(name = "aes_decrypt", description = "AES解密。参数 cipherText：密文(格式由outputFormat指定)；"
+        + "key：密钥(按keyEncoding解码后须为16/24/32字节)；keyEncoding：密钥编码 utf8(默认)/hex/base64；"
+        + "mode：模式 CBC(默认)/ECB/CTR/GCM；padding：填充 PKCS7/NONE，留空时CBC与ECB用PKCS7、CTR与GCM无填充；"
+        + "iv：初始向量，除ECB外必填且须与加密时一致；ivEncoding：IV编码 utf8/hex/base64(默认)；"
+        + "outputFormat：密文格式 hex/base64(默认)。返回 result 字段为明文。"
+        + "所有参数必须与加密时完全一致，任一不符都会解出乱码或直接报错。")
     public Mono<String> aesDecrypt(
-        @ToolParam(name = "cipherText", description = "待解密的Base64密文") String cipherText,
-        @ToolParam(name = "key", description = "密钥，UTF-8字节长度16/24/32") String key,
-        @ToolParam(name = "mode", required = false, description = "模式 CBC/ECB/GCM，默认CBC") String mode,
-        @ToolParam(name = "iv", required = false, description = "IV(Base64)，CBC/GCM必填") String iv) {
-        return respond("aes_decrypt", () -> wrapResult(codecOps.aesDecrypt(cipherText, key, mode, iv)));
+        @ToolParam(name = "cipherText", description = "待解密密文，格式由outputFormat指定") String cipherText,
+        @ToolParam(name = "key", description = "密钥，按keyEncoding解码后须为16/24/32字节") String key,
+        @ToolParam(name = "keyEncoding", required = false, description = "密钥编码 utf8(默认)/hex/base64") String keyEncoding,
+        @ToolParam(name = "mode", required = false, description = "模式 CBC(默认)/ECB/CTR/GCM") String mode,
+        @ToolParam(name = "padding", required = false, description = "填充 PKCS7/NONE，留空按模式取默认") String padding,
+        @ToolParam(name = "iv", required = false, description = "IV，除ECB外必填") String iv,
+        @ToolParam(name = "ivEncoding", required = false, description = "IV编码 utf8/hex/base64(默认)") String ivEncoding,
+        @ToolParam(name = "outputFormat", required = false, description = "密文格式 hex/base64(默认)") String outputFormat) {
+        return respond("aes_decrypt", () -> wrapResult(codecOps.aesDecrypt(cipherText,
+            buildAesParams(key, keyEncoding, mode, padding, iv, ivEncoding, outputFormat))));
+    }
+
+    /** 组装 AES 参数（加解密两侧参数完全一致，抽出来避免两处漏填某一项）。 */
+    private CodecDevToolOps.AesParams buildAesParams(String key, String keyEncoding, String mode, String padding,
+                                                     String iv, String ivEncoding, String outputFormat) {
+        return CodecDevToolOps.AesParams.builder()
+            .key(key)
+            .keyEncoding(keyEncoding)
+            .mode(mode)
+            .padding(padding)
+            .iv(iv)
+            .ivEncoding(ivEncoding)
+            .outputFormat(outputFormat)
+            .build();
     }
 
     // =====================================================================
@@ -208,6 +286,65 @@ public class DevToolboxTools {
         @ToolParam(name = "certPem", description = "证书PEM文本") String certPem,
         @ToolParam(name = "privateKeyPem", description = "私钥PEM文本(不支持加密私钥)") String privateKeyPem) {
         return respond("cert_match", () -> certOps.match(certPem, privateKeyPem));
+    }
+
+    // =====================================================================
+    // Cron / JWT / 文本比对 / 格式互转
+    // =====================================================================
+
+    @Tool(name = "cron_explain", description = "解析cron表达式：校验合法性、逐字段释义、推算后续执行时间。"
+        + "参数 expression：6段cron(秒 分 时 日 月 周)，与本项目调度中心XXL-JOB一致，如 0 0 2 * * ?；"
+        + "count：推算几次执行时间，1~20，默认5；timezone：时区ID，默认 Asia/Shanghai。"
+        + "返回 expression、timezone、fields(每段的name/value/range/description)、nextTimes(后续执行时间列表)。"
+        + "注意：5段的Unix风格cron在这里非法，需在最前面补一段秒；判断任务何时执行请直接看nextTimes，不要自行推算。")
+    public Mono<String> cronExplain(
+        @ToolParam(name = "expression", description = "6段cron表达式(秒 分 时 日 月 周)") String expression,
+        @ToolParam(name = "count", required = false, description = "推算次数，1~20，默认5") Integer count,
+        @ToolParam(name = "timezone", required = false, description = "时区ID，默认 Asia/Shanghai") String timezone) {
+        return respond("cron_explain", () -> cronOps.explain(expression, count, timezone));
+    }
+
+    @Tool(name = "jwt_decode", description = "解析JWT：拆出header与payload、解读标准声明与有效期，可选校验签名。"
+        + "参数 token：JWT字符串(header.payload.signature)；secret：可选，仅HS256/HS384/HS512可校验签名，不传则不校验；"
+        + "secretEncoding：密钥编码 utf8(默认)/hex/base64。"
+        + "返回 algorithm、type、header、payload、issuer/subject/audience/jwtId、"
+        + "issuedAt/notBefore/expiresAt(已格式化为北京时间)、expired(是否过期)、notYetValid(是否未生效)、"
+        + "secondsRemaining(距过期秒数)、unsigned(是否alg=none)、"
+        + "signatureStatus(VALID/INVALID/NOT_CHECKED未提供密钥/UNSUPPORTED_ALG非HS*不验签)。"
+        + "判断是否过期看expired字段，不要自行比较时间戳；signatureStatus为UNSUPPORTED_ALG时不能宣称签名有效。"
+        + "【安全提醒】token与secret会进入模型上下文并落入对话历史，仅在用户明确要求时调用，不要主动索取密钥。")
+    public Mono<String> jwtDecode(
+        @ToolParam(name = "token", description = "JWT字符串") String token,
+        @ToolParam(name = "secret", required = false, description = "可选，HS*签名校验密钥") String secret,
+        @ToolParam(name = "secretEncoding", required = false, description = "密钥编码 utf8(默认)/hex/base64") String secretEncoding) {
+        return respond("jwt_decode", () -> jwtOps.decode(token, secret, secretEncoding));
+    }
+
+    @Tool(name = "text_diff", description = "按行比对两段文本的差异(最长公共子序列算法)。"
+        + "参数 oldText：原文本；newText：新文本；ignoreWhitespace：是否忽略行首尾空白，默认false；"
+        + "ignoreCase：是否忽略大小写，默认false。"
+        + "返回 identical(是否完全一致)、addedLines/deletedLines(增删行数)、totalLines、truncated(是否因差异过多截断)、"
+        + "lines(每行的type=EQUAL/INSERT/DELETE、oldLineNo、newLineNo、content，行号从1起、该侧不存在时为-1)。"
+        + "适合核对改配置前后、两个环境的JSON/YAML差异。单侧行数上限1500行。")
+    public Mono<String> textDiff(
+        @ToolParam(name = "oldText", description = "原文本") String oldText,
+        @ToolParam(name = "newText", description = "新文本") String newText,
+        @ToolParam(name = "ignoreWhitespace", required = false, description = "忽略行首尾空白，默认false") Boolean ignoreWhitespace,
+        @ToolParam(name = "ignoreCase", required = false, description = "忽略大小写，默认false") Boolean ignoreCase) {
+        return respond("text_diff", () -> diffOps.diff(oldText, newText, ignoreWhitespace, ignoreCase));
+    }
+
+    @Tool(name = "data_convert", description = "结构化数据格式互转：JSON、YAML、XML 三者任意方向转换。"
+        + "参数 content：待转换内容；sourceFormat/targetFormat：json/yaml/xml；"
+        + "rootName：转XML时的根元素名，默认root，其它目标格式忽略。返回 sourceFormat、targetFormat、result。"
+        + "已知语义损耗：XML无类型系统故转出的JSON里数字与布尔均为字符串；XML同名重复子元素只保留最后一个"
+        + "(数组型XML请勿依赖本工具)；YAML多文档只处理第一个；数组不能直接作为XML根。")
+    public Mono<String> dataConvert(
+        @ToolParam(name = "content", description = "待转换内容") String content,
+        @ToolParam(name = "sourceFormat", description = "源格式 json/yaml/xml") String sourceFormat,
+        @ToolParam(name = "targetFormat", description = "目标格式 json/yaml/xml") String targetFormat,
+        @ToolParam(name = "rootName", required = false, description = "转XML时的根元素名，默认root") String rootName) {
+        return respond("data_convert", () -> dataFormatOps.convert(content, sourceFormat, targetFormat, rootName));
     }
 
     // =====================================================================

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DiffDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/DiffDevToolOps.java
@@ -1,0 +1,188 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 文本比对纯函数集：行级 diff（基于最长公共子序列）。
+ *
+ * <p>典型用途是核对改配置前后、两个环境的 JSON/YAML 差异。为便于两端一致呈现，结果是结构化的
+ * 行列表而非 unified diff 文本：每行带类型（相同/新增/删除）与两侧行号，页面直接渲染成左右对照，
+ * 智能体也能逐行引用行号说明差异。</p>
+ *
+ * <p>无 Spring 依赖、无状态。LCS 是 O(n×m) 时空复杂度，故对行数设上限 fast-fail，避免大文件
+ * 把内存打满——工具箱定位是"看配置差异"，不是通用 diff 引擎。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class DiffDevToolOps {
+
+    /** 单侧行数上限（1500×1500 的 int 表约 9MB，足够覆盖配置文件比对场景）。 */
+    private static final int MAX_LINES = 1500;
+
+    /** 结果行数上限：差异过多时截断，防止撑爆 LLM 上下文与页面渲染。 */
+    private static final int MAX_RESULT_LINES = 3000;
+
+    /** 行号占位值（该侧不存在此行时）。 */
+    private static final int NO_LINE = -1;
+
+    /** 行类型。 */
+    private static final String TYPE_EQUAL = "EQUAL";
+    private static final String TYPE_INSERT = "INSERT";
+    private static final String TYPE_DELETE = "DELETE";
+
+    /**
+     * 行级比对两段文本。
+     *
+     * @param oldText          原文本（允许空串）
+     * @param newText          新文本（允许空串）
+     * @param ignoreWhitespace 是否忽略行首尾空白差异，null 视为 false
+     * @param ignoreCase       是否忽略大小写差异，null 视为 false
+     * @return 比对结果
+     */
+    public DiffResult diff(String oldText, String newText, Boolean ignoreWhitespace, Boolean ignoreCase) {
+        DevToolArgs.requireNonNull(oldText, "oldText");
+        DevToolArgs.requireNonNull(newText, "newText");
+        boolean trimSpace = Boolean.TRUE.equals(ignoreWhitespace);
+        boolean foldCase = Boolean.TRUE.equals(ignoreCase);
+
+        List<String> oldLines = splitLines(oldText, "oldText");
+        List<String> newLines = splitLines(newText, "newText");
+        // 比较用的归一化副本，展示仍用原文，避免"忽略空白"把用户的原始内容也改了
+        List<String> oldKeys = normalizeAll(oldLines, trimSpace, foldCase);
+        List<String> newKeys = normalizeAll(newLines, trimSpace, foldCase);
+
+        List<DiffLine> lines = backtrack(buildLcsTable(oldKeys, newKeys), oldLines, newLines, oldKeys, newKeys);
+
+        int added = 0;
+        int deleted = 0;
+        for (DiffLine line : lines) {
+            if (TYPE_INSERT.equals(line.getType())) {
+                added++;
+            } else if (TYPE_DELETE.equals(line.getType())) {
+                deleted++;
+            }
+        }
+        boolean truncated = lines.size() > MAX_RESULT_LINES;
+        return DiffResult.builder()
+            .identical(added == 0 && deleted == 0)
+            .addedLines(added)
+            .deletedLines(deleted)
+            .totalLines(lines.size())
+            .truncated(truncated)
+            .lines(truncated ? new ArrayList<>(lines.subList(0, MAX_RESULT_LINES)) : lines)
+            .build();
+    }
+
+    /** 按行切分（兼容 \r\n / \r / \n），并做行数上限校验。空串视为 0 行。 */
+    private List<String> splitLines(String text, String fieldName) {
+        if (text.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] parts = text.split("\r\n|\r|\n", -1);
+        if (parts.length > MAX_LINES) {
+            throw new IllegalArgumentException(fieldName + " 行数超过上限 " + MAX_LINES
+                + "，当前 " + parts.length + " 行（本工具面向配置/报文比对，超大文件请先截取关注片段）");
+        }
+        return List.of(parts);
+    }
+
+    /** 生成比较用的归一化行。 */
+    private List<String> normalizeAll(List<String> lines, boolean trimSpace, boolean foldCase) {
+        List<String> keys = new ArrayList<>(lines.size());
+        for (String line : lines) {
+            String key = trimSpace ? line.trim() : line;
+            keys.add(foldCase ? key.toLowerCase(Locale.ROOT) : key);
+        }
+        return keys;
+    }
+
+    /** 构建 LCS 长度表：dp[i][j] = oldKeys 前 i 行与 newKeys 前 j 行的最长公共子序列长度。 */
+    private int[][] buildLcsTable(List<String> oldKeys, List<String> newKeys) {
+        int oldSize = oldKeys.size();
+        int newSize = newKeys.size();
+        int[][] dp = new int[oldSize + 1][newSize + 1];
+        for (int i = 1; i <= oldSize; i++) {
+            for (int j = 1; j <= newSize; j++) {
+                if (oldKeys.get(i - 1).equals(newKeys.get(j - 1))) {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                }
+            }
+        }
+        return dp;
+    }
+
+    /**
+     * 回溯 LCS 表生成行列表。
+     *
+     * <p>从表尾往前走再整体反转，保证同一位置上"删除"排在"新增"之前，读起来即"旧行改成了新行"。</p>
+     */
+    private List<DiffLine> backtrack(int[][] dp, List<String> oldLines, List<String> newLines,
+                                     List<String> oldKeys, List<String> newKeys) {
+        List<DiffLine> reversed = new ArrayList<>();
+        int i = oldLines.size();
+        int j = newLines.size();
+        while (i > 0 || j > 0) {
+            if (i > 0 && j > 0 && oldKeys.get(i - 1).equals(newKeys.get(j - 1))) {
+                reversed.add(line(TYPE_EQUAL, i, j, oldLines.get(i - 1)));
+                i--;
+                j--;
+            } else if (j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+                reversed.add(line(TYPE_INSERT, NO_LINE, j, newLines.get(j - 1)));
+                j--;
+            } else {
+                reversed.add(line(TYPE_DELETE, i, NO_LINE, oldLines.get(i - 1)));
+                i--;
+            }
+        }
+        Collections.reverse(reversed);
+        return reversed;
+    }
+
+    private DiffLine line(String type, int oldLineNo, int newLineNo, String content) {
+        return DiffLine.builder().type(type).oldLineNo(oldLineNo).newLineNo(newLineNo).content(content).build();
+    }
+
+    /**
+     * 比对结果。
+     */
+    @Getter
+    @Builder
+    public static class DiffResult {
+        /** 两段文本是否完全一致（按当前忽略选项判定）。 */
+        private final boolean identical;
+        /** 新增行数。 */
+        private final int addedLines;
+        /** 删除行数。 */
+        private final int deletedLines;
+        /** 结果总行数（截断前）。 */
+        private final int totalLines;
+        /** 是否因差异过多被截断。 */
+        private final boolean truncated;
+        /** 逐行结果。 */
+        private final List<DiffLine> lines;
+    }
+
+    /**
+     * 比对结果中的一行。行号从 1 起；该侧不存在此行时为 -1。
+     */
+    @Getter
+    @Builder
+    public static class DiffLine {
+        /** 类型：EQUAL(相同) / INSERT(新增) / DELETE(删除)。 */
+        private final String type;
+        /** 在原文本中的行号，新增行为 -1。 */
+        private final int oldLineNo;
+        /** 在新文本中的行号，删除行为 -1。 */
+        private final int newLineNo;
+        /** 行内容（原文，未受忽略选项影响）。 */
+        private final String content;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOps.java
@@ -4,16 +4,24 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
- * JSON 处理纯函数集：格式化 / 压缩 / 校验（行列号定位）。
+ * JSON 处理纯函数集：格式化 / 压缩 / 校验（行列号定位）/ 转义 / 去转义 / Unicode 解码。
  *
  * <p>无 Spring 依赖、无状态。参数非法在方法入口 fast-fail 抛 {@link IllegalArgumentException}，
  * 内部不再层层判空。JSON 解析错误统一带上 Jackson 提供的行列号，便于 LLM 自我纠正。</p>
+ *
+ * <p>转义/去转义/Unicode 解码三项与管理台"开发者工具箱 → JSON 工具"页面同语义（页面侧用
+ * JSON.stringify/JSON.parse 实现），两端对同一输入必须给出相同结果。</p>
  *
  * @author owlzhangfq@gmail.com
  */
@@ -22,12 +30,32 @@ public final class JsonDevToolOps {
     /** 复用同一 ObjectMapper（线程安全，读/写皆无状态使用）。 */
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    /**
+     * 去转义专用的严格 Mapper：必须开启 FAIL_ON_TRAILING_TOKENS。
+     *
+     * <p>Jackson 默认只读第一个 token 就返回，尾部残留内容一概不管——补引号后的
+     * {@code "{"a":1}"} 会被静默解析成字符串 {@code "{"} 而不报错，与页面版 {@code JSON.parse}
+     * 直接抛 SyntaxError 的行为不一致。两端语义必须对齐，否则同一段输入在页面报错、在智能体
+     * 侧却悄悄返回半截内容。</p>
+     */
+    private static final ObjectMapper STRICT_MAPPER = new ObjectMapper()
+        .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
     /** 允许的缩进宽度：2 或 4 个空格。 */
     private static final int INDENT_TWO = 2;
     private static final int INDENT_FOUR = 4;
 
     /** 校验结果中"不适用"的行列号占位值（合法 JSON 时无行列可指）。 */
     private static final int LOCATION_NOT_APPLICABLE = -1;
+
+    /** Unicode 转义序列 \\uXXXX。 */
+    private static final Pattern UNICODE_ESCAPE = Pattern.compile("\\\\u([0-9a-fA-F]{4})");
+
+    /** 十六进制基数。 */
+    private static final int HEX_RADIX = 16;
+
+    /** 判定"已带外层双引号"所需的最短长度（一对引号本身就占 2 个字符）。 */
+    private static final int WRAPPED_MIN_LENGTH = 2;
 
     /**
      * 美化 JSON：按指定缩进（2 或 4 个空格）重排。
@@ -88,6 +116,76 @@ public final class JsonDevToolOps {
                 .column(location == null ? LOCATION_NOT_APPLICABLE : location.getColumnNr())
                 .build();
         }
+    }
+
+    /**
+     * 转义：把任意原文变成"可安全嵌入 JSON 的字符串字面量"，含外层双引号。
+     *
+     * <p>语义与页面版的 {@code JSON.stringify(raw)} 一致：自动处理引号、反斜杠与控制字符，
+     * 非 ASCII（如中文）保持原样、不转成 \\uXXXX。</p>
+     *
+     * @param text 原文（允许空串）
+     * @return 带外层双引号的转义串
+     */
+    public String escape(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        try {
+            return MAPPER.writeValueAsString(text);
+        } catch (JsonProcessingException e) {
+            // 纯 String 序列化不会失败，仅作兜底
+            throw new IllegalArgumentException("转义失败：" + e.getOriginalMessage(), e);
+        }
+    }
+
+    /**
+     * 去转义：把转义串还原成原文。
+     *
+     * <p>语义与页面版一致：外层双引号可有可无——没有时视为"转义串本体"，补上引号后按 JSON
+     * 字符串语法解析。解析结果不是字符串（如传入的是对象/数组）同样视为输入非法。</p>
+     *
+     * @param text 转义串（带或不带外层双引号）
+     * @return 还原后的原文
+     */
+    public String unescape(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        String trimmed = text.trim();
+        boolean alreadyWrapped = trimmed.length() >= WRAPPED_MIN_LENGTH
+            && trimmed.startsWith("\"") && trimmed.endsWith("\"");
+        String candidate = alreadyWrapped ? trimmed : "\"" + trimmed + "\"";
+        JsonNode node;
+        try {
+            node = STRICT_MAPPER.readTree(candidate);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(
+                "内容不是合法的转义字符串（无法按 JSON 字符串语法解析，检查引号/反斜杠是否匹配）："
+                    + e.getOriginalMessage(), e);
+        }
+        if (!node.isTextual()) {
+            throw new IllegalArgumentException("内容不是转义字符串（解析结果是 "
+                + node.getNodeType().name().toLowerCase(Locale.ROOT) + " 而非字符串）");
+        }
+        return node.asText();
+    }
+
+    /**
+     * 把文本里的 Unicode 转义序列（\\uXXXX）解码成真实字符（常见于日志里被转义的中文），
+     * 其余内容原样保留。与页面版一致：代理对由两个连续的 \\uXXXX 表示，逐个解码后自然拼回完整字符。
+     *
+     * @param text 含 \\uXXXX 的文本（允许空串、允许不含转义序列）
+     * @return 解码后的文本
+     */
+    public String decodeUnicode(String text) {
+        DevToolArgs.requireNonNull(text, "text");
+        Matcher matcher = UNICODE_ESCAPE.matcher(text);
+        StringBuilder sb = new StringBuilder(text.length());
+        int cursor = 0;
+        while (matcher.find()) {
+            sb.append(text, cursor, matcher.start());
+            sb.append((char) Integer.parseInt(matcher.group(1), HEX_RADIX));
+            cursor = matcher.end();
+        }
+        sb.append(text, cursor, text.length());
+        return sb.toString();
     }
 
     /** 构造指定空格数的缩进 PrettyPrinter（对象与数组一致缩进）。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/JwtDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/devtool/JwtDevToolOps.java
@@ -1,0 +1,268 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Locale;
+
+/**
+ * JWT 解析纯函数集：拆解 header/payload、解读标准声明与有效期、可选 HS* 签名校验。
+ *
+ * <p>面向"排查登录态与第三方对接"这一实际场景：多数情况下要看的是 payload 里到底签了什么、
+ * 到底过没过期。签名校验只实现 HMAC（HS256/HS384/HS512，本项目自身的用户令牌即 HS256）；
+ * RS、ES、PS 系列非对称算法只解码不验签，结果里以 UNSUPPORTED_ALG 明确标注，不会假装校验通过。</p>
+ *
+ * <p><b>安全</b>：{@code alg=none} 的令牌会被显式标注——它意味着签名可被任意伪造，见到必须当作
+ * 不可信。校验密钥比对走 {@link MessageDigest#isEqual} 常量时间比较。</p>
+ *
+ * <p>无 Spring 依赖、无状态，参数非法入口 fast-fail。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class JwtDevToolOps {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 展示时间用的时区与格式（与工具箱其它工具一致）。 */
+    private static final String DEFAULT_ZONE = "Asia/Shanghai";
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /** JWT 的三段结构。 */
+    private static final int JWT_PART_COUNT = 3;
+
+    /** 签名校验结论。 */
+    private static final String VERIFY_VALID = "VALID";
+    private static final String VERIFY_INVALID = "INVALID";
+    private static final String VERIFY_NOT_CHECKED = "NOT_CHECKED";
+    private static final String VERIFY_UNSUPPORTED_ALG = "UNSUPPORTED_ALG";
+
+    /** 无签名算法标识。 */
+    private static final String ALG_NONE = "none";
+
+    /** 密钥文本编码。 */
+    private static final String ENCODING_UTF8 = "UTF8";
+    private static final String ENCODING_HEX = "HEX";
+    private static final String ENCODING_BASE64 = "BASE64";
+
+    /** 时间戳换算。 */
+    private static final long MILLIS_PER_SECOND = 1000L;
+
+    /**
+     * 解析 JWT。
+     *
+     * @param token          JWT 字符串（header.payload.signature）
+     * @param secret         可选，HS* 签名校验用的密钥；为空则不校验
+     * @param secretEncoding 密钥的文本编码：utf8(默认)/hex/base64
+     * @return 解析结果
+     */
+    public JwtDecodeResult decode(String token, String secret, String secretEncoding) {
+        DevToolArgs.requireNonBlank(token, "token");
+        String trimmed = token.trim();
+        String[] parts = trimmed.split("\\.", -1);
+        if (parts.length != JWT_PART_COUNT) {
+            throw new IllegalArgumentException("JWT 必须是以 . 分隔的三段（header.payload.signature），当前 "
+                + parts.length + " 段");
+        }
+
+        JsonNode header = parseSegment(parts[0], "header");
+        JsonNode payload = parseSegment(parts[1], "payload");
+        String algorithm = header.path("alg").asText(null);
+        ZoneId zoneId = ZoneId.of(DEFAULT_ZONE);
+
+        Long expSeconds = readNumericDate(payload, "exp");
+        Long nbfSeconds = readNumericDate(payload, "nbf");
+        long nowSeconds = Instant.now().getEpochSecond();
+
+        return JwtDecodeResult.builder()
+            .algorithm(algorithm)
+            .type(header.path("typ").asText(null))
+            .header(toPrettyJson(header))
+            .payload(toPrettyJson(payload))
+            .issuer(payload.path("iss").asText(null))
+            .subject(payload.path("sub").asText(null))
+            .audience(payload.path("aud").isMissingNode() ? null : payload.path("aud").toString())
+            .jwtId(payload.path("jti").asText(null))
+            .issuedAt(formatEpochSeconds(readNumericDate(payload, "iat"), zoneId))
+            .notBefore(formatEpochSeconds(nbfSeconds, zoneId))
+            .expiresAt(formatEpochSeconds(expSeconds, zoneId))
+            .expired(expSeconds != null && expSeconds <= nowSeconds)
+            .notYetValid(nbfSeconds != null && nbfSeconds > nowSeconds)
+            .secondsRemaining(expSeconds == null ? null : expSeconds - nowSeconds)
+            .unsigned(ALG_NONE.equalsIgnoreCase(algorithm))
+            .signatureStatus(verifySignature(parts, algorithm, secret, secretEncoding))
+            .build();
+    }
+
+    /** 校验签名：无密钥不校验；非 HS* 明确标为不支持，绝不含糊成"通过"。 */
+    private String verifySignature(String[] parts, String algorithm, String secret, String secretEncoding) {
+        if (secret == null || secret.trim().isEmpty()) {
+            return VERIFY_NOT_CHECKED;
+        }
+        String macAlgorithm = toMacAlgorithm(algorithm);
+        if (macAlgorithm == null) {
+            return VERIFY_UNSUPPORTED_ALG;
+        }
+        byte[] keyBytes = decodeSecret(secret, normalizeEncoding(secretEncoding));
+        String signingInput = parts[0] + "." + parts[1];
+        try {
+            Mac mac = Mac.getInstance(macAlgorithm);
+            mac.init(new SecretKeySpec(keyBytes, macAlgorithm));
+            byte[] expected = mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8));
+            byte[] actual = decodeBase64Url(parts[2], "signature");
+            return MessageDigest.isEqual(expected, actual) ? VERIFY_VALID : VERIFY_INVALID;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("签名校验失败：" + e.getMessage(), e);
+        }
+    }
+
+    /** JWT alg 映射到 JCE 的 Mac 算法名；非 HS* 返回 null 表示不支持验签。 */
+    private String toMacAlgorithm(String algorithm) {
+        if (algorithm == null) {
+            return null;
+        }
+        switch (algorithm.trim().toUpperCase(Locale.ROOT)) {
+            case "HS256":
+                return "HmacSHA256";
+            case "HS384":
+                return "HmacSHA384";
+            case "HS512":
+                return "HmacSHA512";
+            default:
+                return null;
+        }
+    }
+
+    /** 解析某一段：base64url 解码后按 JSON 解析。 */
+    private JsonNode parseSegment(String segment, String name) {
+        byte[] decoded = decodeBase64Url(segment, name);
+        try {
+            return MAPPER.readTree(new String(decoded, StandardCharsets.UTF_8));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(name + " 段解码后不是合法 JSON：" + e.getOriginalMessage(), e);
+        }
+    }
+
+    /** base64url 解码（JWT 各段按 RFC 7515 省略了 padding）。 */
+    private byte[] decodeBase64Url(String segment, String name) {
+        try {
+            return Base64.getUrlDecoder().decode(segment);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(name + " 段不是合法的 base64url 编码：" + e.getMessage(), e);
+        }
+    }
+
+    /** 读取 NumericDate 型声明（秒级时间戳）；缺失或非数字返回 null。 */
+    private Long readNumericDate(JsonNode payload, String field) {
+        JsonNode node = payload.path(field);
+        return node.isNumber() ? node.asLong() : null;
+    }
+
+    /** 秒级时间戳转可读时间；null 原样返回 null。 */
+    private String formatEpochSeconds(Long epochSeconds, ZoneId zoneId) {
+        if (epochSeconds == null) {
+            return null;
+        }
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochSeconds * MILLIS_PER_SECOND), zoneId)
+            .format(TIME_FORMATTER);
+    }
+
+    /** 树模型转带缩进的 JSON 文本。 */
+    private String toPrettyJson(JsonNode node) {
+        try {
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            // 已解析成功的树再序列化不会失败，仅作兜底
+            throw new IllegalArgumentException("序列化失败：" + e.getOriginalMessage(), e);
+        }
+    }
+
+    /** 规范化密钥编码。 */
+    private String normalizeEncoding(String encoding) {
+        if (encoding == null || encoding.trim().isEmpty()) {
+            return ENCODING_UTF8;
+        }
+        String upper = encoding.trim().toUpperCase(Locale.ROOT).replace("-", "").replace("_", "");
+        if (!ENCODING_UTF8.equals(upper) && !ENCODING_HEX.equals(upper) && !ENCODING_BASE64.equals(upper)) {
+            throw new IllegalArgumentException("secretEncoding 仅支持 utf8/hex/base64，当前 " + encoding);
+        }
+        return upper;
+    }
+
+    /** 按编码解出密钥字节。 */
+    private byte[] decodeSecret(String secret, String encoding) {
+        switch (encoding) {
+            case ENCODING_HEX:
+                String cleaned = secret.replaceAll("\\s", "");
+                if (!cleaned.matches("[0-9a-fA-F]+") || cleaned.length() % 2 != 0) {
+                    throw new IllegalArgumentException("secret 不是合法的 hex（只允许 0-9、a-f，且长度为偶数）");
+                }
+                byte[] bytes = new byte[cleaned.length() / 2];
+                for (int i = 0; i < bytes.length; i++) {
+                    bytes[i] = (byte) Integer.parseInt(cleaned.substring(i * 2, i * 2 + 2), 16);
+                }
+                return bytes;
+            case ENCODING_BASE64:
+                try {
+                    return Base64.getDecoder().decode(secret.trim());
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("secret 不是合法的 Base64：" + e.getMessage(), e);
+                }
+            case ENCODING_UTF8:
+            default:
+                return secret.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * JWT 解析结果。时间类字段均已按 Asia/Shanghai 格式化为 yyyy-MM-dd HH:mm:ss，缺失的声明为 null。
+     */
+    @Getter
+    @Builder
+    public static class JwtDecodeResult {
+        /** 签名算法（header.alg）。 */
+        private final String algorithm;
+        /** 令牌类型（header.typ）。 */
+        private final String type;
+        /** header 的格式化 JSON。 */
+        private final String header;
+        /** payload 的格式化 JSON。 */
+        private final String payload;
+        /** 签发方 iss。 */
+        private final String issuer;
+        /** 主体 sub。 */
+        private final String subject;
+        /** 受众 aud（原样 JSON，可能是字符串或数组）。 */
+        private final String audience;
+        /** 令牌 ID jti。 */
+        private final String jwtId;
+        /** 签发时间 iat。 */
+        private final String issuedAt;
+        /** 生效时间 nbf。 */
+        private final String notBefore;
+        /** 过期时间 exp。 */
+        private final String expiresAt;
+        /** 是否已过期（无 exp 声明时为 false）。 */
+        private final boolean expired;
+        /** 是否尚未生效（无 nbf 声明时为 false）。 */
+        private final boolean notYetValid;
+        /** 距过期的秒数，负数表示已过期；无 exp 声明时为 null。 */
+        private final Long secondsRemaining;
+        /** 是否是 alg=none 的无签名令牌（签名可被任意伪造，必须当作不可信）。 */
+        private final boolean unsigned;
+        /** 签名校验结论：VALID / INVALID / NOT_CHECKED(未提供密钥) / UNSUPPORTED_ALG(非 HS* 不验签)。 */
+        private final String signatureStatus;
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/CodecDevToolOpsTest.java
@@ -84,56 +84,164 @@ class CodecDevToolOpsTest {
         assertThrows(IllegalArgumentException.class, () -> ops.uuid(21));
     }
 
-    // -------- AES --------
+    // -------- Hex --------
 
     @Test
-    void aes_cbc_shouldRoundTrip_withGeneratedIv() {
-        String key = "1234567890123456"; // 16 字节
-        CodecDevToolOps.AesResult enc = ops.aesEncrypt("secret-明文", key, "CBC", null);
-        assertNotNull(enc.getIv(), "CBC 应返回随机 IV");
-        assertEquals("secret-明文", ops.aesDecrypt(enc.getCiphertext(), key, "CBC", enc.getIv()));
+    void hex_shouldRoundTrip() {
+        assertEquals("e4bda0e5a5bd68690a", ops.hexEncode("你好hi\n"));
+        assertEquals("你好hi\n", ops.hexDecode("e4bda0e5a5bd68690a"));
     }
 
     @Test
-    void aes_cbc_shouldDefaultMode_whenModeBlank() {
-        String key = "1234567890123456";
-        CodecDevToolOps.AesResult enc = ops.aesEncrypt("hello", key, null, null);
+    void hexDecode_shouldIgnoreWhitespaceAndAcceptUpperCase() {
+        assertEquals("abc", ops.hexDecode("61 62\n63"));
+        assertEquals("abc", ops.hexDecode("616263".toUpperCase(java.util.Locale.ROOT)));
+    }
+
+    @Test
+    void hexDecode_shouldRejectOddLengthAndNonHex() {
+        assertThrows(IllegalArgumentException.class, () -> ops.hexDecode("abc"));
+        assertThrows(IllegalArgumentException.class, () -> ops.hexDecode("zz"));
+    }
+
+    // -------- AES：回环与参数校验 --------
+
+    /** 只给密钥、其余全默认，验证默认值仍是历史行为（CBC + PKCS7 + IV/密文 base64）。 */
+    @Test
+    void aes_shouldKeepLegacyDefaults_whenOnlyKeyGiven() {
+        CodecDevToolOps.AesParams params = params(b -> b.key("1234567890123456"));
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("hello", params);
         assertEquals("CBC", enc.getMode());
-        assertEquals("hello", ops.aesDecrypt(enc.getCiphertext(), key, null, enc.getIv()));
+        assertEquals("PKCS7", enc.getPadding());
+        assertEquals("base64", enc.getOutputFormat());
+        assertNotNull(enc.getIv(), "CBC 应返回随机 IV");
+        assertEquals("hello", ops.aesDecrypt(enc.getCiphertext(),
+            params(b -> b.key("1234567890123456").iv(enc.getIv()))));
     }
 
     @Test
     void aes_ecb_shouldRoundTrip_withoutIv() {
-        String key = "123456789012345678901234"; // 24 字节
-        CodecDevToolOps.AesResult enc = ops.aesEncrypt("ecb-明文", key, "ECB", null);
+        CodecDevToolOps.AesParams params = params(b -> b.key("123456789012345678901234").mode("ECB"));
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("ecb-明文", params);
         assertNull(enc.getIv(), "ECB 不应有 IV");
-        assertEquals("ecb-明文", ops.aesDecrypt(enc.getCiphertext(), key, "ECB", null));
+        assertEquals("ecb-明文", ops.aesDecrypt(enc.getCiphertext(), params));
     }
 
     @Test
     void aes_gcm_shouldRoundTrip() {
-        String key = "12345678901234567890123456789012"; // 32 字节
-        CodecDevToolOps.AesResult enc = ops.aesEncrypt("gcm-明文", key, "GCM", null);
+        CodecDevToolOps.AesParams params = params(b -> b.key("12345678901234567890123456789012").mode("GCM"));
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("gcm-明文", params);
         assertNotNull(enc.getIv());
-        assertEquals("gcm-明文", ops.aesDecrypt(enc.getCiphertext(), key, "GCM", enc.getIv()));
+        assertEquals("gcm-明文", ops.aesDecrypt(enc.getCiphertext(),
+            params(b -> b.key("12345678901234567890123456789012").mode("GCM").iv(enc.getIv()))));
+    }
+
+    @Test
+    void aes_ctr_shouldRoundTrip_withHexEncodings() {
+        CodecDevToolOps.AesParams params = params(b -> b
+            .key("000102030405060708090a0b0c0d0e0f").keyEncoding("hex")
+            .mode("CTR").iv("0f0e0d0c0b0a09080706050403020100").ivEncoding("hex").outputFormat("hex"));
+        CodecDevToolOps.AesResult enc = ops.aesEncrypt("ctr-明文", params);
+        assertEquals("NONE", enc.getPadding(), "CTR 不使用块填充");
+        assertEquals("ctr-明文", ops.aesDecrypt(enc.getCiphertext(), params));
     }
 
     @Test
     void aes_shouldRejectIllegalKeyLength() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-            () -> ops.aesEncrypt("x", "short-key", "CBC", null));
+            () -> ops.aesEncrypt("x", params(b -> b.key("short-key"))));
         assertTrue(ex.getMessage().contains("16/24/32"));
     }
 
     @Test
     void aesDecrypt_shouldRejectMissingIv_forCbc() {
         assertThrows(IllegalArgumentException.class,
-            () -> ops.aesDecrypt("YWJj", "1234567890123456", "CBC", null));
+            () -> ops.aesDecrypt("YWJj", params(b -> b.key("1234567890123456"))));
     }
 
     @Test
     void aes_shouldRejectIllegalMode() {
         assertThrows(IllegalArgumentException.class,
-            () -> ops.aesEncrypt("x", "1234567890123456", "XTS", null));
+            () -> ops.aesEncrypt("x", params(b -> b.key("1234567890123456").mode("XTS"))));
+    }
+
+    /** CTR/GCM 显式指定块填充属于配置错误，必须报错而不是静默忽略。 */
+    @Test
+    void aes_shouldRejectBlockPadding_forStreamModes() {
+        assertThrows(IllegalArgumentException.class,
+            () -> ops.aesEncrypt("x", params(b -> b.key("1234567890123456").mode("CTR").padding("PKCS7"))));
+        assertThrows(IllegalArgumentException.class,
+            () -> ops.aesEncrypt("x", params(b -> b.key("1234567890123456").mode("GCM").padding("PKCS7"))));
+    }
+
+    /** NoPadding 下明文长度不是块长整数倍时，给出明确提示而非底层的 IllegalBlockSizeException。 */
+    @Test
+    void aes_noPadding_shouldRejectUnalignedPlainText() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.aesEncrypt("not-16-bytes", params(b -> b
+                .key("1234567890123456").mode("CBC").padding("NONE").iv("abcdef9876543210").ivEncoding("utf8"))));
+        assertTrue(ex.getMessage().contains("整数倍"));
+    }
+
+    // -------- AES：与管理台页面版(crypto-js)的互通性 --------
+
+    /**
+     * 下列密文全部由页面版实际使用的 crypto-js 生成（脚本逻辑逐行对应 aesCrypto.ts），
+     * 断言后端能原样解出、且相同参数下加密结果逐字节一致。这是"页面加密的密文智能体一定能解"
+     * 这条承诺的回归防线：任何一侧参数语义漂移都会让这些用例先挂。
+     */
+    @Test
+    void aes_shouldInteropWithBrowserCryptoJs_cbcPkcs7Utf8IvHexOutput() {
+        // 页面上的默认组合：CBC + PKCS7 + 密钥/IV 按 UTF-8 输入 + 密文 hex
+        assertInterop("你好 hello 123", "7245506b0a54591da06e2d4e4f03721956ee0d78037759a433af7d0f0055c2ca",
+            b -> b.key("0123456789abcdef").mode("CBC").iv("abcdef9876543210").ivEncoding("utf8").outputFormat("hex"));
+    }
+
+    @Test
+    void aes_shouldInteropWithBrowserCryptoJs_cbcPkcs7Base64IvBase64Output() {
+        assertInterop("你好 hello 123", "ckVQawpUWR2gbi1OTwNyGVbuDXgDd1mkM699DwBVwso=",
+            b -> b.key("0123456789abcdef").mode("CBC").iv("YWJjZGVmOTg3NjU0MzIxMA==").ivEncoding("base64"));
+    }
+
+    @Test
+    void aes_shouldInteropWithBrowserCryptoJs_ecb() {
+        assertInterop("plain-ecb-测试", "37ee00d8416737fdcbde64ef7eb274e5377222e061a924c591cd9c27ea163ed4",
+            b -> b.key("0123456789abcdef").mode("ECB").outputFormat("hex"));
+    }
+
+    @Test
+    void aes_shouldInteropWithBrowserCryptoJs_ctr() {
+        assertInterop("counter mode 中文", "43c68cfcc02929c8697098b94c4a21c7a13023",
+            b -> b.key("000102030405060708090a0b0c0d0e0f").keyEncoding("hex").mode("CTR")
+                .iv("0f0e0d0c0b0a09080706050403020100").ivEncoding("hex").outputFormat("hex"));
+    }
+
+    @Test
+    void aes_shouldInteropWithBrowserCryptoJs_cbcNoPadding() {
+        assertInterop("sixteen-bytes!!!", "7F42+jctB0RlgVrIBBHxIA==",
+            b -> b.key("0123456789abcdef").mode("CBC").padding("NONE")
+                .iv("abcdef9876543210").ivEncoding("utf8").outputFormat("base64"));
+    }
+
+    @Test
+    void aes_shouldInteropWithBrowserCryptoJs_base64Key256() {
+        assertInterop("aes-256 key from base64", "950a4ccdb215265262ad6b085e2d38b038a8ef42a032a545309abda8a37df883",
+            b -> b.key("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=").keyEncoding("base64").mode("CBC")
+                .iv("000102030405060708090a0b0c0d0e0f").ivEncoding("hex").outputFormat("hex"));
+    }
+
+    /** 双向断言：后端加密结果与浏览器密文逐字节相同，且后端能解开浏览器密文。 */
+    private void assertInterop(String plainText, String browserCipher,
+                               java.util.function.UnaryOperator<CodecDevToolOps.AesParams.AesParamsBuilder> customizer) {
+        CodecDevToolOps.AesParams params = params(customizer);
+        assertEquals(browserCipher, ops.aesEncrypt(plainText, params).getCiphertext(),
+            "后端加密结果应与浏览器 crypto-js 逐字节一致");
+        assertEquals(plainText, ops.aesDecrypt(browserCipher, params),
+            "后端应能解开浏览器 crypto-js 产出的密文");
+    }
+
+    private CodecDevToolOps.AesParams params(
+        java.util.function.UnaryOperator<CodecDevToolOps.AesParams.AesParamsBuilder> customizer) {
+        return customizer.apply(CodecDevToolOps.AesParams.builder()).build();
     }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/CronDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/CronDevToolOpsTest.java
@@ -1,0 +1,113 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link CronDevToolOps} 单测：执行时间推算、段数纠错提示、字段释义与参数边界。
+ * @author owlzhangfq@gmail.com
+ */
+class CronDevToolOpsTest {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final CronDevToolOps ops = new CronDevToolOps();
+
+    @Test
+    void explain_shouldComputeDailyNextTimes() {
+        CronDevToolOps.CronExplainResult result = ops.explain("0 0 2 * * ?", 3, null);
+        assertEquals("Asia/Shanghai", result.getTimezone());
+        assertEquals(3, result.getNextTimes().size());
+        // 每天 02:00 触发：相邻两次间隔恰好 24 小时，且时分秒固定
+        List<String> times = result.getNextTimes();
+        for (String time : times) {
+            assertTrue(time.endsWith("02:00:00"), "每次触发都应在 02:00:00，实际 " + time);
+        }
+        LocalDateTime first = LocalDateTime.parse(times.get(0), FORMATTER);
+        LocalDateTime second = LocalDateTime.parse(times.get(1), FORMATTER);
+        assertEquals(Duration.ofDays(1), Duration.between(first, second));
+    }
+
+    @Test
+    void explain_shouldComputeEveryFiveMinutes() {
+        CronDevToolOps.CronExplainResult result = ops.explain("0 */5 * * * ?", 2, "UTC");
+        assertEquals("UTC", result.getTimezone());
+        LocalDateTime first = LocalDateTime.parse(result.getNextTimes().get(0), FORMATTER);
+        LocalDateTime second = LocalDateTime.parse(result.getNextTimes().get(1), FORMATTER);
+        assertEquals(Duration.ofMinutes(5), Duration.between(first, second));
+    }
+
+    @Test
+    void explain_shouldDefaultToFiveTimes() {
+        assertEquals(5, ops.explain("0 0 * * * ?", null, null).getNextTimes().size());
+    }
+
+    @Test
+    void explain_shouldDescribeEachField() {
+        List<CronDevToolOps.CronFieldDesc> fields = ops.explain("0 30 8 * * ?", 1, null).getFields();
+        assertEquals(6, fields.size());
+        assertEquals("秒", fields.get(0).getName());
+        assertEquals("第 0 秒", fields.get(0).getDescription());
+        assertEquals("第 30 分钟", fields.get(1).getDescription());
+        assertEquals("每日", fields.get(3).getDescription());
+        assertEquals("不指定（由另一个日期字段决定）", fields.get(5).getDescription());
+    }
+
+    @Test
+    void explain_shouldDescribeStepAndRange() {
+        List<CronDevToolOps.CronFieldDesc> fields = ops.explain("0 */15 9-18 * * MON-FRI", 1, null).getFields();
+        assertEquals("每隔 15 分钟", fields.get(1).getDescription());
+        assertEquals("第 9 到 18 小时", fields.get(2).getDescription());
+    }
+
+    /** 5 段是最高频的输入错误，提示必须给出可直接照抄的修正结果。 */
+    @Test
+    void explain_shouldGuideWhenUnixStyleFiveFields() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.explain("0 2 * * *", null, null));
+        assertTrue(ex.getMessage().contains("5 段"));
+        assertTrue(ex.getMessage().contains("\"0 0 2 * * *\""), "应给出补秒后的完整表达式，实际：" + ex.getMessage());
+    }
+
+    @Test
+    void explain_shouldRejectQuartzSevenFields() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.explain("0 0 2 * * ? 2030", null, null));
+        assertTrue(ex.getMessage().contains("7 段"));
+    }
+
+    @Test
+    void explain_shouldRejectIllegalExpression() {
+        assertThrows(IllegalArgumentException.class, () -> ops.explain("99 0 2 * * ?", null, null));
+    }
+
+    @Test
+    void explain_shouldRejectBlankExpression() {
+        assertThrows(IllegalArgumentException.class, () -> ops.explain("  ", null, null));
+    }
+
+    @Test
+    void explain_shouldRejectOutOfRangeCount() {
+        assertThrows(IllegalArgumentException.class, () -> ops.explain("0 0 2 * * ?", 0, null));
+        assertThrows(IllegalArgumentException.class, () -> ops.explain("0 0 2 * * ?", 21, null));
+    }
+
+    @Test
+    void explain_shouldRejectIllegalTimezone() {
+        assertThrows(IllegalArgumentException.class, () -> ops.explain("0 0 2 * * ?", 1, "Mars/Base"));
+    }
+
+    /** 多余空白应被归一化，避免因复制粘贴带入的连续空格判成段数不符。 */
+    @Test
+    void explain_shouldNormalizeExtraWhitespace() {
+        assertEquals("0 0 2 * * ?", ops.explain("  0   0  2 * *   ?  ", 1, null).getExpression());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DataFormatDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DataFormatDevToolOpsTest.java
@@ -1,0 +1,123 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DataFormatDevToolOps} 单测：三种格式互转、根元素名校验、XXE 防护与输入边界。
+ * @author owlzhangfq@gmail.com
+ */
+class DataFormatDevToolOpsTest {
+
+    private final DataFormatDevToolOps ops = new DataFormatDevToolOps();
+
+    @Test
+    void convert_jsonToYaml() {
+        String yaml = ops.convert("{\"name\":\"张三\",\"age\":30}", "json", "yaml", null).getResult();
+        assertTrue(yaml.contains("name: \"张三\"") || yaml.contains("name: 张三"), "实际输出：" + yaml);
+        assertTrue(yaml.contains("age: 30"));
+        assertFalseStartsWithDocMarker(yaml);
+    }
+
+    @Test
+    void convert_yamlToJson() {
+        String json = ops.convert("name: 张三\nage: 30\n", "yaml", "json", null).getResult();
+        assertTrue(json.contains("\"name\" : \"张三\""), "实际输出：" + json);
+        assertTrue(json.contains("\"age\" : 30"));
+    }
+
+    @Test
+    void convert_shouldRoundTripJsonYamlJson() {
+        String origin = "{\"a\":1,\"b\":{\"c\":[1,2,3]}}";
+        String yaml = ops.convert(origin, "json", "yaml", null).getResult();
+        String back = ops.convert(yaml, "yaml", "json", null).getResult();
+        // 去掉美化空白后应与原始语义一致
+        assertEquals(origin.replaceAll("\\s", ""), back.replaceAll("\\s", ""));
+    }
+
+    @Test
+    void convert_jsonToXml_shouldUseGivenRootName() {
+        String xml = ops.convert("{\"id\":1,\"name\":\"x\"}", "json", "xml", "order").getResult();
+        assertTrue(xml.startsWith("<order>"), "实际输出：" + xml);
+        assertTrue(xml.contains("<id>1</id>"));
+    }
+
+    @Test
+    void convert_jsonToXml_shouldDefaultRootName() {
+        assertTrue(ops.convert("{\"a\":1}", "json", "xml", null).getResult().startsWith("<root>"));
+    }
+
+    @Test
+    void convert_xmlToJson() {
+        String json = ops.convert("<order><id>1</id><name>x</name></order>", "xml", "json", null).getResult();
+        // XML 无类型系统，数字也会转成字符串，这是已知语义损耗
+        assertTrue(json.contains("\"id\" : \"1\""), "实际输出：" + json);
+        assertTrue(json.contains("\"name\" : \"x\""));
+    }
+
+    @Test
+    void convert_shouldReportFormatsInResult() {
+        DataFormatDevToolOps.ConvertResult result = ops.convert("{\"a\":1}", "JSON", "YAML", null);
+        assertEquals("json", result.getSourceFormat());
+        assertEquals("yaml", result.getTargetFormat());
+    }
+
+    /** 数组做 XML 根元素没有合法表示，必须明确拦下而不是产出结构诡异的 XML。 */
+    @Test
+    void convert_shouldRejectArrayAsXmlRoot() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.convert("[1,2,3]", "json", "xml", null));
+        assertTrue(ex.getMessage().contains("数组"));
+    }
+
+    @Test
+    void convert_shouldRejectIllegalRootName() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("{\"a\":1}", "json", "xml", "1-bad name"));
+    }
+
+    /**
+     * XXE 防护：输入完全来自用户与模型，属不可信输入。禁用 DTD 后带 DOCTYPE 的文档会直接解析失败，
+     * 外部实体自然无从展开——这里断言"解析被拒绝"，而不是断言"实体没被替换"。
+     */
+    @Test
+    void convert_shouldRejectXmlWithDoctype_preventingXxe() {
+        String xxe = "<?xml version=\"1.0\"?>"
+            + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+            + "<foo>&xxe;</foo>";
+        assertThrows(IllegalArgumentException.class, () -> ops.convert(xxe, "xml", "json", null));
+    }
+
+    @Test
+    void convert_shouldRejectUnsupportedFormat() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("{\"a\":1}", "json", "toml", null));
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("{\"a\":1}", "csv", "json", null));
+    }
+
+    @Test
+    void convert_shouldReportParseFailureWithSourceFormat() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.convert("{not json", "json", "yaml", null));
+        assertTrue(ex.getMessage().contains("JSON"));
+    }
+
+    @Test
+    void convert_shouldRejectBlankContent() {
+        assertThrows(IllegalArgumentException.class, () -> ops.convert("  ", "json", "yaml", null));
+    }
+
+    @Test
+    void convert_shouldRejectOversizedContent() {
+        String huge = "a".repeat(512 * 1024 + 1);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.convert(huge, "json", "yaml", null));
+        assertTrue(ex.getMessage().contains("上限"));
+    }
+
+    /** YAML 输出不带文档起始符，与主流在线工具观感一致。 */
+    private void assertFalseStartsWithDocMarker(String yaml) {
+        assertTrue(!yaml.startsWith("---"), "YAML 输出不应带文档起始符，实际：" + yaml);
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxToolsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DevToolboxToolsTest.java
@@ -76,14 +76,26 @@ class DevToolboxToolsTest {
     @Test
     void aes_shouldRoundTripThroughShell() throws Exception {
         String key = "1234567890123456";
-        JsonNode enc = call(tools.aesEncrypt("hi-明文", key, "CBC", null));
-        JsonNode dec = call(tools.aesDecrypt(enc.get("ciphertext").asText(), key, "CBC", enc.get("iv").asText()));
+        JsonNode enc = call(tools.aesEncrypt("hi-明文", key, null, "CBC", null, null, null, null));
+        JsonNode dec = call(tools.aesDecrypt(enc.get("ciphertext").asText(), key, null, "CBC",
+            null, enc.get("iv").asText(), null, null));
         assertEquals("hi-明文", dec.get("result").asText());
+    }
+
+    /** 页面版常用的 hex 组合也要能透过工具壳走通（参数多，壳层漏传某项会直接暴露）。 */
+    @Test
+    void aes_shouldRoundTripThroughShell_withHexEncodings() throws Exception {
+        String key = "000102030405060708090a0b0c0d0e0f";
+        String iv = "0f0e0d0c0b0a09080706050403020100";
+        JsonNode enc = call(tools.aesEncrypt("ctr-明文", key, "hex", "CTR", null, iv, "hex", "hex"));
+        assertEquals("hex", enc.get("outputFormat").asText());
+        JsonNode dec = call(tools.aesDecrypt(enc.get("ciphertext").asText(), key, "hex", "CTR", null, iv, "hex", "hex"));
+        assertEquals("ctr-明文", dec.get("result").asText());
     }
 
     @Test
     void aes_shouldConvergeError_onBadKey() throws Exception {
-        JsonNode node = call(tools.aesEncrypt("x", "short", "CBC", null));
+        JsonNode node = call(tools.aesEncrypt("x", "short", null, "CBC", null, null, null, null));
         assertTrue(node.has("error"));
         assertFalse(node.has("ciphertext"));
     }
@@ -137,5 +149,84 @@ class DevToolboxToolsTest {
     void certMatch_shouldConvergeError_onBadPrivateKey() throws Exception {
         JsonNode node = call(tools.certMatch(SELF_SIGNED_CERT_PEM, "garbage"));
         assertTrue(node.has("error"));
+    }
+
+    // ---------- hex / JSON 转义 ----------
+
+    @Test
+    void hex_shouldRoundTripThroughShell() throws Exception {
+        JsonNode enc = call(tools.hexEncode("你好"));
+        assertEquals("e4bda0e5a5bd", enc.get("result").asText());
+        assertEquals("你好", call(tools.hexDecode("e4bda0e5a5bd")).get("result").asText());
+    }
+
+    @Test
+    void hexDecode_shouldConvergeError_onOddLength() throws Exception {
+        assertTrue(call(tools.hexDecode("abc")).has("error"));
+    }
+
+    @Test
+    void jsonEscapeUnescape_shouldRoundTripThroughShell() throws Exception {
+        String escaped = call(tools.jsonEscape("{\"a\":1}")).get("result").asText();
+        assertEquals("{\"a\":1}", call(tools.jsonUnescape(escaped)).get("result").asText());
+    }
+
+    @Test
+    void jsonUnicodeDecode_shouldRestoreChinese() throws Exception {
+        assertEquals("中文", call(tools.jsonUnicodeDecode("\\u4e2d\\u6587")).get("result").asText());
+    }
+
+    // ---------- cron / JWT / diff / 格式互转 ----------
+
+    @Test
+    void cronExplain_shouldReturnFieldsAndNextTimes() throws Exception {
+        JsonNode node = call(tools.cronExplain("0 0 2 * * ?", 2, null));
+        assertEquals(6, node.get("fields").size());
+        assertEquals(2, node.get("nextTimes").size());
+        assertEquals("Asia/Shanghai", node.get("timezone").asText());
+    }
+
+    @Test
+    void cronExplain_shouldConvergeError_onFiveFieldExpression() throws Exception {
+        JsonNode node = call(tools.cronExplain("0 2 * * *", null, null));
+        assertTrue(node.has("error"));
+        assertTrue(node.get("error").asText().contains("5 段"), "error 应指出段数问题便于自我纠正");
+    }
+
+    @Test
+    void jwtDecode_shouldExposeClaimsAndVerifyStatus() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+            + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        JsonNode node = call(tools.jwtDecode(token, "your-256-bit-secret", null));
+        assertEquals("HS256", node.get("algorithm").asText());
+        assertEquals("1234567890", node.get("subject").asText());
+        assertEquals("VALID", node.get("signatureStatus").asText());
+        assertFalse(node.get("expired").asBoolean());
+    }
+
+    @Test
+    void jwtDecode_shouldConvergeError_onMalformedToken() throws Exception {
+        assertTrue(call(tools.jwtDecode("not-a-jwt", null, null)).has("error"));
+    }
+
+    @Test
+    void textDiff_shouldReportAddedAndDeleted() throws Exception {
+        JsonNode node = call(tools.textDiff("a\nb", "a\nc", null, null));
+        assertFalse(node.get("identical").asBoolean());
+        assertEquals(1, node.get("addedLines").asInt());
+        assertEquals(1, node.get("deletedLines").asInt());
+    }
+
+    @Test
+    void dataConvert_shouldConvertJsonToYaml() throws Exception {
+        JsonNode node = call(tools.dataConvert("{\"a\":1}", "json", "yaml", null));
+        assertEquals("yaml", node.get("targetFormat").asText());
+        assertTrue(node.get("result").asText().contains("a: 1"));
+    }
+
+    @Test
+    void dataConvert_shouldConvergeError_onUnsupportedFormat() throws Exception {
+        assertTrue(call(tools.dataConvert("{\"a\":1}", "json", "toml", null)).has("error"));
     }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DiffDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/DiffDevToolOpsTest.java
@@ -1,0 +1,111 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link DiffDevToolOps} 单测：一致判定、增删识别、行号映射、忽略选项与行数上限。
+ * @author owlzhangfq@gmail.com
+ */
+class DiffDevToolOpsTest {
+
+    private final DiffDevToolOps ops = new DiffDevToolOps();
+
+    @Test
+    void diff_shouldReportIdentical() {
+        DiffDevToolOps.DiffResult result = ops.diff("a\nb\nc", "a\nb\nc", null, null);
+        assertTrue(result.isIdentical());
+        assertEquals(0, result.getAddedLines());
+        assertEquals(0, result.getDeletedLines());
+        assertEquals(3, result.getLines().size());
+        assertTrue(result.getLines().stream().allMatch(line -> "EQUAL".equals(line.getType())));
+    }
+
+    @Test
+    void diff_shouldDetectInsertedLine() {
+        DiffDevToolOps.DiffResult result = ops.diff("a\nc", "a\nb\nc", null, null);
+        assertFalse(result.isIdentical());
+        assertEquals(1, result.getAddedLines());
+        assertEquals(0, result.getDeletedLines());
+        DiffDevToolOps.DiffLine inserted = result.getLines().stream()
+            .filter(line -> "INSERT".equals(line.getType())).findFirst().orElseThrow();
+        assertEquals("b", inserted.getContent());
+        assertEquals(-1, inserted.getOldLineNo(), "新增行在原文本中不存在，行号应为 -1");
+        assertEquals(2, inserted.getNewLineNo());
+    }
+
+    @Test
+    void diff_shouldDetectDeletedLine() {
+        DiffDevToolOps.DiffResult result = ops.diff("a\nb\nc", "a\nc", null, null);
+        assertEquals(0, result.getAddedLines());
+        assertEquals(1, result.getDeletedLines());
+        DiffDevToolOps.DiffLine deleted = result.getLines().stream()
+            .filter(line -> "DELETE".equals(line.getType())).findFirst().orElseThrow();
+        assertEquals("b", deleted.getContent());
+        assertEquals(2, deleted.getOldLineNo());
+        assertEquals(-1, deleted.getNewLineNo());
+    }
+
+    /** 同一位置的修改应呈现为"先删后增"，读起来即旧行改成了新行。 */
+    @Test
+    void diff_shouldOrderDeleteBeforeInsert_onModifiedLine() {
+        DiffDevToolOps.DiffResult result = ops.diff("a\nold\nc", "a\nnew\nc", null, null);
+        assertEquals(1, result.getAddedLines());
+        assertEquals(1, result.getDeletedLines());
+        List<String> types = result.getLines().stream()
+            .map(DiffDevToolOps.DiffLine::getType).collect(Collectors.toList());
+        assertEquals(List.of("EQUAL", "DELETE", "INSERT", "EQUAL"), types);
+    }
+
+    @Test
+    void diff_shouldIgnoreWhitespace_whenRequested() {
+        assertFalse(ops.diff("a\n  b  ", "a\nb", null, null).isIdentical());
+        assertTrue(ops.diff("a\n  b  ", "a\nb", true, null).isIdentical());
+    }
+
+    @Test
+    void diff_shouldIgnoreCase_whenRequested() {
+        assertFalse(ops.diff("Hello", "hello", null, null).isIdentical());
+        assertTrue(ops.diff("Hello", "hello", null, true).isIdentical());
+    }
+
+    /** 忽略选项只影响比较，展示内容必须保留原文。 */
+    @Test
+    void diff_shouldKeepOriginalContent_whenIgnoringWhitespace() {
+        DiffDevToolOps.DiffResult result = ops.diff("  a  ", "a", true, null);
+        assertEquals("  a  ", result.getLines().get(0).getContent());
+    }
+
+    @Test
+    void diff_shouldHandleEmptyInputs() {
+        DiffDevToolOps.DiffResult result = ops.diff("", "a\nb", null, null);
+        assertEquals(2, result.getAddedLines());
+        assertEquals(0, result.getDeletedLines());
+        assertTrue(ops.diff("", "", null, null).isIdentical());
+    }
+
+    @Test
+    void diff_shouldTreatCrlfAsLineBreak() {
+        assertTrue(ops.diff("a\r\nb", "a\nb", null, null).isIdentical());
+    }
+
+    @Test
+    void diff_shouldRejectTooManyLines() {
+        String huge = "x\n".repeat(1501);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.diff(huge, "y", null, null));
+        assertTrue(ex.getMessage().contains("1500"));
+    }
+
+    @Test
+    void diff_shouldRejectNullInput() {
+        assertThrows(IllegalArgumentException.class, () -> ops.diff(null, "a", null, null));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/JsonDevToolOpsTest.java
@@ -77,4 +77,58 @@ class JsonDevToolOpsTest {
         assertThrows(IllegalArgumentException.class, () -> ops.minify(null));
         assertThrows(IllegalArgumentException.class, () -> ops.validate(""));
     }
+
+    // -------- 转义 / 去转义 / Unicode 解码（与页面版同语义） --------
+
+    @Test
+    void escape_shouldWrapWithQuotesAndEscapeSpecialChars() {
+        assertEquals("\"{\\\"a\\\":1}\"", ops.escape("{\"a\":1}"));
+        assertEquals("\"line1\\nline2\"", ops.escape("line1\nline2"));
+    }
+
+    /** 与页面版 JSON.stringify 一致：中文保持原样，不转成 Unicode 转义序列。 */
+    @Test
+    void escape_shouldKeepNonAsciiAsIs() {
+        assertEquals("\"中文\"", ops.escape("中文"));
+    }
+
+    @Test
+    void unescape_shouldAcceptWithOrWithoutOuterQuotes() {
+        assertEquals("{\"a\":1}", ops.unescape("\"{\\\"a\\\":1}\""));
+        assertEquals("{\"a\":1}", ops.unescape("{\\\"a\\\":1}"));
+    }
+
+    @Test
+    void escapeUnescape_shouldRoundTrip() {
+        String origin = "含\"引号\"、反斜杠\\ 与换行\n的原文";
+        assertEquals(origin, ops.unescape(ops.escape(origin)));
+    }
+
+    /** 传入的是对象而非字符串字面量时应报错，而不是悄悄返回对象的文本形式。 */
+    @Test
+    void unescape_shouldRejectNonStringJson() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> ops.unescape("{\"a\":1}"));
+        assertTrue(ex.getMessage().contains("不是"));
+    }
+
+    @Test
+    void unescape_shouldRejectBrokenEscape() {
+        assertThrows(IllegalArgumentException.class, () -> ops.unescape("\"unclosed\\\""));
+    }
+
+    @Test
+    void decodeUnicode_shouldRestoreChineseAndKeepOtherText() {
+        assertEquals("中文 abc", ops.decodeUnicode("\\u4e2d\\u6587 abc"));
+    }
+
+    @Test
+    void decodeUnicode_shouldRestoreSurrogatePair() {
+        assertEquals("😀", ops.decodeUnicode("\\ud83d\\ude00"));
+    }
+
+    @Test
+    void decodeUnicode_shouldLeaveTextWithoutEscapesUntouched() {
+        assertEquals("plain text 中文", ops.decodeUnicode("plain text 中文"));
+        assertEquals("", ops.decodeUnicode(""));
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/JwtDevToolOpsTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/devtool/JwtDevToolOpsTest.java
@@ -1,0 +1,143 @@
+package com.richard.fyoung.customerwork.tool.devtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link JwtDevToolOps} 单测：解码、标准声明解读、有效期判定与 HS* 签名校验。
+ *
+ * <p>用的是 jwt.io 首页那条公开示例令牌（HS256，密钥 your-256-bit-secret），不涉及任何真实凭据。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class JwtDevToolOpsTest {
+
+    /** jwt.io 公开示例：{"sub":"1234567890","name":"John Doe","iat":1516239022}。 */
+    private static final String SAMPLE_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+        + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    private static final String SAMPLE_SECRET = "your-256-bit-secret";
+
+    private final JwtDevToolOps ops = new JwtDevToolOps();
+
+    @Test
+    void decode_shouldExposeHeaderAndClaims() {
+        JwtDevToolOps.JwtDecodeResult result = ops.decode(SAMPLE_TOKEN, null, null);
+        assertEquals("HS256", result.getAlgorithm());
+        assertEquals("JWT", result.getType());
+        assertEquals("1234567890", result.getSubject());
+        assertTrue(result.getPayload().contains("John Doe"));
+        assertEquals("2018-01-18 09:30:22", result.getIssuedAt(), "iat 应按北京时间格式化");
+        assertFalse(result.isUnsigned());
+    }
+
+    /** 没有 exp 声明时不应武断判成已过期。 */
+    @Test
+    void decode_shouldNotMarkExpired_whenNoExpClaim() {
+        JwtDevToolOps.JwtDecodeResult result = ops.decode(SAMPLE_TOKEN, null, null);
+        assertFalse(result.isExpired());
+        assertNull(result.getExpiresAt());
+        assertNull(result.getSecondsRemaining());
+    }
+
+    @Test
+    void decode_shouldNotCheckSignature_whenSecretMissing() {
+        assertEquals("NOT_CHECKED", ops.decode(SAMPLE_TOKEN, null, null).getSignatureStatus());
+    }
+
+    @Test
+    void decode_shouldVerifyHmacSignature() {
+        assertEquals("VALID", ops.decode(SAMPLE_TOKEN, SAMPLE_SECRET, null).getSignatureStatus());
+        assertEquals("INVALID", ops.decode(SAMPLE_TOKEN, "wrong-secret", null).getSignatureStatus());
+    }
+
+    @Test
+    void decode_shouldSupportSecretEncodings() {
+        String hexSecret = toHex(SAMPLE_SECRET.getBytes(StandardCharsets.UTF_8));
+        String base64Secret = Base64.getEncoder().encodeToString(SAMPLE_SECRET.getBytes(StandardCharsets.UTF_8));
+        assertEquals("VALID", ops.decode(SAMPLE_TOKEN, hexSecret, "hex").getSignatureStatus());
+        assertEquals("VALID", ops.decode(SAMPLE_TOKEN, base64Secret, "base64").getSignatureStatus());
+    }
+
+    /** 非 HS* 算法只能解码，绝不能因为"给了密钥"就报成校验通过。 */
+    @Test
+    void decode_shouldReportUnsupportedAlg_forAsymmetric() {
+        String token = buildToken("{\"alg\":\"RS256\",\"typ\":\"JWT\"}", "{\"sub\":\"x\"}", "fake-signature");
+        assertEquals("UNSUPPORTED_ALG", ops.decode(token, "any-secret", null).getSignatureStatus());
+    }
+
+    @Test
+    void decode_shouldFlagExpiredToken() {
+        long past = Instant.now().getEpochSecond() - 3600;
+        String token = buildToken("{\"alg\":\"HS256\"}", "{\"exp\":" + past + "}", "sig");
+        JwtDevToolOps.JwtDecodeResult result = ops.decode(token, null, null);
+        assertTrue(result.isExpired());
+        assertNotNull(result.getExpiresAt());
+        assertTrue(result.getSecondsRemaining() < 0, "已过期时剩余秒数应为负");
+    }
+
+    @Test
+    void decode_shouldFlagNotYetValidToken() {
+        long future = Instant.now().getEpochSecond() + 3600;
+        String token = buildToken("{\"alg\":\"HS256\"}", "{\"nbf\":" + future + "}", "sig");
+        JwtDevToolOps.JwtDecodeResult result = ops.decode(token, null, null);
+        assertTrue(result.isNotYetValid());
+        assertFalse(result.isExpired());
+    }
+
+    /** alg=none 的令牌签名可被任意伪造，必须显式标出来。 */
+    @Test
+    void decode_shouldFlagUnsignedToken() {
+        String token = buildToken("{\"alg\":\"none\"}", "{\"sub\":\"x\"}", "");
+        assertTrue(ops.decode(token, null, null).isUnsigned());
+    }
+
+    @Test
+    void decode_shouldRejectMalformedToken() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ops.decode("only.two", null, null));
+        assertTrue(ex.getMessage().contains("三段"));
+    }
+
+    @Test
+    void decode_shouldRejectNonJsonSegment() {
+        String token = buildToken("not-json-at-all", "{\"sub\":\"x\"}", "sig");
+        assertThrows(IllegalArgumentException.class, () -> ops.decode(token, null, null));
+    }
+
+    @Test
+    void decode_shouldRejectBlankToken() {
+        assertThrows(IllegalArgumentException.class, () -> ops.decode("  ", null, null));
+    }
+
+    @Test
+    void decode_shouldRejectIllegalSecretEncoding() {
+        assertThrows(IllegalArgumentException.class, () -> ops.decode(SAMPLE_TOKEN, "k", "rot13"));
+    }
+
+    /** 按 JWT 规范拼一个 base64url（无 padding）令牌。 */
+    private String buildToken(String headerJson, String payloadJson, String signature) {
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        return encoder.encodeToString(headerJson.getBytes(StandardCharsets.UTF_8)) + "."
+            + encoder.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8)) + "."
+            + signature;
+    }
+
+    private String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -724,7 +724,8 @@ curl -X POST localhost:8080/api/customer/chat -H 'Content-Type: application/json
 
 - **`spotlighted`（隔离标记，恒开、零误杀）**：每个工具结果被随机 nonce 隔离块包裹一次 +1，让智能体调一次工具即可。
   8080 侧问一句会触发七域工具的业务问题（如"我的订单 CW20240001 到哪了"）；admin 侧给测试智能体绑 `httpclient`
-  系统工具组（`http_get` 等——admin 内置的唯一一组 `@Tool`）后让它发一次请求。对话表现完全正常：隔离标记是
+  系统工具组（`http_get` 等；admin 另一组 `devtoolbox` 是纯本地计算、发不出请求，此处要用 `httpclient`）后
+  让它发一次请求。对话表现完全正常：隔离标记是
   **瞬态改写**，不进会话历史、不被持久化，用户端也看不到任何标签。
 
 - **`detected`（检测命中，只告警不拦截）**：要让**工具返回体的文本**命中词表。8080 侧最省事且全本地——往知识库
@@ -908,6 +909,7 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/contentguard/hit-log/{page,stats}` | 敏感词命中看板（明细分页 + 动作/方向分布 + Top 命中词 + 时间趋势，只读，权限点 `sensitive-hit-log:view`） |
 | `POST /api/devtools/http/send` | 开发者工具箱 · HTTP 请求后端代理（免 CORS，权限点复用 `devtools:view`） |
 | `/api/devtools/cert/{parse,match,keystore,keystore/private-key}` | 开发者工具箱 · 证书解析（X.509 证书链 / CSR / 私钥匹配校验 / PFX·JKS 密钥库 / 密钥库私钥导出，权限点复用 `devtools:view`） |
+| `/api/devtools/{cron/explain,jwt/decode,diff/text,format/convert}` | 开发者工具箱 · 纯计算工具（cron 解析与执行时间推算 / JWT 解码与 HS* 验签 / 行级文本比对 / JSON·YAML·XML 互转，权限点复用 `devtools:view`） |
 | `/api/dict/{types,items}` | 字典管理（类型 + 字典项两级 CRUD，权限点 `dict:*`），见「数据字典」小节 |
 | `GET /api/dict/options/{dictType}` | 字典下拉选项（仅启用项，只要求登录不校验权限点，前端 `useDict` 消费） |
 | `/swagger-ui/index.html` | 接口文档 |
@@ -1001,6 +1003,42 @@ VO 转换与异常转换。这么分是因为同一份能力还要暴露给智�
 
 > **证书 PEM 对 LLM 默认不回显**（`parse` 的单参重载 includePem=false）：`cert_parse` 的输入本来
 > 就是 PEM，原样回显纯属浪费上下文。页面侧才传 true。
+
+**开发者工具箱 · cron / JWT / 文本比对 / 格式互转（V48 起）**：系统管理 → 开发者工具箱，四项均走后端
+（`/api/devtools/{cron/explain,jwt/decode,diff/text,format/convert}`），实现在 starter 的
+`CronDevToolOps` / `JwtDevToolOps` / `DiffDevToolOps` / `DataFormatDevToolOps`，页面与 `devtoolbox`
+系统工具（`cron_explain` / `jwt_decode` / `text_diff` / `data_convert`）共用同一份逻辑。
+
+- **cron**：6 段 Quartz 语义（与 XXL-JOB 一致），逐字段释义 + 推算后续执行时间（最多 20 次，可选时区）。
+  用 Spring 的 `CronExpression`，零新依赖。5 段的 Unix cron 与 7 段带年份的写法都会被拦下并给出改法。
+  > **不做成前端计算是刻意的**：表达式最终由 XXL-JOB 触发，浏览器端 cron 库多按 Unix 5 段解析，
+  > 同一串表达式两边算出的"下次执行时间"可能不同——这种工具比没有更糟。
+- **JWT**：解码 header/payload、解读标准声明、直出 `expired` / `notYetValid` / `secondsRemaining`
+  （不让模型自己比时间戳）。签名校验**只做 HS256/HS384/HS512**；RS/ES/PS 系列返回 `UNSUPPORTED_ALG`，
+  绝不因为"给了密钥"就报成通过。`alg=none` 单独标红。令牌与密钥不落库、不写日志，页面也不入 localStorage。
+- **文本比对**：LCS 行级 diff，可忽略行首尾空白与大小写（忽略选项只影响比较，展示仍是原文）。
+  单侧上限 1500 行、结果上限 3000 行，超出显式报错或标 `truncated`，不静默截断。
+- **格式互转**：JSON ⇄ YAML ⇄ XML（新增 `jackson-dataformat-xml` 依赖，版本随 Spring Boot BOM）。
+  XML 解析已禁用 DTD 与外部实体（**防 XXE**，输入完全来自用户与模型）。已知语义损耗写在页面提示与
+  工具描述里：XML 无类型系统故转出的 JSON 里数字与布尔均为字符串、同名重复子元素只保留最后一个、
+  YAML 多文档只处理第一个、数组不能直接作 XML 根。
+
+**同批补齐的两端对齐（V48）**：`devtoolbox` 早期只在页面实现的能力已补到智能体侧——`hex_encode`/`hex_decode`、
+`json_escape`/`json_unescape`/`json_unicode_decode`。
+
+> **AES 是全工具箱唯一保留两套实现的能力**：页面版用 crypto-js 在浏览器本地算，为的是密钥不出浏览器。
+> 代价是两侧曾悄悄分叉——页面支持 CBC/ECB/**CTR**、智能体支持 CBC/ECB/**GCM**，且密钥只认 UTF-8、
+> IV 与密文只认 Base64，而页面三种编码可选、默认还是 hex 输出。结果是**默认配置下同一份密文换一侧就解不开**。
+> V48 把后端做成页面版的**严格超集**：补 CTR、padding（PKCS7/NONE）、密钥与 IV 编码（utf8/hex/base64）、
+> 密文格式（hex/base64）全部可选，默认值保持历史行为不变。`CodecDevToolOpsTest` 里 6 组测试向量由页面
+> 实际使用的 crypto-js 生成，断言后端加密结果与浏览器**逐字节一致**且能解开浏览器密文——任一侧参数语义
+> 再漂移，这些用例先挂。唯一仍不对等的是 GCM（crypto-js 不提供），页面解不了智能体产的 GCM 密文。
+
+**SQL 客户端的 SQL 格式化**：我的工作台 → SQL 客户端，工具栏「格式化 SQL」。这一项**纯前端**做
+（`sql-formatter`）：只此一处、没有智能体版本，不存在两端漂移；方言从数据源 `jdbcUrl` 的驱动名推断
+（mysql/mariadb/postgresql/sqlite/sqlserver/oracle），取不到时回退 MySQL。SQL 写了一半解析不了时保持
+原文不动只给提示，不会把内容弄乱。
+
 **数据字典（V46 起）**：系统管理 → 字典管理，解决"就几条枚举数据、不值当单独建表"的场景。
 两级结构：字典类型（`cw_dict_type`，如 `order_status`）+ 字典项（`cw_dict_item`，键 + 展示标签 + 排序 + 启停）。
 

--- a/mysql/02-customer-admin/48-V48__devtoolbox_more_tools.sql
+++ b/mysql/02-customer-admin/48-V48__devtoolbox_more_tools.sql
@@ -1,0 +1,27 @@
+-- 开发者工具箱系统工具补充一批能力（Flyway V48）。
+--
+-- devtoolbox 这个 @Tool Bean 新增 9 个工具方法，实现全部在 starter 的 Ops 里，与管理台
+-- "开发者工具箱"页面共用同一套逻辑：
+--   hex_encode / hex_decode                                   十六进制编解码（页面早有、智能体侧此前缺）
+--   json_escape / json_unescape / json_unicode_decode         JSON 转义、去转义、Unicode 解码（同上）
+--   cron_explain                                              cron 逐字段释义 + 推算后续执行时间
+--   jwt_decode                                                JWT 解码、有效期判定、HS* 签名校验
+--   text_diff                                                 行级文本比对
+--   data_convert                                              JSON / YAML / XML 互转
+--
+-- 同时 aes_encrypt / aes_decrypt 补齐了 CTR 模式与 padding、密钥/IV 编码、密文输出格式等参数，
+-- 使智能体侧成为页面版能力的严格超集——此前两边模式集合互不包含（页面 CBC/ECB/CTR、智能体
+-- CBC/ECB/GCM），且 IV 与密文编码默认值也不同，同一份密文换一侧就解不开。
+--
+-- 工具目录是代码定义的，本迁移只更新描述文案，让智能体配置页勾选时能看到新能力
+-- （沿用 V15/V27/V47 定的"系统工具目录"范式：无新增/删除，只改描述）。
+--
+-- jwt_decode 的令牌与密钥会进入模型上下文并落进对话历史，约束已写进工具描述（仅在用户明确要求时
+-- 调用、不主动索取密钥），remark 同步标注，供配置智能体的人决策是否勾选。
+
+SET NAMES utf8mb4;
+
+UPDATE `ai_system_tool`
+SET `description` = '开发者常用本地工具集：JSON格式化/压缩/校验/转义/去转义/Unicode解码、时间戳转换、Base64/URL/Hex编解码、哈希(HMAC)、UUID生成、AES加解密(CBC/ECB/CTR/GCM)、正则测试、X.509证书/CSR解析、私钥与证书配对校验、cron表达式解析、JWT解析、文本比对、JSON/YAML/XML互转',
+    `remark`      = '纯本地计算，无外部依赖；注意 cert_match 需传入私钥明文、jwt_decode 可能传入令牌与签名密钥，均会进入模型上下文与对话历史'
+WHERE `tool_code` = 'devtoolbox';


### PR DESCRIPTION
## 背景

盘点「系统工具」时发现的真问题不是缺工具，而是**页面版与智能体版已经悄悄分叉**：工具箱早期把 JSON、编解码等能力在前端各实现了一遍，两侧能力集不再一致。最严重的是 AES——

| 维度 | 页面版(crypto-js) | 智能体版(JCE) |
|---|---|---|
| 模式 | CBC/ECB/**CTR** | CBC/ECB/**GCM** |
| 密钥编码 | utf8/hex/base64 | 仅 utf8 |
| IV 编码 | utf8/hex/base64 | 仅 base64 |
| 密文格式 | hex/base64（默认 **hex**） | 仅 base64 |

**默认配置下，人在页面加密的密文，智能体解不开。**

## 改动

### 一、两端对齐（治已有的病）

- **AES 后端做成页面版的严格超集**：补 CTR 模式、padding(PKCS7/NONE)、密钥与 IV 编码(utf8/hex/base64)、密文格式(hex/base64)。默认值保持历史行为不变，既有调用方不受影响。
- 补 `hex_encode`/`hex_decode`、`json_escape`/`json_unescape`/`json_unicode_decode`（页面早有、智能体侧此前缺）。
- 顺带修掉一处真实语义差异：`unescape` 原用 `ObjectMapper.readTree`，Jackson 默认不检查尾部多余 token，补引号后的 `"{"a":1}"` 会被静默解析成 `"{"` 而不报错，与页面版 `JSON.parse` 抛错的行为不一致；改用开启 `FAIL_ON_TRAILING_TOKENS` 的严格 Mapper。

**互通性有回归防线**：`CodecDevToolOpsTest` 里 6 组 AES 向量由页面实际使用的 crypto-js 生成（脚本逻辑逐行对应 `aesCrypto.ts`），双向断言"后端加密结果与浏览器逐字节一致"且"后端能解开浏览器密文"。任一侧参数语义再漂移，这些用例先挂。

> 唯一仍不对等的是 GCM——crypto-js 不提供，页面解不了智能体产的 GCM 密文。已在工具描述与文档中写明。

### 二、四项新工具（页面版 + 智能体版同时上，共用一套实现）

| 工具 | 说明 |
|---|---|
| **cron 解析** | 6 段 Quartz 语义（与 XXL-JOB 一致），逐字段释义 + 推算后续执行时间。用 Spring 的 `CronExpression`，零新依赖 |
| **JWT 解析** | 解码 header/payload、直出过期判定；签名校验只做 HS\*，非对称算法明确返回 `UNSUPPORTED_ALG` 不假装通过，`alg=none` 单独标红 |
| **文本比对** | LCS 行级 diff，可忽略空白与大小写（只影响比较，展示仍是原文） |
| **格式互转** | JSON ⇄ YAML ⇄ XML；XML 解析**禁用 DTD 与外部实体防 XXE**（输入完全来自用户与模型） |

四项一律走后端接口而非前端本地算，是刻意的——前端各写一套正是这次要治的病根。cron 尤其不能放前端：表达式最终由 XXL-JOB 按 6 段触发，浏览器端 cron 库多按 Unix 5 段解析，算出的"下次执行时间"可能与实际调度不符，那样的工具比没有更糟。

### 三、SQL 客户端「格式化 SQL」

这一项**纯前端**做（`sql-formatter`）：只此一处、没有智能体版本，不存在两端漂移；Java 侧也没有质量相当的格式化库。方言从数据源 `jdbcUrl` 的驱动名推断，取不到回退 MySQL；SQL 写了一半解析不了时保持原文不动只给提示。

## 新增依赖

- 后端：`jackson-dataformat-xml`（版本交由 spring-boot-dependencies 管理，避免与 jackson-core 错版）。cron 用 spring-context 已有的 `CronExpression`，YAML 用已传递进来的 `jackson-dataformat-yaml`，均无新依赖。
- 前端：`sql-formatter`。

## 数据库

Flyway **V48** 只更新 `ai_system_tool` 中 `devtoolbox` 的描述与 remark（工具目录是代码定义的，沿用 V15/V27/V47 的范式），已同步一份到 `mysql/02-customer-admin/` 供 CI 建库。

## 验证

- 全量测试 `BUILD SUCCESS`：starter **1136**（+82）、admin-server **722**（+11）、app 78、customer-channel 65、gateway 1，0 失败。
- 前端 `npm run build`（vue-tsc + vite build）通过。
- **未做端到端页面验证**：新工具都依赖后端接口，验证需要用本分支的代码启动 8082，而该端口上跑着开发者自己的进程，未擅自动。自测步骤见下。

## 自测步骤

1. 起本分支的 admin-server（8082）与 admin-web（5174），登录后进「系统管理 → 开发者工具箱」，左侧应多出 cron 解析 / JWT 解析 / 文本比对 / 格式互转四项。
2. cron 填 `0 0 2 * * ?` → 应给出 6 段释义与最近 5 次执行时间；填 5 段的 `0 2 * * *` → 应提示补秒并给出 `"0 0 2 * * *"`。
3. JWT 用 jwt.io 示例令牌 + 密钥 `your-256-bit-secret` → 签名应显示校验通过；换个密钥 → 应显示不通过。
4. **两端互通实测**：在 AES 页面用默认 CBC + PKCS7 + 密钥 UTF-8 + IV UTF-8 + 输出 hex 加密一段文本，再让挂了 `devtoolbox` 的智能体用 `aes_decrypt` 并把 `mode/padding/keyEncoding/ivEncoding/outputFormat` 填成页面上一致的值 → 应能解出原文。
5. 「我的工作台 → SQL 客户端」写一段乱格式 SQL，点「格式化 SQL」。
