### PR TITLE
fix: 启动日志不再重复打印 mybatis-plus 横幅（3 个 → 1 个）

### DIFF
--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkPersistenceConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkPersistenceConfig.java
@@ -2,6 +2,8 @@ package com.richard.fyoung.customerwork.config;
 
 import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.config.GlobalConfig;
+import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
 import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
@@ -85,6 +87,12 @@ public class CustomerWorkPersistenceConfig {
         MybatisConfiguration configuration = new MybatisConfiguration();
         configuration.setMapUnderscoreToCamelCase(true);
         factoryBean.setConfiguration(configuration);
+
+        // 不打 mybatis-plus 启动横幅：宿主若自带 MyBatis-Plus 环境已打过，本环境再打就是重复噪音
+        //（与 CrossDbGateways 的处理一致）。defaults() 与不设置时框架内部的兜底同源，仅关 banner。
+        GlobalConfig globalConfig = GlobalConfigUtils.defaults();
+        globalConfig.setBanner(false);
+        factoryBean.setGlobalConfig(globalConfig);
 
         factoryBean.setPlugins(paginationInterceptor());
         return factoryBean.getObject();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/gateway/CrossDbGateways.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/gateway/CrossDbGateways.java
@@ -1,6 +1,8 @@
 package com.richard.fyoung.customerwork.gateway;
 
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.config.GlobalConfig;
+import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -168,6 +170,12 @@ public final class CrossDbGateways {
         MybatisSqlSessionFactoryBean factoryBean = new MybatisSqlSessionFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setConfiguration(configuration);
+        // 基建工厂不打 mybatis-plus 启动横幅：宿主的主 SqlSessionFactory 已打过一次，这里每建一个
+        // 跨库网关就再打一个（admin 启动曾连打三个）。defaults() 与不设置时框架内部的兜底同源，
+        // 除 banner 开关外行为零变化。
+        GlobalConfig globalConfig = GlobalConfigUtils.defaults();
+        globalConfig.setBanner(false);
+        factoryBean.setGlobalConfig(globalConfig);
         if (mapperXmlLocations != null && !mapperXmlLocations.isEmpty()) {
             factoryBean.setMapperLocations(resolveMapperXml(mapperXmlLocations));
         }


### PR DESCRIPTION
## 现象

admin-server 启动连打三个 mybatis-plus ASCII 横幅：

1. 主数据源（mybatis-plus-spring-boot-starter 自动装配）
2. `CrossDbGateways` 建 `agent-call-stats-admin` 网关工厂时
3. `CrossDbGateways` 建 `content-guard-pool` 网关工厂时

## 原因

横幅由 `MybatisSqlSessionFactoryBean#buildSqlSessionFactory` 在 `GlobalConfig.banner=true` 时用 `System.out` 输出。手工建厂没设 `GlobalConfig` 时，框架内部兜底 `GlobalConfigUtils.defaults()`，其 banner 默认开——所以**每手工 build 一个工厂就多打一个**。

## 修复

两处手工工厂显式设 `banner=false` 的 GlobalConfig（`GlobalConfigUtils.defaults()` 与框架兜底同源，除横幅外行为零变化）：

- `CrossDbGateways#buildSqlSessionFactory`（admin 的两个重复横幅来源）
- `CustomerWorkPersistenceConfig#customerWorkSqlSessionFactory`（同类噪音：8080 app-server 用它，宿主若自带 MP 环境同样会重复）

宿主自动装配的主环境不动 → **admin 启动保留恰好一个横幅**；8080 侧因唯一 MP 环境就是 starter 自建的这套，启动将不再打横幅（纯装饰性输出，无功能影响）。

## 验证

- `CrossDbGatewaysTest` + `CustomerWorkPersistenceConfigTest` 共 16 例全过：真实建厂走本机 MySQL，**测试输出中横幅出现 0 次**，BaseMapper CRUD 正常（证明显式 GlobalConfig 未破坏 sqlInjector 等默认件）。
- starter 全量 1054 全绿（本分支基于 main，不含 PR #82 的 +82）。
- 重启 admin-server 后肉眼确认只剩一个横幅即可。

> 如果连最后一个也不想要，在 admin 的 application.yml 加 `mybatis-plus.global-config.banner: false` 即可，本 PR 未替你做这个决定。
