### PR TITLE
feat(tenant): B1 租户地基——tenant_id 行级隔离与双视角后台

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,10 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1136** + admin-server **722** + app 78 + customer-channel 65 + gateway 1
-  （2026-08-06 feature/devtoolbox-expansion 实测，该分支给开发者工具箱补了 cron/JWT/diff/格式互转四项
-  与 AES 两端对齐，starter +82 / admin +11。上一版基线是 2026-08-05 的 starter 1054 + admin 711；
+- 测试基线：starter **1150** + admin-server **732** + app 78 + customer-channel 65 + gateway 1
+  （2026-08-10 feature/tenant-foundation 实测，B1 租户地基：starter +14（租户上下文/过滤策略）、
+  admin +11（租户生命周期）。MySQL 不可达时 admin 会少跑 1 个门控用例，显示 721 属正常。
+  上一版基线是 2026-08-06 的 starter 1136 + admin 722；更早是 2026-08-05 的 starter 1054 + admin 711；
   admin-server 更早的实际基线已是 707，CLAUDE.md 曾记的
   701 系陈旧数字。starter 已按下方规则排除 2 个环境门控测试。此前 feature/sink-common-to-starter 把 admin
   十项通用能力下沉 starter：核心逻辑测试随迁，故 starter +226 / admin −106，admin 侧只保留薄壳职责测试；
@@ -49,6 +50,7 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 ## 文档地图（哪个问题去读哪个文档）
 
 - 项目概览/模块说明/全景架构图 → `README.md`
+- 多租户隔离模型/逐表归属/身份链路 → `docs/多租户架构设计.md`
 - 功能总表/配置项/接口速查/各功能用法 → `docs/功能与配置全量参考.md`
 - 1.x→2.0 API 映射、RC4→GA 变更、issue 重新核对 → `docs/MIGRATION-2.0.md`
 - 框架 open issues 与本项目链路的交叉评估 → `docs/生产就绪评估.md`
@@ -75,6 +77,13 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   让 main 的 CI 从 PR #65 起连红 6 次（表现为 `Table 'customer_admin.cw_agent_call_log' doesn't exist`）。
 - **迁移脚本里不要写库名前缀**（`INSERT INTO \`customer_admin\`.\`xxx\``）：脚本执行时已经 USE 到目标库，
   写死库名会让脚本换库不可用，验证/多环境时甚至串库写到别的库去。V14 踩过。
+- **多租户（B1 起）**：隔离靠 MyBatis-Plus `TenantLineInnerInterceptor` 全局改写，租户值取自
+  `TenantContext`（starter 的 ThreadLocal），默认关闭（`customer-work.tenant.enabled` / `admin.tenant.enabled`）。
+  设计与逐表归属见 `docs/多租户架构设计.md`。三条硬约定：
+  ① **新增业务表一律带 `tenant_id`**，不要往忽略清单里加——清单越短越安全，加表等于放弃该表的自动隔离；
+  ② **有意的跨租户查询必须走 `CrossTenantOperations`**（可 grep 的白名单），不要靠"给上下文塞特殊值"；
+  ③ **权限查询用用户归属租户，数据查询用当前视角租户**（`AdminStpInterfaceImpl` 已按此实现），
+  混用会让运营方切视角后当场失去全部权限。缺上下文时持久层 fail-closed 抛错，这是刻意的。
 - 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
 - 持久层异常兜底必须 `catch(Exception)`（HikariPool/MyBatis 初始化异常是 RuntimeException）。
 - 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
@@ -18,6 +18,10 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
+import com.richard.fyoung.customerwork.tenant.CrossTenantOperations;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +61,7 @@ public class AuthService {
     private final AdminLdapProperties ldapProperties;
     private final SysRoleMapper roleMapper;
     private final SysUserRoleMapper userRoleMapper;
+    private final TenantService tenantService;
 
     /** “记住我”勾选后登录态有效期（秒），默认 7 天；不勾选时沿用 sa-token.timeout（2 小时）全局配置。 */
     @Value("${admin.remember-me-timeout-seconds:604800}")
@@ -65,7 +70,7 @@ public class AuthService {
     public AuthService(SysUserMapper userMapper, PasswordEncoder passwordEncoder,
                        OperationLogMapper operationLogMapper, LdapAuthService ldapAuthService,
                        AdminLdapProperties ldapProperties, SysRoleMapper roleMapper,
-                       SysUserRoleMapper userRoleMapper) {
+                       SysUserRoleMapper userRoleMapper, TenantService tenantService) {
         this.userMapper = userMapper;
         this.passwordEncoder = passwordEncoder;
         this.operationLogMapper = operationLogMapper;
@@ -73,17 +78,20 @@ public class AuthService {
         this.ldapProperties = ldapProperties;
         this.roleMapper = roleMapper;
         this.userRoleMapper = userRoleMapper;
+        this.tenantService = tenantService;
     }
 
     public LoginResponse login(LoginRequest request) {
-        SysUser user = userMapper.selectOne(
-            new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, request.username()));
+        // 跨租户查：此刻还不知道这个用户名属于哪个租户，租户上下文正是登录要产出的结果。
+        // sys_user.username 全局唯一（见 docs/多租户架构设计.md §2.3），故按用户名足以唯一定位。
+        SysUser user = CrossTenantOperations.execute(() -> userMapper.selectOne(
+            new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, request.username())));
 
         boolean success = user != null
             && user.getStatus() != null && user.getStatus() == 1
             && passwordEncoder.matches(request.password(), user.getPassword());
 
-        recordLoginLog(request.username(), user == null ? null : user.getId(), success,
+        recordLoginLog(loginLogTenant(user), request.username(), user == null ? null : user.getId(), success,
             success ? null : "用户名或密码错误，或账号已禁用",
             success ? "登录" : "登录失败", "AuthController#login");
 
@@ -116,24 +124,24 @@ public class AuthService {
 
         LdapBindResult bindResult = ldapAuthService.bind(username, request.password());
         if (bindResult == LdapBindResult.SERVICE_UNAVAILABLE) {
-            recordLoginLog(username, null, false, "OA域服务不可用",
+            recordLoginLog(TenantContext.PLATFORM, username, null, false, "OA域服务不可用",
                 "OA登录失败", "AuthController#ssoLogin");
             throw new BizException(ResultCode.SSO_SERVICE_UNAVAILABLE);
         }
         if (bindResult == LdapBindResult.INVALID_CREDENTIALS) {
-            recordLoginLog(username, null, false, "OA账号或密码错误",
+            recordLoginLog(TenantContext.PLATFORM, username, null, false, "OA账号或密码错误",
                 "OA登录失败", "AuthController#ssoLogin");
             throw new BizException(ResultCode.SSO_LOGIN_FAILED);
         }
 
         SysUser user = findOrCreateLdapUser(username);
         if (user.getStatus() == null || user.getStatus() != 1) {
-            recordLoginLog(username, user.getId(), false, "账号已禁用",
+            recordLoginLog(loginLogTenant(user), username, user.getId(), false, "账号已禁用",
                 "OA登录失败", "AuthController#ssoLogin");
             throw new BizException(ResultCode.SSO_LOGIN_FAILED, "账号已被禁用，请联系管理员");
         }
 
-        recordLoginLog(username, user.getId(), true, null, "OA登录", "AuthController#ssoLogin");
+        recordLoginLog(loginLogTenant(user), username, user.getId(), true, null, "OA登录", "AuthController#ssoLogin");
 
         doLogin(user, request.rememberMe());
 
@@ -149,14 +157,31 @@ public class AuthService {
         StpUtil.logout();
     }
 
-    /** 勾选“记住我”时用 {@code rememberMeTimeoutSeconds} 覆盖登录态有效期，否则沿用 sa-token.timeout 全局配置。 */
+    /**
+     * 勾选“记住我”时用 {@code rememberMeTimeoutSeconds} 覆盖登录态有效期，否则沿用 sa-token.timeout 全局配置。
+     *
+     * <p>登录成功即把租户焊进会话与当前线程：会话供后续请求的 {@code TenantContextInterceptor} 读取，
+     * 线程上下文供本次请求剩余的写操作（更新登录时间等）使用——那些操作发生在拦截器 preHandle 之后，
+     * 当时还没有登录态，没有这一步就会因缺租户上下文而 fail-closed。</p>
+     */
     private void doLogin(SysUser user, Boolean rememberMe) {
+        String tenantId = resolveTenantId(user);
+        tenantService.assertAccessible(tenantId);
+
         if (Boolean.TRUE.equals(rememberMe)) {
             StpUtil.login(user.getId(), SaLoginModel.create().setTimeout(rememberMeTimeoutSeconds));
         } else {
             StpUtil.login(user.getId());
         }
         StpUtil.getTokenSession().set("username", user.getUsername());
+        TenantSession.bindTenant(tenantId);
+        TenantContext.set(tenantId);
+    }
+
+    /** 存量用户可能没有租户列值（升级前建的行），一律按平台运营方处理，与 V49 的存量归属口径一致。 */
+    private String resolveTenantId(SysUser user) {
+        String tenantId = user.getTenantId();
+        return tenantId == null || tenantId.isBlank() ? TenantContext.PLATFORM : tenantId;
     }
 
     public void changePassword(ChangePasswordRequest request) {
@@ -173,7 +198,14 @@ public class AuthService {
         log.info("password changed, userId={}", userId);
     }
 
-    private void recordLoginLog(String username, Long userId, boolean success, String errorMsg,
+    /**
+     * 记录登录日志。
+     *
+     * <p>{@code tenantId} 必须显式传入：本方法在 {@code doLogin} 之前调用（登录失败也要留痕），
+     * 那时线程上还没有租户上下文，靠 {@link TenantContext} 推断只会把所有登录日志都算到平台头上，
+     * 租户管理员就看不到自己用户的登录记录了。用户名不存在时归平台——那是平台级安全事件。</p>
+     */
+    private void recordLoginLog(String tenantId, String username, Long userId, boolean success, String errorMsg,
                                  String operation, String method) {
         try {
             SysOperationLog entity = new SysOperationLog();
@@ -186,10 +218,15 @@ public class AuthService {
             entity.setErrorMsg(errorMsg);
             entity.setIp(resolveClientIp());
             entity.setCreateTime(LocalDateTime.now());
-            operationLogMapper.insert(entity);
+            TenantContext.runWith(tenantId, () -> operationLogMapper.insert(entity));
         } catch (Exception e) {
             log.error("record login log failed, code={}", "LOGIN-LOG-RECORD-FAIL", e);
         }
+    }
+
+    /** 登录留痕用的租户归属：用户不存在时算平台级安全事件。 */
+    private String loginLogTenant(SysUser user) {
+        return user == null ? TenantContext.PLATFORM : resolveTenantId(user);
     }
 
     /** 用户可直接输入 RichardFyoung 或 RichardFyoung@xxx，统一取 @ 前半部分再拼接配置的域名后缀发起 Bind。 */
@@ -199,9 +236,21 @@ public class AuthService {
         return at > 0 ? trimmed.substring(0, at) : trimmed;
     }
 
+    /**
+     * LDAP 影子账号的查找与自动创建。
+     *
+     * <p>整段跑在平台租户上下文里：LDAP 是企业内部域，通过它进来的都是运营方员工，
+     * 影子账号与默认角色都归 {@code __platform__}。若将来要支持"租户自带 AD 域"，
+     * 这里换成按域名映射租户即可，其余链路不用动。</p>
+     */
     private SysUser findOrCreateLdapUser(String username) {
-        SysUser user = userMapper.selectOne(
-            new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, username));
+        return TenantContext.callWith(TenantContext.PLATFORM, () -> doFindOrCreateLdapUser(username));
+    }
+
+    private SysUser doFindOrCreateLdapUser(String username) {
+        // 跨租户查：与本地登录同理，此刻还不知道该用户名归属哪个租户
+        SysUser user = CrossTenantOperations.execute(() -> userMapper.selectOne(
+            new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, username)));
         if (user != null) {
             return user;
         }
@@ -211,7 +260,8 @@ public class AuthService {
         // MyBatis-Plus 自动拼接的 deleted=0 过滤而查不到，但直接 INSERT 会因用户名被旧行占住而报
         // DuplicateKeyException（已实测复现）。这里先查有没有被软删除过的旧行，有就“复活”它而不是插新行；
         // 即使确实无旧行（纯并发竞争），下面 insert 仍包 catch DuplicateKeyException 兼底。
-        SysUser deletedUser = userMapper.selectByUsernameIgnoreLogicDelete(username);
+        SysUser deletedUser = CrossTenantOperations.execute(
+            () -> userMapper.selectByUsernameIgnoreLogicDelete(username));
         if (deletedUser != null) {
             userMapper.reviveDeletedUser(deletedUser.getId(), username);
             userRoleMapper.delete(new LambdaQueryWrapper<SysUserRole>().eq(SysUserRole::getUserId, deletedUser.getId()));
@@ -227,13 +277,15 @@ public class AuthService {
         created.setNickname(username);
         created.setLoginType("LDAP");
         created.setStatus(1);
+        // 显式写租户而非依赖拦截器补值：多租户关闭时拦截器根本没挂，落到 DDL 默认的 default 就错了
+        created.setTenantId(TenantContext.PLATFORM);
         try {
             userMapper.insert(created);
         } catch (DuplicateKeyException e) {
             // 坑：高并发下两个请求同时到这里，上面的查询都没命中另一个已提交的 INSERT，先插那个提交了、
             // 后插的就会撞唯一约束；这时其实对方已经建好了号，重新查一次拿那个已存在的行即可，不需要重试插入。
-            SysUser existing = userMapper.selectOne(
-                new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, username));
+            SysUser existing = CrossTenantOperations.execute(() -> userMapper.selectOne(
+                new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, username)));
             if (existing != null) {
                 return existing;
             }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -77,6 +77,14 @@ public enum ResultCode {
     KNOWLEDGE_BASE_HTTP_FORBIDDEN(40035, "知识库服务地址不在允许访问范围内，已被安全策略拦截"),
     KNOWLEDGE_BASE_SEARCH_FAILED(40036, "知识库检索失败"),
 
+    // 多租户（B1 租户地基）
+    TENANT_NOT_FOUND(40037, "租户不存在"),
+    TENANT_CODE_DUPLICATE(40038, "租户编码已存在"),
+    TENANT_CODE_IMMUTABLE(40039, "租户编码创建后不可修改"),
+    TENANT_RESERVED_PROTECTED(40040, "系统保留租户不允许该操作"),
+    TENANT_SUSPENDED(40041, "租户已被冻结或已退租，请联系运营方"),
+    TENANT_VIEW_FORBIDDEN(40042, "只有平台运营方可以切换租户视角"),
+
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImpl.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImpl.java
@@ -10,6 +10,8 @@ import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRolePermissionMapper;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
@@ -20,6 +22,14 @@ import java.util.List;
  *
  * <p>{@code role_code=super_admin} 特判直接放行全部权限点——{@code sys_role_permission}
  * 不为超管冗余插入记录（种子数据 V2 已注明该约定），减少维护成本。</p>
+ *
+ * <p><b>多租户下的两个要点</b>：</p>
+ * <ul>
+ *   <li>角色查询一律在<b>用户归属租户</b>下进行，而不是当前视角租户。运营方切到租户 X 的视角后，
+ *       自己的角色仍在 {@code __platform__} 里，若按视角租户查会一条都查不到，当场失去全部权限。</li>
+ *   <li>超管特判额外要求用户属于平台租户。租户可以自建角色，若只比 {@code role_code}，
+ *       任何租户建一个叫 {@code super_admin} 的角色就能拿到含 {@code tenant:*} 在内的全部权限点。</li>
+ * </ul>
  * @author owlzhangfq@gmail.com
  */
 @Component
@@ -47,7 +57,8 @@ public class AdminStpInterfaceImpl implements StpInterface {
         if (roles.isEmpty()) {
             return List.of();
         }
-        boolean isSuperAdmin = roles.stream().anyMatch(r -> SUPER_ADMIN_ROLE_CODE.equals(r.getRoleCode()));
+        boolean isSuperAdmin = TenantSession.isPlatformOperator()
+            && roles.stream().anyMatch(r -> SUPER_ADMIN_ROLE_CODE.equals(r.getRoleCode()));
         if (isSuperAdmin) {
             return permissionMapper.selectList(null).stream()
                 .map(SysPermission::getPermCode)
@@ -71,7 +82,21 @@ public class AdminStpInterfaceImpl implements StpInterface {
         return rolesOf(loginId).stream().map(SysRole::getRoleCode).toList();
     }
 
+    /**
+     * 查用户的启用角色。
+     *
+     * <p>固定在用户归属租户下查询：权限属于"用户是谁"，与"当前在看哪个租户的数据"是两件事。
+     * 未登录（如 Sa-Token 在解析阶段回调）时归属租户为空，此时不切上下文，沿用调用方的现状。</p>
+     */
     private List<SysRole> rolesOf(Object loginId) {
+        String userTenant = TenantSession.currentUserTenant();
+        if (userTenant == null) {
+            return doRolesOf(loginId);
+        }
+        return TenantContext.callWith(userTenant, () -> doRolesOf(loginId));
+    }
+
+    private List<SysRole> doRolesOf(Object loginId) {
         Long userId = Long.valueOf(loginId.toString());
         List<Long> roleIds = userRoleMapper.selectList(
                 new LambdaQueryWrapper<SysUserRole>().eq(SysUserRole::getUserId, userId))

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/MybatisPlusConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/MybatisPlusConfig.java
@@ -3,19 +3,36 @@ package com.richard.fyoung.customeradmin.config;
 import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
+import com.richard.fyoung.customerwork.tenant.TenantInterceptors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * MyBatis-Plus 分页插件配置（列表接口服务端分页，需求文档 3.2/4.1）。
+ * MyBatis-Plus 插件配置：租户行级过滤 + 分页（列表接口服务端分页，需求文档 3.2/4.1）。
+ *
+ * <p>租户拦截器复用 starter 的 {@link TenantInterceptors} 构建器（当普通构建器 new，不当配置类），
+ * 与 {@code AdminOtelTracingConfig} 复用 starter 构建器的做法一致——admin 排除了 starter 的自动装配，
+ * 但共享同一份"哪些表不参与过滤"的口径，两边分头维护迟早漂移。</p>
  * @author owlzhangfq@gmail.com
  */
+@Slf4j
 @Configuration
 public class MybatisPlusConfig {
 
+    /**
+     * 插件链顺序有讲究：租户过滤必须排在分页之前。
+     * 分页插件会先跑一次 count 查询，租户条件若还没拼上，count 与数据页的口径就对不上。
+     */
     @Bean
-    public MybatisPlusInterceptor mybatisPlusInterceptor() {
+    public MybatisPlusInterceptor mybatisPlusInterceptor(AdminTenantProperties tenantProperties) {
         MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        if (tenantProperties.isEnabled()) {
+            interceptor.addInnerInterceptor(
+                TenantInterceptors.build(tenantProperties.getColumnName(), tenantProperties.getIgnoredTables()));
+            log.info("admin tenant line filter enabled, column={}", tenantProperties.getColumnName());
+        }
         interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
         return interceptor;
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/entity/SysUser.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/entity/SysUser.java
@@ -24,6 +24,14 @@ public class SysUser {
 
     private String username;
 
+    /**
+     * 归属租户；运营方为 {@code __platform__}。
+     *
+     * <p>其它业务实体都不需要这个字段（写入由租户拦截器自动补、查询自动过滤），
+     * 唯独它要显式持有：登录时正是靠它决定这个用户该进哪个租户的上下文。</p>
+     */
+    private String tenantId;
+
     /** BCrypt 哈希，永不通过接口返回给前端。 */
     @JsonIgnore
     private String password;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/AdminTenantProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/AdminTenantProperties.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customeradmin.tenant;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 后台多租户配置（{@code admin.tenant.*}）。默认关闭，单租户部署行为与升级前完全一致。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "admin.tenant")
+public class AdminTenantProperties {
+
+    /** 是否开启多租户行级隔离。 */
+    private boolean enabled = false;
+
+    /** 租户列名（与客服端库统一）。 */
+    private String columnName = "tenant_id";
+
+    /** 在内置平台级表之外，额外不参与租户过滤的表。 */
+    private List<String> ignoredTables = new ArrayList<>();
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/TenantContextInterceptor.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/TenantContextInterceptor.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customeradmin.tenant;
+
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 把登录态里的租户写入 {@link TenantContext}，供持久层拦截器读取。
+ *
+ * <p>未登录请求（登录接口、静态资源、健康检查）不设置上下文——这些链路要么不碰业务表，
+ * 要么必须显式走 {@code CrossTenantOperations}（如登录时按用户名跨租户查用户）。</p>
+ *
+ * <p>admin 是 Spring MVC，一个请求一个线程，因此 ThreadLocal 直接可用，
+ * 不需要客服端那套 Reactor 上下文传播。但线程是复用的，{@code afterCompletion} 的清理不能省，
+ * 否则下一个请求会读到上一个租户——这类串号比查不到数据危险得多。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class TenantContextInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String tenantId = TenantSession.effectiveTenant();
+        if (tenantId != null) {
+            TenantContext.set(tenantId);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        TenantContext.clear();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/TenantSession.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/TenantSession.java
@@ -1,0 +1,65 @@
+package com.richard.fyoung.customeradmin.tenant;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+
+/**
+ * 登录态里的租户信息读写（Sa-Token Session 为载体）。
+ *
+ * <p>存两个值：{@code tenantId} 是登录用户自身的归属租户（登录时焊死，全程不可改）；
+ * {@code viewTenantId} 是运营方切换到的目标租户视角（仅运营方可设，可随时切换）。
+ * 生效租户 = viewTenantId 优先，回落 tenantId。</p>
+ *
+ * <p>租户归属放登录态而非每请求查库，是因为它在登录后就不会变；运营方切视角也只改自己这一份会话数据。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class TenantSession {
+
+    /** 登录用户自身归属的租户。 */
+    public static final String KEY_TENANT_ID = "tenantId";
+
+    /** 运营方切换到的目标租户视角（非运营方不写此键）。 */
+    public static final String KEY_VIEW_TENANT_ID = "viewTenantId";
+
+    private TenantSession() {
+    }
+
+    /** 登录成功时写入归属租户。 */
+    public static void bindTenant(String tenantId) {
+        StpUtil.getSession().set(KEY_TENANT_ID, tenantId);
+    }
+
+    /** 读取登录用户的归属租户；未登录返回 {@code null}。 */
+    public static String currentUserTenant() {
+        if (!StpUtil.isLogin()) {
+            return null;
+        }
+        return (String) StpUtil.getSession().get(KEY_TENANT_ID);
+    }
+
+    /** 运营方切换视角；传空表示回到平台自身视角。 */
+    public static void switchView(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            StpUtil.getSession().delete(KEY_VIEW_TENANT_ID);
+            return;
+        }
+        StpUtil.getSession().set(KEY_VIEW_TENANT_ID, tenantId);
+    }
+
+    /** 当前生效租户：运营方视角优先，回落用户归属租户；未登录返回 {@code null}。 */
+    public static String effectiveTenant() {
+        if (!StpUtil.isLogin()) {
+            return null;
+        }
+        String view = (String) StpUtil.getSession().get(KEY_VIEW_TENANT_ID);
+        if (view != null && !view.isBlank()) {
+            return view;
+        }
+        return (String) StpUtil.getSession().get(KEY_TENANT_ID);
+    }
+
+    /** 当前登录用户是否为平台运营方（决定能否切换视角、能否做跨租户查询）。 */
+    public static boolean isPlatformOperator() {
+        return TenantContext.PLATFORM.equals(currentUserTenant());
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/TenantWebConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/TenantWebConfig.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customeradmin.tenant;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 注册租户上下文拦截器（仅 {@code admin.tenant.enabled=true} 时生效）。
+ *
+ * <p>排在最后执行：Sa-Token 的鉴权拦截器先跑完，未登录请求已被拦下，
+ * 到这里剩下的要么带着登录态、要么是放行的公开接口。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "admin.tenant", name = "enabled", havingValue = "true")
+public class TenantWebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new TenantContextInterceptor())
+            .addPathPatterns("/**")
+            .order(Ordered.LOWEST_PRECEDENCE);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/controller/TenantController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/controller/TenantController.java
@@ -1,0 +1,139 @@
+package com.richard.fyoung.customeradmin.tenant.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantPageQuery;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantSaveRequest;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantVO;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantViewVO;
+import com.richard.fyoung.customeradmin.tenant.entity.TenantStatus;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 租户管理：CRUD + 生命周期 + 运营方视角切换。
+ *
+ * <p>整个 Controller 是平台运营方专属。两道防线：{@code tenant:*} 权限点在租户开通时被显式排除，
+ * 不会落到租户管理员的角色上；每个方法再校验一次调用者确实是运营方。
+ * 后者不是冗余——权限点是通用 RBAC，可能被误配置，而租户列表泄露的是全体客户名单。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/tenant")
+public class TenantController {
+
+    private final TenantService tenantService;
+
+    public TenantController(TenantService tenantService) {
+        this.tenantService = tenantService;
+    }
+
+    @SaCheckPermission("tenant:view")
+    @GetMapping("/page")
+    public Result<PageResult<TenantVO>> page(TenantPageQuery query) {
+        assertPlatformOperator();
+        return Result.success(tenantService.page(query));
+    }
+
+    @SaCheckPermission("tenant:view")
+    @GetMapping("/{id}")
+    public Result<TenantVO> get(@PathVariable Long id) {
+        assertPlatformOperator();
+        return Result.success(tenantService.get(id));
+    }
+
+    /** 可切换的租户下拉（运营方顶部租户切换器的数据源）。 */
+    @SaCheckPermission("tenant:view")
+    @GetMapping("/options")
+    public Result<List<TenantVO>> options() {
+        assertPlatformOperator();
+        return Result.success(tenantService.listActive());
+    }
+
+    @SaCheckPermission("tenant:add")
+    @OperationLog(operation = "新增租户", target = "sys_tenant")
+    @PostMapping
+    public Result<Long> create(@Valid @RequestBody TenantSaveRequest request) {
+        assertPlatformOperator();
+        return Result.success(tenantService.create(request));
+    }
+
+    @SaCheckPermission("tenant:edit")
+    @OperationLog(operation = "编辑租户", target = "sys_tenant")
+    @PutMapping
+    public Result<Void> update(@Valid @RequestBody TenantSaveRequest request) {
+        assertPlatformOperator();
+        tenantService.update(request);
+        return Result.success();
+    }
+
+    /** 冻结 / 恢复 / 退租：只改状态不动数据。 */
+    @SaCheckPermission("tenant:edit")
+    @OperationLog(operation = "变更租户状态", target = "sys_tenant")
+    @PutMapping("/{id}/status")
+    public Result<Void> changeStatus(@PathVariable Long id, @RequestParam String status) {
+        assertPlatformOperator();
+        tenantService.changeStatus(id, TenantStatus.parse(status));
+        return Result.success();
+    }
+
+    @SaCheckPermission("tenant:delete")
+    @OperationLog(operation = "删除租户", target = "sys_tenant")
+    @DeleteMapping("/{id}")
+    public Result<Void> delete(@PathVariable Long id) {
+        assertPlatformOperator();
+        tenantService.delete(id);
+        return Result.success();
+    }
+
+    /**
+     * 当前视角信息：前端据此决定是否渲染租户切换器、当前停在哪个租户。
+     * 不加权限点——任何登录用户都要知道自己在哪个租户下，租户管理员拿到的永远是自己那一个。
+     */
+    @GetMapping("/current-view")
+    public Result<TenantViewVO> currentView() {
+        TenantViewVO vo = new TenantViewVO();
+        vo.setUserTenantId(TenantSession.currentUserTenant());
+        vo.setEffectiveTenantId(TenantSession.effectiveTenant());
+        vo.setPlatformOperator(TenantSession.isPlatformOperator());
+        return Result.success(vo);
+    }
+
+    /**
+     * 运营方切换目标租户视角；传空回到平台自身视角。
+     *
+     * <p>切换只改自己会话里的一个值，不影响其他登录会话，也不改任何业务数据。</p>
+     */
+    @OperationLog(operation = "切换租户视角", target = "sys_tenant")
+    @PutMapping("/switch-view")
+    public Result<Void> switchView(@RequestParam(required = false) String tenantCode) {
+        assertPlatformOperator();
+        if (tenantCode != null && !tenantCode.isBlank() && !tenantService.existsAccessible(tenantCode)) {
+            throw new BizException(ResultCode.TENANT_NOT_FOUND);
+        }
+        TenantSession.switchView(tenantCode);
+        return Result.success();
+    }
+
+    private void assertPlatformOperator() {
+        if (!TenantSession.isPlatformOperator()) {
+            throw new BizException(ResultCode.TENANT_VIEW_FORBIDDEN);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantPageQuery.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantPageQuery.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.tenant.dto;
+
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * 租户分页查询。
+ *
+ * <p>不复用父类的 {@code status}（Integer 的 0/1 启停语义）：租户是三态生命周期
+ * ACTIVE/SUSPENDED/TERMINATED，硬塞进两态布尔会丢掉"退租"与"冻结"的区别。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class TenantPageQuery extends PageQuery {
+
+    /** 生命周期状态枚举名，空表示不筛。 */
+    private String tenantStatus;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantSaveRequest.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customeradmin.tenant.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 租户新增/编辑请求。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class TenantSaveRequest {
+
+    /** 主键；新增留空。 */
+    private Long id;
+
+    /**
+     * 租户编码，创建后不可改——它会被写进各业务表的 tenant_id、API Key 映射、日志与指标标签，
+     * 改一次等于让所有存量数据失去归属。
+     * 限定字母数字与连字符：编码会出现在日志、指标标签与 Nacos dataId 里，特殊字符会带来转义问题。
+     */
+    @NotBlank(message = "租户编码不能为空")
+    @Size(max = 64, message = "租户编码长度不能超过 64")
+    @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9-_]*$", message = "租户编码只能包含字母、数字、连字符和下划线，且以字母或数字开头")
+    private String tenantCode;
+
+    @NotBlank(message = "租户名称不能为空")
+    @Size(max = 128, message = "租户名称长度不能超过 128")
+    private String tenantName;
+
+    @Size(max = 64, message = "联系人长度不能超过 64")
+    private String contactName;
+
+    @Size(max = 32, message = "联系电话长度不能超过 32")
+    private String contactPhone;
+
+    @Email(message = "联系邮箱格式不正确")
+    @Size(max = 128, message = "联系邮箱长度不能超过 128")
+    private String contactEmail;
+
+    @Size(max = 500, message = "备注长度不能超过 500")
+    private String remark;
+
+    /** 到期时间，空 = 不限期。 */
+    private LocalDateTime expireTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantVO.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customeradmin.tenant.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 租户列表/详情返回体。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class TenantVO {
+
+    private Long id;
+    private String tenantCode;
+    private String tenantName;
+    private String status;
+    private String contactName;
+    private String contactPhone;
+    private String contactEmail;
+    private String remark;
+    private LocalDateTime expireTime;
+    private LocalDateTime createTime;
+
+    /** 是否为保留租户（default / __platform__）：保留租户不允许改编码、不允许冻结或退租。 */
+    private Boolean reserved;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantViewVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/dto/TenantViewVO.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.tenant.dto;
+
+import lombok.Data;
+
+/**
+ * 当前登录用户的租户视角信息（前端据此决定是否渲染租户切换器）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class TenantViewVO {
+
+    /** 登录用户自身归属的租户。 */
+    private String userTenantId;
+
+    /** 当前生效的租户（运营方切换视角后与上一个不同）。 */
+    private String effectiveTenantId;
+
+    /** 是否平台运营方：只有它能切换视角。 */
+    private Boolean platformOperator;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/entity/SysTenant.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/entity/SysTenant.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customeradmin.tenant.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 租户主数据。
+ *
+ * <p>本表自身不带 {@code tenant_id}——它是租户的定义方，参与不了自己的过滤，
+ * 因此在 {@code TenantInterceptors.PLATFORM_LEVEL_TABLES} 忽略清单里，
+ * 访问控制由 Controller 层的运营方权限校验负责。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("sys_tenant")
+public class SysTenant {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** 业务主键，出现在 API Key 映射 / 日志 / 指标标签里，故用可读编码而非自增数字。 */
+    private String tenantCode;
+    private String tenantName;
+    /** ACTIVE 正常 / SUSPENDED 冻结 / TERMINATED 退租，见 {@link TenantStatus}。 */
+    private String status;
+    private String contactName;
+    private String contactPhone;
+    private String contactEmail;
+    private String remark;
+    /** 到期时间，空 = 不限期。 */
+    private LocalDateTime expireTime;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private Long updateBy;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    @TableLogic
+    private Integer deleted;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/entity/TenantStatus.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/entity/TenantStatus.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customeradmin.tenant.entity;
+
+/**
+ * 租户生命周期状态。
+ *
+ * <p>冻结与退租都只改状态、不删数据：退租后的数据主权（导出/清理）属于合规议题，
+ * 由后续批次的租户数据导出能力承接，这里绝不做级联删除。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum TenantStatus {
+
+    /** 正常，可登录可调用。 */
+    ACTIVE,
+
+    /** 冻结：登录与 API 一律拒绝，数据保留（欠费、违规处置等场景）。 */
+    SUSPENDED,
+
+    /** 退租：等同冻结，额外标记该租户已终止合作，数据待导出或清理。 */
+    TERMINATED;
+
+    /** 是否允许登录与接口调用。 */
+    public boolean allowsAccess() {
+        return this == ACTIVE;
+    }
+
+    /** 宽松解析：库里存的是字符串，脏值一律当作不可访问处理（fail-closed）。 */
+    public static TenantStatus parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return SUSPENDED;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return SUSPENDED;
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/mapper/SysTenantMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/mapper/SysTenantMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.tenant.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.tenant.entity.SysTenant;
+
+/**
+ * 租户主数据 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface SysTenantMapper extends BaseMapper<SysTenant> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/service/TenantProvisionService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/service/TenantProvisionService.java
@@ -1,0 +1,97 @@
+package com.richard.fyoung.customeradmin.tenant.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.system.permission.entity.SysPermission;
+import com.richard.fyoung.customeradmin.system.permission.mapper.SysPermissionMapper;
+import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
+import com.richard.fyoung.customeradmin.system.role.entity.SysRolePermission;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRolePermissionMapper;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * 新租户开通：建一个租户内的全权管理员角色，并授予除平台专属之外的全部权限点。
+ *
+ * <p>不做则新租户是个空壳——没有任何角色可分配，租户管理员建了也用不了。</p>
+ *
+ * <p><b>为什么是"新建角色 + 授权限"而不是"复制平台角色"</b>：平台侧的角色是按运营方职责划分的
+ * （超管、运维、只读等），对租户没有意义；租户要的是"我这边的管理员"。复制反而会把
+ * 平台的角色语义连同其权限一起漏给租户。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class TenantProvisionService {
+
+    /** 租户内建管理员角色编码。 */
+    public static final String TENANT_ADMIN_ROLE_CODE = "tenant_admin";
+
+    /**
+     * 平台专属权限前缀：租户管理本身只能由运营方操作，绝不能授给租户管理员，
+     * 否则租户能看到、甚至冻结别的租户。
+     */
+    private static final String PLATFORM_ONLY_PERM_PREFIX = "tenant:";
+
+    private final SysRoleMapper roleMapper;
+    private final SysRolePermissionMapper rolePermissionMapper;
+    private final SysPermissionMapper permissionMapper;
+
+    public TenantProvisionService(SysRoleMapper roleMapper,
+                                  SysRolePermissionMapper rolePermissionMapper,
+                                  SysPermissionMapper permissionMapper) {
+        this.roleMapper = roleMapper;
+        this.rolePermissionMapper = rolePermissionMapper;
+        this.permissionMapper = permissionMapper;
+    }
+
+    /**
+     * 为指定租户初始化内建角色。
+     *
+     * <p>整段跑在目标租户的上下文里，插入 {@code sys_role} / {@code sys_role_permission} 时
+     * 由租户拦截器自动补 {@code tenant_id}——这样就不需要在实体上挂租户字段、也不会写错归属。</p>
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public void provision(String tenantCode) {
+        // sys_permission 是平台级表（不参与租户过滤），在哪个上下文里读都是同一份
+        List<SysPermission> permissions = permissionMapper.selectList(new LambdaQueryWrapper<>());
+        List<Long> grantablePermissionIds = permissions.stream()
+            .filter(p -> p.getPermCode() == null || !p.getPermCode().startsWith(PLATFORM_ONLY_PERM_PREFIX))
+            .map(SysPermission::getId)
+            .toList();
+
+        TenantContext.runWith(tenantCode, () -> {
+            SysRole existing = roleMapper.selectOne(
+                new LambdaQueryWrapper<SysRole>().eq(SysRole::getRoleCode, TENANT_ADMIN_ROLE_CODE));
+            if (existing != null) {
+                log.info("tenant admin role already exists, skip provision, tenant={}", tenantCode);
+                return;
+            }
+
+            SysRole role = new SysRole();
+            role.setRoleName("租户管理员");
+            role.setRoleCode(TENANT_ADMIN_ROLE_CODE);
+            role.setRemark("租户开通时自动创建，拥有本租户内全部管理权限");
+            role.setStatus(1);
+            roleMapper.insert(role);
+
+            if (CollectionUtils.isEmpty(grantablePermissionIds)) {
+                log.info("no grantable permission found, tenant={}, roleId={}", tenantCode, role.getId());
+                return;
+            }
+            for (Long permissionId : grantablePermissionIds) {
+                SysRolePermission rp = new SysRolePermission();
+                rp.setRoleId(role.getId());
+                rp.setPermissionId(permissionId);
+                rolePermissionMapper.insert(rp);
+            }
+            log.info("tenant provisioned, tenant={}, roleId={}, permissionCount={}",
+                tenantCode, role.getId(), grantablePermissionIds.size());
+        });
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/service/TenantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/tenant/service/TenantService.java
@@ -1,0 +1,191 @@
+package com.richard.fyoung.customeradmin.tenant.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantPageQuery;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantSaveRequest;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantVO;
+import com.richard.fyoung.customeradmin.tenant.entity.SysTenant;
+import com.richard.fyoung.customeradmin.tenant.entity.TenantStatus;
+import com.richard.fyoung.customeradmin.tenant.mapper.SysTenantMapper;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 租户主数据与生命周期。
+ *
+ * <p>本服务只管租户这一实体本身；新租户的角色与管理员账号初始化交给
+ * {@link TenantProvisionService}——那是"开通"动作，涉及 RBAC 多张表，与租户 CRUD 是两件事。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class TenantService {
+
+    /** 系统保留租户：不允许改编码、不允许冻结/退租/删除，否则存量数据会失去归属或平台自身被锁死。 */
+    private static final Set<String> RESERVED_TENANTS = Set.of(TenantContext.DEFAULT, TenantContext.PLATFORM);
+
+    private final SysTenantMapper tenantMapper;
+    private final TenantProvisionService provisionService;
+
+    public TenantService(SysTenantMapper tenantMapper, TenantProvisionService provisionService) {
+        this.tenantMapper = tenantMapper;
+        this.provisionService = provisionService;
+    }
+
+    public PageResult<TenantVO> page(TenantPageQuery query) {
+        LambdaQueryWrapper<SysTenant> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(query.getKeyword())) {
+            wrapper.and(w -> w.like(SysTenant::getTenantName, query.getKeyword())
+                .or().like(SysTenant::getTenantCode, query.getKeyword()));
+        }
+        if (StringUtils.hasText(query.getTenantStatus())) {
+            wrapper.eq(SysTenant::getStatus, TenantStatus.parse(query.getTenantStatus()).name());
+        }
+        wrapper.orderBy(true, "asc".equalsIgnoreCase(query.getSortOrder()), SysTenant::getCreateTime);
+
+        Page<SysTenant> page = tenantMapper.selectPage(
+            Page.of(query.getPageNum(), query.getPageSize()), wrapper);
+
+        PageResult<TenantVO> result = new PageResult<>();
+        result.setPageNum(page.getCurrent());
+        result.setPageSize(page.getSize());
+        result.setTotal(page.getTotal());
+        result.setList(page.getRecords().stream().map(this::toVO).toList());
+        return result;
+    }
+
+    /** 全部可用租户（运营方切换视角的下拉数据源）。 */
+    public List<TenantVO> listActive() {
+        return tenantMapper.selectList(new LambdaQueryWrapper<SysTenant>()
+                .eq(SysTenant::getStatus, TenantStatus.ACTIVE.name())
+                .orderByAsc(SysTenant::getTenantCode))
+            .stream().map(this::toVO).toList();
+    }
+
+    public TenantVO get(Long id) {
+        return toVO(requireById(id));
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public Long create(TenantSaveRequest request) {
+        if (findByCode(request.getTenantCode()) != null) {
+            throw new BizException(ResultCode.TENANT_CODE_DUPLICATE);
+        }
+        SysTenant entity = new SysTenant();
+        BeanUtils.copyProperties(request, entity);
+        entity.setId(null);
+        entity.setStatus(TenantStatus.ACTIVE.name());
+        tenantMapper.insert(entity);
+
+        provisionService.provision(entity.getTenantCode());
+        log.info("tenant created, code={}, name={}", entity.getTenantCode(), entity.getTenantName());
+        return entity.getId();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void update(TenantSaveRequest request) {
+        SysTenant existing = requireById(request.getId());
+        // 编码是各业务表 tenant_id 的取值来源，改它等于让该租户的存量数据集体失去归属
+        if (!existing.getTenantCode().equals(request.getTenantCode())) {
+            throw new BizException(ResultCode.TENANT_CODE_IMMUTABLE);
+        }
+        SysTenant entity = new SysTenant();
+        BeanUtils.copyProperties(request, entity);
+        entity.setStatus(existing.getStatus());
+        tenantMapper.updateById(entity);
+        log.info("tenant updated, code={}", entity.getTenantCode());
+    }
+
+    /** 冻结/恢复/退租统一入口：只改状态不动数据。 */
+    @Transactional(rollbackFor = Exception.class)
+    public void changeStatus(Long id, TenantStatus target) {
+        SysTenant existing = requireById(id);
+        assertNotReserved(existing.getTenantCode());
+
+        SysTenant update = new SysTenant();
+        update.setId(id);
+        update.setStatus(target.name());
+        tenantMapper.updateById(update);
+        log.info("tenant status changed, code={}, status={}", existing.getTenantCode(), target);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void delete(Long id) {
+        SysTenant existing = requireById(id);
+        assertNotReserved(existing.getTenantCode());
+        // 逻辑删除：租户下的业务数据仍在库里，物理清理属于退租数据主权流程，不在这里做
+        tenantMapper.deleteById(id);
+        log.info("tenant deleted (logical), code={}", existing.getTenantCode());
+    }
+
+    /**
+     * 登录与接口调用前的租户可用性校验：不存在、已冻结、已退租、已过期一律拒绝。
+     *
+     * <p>这是"租户级熔断"的唯一落点——运营方冻结一个租户后，该租户的所有登录立刻失效。</p>
+     */
+    public void assertAccessible(String tenantCode) {
+        // 平台自身不受租户生命周期约束，否则运营方会把自己锁在门外
+        if (TenantContext.PLATFORM.equals(tenantCode)) {
+            return;
+        }
+        SysTenant tenant = findByCode(tenantCode);
+        if (tenant == null) {
+            throw new BizException(ResultCode.TENANT_NOT_FOUND);
+        }
+        if (!TenantStatus.parse(tenant.getStatus()).allowsAccess()) {
+            throw new BizException(ResultCode.TENANT_SUSPENDED);
+        }
+        if (tenant.getExpireTime() != null && tenant.getExpireTime().isBefore(java.time.LocalDateTime.now())) {
+            throw new BizException(ResultCode.TENANT_SUSPENDED, "租户已到期，请联系运营方续约");
+        }
+    }
+
+    /** 租户编码是否存在且可用（运营方切换视角时校验目标租户）。 */
+    public boolean existsAccessible(String tenantCode) {
+        if (TenantContext.PLATFORM.equals(tenantCode)) {
+            return true;
+        }
+        SysTenant tenant = findByCode(tenantCode);
+        return tenant != null && TenantStatus.parse(tenant.getStatus()).allowsAccess();
+    }
+
+    public SysTenant findByCode(String tenantCode) {
+        if (!StringUtils.hasText(tenantCode)) {
+            return null;
+        }
+        return tenantMapper.selectOne(
+            new LambdaQueryWrapper<SysTenant>().eq(SysTenant::getTenantCode, tenantCode));
+    }
+
+    private SysTenant requireById(Long id) {
+        SysTenant tenant = id == null ? null : tenantMapper.selectById(id);
+        if (tenant == null) {
+            throw new BizException(ResultCode.TENANT_NOT_FOUND);
+        }
+        return tenant;
+    }
+
+    private void assertNotReserved(String tenantCode) {
+        if (RESERVED_TENANTS.contains(tenantCode)) {
+            throw new BizException(ResultCode.TENANT_RESERVED_PROTECTED);
+        }
+    }
+
+    private TenantVO toVO(SysTenant entity) {
+        TenantVO vo = new TenantVO();
+        BeanUtils.copyProperties(entity, vo);
+        vo.setReserved(RESERVED_TENANTS.contains(entity.getTenantCode()));
+        return vo;
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V49__tenant_foundation.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V49__tenant_foundation.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- B1 租户地基：租户主数据 + 全量业务表 tenant_id 行级隔离列
+--
+-- 设计依据见 docs/多租户架构设计.md：
+--   - 隔离级别 = 共享库 + tenant_id 行级过滤，强制点在 MyBatis-Plus TenantLineInnerInterceptor；
+--   - 原则是"能加列的全加"，忽略表清单越短越安全，故这里只排除三类平台级/框架自建表；
+--   - 存量数据归入 default 租户，存量后台用户归入 __platform__（升级前的后台用户都是运营方）。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `sys_tenant` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `tenant_code`    VARCHAR(64) NOT NULL COMMENT '租户编码（业务主键，出现在 API Key 映射/日志/指标标签里）',
+    `tenant_name`    VARCHAR(128) NOT NULL COMMENT '租户名称',
+    `status`         VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态：ACTIVE正常 / SUSPENDED冻结 / TERMINATED退租',
+    `contact_name`   VARCHAR(64) COMMENT '联系人',
+    `contact_phone`  VARCHAR(32) COMMENT '联系电话',
+    `contact_email`  VARCHAR(128) COMMENT '联系邮箱',
+    `remark`         VARCHAR(500) COMMENT '备注',
+    `expire_time`    DATETIME COMMENT '到期时间（空=不限期）',
+    `create_by`      BIGINT COMMENT '创建人ID',
+    `create_time`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`      BIGINT COMMENT '更新人ID',
+    `update_time`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`        TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    UNIQUE KEY `uk_sys_tenant_code` (`tenant_code`),
+    KEY `idx_sys_tenant_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户主数据';
+
+-- 两个保留租户：default 承接升级前的存量数据，__platform__ 是平台运营方自身
+INSERT INTO `sys_tenant` (`tenant_code`, `tenant_name`, `status`, `remark`)
+SELECT 'default', '默认租户', 'ACTIVE', '升级前的存量数据归属，等价于原单租户系统'
+WHERE NOT EXISTS (SELECT 1 FROM `sys_tenant` WHERE `tenant_code` = 'default');
+
+INSERT INTO `sys_tenant` (`tenant_code`, `tenant_name`, `status`, `remark`)
+SELECT '__platform__', '平台运营方', 'ACTIVE', '运营方自身，承载平台级共享配置与全局管理员'
+WHERE NOT EXISTS (SELECT 1 FROM `sys_tenant` WHERE `tenant_code` = '__platform__');
+
+-- ============================================================================
+-- 全量业务表加 tenant_id（34 张，Flyway 保证只执行一次故无需幂等判定）。
+--
+-- 未列入的 4 张即拦截器忽略清单（须与 TenantInterceptors.PLATFORM_LEVEL_TABLES 一致）：
+--   sys_permission        权限点/菜单树的代码级定义，平台统一，租户只读
+--   sys_menu_change_log   菜单变更审计，随 sys_permission 同属平台级
+--   ai_system_tool        代码里 @Tool 注册的工具目录（租户是否启用走租户级的 ai_agent_system_tool）
+--   ai_chat_session_state 框架 MysqlAgentStateStore 直接持 DataSource 读写，绕过 MyBatis，加了列也没人填
+--
+-- ai_model_config 在列——它要加列，只是因承载模型凭据而额外由 Service 层做两级可见性（见 §2.4）。
+-- 刻意用显式清单而非 information_schema 游标：本库无 DROP TABLE 历史，表集合确定，
+-- 而 DELIMITER/存储过程在本项目的 Flyway 迁移里尚无先例，不值得为省几十行去冒解析风险。
+-- ============================================================================
+
+ALTER TABLE `ai_agent` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_backup_model` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_backup_model_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_knowledge_base` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_knowledge_base_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_mcp` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_mcp_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_memory` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_memory_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_skill` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_skill_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_sub_agent` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_sub_agent_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_system_tool` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_system_tool_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_task` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_task_tenant` (`tenant_id`);
+ALTER TABLE `ai_channel_binding` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_channel_binding_tenant` (`tenant_id`);
+ALTER TABLE `ai_channel_robot` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_channel_robot_tenant` (`tenant_id`);
+ALTER TABLE `ai_channel_session` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_channel_session_tenant` (`tenant_id`);
+ALTER TABLE `ai_chat_attachment` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_chat_attachment_tenant` (`tenant_id`);
+ALTER TABLE `ai_code_knowledge_chunk` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_code_knowledge_chunk_tenant` (`tenant_id`);
+ALTER TABLE `ai_code_knowledge_index` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_code_knowledge_index_tenant` (`tenant_id`);
+ALTER TABLE `ai_code_review_task` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_code_review_task_tenant` (`tenant_id`);
+ALTER TABLE `ai_coding_audit_log` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_coding_audit_log_tenant` (`tenant_id`);
+ALTER TABLE `ai_knowledge_base` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_knowledge_base_tenant` (`tenant_id`);
+ALTER TABLE `ai_mcp` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_mcp_tenant` (`tenant_id`);
+ALTER TABLE `ai_model_config` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_model_config_tenant` (`tenant_id`);
+ALTER TABLE `ai_project` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_project_tenant` (`tenant_id`);
+ALTER TABLE `ai_project_session` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_project_session_tenant` (`tenant_id`);
+ALTER TABLE `ai_scheduled_task` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_scheduled_task_tenant` (`tenant_id`);
+ALTER TABLE `ai_scheduled_task_run` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_scheduled_task_run_tenant` (`tenant_id`);
+ALTER TABLE `ai_site_message` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_site_message_tenant` (`tenant_id`);
+ALTER TABLE `ai_skill` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_skill_tenant` (`tenant_id`);
+ALTER TABLE `ai_skill_file` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_skill_file_tenant` (`tenant_id`);
+ALTER TABLE `cw_agent_call_log` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_cw_agent_call_log_tenant` (`tenant_id`);
+ALTER TABLE `cw_agent_call_segment` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_cw_agent_call_segment_tenant` (`tenant_id`);
+ALTER TABLE `sys_operation_log` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_operation_log_tenant` (`tenant_id`);
+ALTER TABLE `sys_role` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_role_tenant` (`tenant_id`);
+ALTER TABLE `sys_role_permission` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_role_permission_tenant` (`tenant_id`);
+ALTER TABLE `sys_user` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_user_tenant` (`tenant_id`);
+ALTER TABLE `sys_user_role` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_user_role_tenant` (`tenant_id`);
+
+-- ============================================================================
+-- 存量数据归属修正
+-- ============================================================================
+
+-- 升级前的后台用户/角色/权限关联都是运营方的，归入 __platform__；
+-- sys_user.username 刻意保持全局唯一（admin 只有一个登录入口，跨租户重名就无法定位归属租户），故不重建唯一键。
+UPDATE `sys_user` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+UPDATE `sys_role` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+UPDATE `sys_user_role` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+UPDATE `sys_role_permission` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+
+-- 存量模型配置转为平台共享（租户视角只读且 api_key 脱敏，见 docs/多租户架构设计.md §2.4）
+UPDATE `ai_model_config` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+
+-- ============================================================================
+-- 租户管理菜单与权限点（id 从 220 起，219 是 V46 字典管理占用的最后一个）
+--
+-- perm_code 一律以 tenant: 开头不是命名巧合：TenantProvisionService 正是按这个前缀
+-- 把租户管理权限从租户管理员角色里排除掉的。新增租户相关权限点务必沿用该前缀。
+-- 超管无需授权记录（AdminStpInterfaceImpl 对平台租户的 super_admin 直接放行全部权限点）。
+-- ============================================================================
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (220, 1, '租户管理', 'tenant:view', 1, '/system/tenant', 'OfficeBuilding', 'library', 9);
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (221, 220, '新增租户', 'tenant:add', 2, 1),
+    (222, 220, '编辑租户', 'tenant:edit', 2, 2),
+    (223, 220, '删除租户', 'tenant:delete', 2, 3);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/tenant/service/TenantServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/tenant/service/TenantServiceTest.java
@@ -1,0 +1,160 @@
+package com.richard.fyoung.customeradmin.tenant.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantSaveRequest;
+import com.richard.fyoung.customeradmin.tenant.entity.SysTenant;
+import com.richard.fyoung.customeradmin.tenant.entity.TenantStatus;
+import com.richard.fyoung.customeradmin.tenant.mapper.SysTenantMapper;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link TenantService} 单测：保留租户保护、编码不可变、生命周期与可访问性判定。
+ * @author owlzhangfq@gmail.com
+ */
+class TenantServiceTest {
+
+    private SysTenantMapper tenantMapper;
+    private TenantProvisionService provisionService;
+    private TenantService service;
+
+    @BeforeEach
+    void setUp() {
+        tenantMapper = mock(SysTenantMapper.class);
+        provisionService = mock(TenantProvisionService.class);
+        service = new TenantService(tenantMapper, provisionService);
+    }
+
+    private SysTenant tenant(Long id, String code, TenantStatus status) {
+        SysTenant entity = new SysTenant();
+        entity.setId(id);
+        entity.setTenantCode(code);
+        entity.setTenantName(code + " 名称");
+        entity.setStatus(status.name());
+        return entity;
+    }
+
+    @Test
+    void create_shouldRejectDuplicateCode() {
+        when(tenantMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(tenant(1L, "acme", TenantStatus.ACTIVE));
+
+        TenantSaveRequest request = new TenantSaveRequest();
+        request.setTenantCode("acme");
+        request.setTenantName("重复租户");
+
+        BizException e = assertThrows(BizException.class, () -> service.create(request));
+        assertEquals(ResultCode.TENANT_CODE_DUPLICATE, e.getResultCode(), "编码重复应拦在插入之前");
+        verify(tenantMapper, never()).insert(any(SysTenant.class));
+    }
+
+    @Test
+    void create_shouldProvisionNewTenant() {
+        when(tenantMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+
+        TenantSaveRequest request = new TenantSaveRequest();
+        request.setTenantCode("acme");
+        request.setTenantName("Acme");
+        service.create(request);
+
+        // 不初始化角色的新租户是个空壳：管理员建了也没有任何角色可分配
+        verify(provisionService).provision("acme");
+    }
+
+    @Test
+    void update_shouldRejectCodeChange() {
+        when(tenantMapper.selectById(1L)).thenReturn(tenant(1L, "acme", TenantStatus.ACTIVE));
+
+        TenantSaveRequest request = new TenantSaveRequest();
+        request.setId(1L);
+        request.setTenantCode("acme-renamed");
+        request.setTenantName("Acme");
+
+        BizException e = assertThrows(BizException.class, () -> service.update(request));
+        assertEquals(ResultCode.TENANT_CODE_IMMUTABLE, e.getResultCode(),
+            "编码是业务数据的归属标识，改了等于让存量数据失去归属");
+    }
+
+    @Test
+    void changeStatus_shouldProtectReservedTenants() {
+        when(tenantMapper.selectById(1L)).thenReturn(tenant(1L, TenantContext.DEFAULT, TenantStatus.ACTIVE));
+        when(tenantMapper.selectById(2L)).thenReturn(tenant(2L, TenantContext.PLATFORM, TenantStatus.ACTIVE));
+
+        assertEquals(ResultCode.TENANT_RESERVED_PROTECTED,
+            assertThrows(BizException.class, () -> service.changeStatus(1L, TenantStatus.SUSPENDED)).getResultCode(),
+            "冻结 default 会让存量数据整体不可访问");
+        assertEquals(ResultCode.TENANT_RESERVED_PROTECTED,
+            assertThrows(BizException.class, () -> service.changeStatus(2L, TenantStatus.SUSPENDED)).getResultCode(),
+            "冻结平台租户等于运营方把自己锁在门外");
+    }
+
+    @Test
+    void delete_shouldProtectReservedTenants() {
+        when(tenantMapper.selectById(1L)).thenReturn(tenant(1L, TenantContext.PLATFORM, TenantStatus.ACTIVE));
+        assertThrows(BizException.class, () -> service.delete(1L));
+        verify(tenantMapper, never()).deleteById(any(Long.class));
+    }
+
+    @Test
+    void changeStatus_shouldAllowNormalTenant() {
+        when(tenantMapper.selectById(9L)).thenReturn(tenant(9L, "acme", TenantStatus.ACTIVE));
+        service.changeStatus(9L, TenantStatus.SUSPENDED);
+        verify(tenantMapper).updateById(any(SysTenant.class));
+    }
+
+    @Test
+    void assertAccessible_shouldAlwaysAllowPlatform() {
+        assertDoesNotThrow(() -> service.assertAccessible(TenantContext.PLATFORM),
+            "平台自身不受租户生命周期约束");
+        verify(tenantMapper, never()).selectOne(any(LambdaQueryWrapper.class));
+    }
+
+    @Test
+    void assertAccessible_shouldRejectUnknownTenant() {
+        when(tenantMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+        assertEquals(ResultCode.TENANT_NOT_FOUND,
+            assertThrows(BizException.class, () -> service.assertAccessible("ghost")).getResultCode());
+    }
+
+    @Test
+    void assertAccessible_shouldRejectSuspendedTenant() {
+        when(tenantMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(tenant(1L, "acme", TenantStatus.SUSPENDED));
+        assertEquals(ResultCode.TENANT_SUSPENDED,
+            assertThrows(BizException.class, () -> service.assertAccessible("acme")).getResultCode(),
+            "冻结即刻生效于登录，这是租户级熔断的落点");
+    }
+
+    @Test
+    void assertAccessible_shouldRejectExpiredTenant() {
+        SysTenant expired = tenant(1L, "acme", TenantStatus.ACTIVE);
+        expired.setExpireTime(LocalDateTime.now().minusDays(1));
+        when(tenantMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(expired);
+
+        assertThrows(BizException.class, () -> service.assertAccessible("acme"), "已过期租户不应放行");
+    }
+
+    @Test
+    void existsAccessible_shouldReflectStatus() {
+        when(tenantMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(tenant(1L, "acme", TenantStatus.TERMINATED));
+        assertFalse(service.existsAccessible("acme"), "已退租的租户不能作为切换目标");
+        assertTrue(service.existsAccessible(TenantContext.PLATFORM), "平台视角恒可用");
+    }
+}

--- a/customer-admin-web/src/api/tenant.ts
+++ b/customer-admin-web/src/api/tenant.ts
@@ -1,0 +1,90 @@
+import { request } from './request'
+
+// 租户管理 API，与 admin-server /api/tenant/** 契约对应。
+// 除 current-view 外全部是平台运营方专属接口，后端会二次校验调用者身份。
+
+export interface TenantVO {
+  id: number
+  tenantCode: string
+  tenantName: string
+  status: string
+  contactName: string | null
+  contactPhone: string | null
+  contactEmail: string | null
+  remark: string | null
+  expireTime: string | null
+  createTime: string | null
+  /** 保留租户（default / __platform__）不允许改编码、冻结、退租或删除。 */
+  reserved: boolean
+}
+
+export interface TenantSaveRequest {
+  id?: number
+  tenantCode: string
+  tenantName: string
+  contactName?: string | null
+  contactPhone?: string | null
+  contactEmail?: string | null
+  remark?: string | null
+  expireTime?: string | null
+}
+
+export interface TenantPageQuery {
+  pageNum: number
+  pageSize: number
+  keyword?: string
+  tenantStatus?: string
+}
+
+export interface TenantPageResult {
+  pageNum: number
+  pageSize: number
+  total: number
+  list: TenantVO[]
+}
+
+/** 当前登录用户的租户视角，前端据此决定是否渲染租户切换器。 */
+export interface TenantViewVO {
+  userTenantId: string | null
+  effectiveTenantId: string | null
+  platformOperator: boolean
+}
+
+export function pageTenants(params: TenantPageQuery) {
+  return request<TenantPageResult>({ url: '/tenant/page', method: 'get', params })
+}
+
+export function getTenant(id: number) {
+  return request<TenantVO>({ url: `/tenant/${id}`, method: 'get' })
+}
+
+/** 可切换的租户下拉（仅 ACTIVE）。 */
+export function listTenantOptions() {
+  return request<TenantVO[]>({ url: '/tenant/options', method: 'get' })
+}
+
+export function createTenant(data: TenantSaveRequest) {
+  return request<number>({ url: '/tenant', method: 'post', data })
+}
+
+export function updateTenant(data: TenantSaveRequest) {
+  return request<void>({ url: '/tenant', method: 'put', data })
+}
+
+/** 冻结 / 恢复 / 退租：只改状态不动数据。 */
+export function changeTenantStatus(id: number, status: string) {
+  return request<void>({ url: `/tenant/${id}/status`, method: 'put', params: { status } })
+}
+
+export function deleteTenant(id: number) {
+  return request<void>({ url: `/tenant/${id}`, method: 'delete' })
+}
+
+export function fetchCurrentView() {
+  return request<TenantViewVO>({ url: '/tenant/current-view', method: 'get' })
+}
+
+/** 运营方切换目标租户视角；不传 tenantCode 回到平台自身视角。 */
+export function switchTenantView(tenantCode?: string) {
+  return request<void>({ url: '/tenant/switch-view', method: 'put', params: { tenantCode } })
+}

--- a/customer-admin-web/src/components/TenantSwitcher.vue
+++ b/customer-admin-web/src/components/TenantSwitcher.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { fetchCurrentView, listTenantOptions, switchTenantView, type TenantVO } from '@/api/tenant'
+
+// 顶栏租户切换器：只有平台运营方看得到。租户管理员的视角恒等于自己所属租户，
+// 给他渲染一个只有一项的下拉毫无意义，故直接不渲染。
+
+const PLATFORM = '__platform__'
+
+const platformOperator = ref(false)
+const effectiveTenant = ref<string | null>(null)
+const options = ref<TenantVO[]>([])
+const switching = ref(false)
+
+/** 平台视角在下拉里是一个显式选项，而不是"空值"——空值看起来像没选，容易误以为出了问题。 */
+const selected = computed({
+  get: () => effectiveTenant.value ?? PLATFORM,
+  set: (value: string) => void handleSwitch(value),
+})
+
+async function load() {
+  const view = await fetchCurrentView()
+  platformOperator.value = view.platformOperator === true
+  effectiveTenant.value = view.effectiveTenantId
+  if (platformOperator.value) {
+    options.value = await listTenantOptions()
+  }
+}
+
+async function handleSwitch(tenantCode: string) {
+  if (switching.value || tenantCode === (effectiveTenant.value ?? PLATFORM)) return
+  switching.value = true
+  try {
+    await switchTenantView(tenantCode === PLATFORM ? undefined : tenantCode)
+    ElMessage.success(tenantCode === PLATFORM ? '已回到平台视角' : `已切换到租户 ${tenantCode}`)
+    // 整页重载：当前页面上的列表、详情、缓存都属于上一个租户，逐个刷新既繁琐又容易漏掉一处
+    window.location.reload()
+  } finally {
+    switching.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <el-select
+    v-if="platformOperator"
+    v-model="selected"
+    class="tenant-switcher"
+    size="default"
+    :loading="switching"
+    filterable
+  >
+    <template #prefix>
+      <el-icon><OfficeBuilding /></el-icon>
+    </template>
+    <el-option label="平台视角（全部）" :value="PLATFORM" />
+    <el-option
+      v-for="item in options"
+      :key="item.tenantCode"
+      :label="`${item.tenantName}（${item.tenantCode}）`"
+      :value="item.tenantCode"
+    />
+  </el-select>
+</template>
+
+<style scoped>
+.tenant-switcher {
+  width: 220px;
+  margin-right: 8px;
+}
+</style>

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -10,6 +10,7 @@ import TabsBar from './TabsBar.vue'
 import AppBreadcrumb from './AppBreadcrumb.vue'
 import FooterCopyright from '@/components/FooterCopyright.vue'
 import NotificationBell from '@/components/NotificationBell.vue'
+import TenantSwitcher from '@/components/TenantSwitcher.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -66,6 +67,7 @@ async function handleLogout() {
           />
         </div>
         <div class="header-right">
+          <TenantSwitcher />
           <el-button
             class="collapse-btn"
             text

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -15,6 +15,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/devtools': () => import('@/views/system/DevToolboxView.vue'),
   '/system/login-image': () => import('@/views/system/LoginImageManage.vue'),
   '/system/dict': () => import('@/views/system/DictManage.vue'),
+  '/system/tenant': () => import('@/views/system/TenantManage.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),

--- a/customer-admin-web/src/views/system/TenantManage.vue
+++ b/customer-admin-web/src/views/system/TenantManage.vue
@@ -1,0 +1,296 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import type { FormInstance, FormRules } from 'element-plus'
+import {
+  changeTenantStatus,
+  createTenant,
+  deleteTenant,
+  pageTenants,
+  updateTenant,
+  type TenantSaveRequest,
+  type TenantVO,
+} from '@/api/tenant'
+
+// 租户管理：平台运营方专属。保留租户（default / __platform__）在后端受保护，
+// 前端同步禁用相应按钮，避免用户点了才收到报错。
+
+const STATUS_LABELS: Record<string, { text: string; type: 'success' | 'warning' | 'info' }> = {
+  ACTIVE: { text: '正常', type: 'success' },
+  SUSPENDED: { text: '已冻结', type: 'warning' },
+  TERMINATED: { text: '已退租', type: 'info' },
+}
+
+const loading = ref(false)
+const list = ref<TenantVO[]>([])
+const total = ref(0)
+const query = reactive({ pageNum: 1, pageSize: 10, keyword: '', tenantStatus: '' })
+
+async function loadList() {
+  loading.value = true
+  try {
+    const data = await pageTenants(query)
+    list.value = data.list
+    total.value = data.total
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleSearch() {
+  query.pageNum = 1
+  return loadList()
+}
+
+// ---------- 新建 / 编辑 ----------
+
+const dialogVisible = ref(false)
+const dialogMode = ref<'create' | 'edit'>('create')
+const formRef = ref<FormInstance>()
+const form = reactive<TenantSaveRequest>({
+  tenantCode: '',
+  tenantName: '',
+  contactName: '',
+  contactPhone: '',
+  contactEmail: '',
+  remark: '',
+  expireTime: null,
+})
+
+const rules: FormRules = {
+  tenantCode: [
+    { required: true, message: '请输入租户编码', trigger: 'blur' },
+    {
+      pattern: /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/,
+      message: '只能包含字母、数字、连字符和下划线，且以字母或数字开头',
+      trigger: 'blur',
+    },
+  ],
+  tenantName: [{ required: true, message: '请输入租户名称', trigger: 'blur' }],
+  contactEmail: [{ type: 'email', message: '邮箱格式不正确', trigger: 'blur' }],
+}
+
+function openCreate() {
+  dialogMode.value = 'create'
+  Object.assign(form, {
+    id: undefined,
+    tenantCode: '',
+    tenantName: '',
+    contactName: '',
+    contactPhone: '',
+    contactEmail: '',
+    remark: '',
+    expireTime: null,
+  })
+  dialogVisible.value = true
+}
+
+function openEdit(row: TenantVO) {
+  dialogMode.value = 'edit'
+  Object.assign(form, {
+    id: row.id,
+    tenantCode: row.tenantCode,
+    tenantName: row.tenantName,
+    contactName: row.contactName ?? '',
+    contactPhone: row.contactPhone ?? '',
+    contactEmail: row.contactEmail ?? '',
+    remark: row.remark ?? '',
+    expireTime: row.expireTime,
+  })
+  dialogVisible.value = true
+}
+
+async function submit() {
+  const valid = await formRef.value?.validate().catch(() => false)
+  if (!valid) return
+  if (dialogMode.value === 'create') {
+    await createTenant(form)
+    ElMessage.success('租户已创建，已自动初始化租户管理员角色')
+  } else {
+    await updateTenant(form)
+    ElMessage.success('租户已更新')
+  }
+  dialogVisible.value = false
+  await loadList()
+}
+
+// ---------- 生命周期 ----------
+
+async function handleStatusChange(row: TenantVO, target: string) {
+  const action = target === 'ACTIVE' ? '恢复' : target === 'SUSPENDED' ? '冻结' : '退租'
+  const extra =
+    target === 'ACTIVE'
+      ? ''
+      : '该租户下的所有账号将立即无法登录，业务数据保留不受影响。'
+  await ElMessageBox.confirm(`确认${action}租户「${row.tenantName}」？${extra}`, `${action}确认`, {
+    type: 'warning',
+  })
+  await changeTenantStatus(row.id, target)
+  ElMessage.success(`租户已${action}`)
+  await loadList()
+}
+
+async function handleDelete(row: TenantVO) {
+  await ElMessageBox.confirm(
+    `确认删除租户「${row.tenantName}」？删除后该租户无法登录，但其业务数据仍保留在库中。`,
+    '删除确认',
+    { type: 'warning' },
+  )
+  await deleteTenant(row.id)
+  ElMessage.success('租户已删除')
+  await loadList()
+}
+
+onMounted(loadList)
+</script>
+
+<template>
+  <div class="page">
+    <el-card>
+      <div class="toolbar">
+        <el-input
+          v-model="query.keyword"
+          placeholder="按租户编码或名称搜索"
+          style="width: 240px"
+          clearable
+          @keyup.enter="handleSearch"
+        />
+        <el-select v-model="query.tenantStatus" placeholder="全部状态" clearable style="width: 140px">
+          <el-option label="正常" value="ACTIVE" />
+          <el-option label="已冻结" value="SUSPENDED" />
+          <el-option label="已退租" value="TERMINATED" />
+        </el-select>
+        <el-button type="primary" @click="handleSearch">搜索</el-button>
+        <el-button v-permission="'tenant:add'" type="primary" @click="openCreate">新建租户</el-button>
+      </div>
+
+      <el-table v-loading="loading" :data="list" style="width: 100%">
+        <el-table-column prop="tenantCode" label="租户编码" width="160">
+          <template #default="{ row }">
+            {{ row.tenantCode }}
+            <el-tag v-if="row.reserved" size="small" type="info" style="margin-left: 6px">系统保留</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="tenantName" label="租户名称" />
+        <el-table-column label="状态" width="100">
+          <template #default="{ row }">
+            <el-tag :type="STATUS_LABELS[row.status]?.type ?? 'info'">
+              {{ STATUS_LABELS[row.status]?.text ?? row.status }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="contactName" label="联系人" width="120" />
+        <el-table-column prop="contactPhone" label="联系电话" width="140" />
+        <el-table-column prop="expireTime" label="到期时间" width="180">
+          <template #default="{ row }">{{ row.expireTime ?? '不限期' }}</template>
+        </el-table-column>
+        <el-table-column prop="createTime" label="创建时间" width="180" />
+        <el-table-column label="操作" width="240" fixed="right">
+          <template #default="{ row }">
+            <el-button v-permission="'tenant:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
+            <el-button
+              v-if="row.status === 'ACTIVE'"
+              v-permission="'tenant:edit'"
+              link
+              type="warning"
+              :disabled="row.reserved"
+              @click="handleStatusChange(row, 'SUSPENDED')"
+            >
+              冻结
+            </el-button>
+            <el-button
+              v-else
+              v-permission="'tenant:edit'"
+              link
+              type="success"
+              :disabled="row.reserved"
+              @click="handleStatusChange(row, 'ACTIVE')"
+            >
+              恢复
+            </el-button>
+            <el-button
+              v-permission="'tenant:edit'"
+              link
+              type="info"
+              :disabled="row.reserved || row.status === 'TERMINATED'"
+              @click="handleStatusChange(row, 'TERMINATED')"
+            >
+              退租
+            </el-button>
+            <el-button
+              v-permission="'tenant:delete'"
+              link
+              type="danger"
+              :disabled="row.reserved"
+              @click="handleDelete(row)"
+            >
+              删除
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-model:current-page="query.pageNum"
+        v-model:page-size="query.pageSize"
+        :total="total"
+        layout="total, prev, pager, next"
+        style="margin-top: 16px; justify-content: flex-end"
+        @current-change="loadList"
+      />
+    </el-card>
+
+    <el-dialog v-model="dialogVisible" :title="dialogMode === 'create' ? '新建租户' : '编辑租户'" width="560px">
+      <el-form ref="formRef" :model="form" :rules="rules" label-width="90px">
+        <el-form-item label="租户编码" prop="tenantCode">
+          <el-input v-model="form.tenantCode" :disabled="dialogMode === 'edit'" placeholder="如 acme" />
+          <div v-if="dialogMode === 'create'" class="form-tip">
+            创建后不可修改：它会写进该租户所有业务数据的归属标识。
+          </div>
+        </el-form-item>
+        <el-form-item label="租户名称" prop="tenantName">
+          <el-input v-model="form.tenantName" />
+        </el-form-item>
+        <el-form-item label="联系人">
+          <el-input v-model="form.contactName!" />
+        </el-form-item>
+        <el-form-item label="联系电话">
+          <el-input v-model="form.contactPhone!" />
+        </el-form-item>
+        <el-form-item label="联系邮箱" prop="contactEmail">
+          <el-input v-model="form.contactEmail!" />
+        </el-form-item>
+        <el-form-item label="到期时间">
+          <el-date-picker
+            v-model="form.expireTime"
+            type="datetime"
+            placeholder="留空表示不限期"
+            value-format="YYYY-MM-DDTHH:mm:ss"
+            style="width: 100%"
+          />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="form.remark!" type="textarea" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submit">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.form-tip {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.6;
+}
+</style>

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserAuthController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserAuthController.java
@@ -4,6 +4,7 @@ import com.richard.fyoung.customerwork.user.UserAccount;
 import com.richard.fyoung.customerwork.user.UserAccountService;
 import com.richard.fyoung.customerwork.security.UserJwtService;
 import com.richard.fyoung.customerwork.security.UserPrincipal;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
 import com.richard.fyoung.customerworkapp.service.AvatarStorageService;
 import com.richard.fyoung.customerworkapp.service.DemoOrderSeeder;
 import io.swagger.v3.oas.annotations.Operation;
@@ -57,24 +58,32 @@ public class UserAuthController {
         this.avatarStorageService = avatarStorageService;
     }
 
-    /** 注册请求体。 */
+    /**
+     * 注册请求体。
+     *
+     * <p>{@code tenantCode} 由前端按接入方部署注入（URL 参数或构建期配置），留空归默认租户。
+     * 注册与登录是仅有的两个必须由客户端提供租户线索的接口——此时还没有登录态可依据。</p>
+     */
     public record RegisterRequest(
         @NotBlank @Size(min = 3, max = 64) String username,
         @NotBlank @Size(min = 6, max = 64) String password,
         String nickname,
-        String phone) {
+        String phone,
+        String tenantCode) {
     }
 
-    /** 登录请求体。 */
+    /** 登录请求体，{@code tenantCode} 语义同注册。 */
     public record LoginRequest(
         @NotBlank String username,
-        @NotBlank String password) {
+        @NotBlank String password,
+        String tenantCode) {
     }
 
     @Operation(summary = "注册", description = "用户名 3-64、密码 6-64；用户名重复返回 409")
     @PostMapping("/register")
     public Mono<Map<String, Object>> register(@Valid @RequestBody RegisterRequest request) {
-        return Mono.fromCallable(() -> {
+        String tenantId = resolveTenant(request.tenantCode());
+        return Mono.fromCallable(() -> TenantContext.callWith(tenantId, () -> {
                 UserAccount account = userAccountService.register(
                     request.username(), request.password(), request.nickname(), request.phone());
                 // 演示订单播种：失败已在 seeder 内部 catch 并 error 日志，不影响注册主流程
@@ -82,7 +91,7 @@ public class UserAuthController {
                 Map<String, Object> body = new LinkedHashMap<>();
                 body.put("userId", account.getId());
                 return body;
-            })
+            }))
             .subscribeOn(Schedulers.boundedElastic())
             .onErrorMap(IllegalStateException.class,
                 e -> new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage()));
@@ -91,19 +100,28 @@ public class UserAuthController {
     @Operation(summary = "登录", description = "校验失败返回 401；成功返回 JWT 登录态令牌")
     @PostMapping("/login")
     public Mono<Map<String, Object>> login(@Valid @RequestBody LoginRequest request) {
-        return Mono.fromCallable(() -> userAccountService.verifyLogin(request.username(), request.password()))
+        String tenantId = resolveTenant(request.tenantCode());
+        return Mono.fromCallable(() -> TenantContext.callWith(tenantId,
+                () -> userAccountService.verifyLogin(request.username(), request.password())))
             .subscribeOn(Schedulers.boundedElastic())
             .flatMap(Mono::justOrEmpty)
             .switchIfEmpty(Mono.error(new ResponseStatusException(
                 HttpStatus.UNAUTHORIZED, "用户名或密码错误")))
             .map(account -> {
                 Map<String, Object> body = new LinkedHashMap<>();
-                body.put("token", jwtService.issue(account.getId(), account.getUsername(), account.getNickname()));
+                // 租户焊进令牌：后续请求一律以令牌里的为准，不再看客户端传什么
+                body.put("token", jwtService.issue(
+                    account.getId(), account.getUsername(), account.getNickname(), tenantId));
                 body.put("userId", account.getId());
                 body.put("nickname", account.getNickname());
                 body.put("expiresAtMs", jwtService.expiresAtMs());
                 return body;
             });
+    }
+
+    /** 客户端未提供租户线索时归默认租户，保证单租户部署的既有前端不改一行也能继续用。 */
+    private String resolveTenant(String tenantCode) {
+        return tenantCode == null || tenantCode.isBlank() ? TenantContext.DEFAULT : tenantCode;
     }
 
     @Operation(summary = "当前登录信息", description = "需 Bearer 令牌；令牌无效返回 401")

--- a/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchServiceTest.java
+++ b/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchServiceTest.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerworkapp.chat;
 import com.richard.fyoung.customerwork.chatlog.ChatLogService;
 import com.richard.fyoung.customerwork.chatlog.ChatMessage;
 import com.richard.fyoung.customerwork.service.CustomerServiceService;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
 import com.richard.fyoung.customerwork.ticket.Ticket;
 import com.richard.fyoung.customerwork.ticket.TicketActorType;
 import com.richard.fyoung.customerwork.ticket.TicketCategory;
@@ -46,7 +47,7 @@ class ChatDispatchServiceTest {
     private WsSessionRegistry registry;
     private ChatDispatchService dispatch;
 
-    private final UserPrincipal user = new UserPrincipal(USER_ID, "alice", "Alice");
+    private final UserPrincipal user = new UserPrincipal(USER_ID, "alice", "Alice", TenantContext.DEFAULT);
 
     @BeforeEach
     void setUp() {

--- a/customer-work-app/src/api/auth.ts
+++ b/customer-work-app/src/api/auth.ts
@@ -1,13 +1,25 @@
 import { request } from '@/api/request'
 import type { LoginRequest, LoginResponse, RegisterRequest, RegisterResponse, UserInfo } from '@/types/api'
+import { currentTenantCode } from '@/utils/tenant'
 
 // baseURL 已配置为 /api（见 request.ts + .env.development），此处 url 不再重复 /api 前缀
+
+// 租户编码在这里统一注入，调用方（登录页/注册页）无需感知多租户；
+// 单租户部署下 currentTenantCode() 返回 undefined，请求体与改造前完全一致。
 export function register(payload: RegisterRequest): Promise<RegisterResponse> {
-  return request({ url: '/customer/auth/register', method: 'post', data: payload })
+  return request({
+    url: '/customer/auth/register',
+    method: 'post',
+    data: { ...payload, tenantCode: currentTenantCode() },
+  })
 }
 
 export function login(payload: LoginRequest): Promise<LoginResponse> {
-  return request({ url: '/customer/auth/login', method: 'post', data: payload })
+  return request({
+    url: '/customer/auth/login',
+    method: 'post',
+    data: { ...payload, tenantCode: currentTenantCode() },
+  })
 }
 
 export function fetchMe(): Promise<UserInfo> {

--- a/customer-work-app/src/main.ts
+++ b/customer-work-app/src/main.ts
@@ -4,11 +4,15 @@ import Vant from 'vant'
 import 'vant/lib/index.css'
 import App from './App.vue'
 import router from './router'
+import { captureTenantFromUrl } from './utils/tenant'
 import './style.css'
 
 // 电脑浏览器鼠标模拟触摸：用户只在电脑浏览器验证移动端页面，van-swipe-cell/van-list 等手势交互
 // 依赖 touchstart/touchmove/touchend，仅有 mouse 事件的桌面浏览器需要这个 polyfill 才能操作。
 import '@vant/touch-emulator'
+
+// 接入方通常带 ?tenant=xxx 首次进入，这里在建应用前落缓存，之后登录/注册自动携带
+captureTenantFromUrl()
 
 const app = createApp(App)
 

--- a/customer-work-app/src/utils/tenant.ts
+++ b/customer-work-app/src/utils/tenant.ts
@@ -1,0 +1,36 @@
+/**
+ * H5 端的租户标识解析。
+ *
+ * 登录与注册是仅有的两个需要客户端提供租户线索的接口——那时还没有登录态可依据。
+ * 登录成功后租户被焊进 JWT，后续请求一律以令牌里的为准，这里存的值不再参与鉴权，
+ * 所以它被改写也不构成越权（改了只会导致登录失败或登进另一个自己本就有账号的租户）。
+ *
+ * 来源优先级：URL 参数 > 本地缓存 > 构建期配置。
+ * 接入方通常把 H5 嵌在自己站点里，首次带 ?tenant=xxx 进来即可，之后由缓存接管。
+ */
+
+const STORAGE_KEY = 'cw_tenant_code'
+const QUERY_KEY = 'tenant'
+
+/** 从 URL 读租户并落缓存；应在应用启动时调用一次。 */
+export function captureTenantFromUrl(): void {
+  const fromQuery = new URLSearchParams(window.location.search).get(QUERY_KEY)
+  if (fromQuery && fromQuery.trim()) {
+    localStorage.setItem(STORAGE_KEY, fromQuery.trim())
+  }
+}
+
+/** 当前租户编码；未知时返回 undefined，由后端回落默认租户。 */
+export function currentTenantCode(): string | undefined {
+  const cached = localStorage.getItem(STORAGE_KEY)
+  if (cached && cached.trim()) {
+    return cached.trim()
+  }
+  const configured = import.meta.env.VITE_TENANT_CODE as string | undefined
+  return configured && configured.trim() ? configured.trim() : undefined
+}
+
+/** 退出登录时清理，避免换租户登录时沿用上一个租户。 */
+export function clearTenantCode(): void {
+  localStorage.removeItem(STORAGE_KEY)
+}

--- a/customer-work-starter/pom.xml
+++ b/customer-work-starter/pom.xml
@@ -69,6 +69,17 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
+        <!-- 多租户上下文跨线程传播：TenantContext 是 ThreadLocal（MyBatis 拦截器只能同步读），
+             而 WebFlux 主链路会切到 boundedElastic 执行阻塞 JDBC。context-propagation 提供
+             ThreadLocalAccessor SPI，配合 Hooks.enableAutomaticContextPropagation() 在线程边界还原。
+             虽由 micrometer-observation 传递可得，仍显式声明——它是租户隔离正确性的直接依赖，
+             不能寄望于传递链上游哪天不再引它。Boot 不托管该坐标，版本钉在根 pom。 -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>context-propagation</artifactId>
+            <version>${context-propagation.version}</version>
+        </dependency>
+
         <!-- 会话持久化：HikariCP 连接池 + MySQL 驱动。
              用 HikariCP 而非 spring-boot-starter-jdbc，避免引入 spring-jdbc 触发
              DataSourceAutoConfiguration（否则下游需配 spring.datasource.url 或排除它）。 -->

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkPersistenceConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkPersistenceConfig.java
@@ -7,6 +7,7 @@ import com.baomidou.mybatisplus.core.toolkit.GlobalConfigUtils;
 import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
 import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
 import com.baomidou.mybatisplus.extension.spring.MybatisSqlSessionFactoryBean;
+import com.richard.fyoung.customerwork.tenant.TenantInterceptors;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -79,7 +80,8 @@ public class CustomerWorkPersistenceConfig {
      */
     @Bean("customerWorkSqlSessionFactory")
     @ConditionalOnMissingBean(name = "customerWorkSqlSessionFactory")
-    public SqlSessionFactory customerWorkSqlSessionFactory(DataSource customerWorkDataSource) throws Exception {
+    public SqlSessionFactory customerWorkSqlSessionFactory(DataSource customerWorkDataSource,
+                                                           CustomerWorkProperties properties) throws Exception {
         MybatisSqlSessionFactoryBean factoryBean = new MybatisSqlSessionFactoryBean();
         factoryBean.setDataSource(customerWorkDataSource);
         factoryBean.setMapperLocations(resolveMapperLocations());
@@ -94,7 +96,7 @@ public class CustomerWorkPersistenceConfig {
         globalConfig.setBanner(false);
         factoryBean.setGlobalConfig(globalConfig);
 
-        factoryBean.setPlugins(paginationInterceptor());
+        factoryBean.setPlugins(buildInterceptor(properties));
         return factoryBean.getObject();
     }
 
@@ -113,9 +115,20 @@ public class CustomerWorkPersistenceConfig {
         return new SchemaInitializer(customerWorkDataSource, properties);
     }
 
-    /** 分页插件（MySQL 方言）：工单 findPage 用 {@code Page} 服务端分页。 */
-    private MybatisPlusInterceptor paginationInterceptor() {
+    /**
+     * 插件链：租户过滤 + 分页（MySQL 方言，工单 findPage 用 {@code Page} 服务端分页）。
+     *
+     * <p><b>租户拦截器必须排在分页之前</b>：MyBatis-Plus 按注册顺序执行内部拦截器，
+     * 分页插件会先执行 count 查询，若租户条件尚未拼上，count 与实际数据页的口径就会不一致。</p>
+     */
+    private MybatisPlusInterceptor buildInterceptor(CustomerWorkProperties properties) {
         MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        CustomerWorkProperties.Tenant tenant = properties.getTenant();
+        if (tenant.isEnabled()) {
+            interceptor.addInnerInterceptor(
+                TenantInterceptors.build(tenant.getColumnName(), tenant.getIgnoredTables()));
+            log.info("customer-work tenant line filter enabled, column={}", tenant.getColumnName());
+        }
         interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
         return interceptor;
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -104,6 +104,42 @@ public class CustomerWorkProperties {
     /** 分布式锁（跨实例互斥场景，如后台管理并发写操作互斥），基于 Redisson。 */
     private final DistributedLock distributedLock = new DistributedLock();
 
+    /** 多租户隔离（tenant_id 行级过滤），SaaS 部署开启。 */
+    private final Tenant tenant = new Tenant();
+
+    /**
+     * 多租户配置。默认关闭——单租户部署（升级前的既有形态）行为完全不变。
+     *
+     * <p>开启后 {@code TenantLineInnerInterceptor} 接管本 starter 独立 MyBatis 环境下的全部
+     * SELECT/UPDATE/DELETE 改写与 INSERT 补列，且缺失租户上下文时 fail-closed 直接报错，
+     * 而不是放行成全量查询——静默返回跨租户数据比报错危险得多。</p>
+     */
+    @Data
+    public static class Tenant {
+
+        /** 是否开启多租户行级隔离。 */
+        private boolean enabled = false;
+
+        /** 租户列名（全部业务表统一）。 */
+        private String columnName = "tenant_id";
+
+        /**
+         * 不参与租户过滤的表（平台级数据 + 框架自建表）。
+         *
+         * <p>清单语义见 {@code docs/多租户架构设计.md}：这里的表要么内容由平台定义租户只读，
+         * 要么根本没有 {@code tenant_id} 列（框架自建），漏配会让 SQL 拼出不存在的列而报错。</p>
+         */
+        private List<String> ignoredTables = new ArrayList<>();
+
+        /**
+         * 是否在 starter 内开启 Reactor 自动上下文传播（{@code Hooks.enableAutomaticContextPropagation()}）。
+         *
+         * <p>WebFlux 主链路会切到 boundedElastic 执行阻塞 JDBC，而 MyBatis 拦截器读的是 ThreadLocal——
+         * 不传播就必然在跨线程边界丢租户。该 Hook 是 JVM 全局的，故只在多租户开启时才装。</p>
+         */
+        private boolean autoContextPropagation = true;
+    }
+
     /**
      * 会话总结建议配置。默认关闭。
      *
@@ -834,6 +870,17 @@ public class CustomerWorkProperties {
             private String headerName = "X-API-Key";
             /** 合法 API Key 列表。 */
             private List<String> apiKeys = new ArrayList<>();
+
+            /**
+             * 多租户下的 Key→租户映射：{@code key: 租户ID}。
+             *
+             * <p>开启多租户后，服务端接入方的租户身份就取自这里——Key 是接入方唯一提供的凭据，
+             * 也是唯一不可伪造的租户线索（请求头里的租户参数谁都能改）。</p>
+             *
+             * <p>与 {@code apiKeys} 并存：本映射里的 Key 同样视为合法凭据，无需再往 {@code apiKeys} 抄一份；
+             * 只在 {@code apiKeys} 里的 Key 归入默认租户，保证单租户部署升级后行为不变。</p>
+             */
+            private Map<String, String> tenantKeys = new LinkedHashMap<>();
         }
 
         /**

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/ApiKeyAuthWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/ApiKeyAuthWebFilter.java
@@ -1,6 +1,8 @@
 package com.richard.fyoung.customerwork.security;
 
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import com.richard.fyoung.customerwork.tenant.TenantContextThreadLocalAccessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -13,12 +15,17 @@ import reactor.core.publisher.Mono;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.List;
+import java.util.Map;
 
 /**
- * API Key 鉴权过滤器（接入层安全）。
+ * API Key 鉴权过滤器（接入层安全 + 服务端接入方的租户身份来源）。
  *
  * <p>校验请求头中的 API Key 是否合法；健康检查与 Actuator 端点放行。默认关闭，
  * 生产开启 {@code customer-work.security.auth.enabled=true} 并配置 {@code api-keys} 后强制鉴权。</p>
+ *
+ * <p>多租户开启时，Key 同时承担租户身份：{@code tenant-keys} 里配置 Key→租户映射，
+ * 鉴权通过即把对应租户写入下游上下文。Key 是接入方唯一不可伪造的凭据，
+ * 因此也是唯一可信的租户线索——请求头里带的租户参数一概不采信。</p>
  * @author owlzhangfq@gmail.com
  */
 @Component
@@ -38,31 +45,68 @@ public class ApiKeyAuthWebFilter implements WebFilter {
             return chain.filter(exchange);
         }
         String provided = exchange.getRequest().getHeaders().getFirst(auth.getHeaderName());
-        if (matches(provided, auth.getApiKeys())) {
-            return chain.filter(exchange);
+        String tenantId = resolveTenant(provided, auth);
+        if (tenantId != null) {
+            return chainWithTenant(exchange, chain, tenantId);
         }
         exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
         return exchange.getResponse().setComplete();
     }
 
     /**
-     * 常量时间校验：用 {@link MessageDigest#isEqual} 比对，且遍历所有配置的 Key 不做短路返回，
+     * 校验 Key 并解析其租户，非法返回 {@code null}。
+     *
+     * <p>常量时间校验：用 {@link MessageDigest#isEqual} 比对，且遍历所有配置的 Key 不做短路返回，
      * 避免按"命中位置 / 前缀匹配长度"产生可被测量的耗时差异（时序侧信道）。
-     * 同时省去原先每请求 {@code new HashSet<>(...)} 的临时对象分配。
+     * 加入租户映射后同样逐条走完——命中后仅记录结果，不提前结束循环。</p>
      */
-    private boolean matches(String provided, List<String> validKeys) {
-        if (provided == null || validKeys == null || validKeys.isEmpty()) {
-            return false;
+    private String resolveTenant(String provided, CustomerWorkProperties.Security.Auth auth) {
+        if (provided == null) {
+            return null;
         }
         byte[] providedBytes = provided.getBytes(StandardCharsets.UTF_8);
-        boolean matched = false;
-        for (String key : validKeys) {
-            if (key != null
-                && MessageDigest.isEqual(providedBytes, key.getBytes(StandardCharsets.UTF_8))) {
-                matched = true;   // 不 break：保持比对次数与输入无关
+        String matchedTenant = null;
+
+        Map<String, String> tenantKeys = auth.getTenantKeys();
+        if (tenantKeys != null) {
+            for (Map.Entry<String, String> entry : tenantKeys.entrySet()) {
+                if (constantTimeEquals(providedBytes, entry.getKey())) {
+                    matchedTenant = entry.getValue();
+                }
             }
         }
-        return matched;
+
+        List<String> validKeys = auth.getApiKeys();
+        if (validKeys != null) {
+            for (String key : validKeys) {
+                if (constantTimeEquals(providedBytes, key)) {
+                    // 未配租户的 Key 归默认租户：单租户部署升级后行为不变
+                    if (matchedTenant == null) {
+                        matchedTenant = TenantContext.DEFAULT;
+                    }
+                }
+            }
+        }
+        return matchedTenant;
+    }
+
+    private boolean constantTimeEquals(byte[] providedBytes, String candidate) {
+        return candidate != null
+            && MessageDigest.isEqual(providedBytes, candidate.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * 把租户放进 Reactor Context，并在本过滤器所在线程同步设置 ThreadLocal。
+     *
+     * <p>两者都要：Reactor Context 是跨线程边界的权威载体（配合
+     * {@code Hooks.enableAutomaticContextPropagation()} 在切到 boundedElastic 时还原 ThreadLocal）；
+     * 而同步的 MyBatis 拦截器只认 ThreadLocal，若下游恰好没发生线程切换，就靠这里直接设的这一份。</p>
+     */
+    private Mono<Void> chainWithTenant(ServerWebExchange exchange, WebFilterChain chain, String tenantId) {
+        TenantContext.set(tenantId);
+        return chain.filter(exchange)
+            .contextWrite(ctx -> ctx.put(TenantContextThreadLocalAccessor.KEY, tenantId))
+            .doFinally(signal -> TenantContext.clear());
     }
 
     /** 健康检查、可观测端点、Swagger 文档免鉴权（便于探针 / 监控抓取 / 查看 API 文档）。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/UserAuthWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/UserAuthWebFilter.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customerwork.security;
 
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import com.richard.fyoung.customerwork.tenant.TenantContextThreadLocalAccessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
@@ -54,6 +56,25 @@ public class UserAuthWebFilter implements WebFilter {
             return AuthResponses.unauthorized(exchange, "invalid or expired token");
         }
         exchange.getAttributes().put(PRINCIPAL_ATTR, principal.get());
-        return chain.filter(exchange);
+        return chainWithTenant(exchange, chain, principal.get().tenantId());
+    }
+
+    /**
+     * 把令牌里的租户写入下游上下文。
+     *
+     * <p>不覆盖已有值：{@code ApiKeyAuthWebFilter} 先于本过滤器执行，若接入方走的是 API Key，
+     * 租户已由那把 Key 决定；同一请求两个身份来源打架时，以更靠前的基础设施闸门为准。</p>
+     *
+     * <p>Reactor Context 与 ThreadLocal 都写，理由同 {@code ApiKeyAuthWebFilter}：
+     * 前者跨线程边界还原，后者供未发生线程切换时的同步持久层读取。</p>
+     */
+    private Mono<Void> chainWithTenant(ServerWebExchange exchange, WebFilterChain chain, String tenantId) {
+        if (tenantId == null || tenantId.isBlank() || TenantContext.isPresent()) {
+            return chain.filter(exchange);
+        }
+        TenantContext.set(tenantId);
+        return chain.filter(exchange)
+            .contextWrite(ctx -> ctx.put(TenantContextThreadLocalAccessor.KEY, tenantId))
+            .doFinally(signal -> TenantContext.clear());
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/UserJwtService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/UserJwtService.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.security;
 
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -37,6 +38,7 @@ public class UserJwtService {
 
     private static final String CLAIM_USERNAME = "username";
     private static final String CLAIM_NICKNAME = "nickname";
+    private static final String CLAIM_TENANT = "tenant";
     private static final long HOUR_MS = 3600_000L;
 
     private final SecretKey signingKey;
@@ -55,16 +57,27 @@ public class UserJwtService {
     }
 
     /**
-     * 签发登录态令牌：subject=userId，附带 username / nickname，过期时间为签发时刻 + 有效期。
+     * 签发默认租户的登录态令牌。
+     *
+     * <p>保留三参重载是为了不破坏已接入的下游（本类是 starter 的公开 API）。
+     * 多租户部署必须用四参版本显式传租户，否则所有用户都会落到默认租户。</p>
+     */
+    public String issue(String userId, String username, String nickname) {
+        return issue(userId, username, nickname, TenantContext.DEFAULT);
+    }
+
+    /**
+     * 签发登录态令牌：subject=userId，附带 username / nickname / tenant，过期时间为签发时刻 + 有效期。
      *
      * @return 已签名的紧凑 JWT 字符串
      */
-    public String issue(String userId, String username, String nickname) {
+    public String issue(String userId, String username, String nickname, String tenantId) {
         long now = System.currentTimeMillis();
         return Jwts.builder()
             .subject(userId)
             .claim(CLAIM_USERNAME, username)
             .claim(CLAIM_NICKNAME, nickname)
+            .claim(CLAIM_TENANT, normalizeTenant(tenantId))
             .issuedAt(new Date(now))
             .expiration(new Date(now + expireMs))
             .signWith(signingKey)
@@ -94,11 +107,17 @@ public class UserJwtService {
             return Optional.of(new UserPrincipal(
                 claims.getSubject(),
                 claims.get(CLAIM_USERNAME, String.class),
-                claims.get(CLAIM_NICKNAME, String.class)));
+                claims.get(CLAIM_NICKNAME, String.class),
+                // 多租户上线前签发的令牌没有这个 claim，回落默认租户，避免存量用户被强制登出
+                normalizeTenant(claims.get(CLAIM_TENANT, String.class))));
         } catch (Exception e) {
             // 验签失败 / 过期 / 格式非法：统一按未认证处理，不打堆栈（正常的攻击面噪声）
             return Optional.empty();
         }
+    }
+
+    private static String normalizeTenant(String tenantId) {
+        return tenantId == null || tenantId.isBlank() ? TenantContext.DEFAULT : tenantId;
     }
 
     /** 把任意长度密钥摘要成 256bit 定长密钥，满足 HS256 强度且不约束配置密钥长度。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/UserPrincipal.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/UserPrincipal.java
@@ -7,10 +7,14 @@ package com.richard.fyoung.customerwork.security;
  * {@code ServerWebExchange} 属性，供 {@code /api/customer/user/**} 控制器取用——控制器不再信任
  * 客户端自报的 userId，一律以此为准（避免越权操作他人工单）。</p>
  *
+ * <p>{@code tenantId} 同理：登录时焊进令牌，后续请求一律以令牌里的为准，
+ * 前端再传任何租户参数都不采信——否则改一个请求参数就能读别的租户的数据。</p>
+ *
  * @param userId   用户业务 ID（JWT subject）
  * @param username 登录名
  * @param nickname 昵称
+ * @param tenantId 归属租户
  * @author owlzhangfq@gmail.com
  */
-public record UserPrincipal(String userId, String username, String nickname) {
+public record UserPrincipal(String userId, String username, String nickname, String tenantId) {
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/CrossTenantOperations.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/CrossTenantOperations.java
@@ -1,0 +1,71 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import com.baomidou.mybatisplus.core.plugins.IgnoreStrategy;
+import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
+
+import java.util.function.Supplier;
+
+/**
+ * 有意的跨租户操作：在给定代码块内跳过 {@code tenant_id} 行级过滤。
+ *
+ * <p>合法用途只有两类，且都必须在调用点写明理由：</p>
+ * <ul>
+ *   <li><b>登录</b>——按用户名查 {@code sys_user} 时还不知道用户属于哪个租户，这是先有鸡还是先有蛋的必然；</li>
+ *   <li><b>运营方全局视角</b>——租户列表、跨租户统计，调用入口须先过运营方权限校验。</li>
+ * </ul>
+ *
+ * <p>刻意做成显式方法而非"给 TenantContext 塞一个代表全局的特殊值"：后者会让
+ * "忘记设置上下文"和"故意查全局"在代码上长得一模一样，一处疏漏就是全量数据泄露。
+ * 显式包裹则是可 grep、可 review 的白名单——搜这个类的调用点就能穷举所有越权口子。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class CrossTenantOperations {
+
+    private static final IgnoreStrategy TENANT_LINE_OFF = IgnoreStrategy.builder().tenantLine(true).build();
+
+    /**
+     * 嵌套深度：MyBatis-Plus 的 {@code clearIgnoreStrategy()} 是无条件 remove，
+     * 内层作用域结束会把外层的豁免一并清掉，导致外层剩余语句意外恢复过滤。
+     * 自己数一层深度，只在最外层进入/退出时开关，嵌套调用才是安全的。
+     */
+    private static final ThreadLocal<Integer> DEPTH = ThreadLocal.withInitial(() -> 0);
+
+    private CrossTenantOperations() {
+    }
+
+    /** 在跳过租户过滤的作用域内执行查询并返回结果。 */
+    public static <T> T execute(Supplier<T> action) {
+        enter();
+        try {
+            return action.get();
+        } finally {
+            exit();
+        }
+    }
+
+    /** {@link #execute(Supplier)} 的无返回值版本。 */
+    public static void run(Runnable action) {
+        execute(() -> {
+            action.run();
+            return null;
+        });
+    }
+
+    private static void enter() {
+        int depth = DEPTH.get();
+        if (depth == 0) {
+            InterceptorIgnoreHelper.handle(TENANT_LINE_OFF);
+        }
+        DEPTH.set(depth + 1);
+    }
+
+    private static void exit() {
+        int depth = DEPTH.get() - 1;
+        if (depth <= 0) {
+            InterceptorIgnoreHelper.clearIgnoreStrategy();
+            DEPTH.remove();
+            return;
+        }
+        DEPTH.set(depth);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/CustomerWorkTenantLineHandler.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/CustomerWorkTenantLineHandler.java
@@ -1,0 +1,56 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import com.baomidou.mybatisplus.extension.plugins.handler.TenantLineHandler;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.StringValue;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * MyBatis-Plus 租户行级过滤策略：租户值取自 {@link TenantContext}，忽略表清单由装配方给定。
+ *
+ * <p>本类是"数据不串"的唯一强制点——SELECT/UPDATE/DELETE 自动带 {@code tenant_id} 条件，
+ * INSERT 自动补列与值，业务代码一行不改。相应地，它必须 fail-closed：
+ * {@link TenantContext#require()} 在缺上下文时抛出，让链路断在这里而不是悄悄查出别人的数据。</p>
+ *
+ * <p>不做成 Spring Bean、忽略表清单走构造参数，是为了让 admin 模块（排除了 starter 自动装配）
+ * 能当普通构建器直接 new 出自己那套清单，与 {@code AdminOtelTracingConfig} 复用 starter 构建器的做法一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class CustomerWorkTenantLineHandler implements TenantLineHandler {
+
+    private final String columnName;
+
+    /** 统一转小写存放：MySQL 表名大小写敏感性依赖服务器配置，比对时不受其影响。 */
+    private final Set<String> ignoredTables;
+
+    public CustomerWorkTenantLineHandler(String columnName, Collection<String> ignoredTables) {
+        this.columnName = columnName;
+        this.ignoredTables = new HashSet<>();
+        if (ignoredTables != null) {
+            for (String table : ignoredTables) {
+                if (table != null && !table.isBlank()) {
+                    this.ignoredTables.add(table.trim().toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+    }
+
+    @Override
+    public Expression getTenantId() {
+        return new StringValue(TenantContext.require());
+    }
+
+    @Override
+    public String getTenantIdColumn() {
+        return columnName;
+    }
+
+    @Override
+    public boolean ignoreTable(String tableName) {
+        return tableName != null && ignoredTables.contains(tableName.trim().toLowerCase(Locale.ROOT));
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantConfig.java
@@ -1,0 +1,46 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import io.micrometer.context.ContextRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Hooks;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * 多租户上下文传播装配（仅 {@code customer-work.tenant.enabled=true} 时生效）。
+ *
+ * <p>做两件事：把 {@link TenantContextThreadLocalAccessor} 注册进 {@link ContextRegistry}，
+ * 并开启 Reactor 自动上下文传播。二者缺一不可——只注册不开 Hook，跨线程照样丢租户。</p>
+ *
+ * <p><b>Hook 是 JVM 全局的</b>，会给所有 reactive 链的线程边界加上 ThreadLocal 存取开销，
+ * 因此绑定在多租户开关上：单租户部署不装配本类，运行时行为与升级前完全一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "customer-work.tenant", name = "enabled", havingValue = "true")
+public class TenantConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantConfig.class);
+
+    private final CustomerWorkProperties properties;
+
+    public TenantConfig(CustomerWorkProperties properties) {
+        this.properties = properties;
+    }
+
+    @PostConstruct
+    public void setUpContextPropagation() {
+        ContextRegistry.getInstance().registerThreadLocalAccessor(new TenantContextThreadLocalAccessor());
+        if (properties.getTenant().isAutoContextPropagation()) {
+            Hooks.enableAutomaticContextPropagation();
+            log.info("tenant context propagation enabled (reactor automatic propagation on)");
+            return;
+        }
+        // 关掉自动传播意味着调用方自己保证跨线程边界的租户传递，仅供宿主已自建传播机制时使用
+        log.info("tenant context accessor registered, automatic propagation disabled by configuration");
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantContext.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantContext.java
@@ -1,0 +1,86 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import java.util.function.Supplier;
+
+/**
+ * 当前请求的租户上下文（全链路唯一真源）。
+ *
+ * <p>由接入层（API Key 鉴权 / H5 登录态 / admin 登录用户）在入口写入，持久层
+ * {@link CustomerWorkTenantLineHandler} 在拼 SQL 时读取。中间的业务代码不感知租户——
+ * 这正是把隔离做在拦截器而非各 Store 里的意义。</p>
+ *
+ * <p><b>为什么是 ThreadLocal 而不是 Reactor Context</b>：MyBatis 拦截器是同步 API，
+ * 拿不到 Reactor Context。反过来让 WebFlux 侧把值同步到 ThreadLocal 才是可行方向，
+ * 跨线程边界由 {@link TenantContextThreadLocalAccessor} + Reactor 自动传播兜住。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class TenantContext {
+
+    /** 平台运营方自身的租户 ID（运营方后台用户、平台共享模型配置挂在此租户下）。 */
+    public static final String PLATFORM = "__platform__";
+
+    /** 升级前存量数据归属的默认租户，等价于"原来那个单租户系统"。 */
+    public static final String DEFAULT = "default";
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private TenantContext() {
+    }
+
+    /** 写入当前租户；传空视为清理，避免半初始化状态被后续 SQL 读到。 */
+    public static void set(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            CURRENT.remove();
+            return;
+        }
+        CURRENT.set(tenantId);
+    }
+
+    /** 读取当前租户，未设置返回 {@code null}（判空由调用方按场景决定 fail-open 还是 fail-closed）。 */
+    public static String get() {
+        return CURRENT.get();
+    }
+
+    /** 读取当前租户，未设置直接抛出——持久层等安全边界用这个，绝不允许"没租户也查得到数据"。 */
+    public static String require() {
+        String tenantId = CURRENT.get();
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new TenantContextMissingException();
+        }
+        return tenantId;
+    }
+
+    /** 是否已设置租户。 */
+    public static boolean isPresent() {
+        return CURRENT.get() != null;
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+
+    /**
+     * 在指定租户下执行一段逻辑，结束后恢复原值。
+     *
+     * <p>给三类没有请求上下文的场景用：定时任务、启动期初始化、运营方切换目标租户后的跨租户操作。
+     * 恢复而非清理，是因为调用可能嵌套（运营方在自己上下文里临时进入某租户）。</p>
+     */
+    public static <T> T callWith(String tenantId, Supplier<T> action) {
+        String previous = CURRENT.get();
+        set(tenantId);
+        try {
+            return action.get();
+        } finally {
+            set(previous);
+        }
+    }
+
+    /** {@link #callWith(String, Supplier)} 的无返回值版本。 */
+    public static void runWith(String tenantId, Runnable action) {
+        callWith(tenantId, () -> {
+            action.run();
+            return null;
+        });
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantContextMissingException.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantContextMissingException.java
@@ -1,0 +1,16 @@
+package com.richard.fyoung.customerwork.tenant;
+
+/**
+ * 多租户已开启但当前执行链路没有租户上下文：拒绝执行，而不是放行成跨租户全量查询。
+ *
+ * <p>触发点通常是三类遗漏：接入层入口没写上下文、跨线程边界没传播、系统级任务没显式
+ * {@code TenantContext.runWith(...)}。让它炸出来是刻意的——静默返回别的租户的数据，
+ * 后果远重于一次 500。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class TenantContextMissingException extends RuntimeException {
+
+    public TenantContextMissingException() {
+        super("tenant context is required but absent in current execution chain");
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantContextThreadLocalAccessor.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantContextThreadLocalAccessor.java
@@ -1,0 +1,38 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import io.micrometer.context.ThreadLocalAccessor;
+
+/**
+ * 把 {@link TenantContext} 的 ThreadLocal 接入 Reactor 自动上下文传播。
+ *
+ * <p>WebFlux 请求链会在 boundedElastic 上执行阻塞 JDBC，线程一换 ThreadLocal 就没了。
+ * 注册本 Accessor 并开启 {@code Hooks.enableAutomaticContextPropagation()} 后，
+ * Reactor 会在每个线程边界把 Reactor Context 里的租户值还原进 ThreadLocal，
+ * 使同步的 MyBatis 拦截器也能读到——这是"上下文只在入口写一次"能成立的前提。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class TenantContextThreadLocalAccessor implements ThreadLocalAccessor<String> {
+
+    /** Reactor Context 中承载租户的键，写入方（WebFilter）与本 Accessor 必须用同一个。 */
+    public static final String KEY = "customer-work.tenant";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return TenantContext.get();
+    }
+
+    @Override
+    public void setValue(String value) {
+        TenantContext.set(value);
+    }
+
+    @Override
+    public void setValue() {
+        TenantContext.clear();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantInterceptors.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantInterceptors.java
@@ -1,0 +1,58 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import com.baomidou.mybatisplus.extension.plugins.inner.TenantLineInnerInterceptor;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 租户行级过滤拦截器的构建器（starter 与 admin 共用一套忽略表口径）。
+ *
+ * <p>两个模块各有独立的 MyBatis 环境，但"哪些表不参与租户过滤"必须是同一份答案——
+ * 分成两份迟早会漂移，而漂移的后果是某一侧漏过滤（串数据）或多过滤（SQL 报不存在的列）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class TenantInterceptors {
+
+    /**
+     * 内置忽略表：平台级数据 + 框架自建表。判定依据与新增规则见 {@code docs/多租户架构设计.md}。
+     *
+     * <p>加表进这份清单等于放弃该表的自动隔离，务必确认它属于下面三类之一：
+     * 内容由平台定义租户只读（{@code sys_permission} 权限点定义、{@code ai_system_tool} 代码级工具目录）、
+     * 框架自建无法加列（{@code ai_chat_session_state} 由 MysqlAgentStateStore 直接持 DataSource 读写）、
+     * 需要两级可见性因而由 Service 层手工过滤（{@code ai_model_config} 承载模型凭据）。</p>
+     */
+    public static final List<String> PLATFORM_LEVEL_TABLES = List.of(
+        "sys_tenant",
+        "sys_permission",
+        "sys_menu_change_log",
+        "ai_system_tool",
+        "ai_chat_session_state",
+        "ai_model_config",
+        "flyway_schema_history");
+
+    private TenantInterceptors() {
+    }
+
+    /**
+     * 构建拦截器：内置平台级表清单 + 调用方追加的忽略表。
+     *
+     * @param columnName    租户列名
+     * @param extraIgnored  额外忽略表（可为空），用于宿主自有表的按需豁免
+     */
+    public static TenantLineInnerInterceptor build(String columnName, Collection<String> extraIgnored) {
+        Set<String> ignored = new LinkedHashSet<>(PLATFORM_LEVEL_TABLES);
+        if (extraIgnored != null) {
+            ignored.addAll(extraIgnored);
+        }
+        return new TenantLineInnerInterceptor(new CustomerWorkTenantLineHandler(columnName, ignored));
+    }
+
+    /** 便捷重载：默认列名 {@code tenant_id}，无额外忽略表。 */
+    public static TenantLineInnerInterceptor build(String... extraIgnored) {
+        return build("tenant_id", Arrays.asList(extraIgnored));
+    }
+}

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -11,6 +11,7 @@
 
 -- 合规审计日志表（MybatisAuditSink）。
 CREATE TABLE IF NOT EXISTS `cw_audit_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
     `event_type`  VARCHAR(64) NOT NULL COMMENT '事件类型: tool-call / final-answer / error',
     `agent_name`  VARCHAR(128) DEFAULT '' COMMENT 'Agent 名称',
@@ -18,11 +19,13 @@ CREATE TABLE IF NOT EXISTS `cw_audit_log` (
     `created_at`  TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '记录时间',
     INDEX `idx_audit_type` (`event_type`),
     INDEX `idx_audit_created` (`created_at`),
-    INDEX `idx_audit_agent` (`agent_name`)
+    INDEX `idx_audit_agent` (`agent_name`),
+    INDEX `idx_audit_log_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='合规审计轨迹（结构化存储）';
 
 -- 人工审批工单表（MybatisApprovalStore）。
 CREATE TABLE IF NOT EXISTS `cw_approval` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`                        VARCHAR(64) PRIMARY KEY COMMENT '审批单号',
     `type`                      VARCHAR(32) NOT NULL COMMENT '审批类型：REFUND 等',
     `session_id`                VARCHAR(128) COMMENT '关联会话',
@@ -38,24 +41,30 @@ CREATE TABLE IF NOT EXISTS `cw_approval` (
     `execution_failure_reason`  TEXT COMMENT '下游执行失败原因',
     `execution_attempts`        INT DEFAULT 0 COMMENT '下游执行尝试次数',
     INDEX `idx_approval_status` (`status`),
-    INDEX `idx_approval_created` (`created_at_ms`)
+    INDEX `idx_approval_created` (`created_at_ms`),
+    INDEX `idx_approval_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='人工审批工单（退款放行等资金动作）';
 
 -- 多轮槽位收集进度表（MybatisSlotFillingStore）。
 CREATE TABLE IF NOT EXISTS `cw_slot_filling_progress` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `progress_key`    VARCHAR(191) PRIMARY KEY COMMENT '收集进度键：sessionId:formName',
     `asking`          VARCHAR(64) COMMENT '当前追问的槽位名',
-    `collected_json`  TEXT COMMENT '已收集槽位值（JSON）'
+    `collected_json`  TEXT COMMENT '已收集槽位值（JSON）',
+    INDEX `idx_slot_filling_progress_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='多轮槽位收集进度（如退款表单信息采集）';
 
 -- 对话阶段状态机表（MybatisDialogStageStore）。
 CREATE TABLE IF NOT EXISTS `cw_dialog_stage` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `session_id`  VARCHAR(191) PRIMARY KEY COMMENT '会话 ID',
-    `stage`       VARCHAR(24) NOT NULL COMMENT '当前对话阶段：GREETING/COLLECTING/PROCESSING/CONFIRMING/ESCALATED'
+    `stage`       VARCHAR(24) NOT NULL COMMENT '当前对话阶段：GREETING/COLLECTING/PROCESSING/CONFIRMING/ESCALATED',
+    INDEX `idx_dialog_stage_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='对话阶段状态机（多实例共享）';
 
 -- 人机切换工单表（MybatisHandoffStore）。
 CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`                VARCHAR(64) PRIMARY KEY COMMENT '工单号',
     `session_id`        VARCHAR(128) COMMENT '关联会话',
     `reason`            TEXT COMMENT '转人工原因',
@@ -71,7 +80,8 @@ CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
     `emotion`           VARCHAR(32) COMMENT '用户情绪（LLM 分类，可空）',
     `suggested_assignees` TEXT COMMENT '推荐坐席列表 JSON（HITL 推荐，人工点选非自动派单，可空）',
     INDEX `idx_handoff_status` (`status`),
-    INDEX `idx_handoff_created` (`created_at_ms`)
+    INDEX `idx_handoff_created` (`created_at_ms`),
+    INDEX `idx_handoff_ticket_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='人机切换工单（AI 转人工闭环 + 智能分配增强）';
 
 -- 人机切换工单智能分配增强列（cw_handoff_ticket 已在上文建表时含 category/required_skill/priority/emotion/suggested_assignees；
@@ -85,17 +95,20 @@ CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
 
 -- 消息级用户反馈表（MybatisFeedbackStore）。
 CREATE TABLE IF NOT EXISTS `cw_message_feedback` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `message_id`     VARCHAR(64) PRIMARY KEY COMMENT '被反馈的消息ID',
     `session_id`     VARCHAR(128) COMMENT '所属会话',
     `type`           VARCHAR(8) NOT NULL COMMENT 'UP/DOWN',
     `comment`        TEXT COMMENT '文字说明',
     `created_at_ms`  BIGINT NOT NULL COMMENT '提交时间戳（毫秒，重复提交取最新）',
     INDEX `idx_feedback_session` (`session_id`),
-    INDEX `idx_feedback_type` (`type`)
+    INDEX `idx_feedback_type` (`type`),
+    INDEX `idx_message_feedback_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='消息级用户反馈（点赞/点踩）';
 
 -- 终端用户账户表（MybatisUserAccountStore）。
 CREATE TABLE IF NOT EXISTS `cw_user` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             VARCHAR(64) PRIMARY KEY COMMENT '用户ID',
     `username`       VARCHAR(64) NOT NULL COMMENT '用户名',
     `password_hash`  VARCHAR(100) NOT NULL COMMENT 'BCrypt 密码哈希',
@@ -104,11 +117,13 @@ CREATE TABLE IF NOT EXISTS `cw_user` (
     `status`         VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/DISABLED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
     `avatar_url`     VARCHAR(255) COMMENT '头像访问URL（相对路径，可为空）',
-    UNIQUE KEY `uk_user_username` (`username`)
+    UNIQUE KEY `uk_user_username` (`tenant_id`, `username`),
+    INDEX `idx_user_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='客服系统终端用户账户';
 
 -- 客服工单主表（MybatisTicketStore）。
 CREATE TABLE IF NOT EXISTS `cw_ticket` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`              VARCHAR(64) PRIMARY KEY COMMENT '工单号',
     `session_id`      VARCHAR(128) NOT NULL COMMENT '关联会话',
     `user_id`         VARCHAR(64) NOT NULL COMMENT '发起用户',
@@ -130,11 +145,13 @@ CREATE TABLE IF NOT EXISTS `cw_ticket` (
     INDEX `idx_ticket_session` (`session_id`),
     INDEX `idx_ticket_user` (`user_id`, `created_at_ms`),
     INDEX `idx_ticket_status` (`status`, `updated_at_ms`),
-    INDEX `idx_ticket_assignee` (`assignee`, `status`)
+    INDEX `idx_ticket_assignee` (`assignee`, `status`),
+    INDEX `idx_ticket_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='客服工单（完整生命周期状态机）';
 
 -- 工单事件轨迹表（MybatisTicketStore）。
 CREATE TABLE IF NOT EXISTS `cw_ticket_event` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '事件自增主键',
     `ticket_id`      VARCHAR(64) NOT NULL COMMENT '所属工单号',
     `event_type`     VARCHAR(32) NOT NULL COMMENT '事件类型',
@@ -144,11 +161,13 @@ CREATE TABLE IF NOT EXISTS `cw_ticket_event` (
     `actor_id`       VARCHAR(64) COMMENT '动作发起方标识',
     `note`           VARCHAR(500) COMMENT '备注',
     `created_at_ms`  BIGINT NOT NULL COMMENT '事件时间戳（毫秒）',
-    INDEX `idx_ticket_event` (`ticket_id`, `id`)
+    INDEX `idx_ticket_event` (`ticket_id`, `id`),
+    INDEX `idx_ticket_event_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='工单事件轨迹（不可变审计）';
 
 -- 聊天消息留痕表（MybatisChatMessageStore）。
 CREATE TABLE IF NOT EXISTS `cw_chat_message` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键（游标翻页）',
     `message_id`     VARCHAR(64) NOT NULL COMMENT '业务消息号 MSG-<uuid>',
     `session_id`     VARCHAR(128) NOT NULL COMMENT '所属会话',
@@ -159,11 +178,13 @@ CREATE TABLE IF NOT EXISTS `cw_chat_message` (
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
     UNIQUE KEY `uk_chat_message_id` (`message_id`),
     INDEX `idx_chat_session` (`session_id`, `id`),
-    INDEX `idx_chat_ticket` (`ticket_id`, `id`)
+    INDEX `idx_chat_ticket` (`ticket_id`, `id`),
+    INDEX `idx_chat_message_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='会话/工单聊天消息留痕';
 
 -- 智能体调用主记录表（MybatisAgentCallLogStore）：每次调用一行，含分段耗时冗余汇总。
 CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `request_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
     `user_id`        VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
@@ -194,11 +215,13 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
     INDEX `idx_call_username` (`username`),
     INDEX `idx_call_agent_code` (`agent_code`),
     INDEX `idx_call_session` (`session_id`),
-    INDEX `idx_call_start` (`start_time`)
+    INDEX `idx_call_start` (`start_time`),
+    INDEX `idx_agent_call_log_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用主记录（分段耗时统计）';
 
 -- 智能体调用分段明细表（MybatisAgentCallLogStore）：一次调用的每段耗时一行。
 CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `call_log_id`    BIGINT NOT NULL COMMENT '所属主记录ID',
     `seq`            INT NOT NULL COMMENT '调用内分段序号（从1起）',
@@ -212,7 +235,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
-    INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
+    INDEX `idx_segment_call_log` (`call_log_id`, `seq`),
+    INDEX `idx_agent_call_segment_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='智能体调用分段明细';
 
 -- token 统计补列（2026-07-28）：CREATE TABLE IF NOT EXISTS 对已存在的表不加列，
@@ -226,6 +250,7 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
 
 -- 对话附件表（MybatisAttachmentStore）：上传附件落盘 + 落库，解析文本可追溯。
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             VARCHAR(64) NOT NULL COMMENT '附件ID(UUID)',
     `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
     `message_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）',
@@ -242,11 +267,13 @@ CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
     `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     PRIMARY KEY (`id`),
     INDEX `idx_cw_attachment_session` (`session_id`),
-    INDEX `idx_cw_attachment_created` (`created_at`)
+    INDEX `idx_cw_attachment_created` (`created_at`),
+    INDEX `idx_chat_attachment_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='对话附件';
 
 -- 商品表（MybatisProductBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_product` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `product_id`   VARCHAR(32) PRIMARY KEY COMMENT '商品ID',
     `name`         VARCHAR(128) NOT NULL COMMENT '商品名称',
     `category`     VARCHAR(64) COMMENT '品类',
@@ -255,16 +282,18 @@ CREATE TABLE IF NOT EXISTS `cw_product` (
     `description`  VARCHAR(500) COMMENT '商品描述',
     `promotion`    VARCHAR(255) COMMENT '优惠活动',
     `status`       VARCHAR(16) NOT NULL DEFAULT 'ON_SALE' COMMENT 'ON_SALE/OFF_SALE',
-    INDEX `idx_product_category` (`category`)
+    INDEX `idx_product_category` (`category`),
+    INDEX `idx_product_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='商品（JDBC 后端演示表）';
 
-INSERT IGNORE INTO `cw_product` (`product_id`, `name`, `category`, `price`, `stock`, `description`, `promotion`, `status`) VALUES
-('P001', '旗舰款无线降噪耳机', '耳机', 299.00, 100, '旗舰款无线降噪耳机，蓝牙 5.3，续航 30 小时，支持多点连接，颜色 黑/白，质保 1 年', '满 300 减 50；可叠加新人券 20 元；下单送收纳包', 'ON_SALE'),
-('P002', '运动防汗蓝牙耳机', '耳机', 199.00, 50, '运动防汗蓝牙耳机，IPX5 级防水，佩戴稳固，适合健身运动', '限时直降 30 元，晒单再返 10 元', 'ON_SALE'),
-('P003', '商务降噪头戴耳机', '耳机', 599.00, 0, '商务降噪头戴耳机，主动降噪，麦克风通话清晰，续航 40 小时', '', 'ON_SALE');
+INSERT IGNORE INTO `cw_product` (`tenant_id`, `product_id`, `name`, `category`, `price`, `stock`, `description`, `promotion`, `status`) VALUES
+('default', 'P001', '旗舰款无线降噪耳机', '耳机', 299.00, 100, '旗舰款无线降噪耳机，蓝牙 5.3，续航 30 小时，支持多点连接，颜色 黑/白，质保 1 年', '满 300 减 50；可叠加新人券 20 元；下单送收纳包', 'ON_SALE'),
+('default', 'P002', '运动防汗蓝牙耳机', '耳机', 199.00, 50, '运动防汗蓝牙耳机，IPX5 级防水，佩戴稳固，适合健身运动', '限时直降 30 元，晒单再返 10 元', 'ON_SALE'),
+('default', 'P003', '商务降噪头戴耳机', '耳机', 599.00, 0, '商务降噪头戴耳机，主动降噪，麦克风通话清晰，续航 40 小时', '', 'ON_SALE');
 
 -- 订单表（MybatisOrderBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_order` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `order_id`         VARCHAR(32) PRIMARY KEY COMMENT '订单号',
     `user_id`          VARCHAR(64) NOT NULL COMMENT '下单用户',
     `product_id`       VARCHAR(32) NOT NULL COMMENT '商品ID',
@@ -274,17 +303,19 @@ CREATE TABLE IF NOT EXISTS `cw_order` (
     `receiver_addr`    VARCHAR(255) COMMENT '收货地址',
     `logistics_trace`  TEXT COMMENT '物流轨迹',
     `created_at_ms`    BIGINT NOT NULL COMMENT '下单时间戳（毫秒）',
-    INDEX `idx_order_user` (`user_id`, `created_at_ms`)
+    INDEX `idx_order_user` (`user_id`, `created_at_ms`),
+    INDEX `idx_order_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='订单（JDBC 后端演示表）';
 
-INSERT IGNORE INTO `cw_order` (`order_id`, `user_id`, `product_id`, `product_name`, `amount`, `status`, `receiver_addr`, `logistics_trace`, `created_at_ms`) VALUES
-('20260613001', 'U-demo-1', 'P001', '旗舰款无线降噪耳机', 299.00, '已发货', '北京市朝阳区建国路 88 号', '[6-11 已揽收]→[6-12 到达分拨中心]→[6-13 派送中]。', 1781049600000),
-('20260613002', 'U-demo-1', 'P003', '商务降噪头戴耳机', 1599.00, '已签收', '上海市浦东新区世纪大道 100 号', '[5-18 已揽收]→[5-19 运输中]→[5-20 已签收]。', 1779235200000),
-('20260613003', 'U-demo-2', 'P002', '运动防汗蓝牙耳机', 199.00, '待发货', '广州市天河区体育西路 1 号', '[6-13 已下单，仓库备货中]', 1781308800000),
-('20260613004', 'U-demo-2', 'P001', '旗舰款无线降噪耳机', 299.00, '已退款', '深圳市南山区科技园路 5 号', '[6-08 已揽收]→[6-09 用户取消]→[6-10 已退款]', 1780876800000);
+INSERT IGNORE INTO `cw_order` (`tenant_id`, `order_id`, `user_id`, `product_id`, `product_name`, `amount`, `status`, `receiver_addr`, `logistics_trace`, `created_at_ms`) VALUES
+('default', '20260613001', 'U-demo-1', 'P001', '旗舰款无线降噪耳机', 299.00, '已发货', '北京市朝阳区建国路 88 号', '[6-11 已揽收]→[6-12 到达分拨中心]→[6-13 派送中]。', 1781049600000),
+('default', '20260613002', 'U-demo-1', 'P003', '商务降噪头戴耳机', 1599.00, '已签收', '上海市浦东新区世纪大道 100 号', '[5-18 已揽收]→[5-19 运输中]→[5-20 已签收]。', 1779235200000),
+('default', '20260613003', 'U-demo-2', 'P002', '运动防汗蓝牙耳机', 199.00, '待发货', '广州市天河区体育西路 1 号', '[6-13 已下单，仓库备货中]', 1781308800000),
+('default', '20260613004', 'U-demo-2', 'P001', '旗舰款无线降噪耳机', 299.00, '已退款', '深圳市南山区科技园路 5 号', '[6-08 已揽收]→[6-09 用户取消]→[6-10 已退款]', 1780876800000);
 
 -- 售后工单表（MybatisAfterSalesBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_refund` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `refund_no`      VARCHAR(64) PRIMARY KEY COMMENT '售后工单号',
     `order_id`       VARCHAR(32) NOT NULL COMMENT '关联订单号',
     `type`           VARCHAR(16) NOT NULL COMMENT '类型：REFUND/RETURN/EXCHANGE',
@@ -293,24 +324,28 @@ CREATE TABLE IF NOT EXISTS `cw_refund` (
     `reason`         VARCHAR(500) COMMENT '诉求原因',
     `new_spec`       VARCHAR(128) COMMENT '换货目标规格',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_refund_order` (`order_id`, `created_at_ms`)
+    INDEX `idx_refund_order` (`order_id`, `created_at_ms`),
+    INDEX `idx_refund_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='售后工单（JDBC 后端演示表）';
 
-INSERT IGNORE INTO `cw_refund` (`refund_no`, `order_id`, `type`, `status`, `amount`, `reason`, `new_spec`, `created_at_ms`) VALUES
-('RF-seed-20260613004', '20260613004', 'REFUND', 'APPROVED', 299.00, '七天无理由退款', NULL, 1781049600000);
+INSERT IGNORE INTO `cw_refund` (`tenant_id`, `refund_no`, `order_id`, `type`, `status`, `amount`, `reason`, `new_spec`, `created_at_ms`) VALUES
+('default', 'RF-seed-20260613004', '20260613004', 'REFUND', 'APPROVED', 299.00, '七天无理由退款', NULL, 1781049600000);
 
 -- 发票申请表（MybatisAfterSalesBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_invoice_request` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '发票申请自增主键',
     `order_id`       VARCHAR(32) NOT NULL COMMENT '关联订单号',
     `invoice_title`  VARCHAR(255) NOT NULL COMMENT '发票抬头',
     `status`         VARCHAR(16) NOT NULL DEFAULT 'PENDING' COMMENT '状态：PENDING/ISSUED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_invoice_order` (`order_id`, `created_at_ms`)
+    INDEX `idx_invoice_order` (`order_id`, `created_at_ms`),
+    INDEX `idx_invoice_request_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='发票申请（JDBC 后端演示表）';
 
 -- 会员表（MybatisMemberBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_member` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `member_id`        VARCHAR(64) PRIMARY KEY COMMENT '会员ID（对应用户ID）',
     `level`            VARCHAR(32) NOT NULL COMMENT '会员等级',
     `points`           INT NOT NULL DEFAULT 0 COMMENT '当前积分',
@@ -318,53 +353,61 @@ CREATE TABLE IF NOT EXISTS `cw_member` (
     `benefits`         VARCHAR(255) COMMENT '等级权益',
     `next_level`       VARCHAR(32) COMMENT '下一等级',
     `upgrade_gap`      DECIMAL(10,2) DEFAULT 0 COMMENT '升级所需再消费金额',
-    `phone`            VARCHAR(32) COMMENT '注册手机号'
+    `phone`            VARCHAR(32) COMMENT '注册手机号',
+    INDEX `idx_member_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='会员（JDBC 后端演示表）';
 
-INSERT IGNORE INTO `cw_member` (`member_id`, `level`, `points`, `points_expiring`, `benefits`, `next_level`, `upgrade_gap`, `phone`) VALUES
-('U-demo-1', '黄金会员', 1280, 200, '免运费、专属客服、生日双倍积分', '铂金', 500.00, '138****0001'),
-('U-demo-2', '白银会员', 320, 0, '满额包邮、积分商城兑换', '黄金', 800.00, '139****0002');
+INSERT IGNORE INTO `cw_member` (`tenant_id`, `member_id`, `level`, `points`, `points_expiring`, `benefits`, `next_level`, `upgrade_gap`, `phone`) VALUES
+('default', 'U-demo-1', '黄金会员', 1280, 200, '免运费、专属客服、生日双倍积分', '铂金', 500.00, '138****0001'),
+('default', 'U-demo-2', '白银会员', 320, 0, '满额包邮、积分商城兑换', '黄金', 800.00, '139****0002');
 
 -- 会员账户问题处理日志表（MybatisMemberBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_member_account_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '处理日志自增主键',
     `issue`          VARCHAR(255) NOT NULL COMMENT '账户问题描述',
     `handling`       VARCHAR(500) COMMENT '处置话术',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_account_log_created` (`created_at_ms`)
+    INDEX `idx_account_log_created` (`created_at_ms`),
+    INDEX `idx_member_account_log_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='会员账户问题处理日志（JDBC 后端演示表）';
 
 -- 投诉工单表（MybatisComplaintBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_complaint` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `complaint_no`   VARCHAR(64) PRIMARY KEY COMMENT '投诉工单号',
     `order_id`       VARCHAR(32) COMMENT '关联订单号（可空）',
     `content`        TEXT COMMENT '投诉内容',
     `status`         VARCHAR(16) NOT NULL COMMENT '状态：PROCESSING/RESOLVED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_complaint_order` (`order_id`, `created_at_ms`)
+    INDEX `idx_complaint_order` (`order_id`, `created_at_ms`),
+    INDEX `idx_complaint_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='投诉工单（JDBC 后端演示表）';
 
-INSERT IGNORE INTO `cw_complaint` (`complaint_no`, `order_id`, `content`, `status`, `created_at_ms`) VALUES
-('CP-seed-0001', '20260613002', '物流配送太慢，希望加快处理', 'PROCESSING', 1779235200000);
+INSERT IGNORE INTO `cw_complaint` (`tenant_id`, `complaint_no`, `order_id`, `content`, `status`, `created_at_ms`) VALUES
+('default', 'CP-seed-0001', '20260613002', '物流配送太慢，希望加快处理', 'PROCESSING', 1779235200000);
 
 -- 知识库 FAQ 表（MybatisKnowledgeBackend 演示表）。
 CREATE TABLE IF NOT EXISTS `cw_knowledge` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`         BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '知识条目自增主键',
     `keyword`    VARCHAR(255) NOT NULL COMMENT '命中关键词（逗号分隔）',
     `title`      VARCHAR(255) NOT NULL COMMENT '条目标题',
     `content`    TEXT NOT NULL COMMENT '条目内容',
     `source`     VARCHAR(255) COMMENT '来源标注',
-    UNIQUE KEY `uk_knowledge_title` (`title`)
+    UNIQUE KEY `uk_knowledge_title` (`tenant_id`, `title`),
+    INDEX `idx_knowledge_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='知识库 FAQ（JDBC 后端演示表）';
 
-INSERT IGNORE INTO `cw_knowledge` (`keyword`, `title`, `content`, `source`) VALUES
-('退货,退款,七天,无理由', '七天无理由退货政策', '支持七天无理由退货，商品需保持完好、不影响二次销售；定制类、生鲜类除外。', '《售后服务政策》第 3 条'),
-('发票,开票,报销', '发票开具规则', '支持开具电子普通发票与增值税专用发票，可在订单详情页自助申请，1-3 个工作日开具。', '《发票管理规则》第 1 条'),
-('运费,包邮,邮费', '运费说明', '单笔订单满 99 元包邮，偏远地区除外；退货运费由责任方承担。', '《运费说明》第 2 条');
+INSERT IGNORE INTO `cw_knowledge` (`tenant_id`, `keyword`, `title`, `content`, `source`) VALUES
+('default', '退货,退款,七天,无理由', '七天无理由退货政策', '支持七天无理由退货，商品需保持完好、不影响二次销售；定制类、生鲜类除外。', '《售后服务政策》第 3 条'),
+('default', '发票,开票,报销', '发票开具规则', '支持开具电子普通发票与增值税专用发票，可在订单详情页自助申请，1-3 个工作日开具。', '《发票管理规则》第 1 条'),
+('default', '运费,包邮,邮费', '运费说明', '单笔订单满 99 元包邮，偏远地区除外；退货运费由责任方承担。', '《运费说明》第 2 条');
 
 -- 敏感词表（SensitiveWordFilter / cw_sensitive_word）：智能路由中控"一次拦截"词库。
 -- 种子为脱敏占位词（非真实违禁词），覆盖 BLOCK/MASK/REVIEW 三种动作与多类目。
 CREATE TABLE IF NOT EXISTS `cw_sensitive_word` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `word`           VARCHAR(128) NOT NULL COMMENT '敏感词原词面',
     `category`       VARCHAR(32) NOT NULL COMMENT '类目: POLITICS/PORN/ABUSE/COMPETITOR/CUSTOM',
@@ -372,20 +415,22 @@ CREATE TABLE IF NOT EXISTS `cw_sensitive_word` (
     `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_sensitive_word` (`word`)
+    UNIQUE KEY `uk_sensitive_word` (`tenant_id`, `word`),
+    INDEX `idx_sensitive_word_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词表（一次拦截词库）';
 
-INSERT IGNORE INTO `cw_sensitive_word` (`word`, `category`, `action`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
-('测试敏感词A', 'CUSTOM', 'BLOCK', 1, 1779235200000, 1779235200000),
-('涉政占位', 'POLITICS', 'BLOCK', 1, 1779235200000, 1779235200000),
-('辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
-('竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
-('复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_sensitive_word` (`tenant_id`, `word`, `category`, `action`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', '测试敏感词A', 'CUSTOM', 'BLOCK', 1, 1779235200000, 1779235200000),
+('default', '涉政占位', 'POLITICS', 'BLOCK', 1, 1779235200000, 1779235200000),
+('default', '辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
+('default', '竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
+('default', '复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);
 
 -- 敏感词命中日志表（AsyncSensitiveWordHitSink / cw_sensitive_word_hit_log）：后台"命中看板"的数据源。
 -- 仅当 customer-work.sensitive-word.hit-log.enabled=true 且 store-mode=jdbc 时写入。
 -- snippet 存用户/模型原文片段（已截断），属敏感数据，是否留存由使用方按合规要求决定，故整块默认关闭。
 CREATE TABLE IF NOT EXISTS `cw_sensitive_word_hit_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `direction`      VARCHAR(16) NOT NULL COMMENT '命中方向: INBOUND用户输入/OUTBOUND模型输出',
     `action`         VARCHAR(16) NOT NULL COMMENT '整体决策: BLOCK/MASK/REVIEW',
@@ -399,12 +444,14 @@ CREATE TABLE IF NOT EXISTS `cw_sensitive_word_hit_log` (
     `created_at_ms`  BIGINT COMMENT '命中时间戳（毫秒）',
     KEY `idx_hit_created` (`created_at_ms`),
     KEY `idx_hit_action` (`action`),
-    KEY `idx_hit_session` (`session_id`)
+    KEY `idx_hit_session` (`session_id`),
+    INDEX `idx_sensitive_word_hit_log_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词命中日志（后台看板数据源）';
 
 -- 限流规则表（RateLimitRuleProvider / cw_rate_limit_rule）：接入层限流的规则层，后台运营维护。
 -- 刻意不给种子：空表 = 无规则命中 = 回退 yml 全局兜底参数，与规则化之前行为完全一致。
 CREATE TABLE IF NOT EXISTS `cw_rate_limit_rule` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `rule_name`      VARCHAR(64) NOT NULL COMMENT '规则名（运营可读）',
     `path_prefix`    VARCHAR(128) NOT NULL COMMENT '匹配的请求路径前缀',
@@ -416,13 +463,15 @@ CREATE TABLE IF NOT EXISTS `cw_rate_limit_rule` (
     `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_rate_limit_rule_name` (`rule_name`),
-    KEY `idx_rate_limit_priority` (`priority`)
+    UNIQUE KEY `uk_rate_limit_rule_name` (`tenant_id`, `rule_name`),
+    KEY `idx_rate_limit_priority` (`priority`),
+    INDEX `idx_rate_limit_rule_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='限流规则表（接入层限流规则层）';
 
 -- 坐席库表（MybatisSeatAgentStore / cw_seat_agent）：智能路由中控"工单智能分配"的候选坐席池。
 -- skills 为逗号分隔技能标签串；seat_group 避开 SQL 保留字 group；种子为演示坐席（多技能/负载/在离线）。
 CREATE TABLE IF NOT EXISTS `cw_seat_agent` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             VARCHAR(64) PRIMARY KEY COMMENT '坐席ID',
     `name`           VARCHAR(64) NOT NULL COMMENT '坐席名',
     `skills`         VARCHAR(512) COMMENT '技能标签（逗号分隔，如 refund,invoice）',
@@ -432,19 +481,21 @@ CREATE TABLE IF NOT EXISTS `cw_seat_agent` (
     `seat_group`     VARCHAR(64) COMMENT '坐席分组',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    INDEX `idx_seat_online` (`online`)
+    INDEX `idx_seat_online` (`online`),
+    INDEX `idx_seat_agent_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='坐席库（智能分配候选坐席池）';
 
-INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current_load`, `online`, `seat_group`, `created_at_ms`, `updated_at_ms`) VALUES
-('SEAT-1001', '退款专员-小赵', 'refund,invoice', 5, 1, 1, 'aftersales', 1779235200000, 1779235200000),
-('SEAT-1002', '物流专员-小钱', 'logistics', 5, 3, 1, 'logistics', 1779235200000, 1779235200000),
-('SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
-('SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
-('SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_seat_agent` (`tenant_id`, `id`, `name`, `skills`, `max_load`, `current_load`, `online`, `seat_group`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', 'SEAT-1001', '退款专员-小赵', 'refund,invoice', 5, 1, 1, 'aftersales', 1779235200000, 1779235200000),
+('default', 'SEAT-1002', '物流专员-小钱', 'logistics', 5, 3, 1, 'logistics', 1779235200000, 1779235200000),
+('default', 'SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
+('default', 'SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
+('default', 'SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);
 
 -- 数据字典（DictStore / cw_dict_type + cw_dict_item）：少量枚举型键值数据的统一落点，免于逐个建表。
 -- 后台管理系统"字典管理"页直连维护这两张表（单一数据真源，照内容风控先例不做双写同步）。
 CREATE TABLE IF NOT EXISTS `cw_dict_type` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `dict_type`      VARCHAR(64) NOT NULL COMMENT '字典类型编码（如 order_status）',
     `type_name`      VARCHAR(64) NOT NULL COMMENT '类型名称（展示用）',
@@ -452,10 +503,12 @@ CREATE TABLE IF NOT EXISTS `cw_dict_type` (
     `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_dict_type` (`dict_type`)
+    UNIQUE KEY `uk_dict_type` (`tenant_id`, `dict_type`),
+    INDEX `idx_dict_type_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典类型表';
 
 CREATE TABLE IF NOT EXISTS `cw_dict_item` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `dict_type`      VARCHAR(64) NOT NULL COMMENT '所属字典类型编码',
     `item_key`       VARCHAR(128) NOT NULL COMMENT '字典项键（业务值）',
@@ -465,19 +518,20 @@ CREATE TABLE IF NOT EXISTS `cw_dict_item` (
     `remark`         VARCHAR(255) COMMENT '备注说明',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_dict_item` (`dict_type`, `item_key`),
-    KEY `idx_dict_item_type` (`dict_type`)
+    UNIQUE KEY `uk_dict_item` (`tenant_id`, `dict_type`, `item_key`),
+    KEY `idx_dict_item_type` (`dict_type`),
+    INDEX `idx_dict_item_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典项表';
 
 -- 演示种子：订单状态（与 InMemoryDictStore 种子、后台订单页硬编码文案一致）。
-INSERT IGNORE INTO `cw_dict_type` (`dict_type`, `type_name`, `remark`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
-('order_status', '订单状态', '用户订单状态筛选项（与后端返回的中文文案一致）', 1, 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_dict_type` (`tenant_id`, `dict_type`, `type_name`, `remark`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', 'order_status', '订单状态', '用户订单状态筛选项（与后端返回的中文文案一致）', 1, 1779235200000, 1779235200000);
 
-INSERT IGNORE INTO `cw_dict_item` (`dict_type`, `item_key`, `item_label`, `sort`, `enabled`, `remark`, `created_at_ms`, `updated_at_ms`) VALUES
-('order_status', '待支付', '待支付', 1, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已支付', '已支付', 2, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '待发货', '待发货', 3, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已发货', '已发货', 4, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_dict_item` (`tenant_id`, `dict_type`, `item_key`, `item_label`, `sort`, `enabled`, `remark`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', 'order_status', '待支付', '待支付', 1, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已支付', '已支付', 2, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '待发货', '待发货', 3, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已发货', '已发货', 4, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tenant/TenantContextTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tenant/TenantContextTest.java
@@ -1,0 +1,77 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 租户上下文单测：持有、fail-closed 语义与嵌套作用域恢复。
+ * @author owlzhangfq@gmail.com
+ */
+class TenantContextTest {
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void setAndGet_shouldRoundTrip() {
+        TenantContext.set("acme");
+        assertEquals("acme", TenantContext.get(), "应读回写入的租户");
+        assertTrue(TenantContext.isPresent(), "写入后应判定为已设置");
+    }
+
+    @Test
+    void set_shouldTreatBlankAsClear() {
+        TenantContext.set("acme");
+        TenantContext.set("  ");
+        assertNull(TenantContext.get(), "空白值应视为清理，不能留下半初始化状态");
+        assertFalse(TenantContext.isPresent(), "清理后应判定为未设置");
+    }
+
+    @Test
+    void require_shouldThrow_whenAbsent() {
+        assertThrows(TenantContextMissingException.class, TenantContext::require,
+            "缺上下文必须抛出，绝不能放行成跨租户查询");
+    }
+
+    @Test
+    void callWith_shouldRestorePreviousTenant() {
+        TenantContext.set("outer");
+
+        String inner = TenantContext.callWith("inner", TenantContext::require);
+
+        assertEquals("inner", inner, "作用域内应生效指定租户");
+        assertEquals("outer", TenantContext.get(), "作用域结束应恢复原租户，而不是清空");
+    }
+
+    @Test
+    void callWith_shouldRestoreEmpty_whenNoPreviousTenant() {
+        TenantContext.callWith("temp", () -> null);
+        assertNull(TenantContext.get(), "原本无租户时，作用域结束应回到无租户");
+    }
+
+    @Test
+    void callWith_shouldRestore_evenWhenActionThrows() {
+        TenantContext.set("outer");
+
+        assertThrows(IllegalStateException.class, () -> TenantContext.callWith("inner", () -> {
+            throw new IllegalStateException("boom");
+        }));
+
+        assertEquals("outer", TenantContext.get(), "异常路径同样要恢复，否则上下文会永久错乱");
+    }
+
+    @Test
+    void runWith_shouldExecuteInGivenTenant() {
+        StringBuilder seen = new StringBuilder();
+        TenantContext.runWith("job-tenant", () -> seen.append(TenantContext.require()));
+        assertEquals("job-tenant", seen.toString(), "无请求上下文的任务应能显式指定租户");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tenant/TenantLineHandlerTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tenant/TenantLineHandlerTest.java
@@ -1,0 +1,91 @@
+package com.richard.fyoung.customerwork.tenant;
+
+import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
+import com.baomidou.mybatisplus.extension.plugins.inner.TenantLineInnerInterceptor;
+import net.sf.jsqlparser.expression.StringValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 租户过滤策略单测：租户值来源、忽略表口径与跨租户豁免的嵌套安全。
+ * @author owlzhangfq@gmail.com
+ */
+class TenantLineHandlerTest {
+
+    private final CustomerWorkTenantLineHandler handler =
+        new CustomerWorkTenantLineHandler("tenant_id", List.of("sys_permission", "ai_system_tool"));
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void getTenantId_shouldReturnCurrentTenantAsStringValue() {
+        TenantContext.set("acme");
+        assertEquals("acme", ((StringValue) handler.getTenantId()).getValue(), "应取当前上下文的租户值");
+    }
+
+    @Test
+    void getTenantId_shouldFailClosed_whenContextAbsent() {
+        assertThrows(TenantContextMissingException.class, handler::getTenantId,
+            "缺上下文时必须拒绝拼 SQL，而不是查出全量数据");
+    }
+
+    @Test
+    void ignoreTable_shouldBeCaseInsensitive() {
+        assertTrue(handler.ignoreTable("sys_permission"), "清单内的表应忽略过滤");
+        assertTrue(handler.ignoreTable("SYS_PERMISSION"), "表名大小写不应影响判定");
+        assertTrue(handler.ignoreTable("  ai_system_tool "), "两端空白不应影响判定");
+        assertFalse(handler.ignoreTable("cw_ticket"), "业务表必须参与过滤");
+        assertFalse(handler.ignoreTable(null), "表名为空时按不忽略处理，宁可报错也不放行");
+    }
+
+    @Test
+    void build_shouldCoverPlatformLevelTables() {
+        TenantLineInnerInterceptor interceptor = TenantInterceptors.build("tenant_id", List.of("host_own_table"));
+        assertNotNull(interceptor, "应构建出可用拦截器");
+
+        CustomerWorkTenantLineHandler built =
+            new CustomerWorkTenantLineHandler("tenant_id", TenantInterceptors.PLATFORM_LEVEL_TABLES);
+        assertTrue(built.ignoreTable("ai_chat_session_state"), "框架自建表必须在忽略清单里，否则会拼出不存在的列");
+        assertTrue(built.ignoreTable("ai_model_config"), "两级可见的模型配置由 Service 层过滤，不走自动改写");
+        assertTrue(built.ignoreTable("flyway_schema_history"), "迁移元数据表不属于任何租户");
+    }
+
+    @Test
+    void crossTenantOperations_shouldToggleIgnoreFlag() {
+        assertFalse(InterceptorIgnoreHelper.willIgnoreTenantLine("any"), "默认不豁免");
+
+        CrossTenantOperations.run(() ->
+            assertTrue(InterceptorIgnoreHelper.willIgnoreTenantLine("any"), "作用域内应豁免租户过滤"));
+
+        assertFalse(InterceptorIgnoreHelper.willIgnoreTenantLine("any"), "作用域结束应恢复过滤");
+    }
+
+    @Test
+    void crossTenantOperations_shouldSurviveNesting() {
+        CrossTenantOperations.run(() -> {
+            CrossTenantOperations.run(() -> { });
+            assertTrue(InterceptorIgnoreHelper.willIgnoreTenantLine("any"),
+                "内层作用域结束不得清掉外层豁免——MyBatis-Plus 的 clear 是无条件 remove");
+        });
+        assertFalse(InterceptorIgnoreHelper.willIgnoreTenantLine("any"), "最外层结束才恢复过滤");
+    }
+
+    @Test
+    void crossTenantOperations_shouldRestore_evenWhenActionThrows() {
+        assertThrows(IllegalStateException.class, () -> CrossTenantOperations.run(() -> {
+            throw new IllegalStateException("boom");
+        }));
+        assertFalse(InterceptorIgnoreHelper.willIgnoreTenantLine("any"), "异常路径也必须恢复过滤");
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -106,6 +106,7 @@
 | **合成监控（主动探活）** | `SyntheticMonitor` | 关 | `synthetic-monitor.enabled=true`（真实链路探测，指标 `customerwork.synthetic.probe`） |
 | 原生 Tracing | `TracingConfig` | 关 | `observability.tracing-enabled=true` |
 | **OTel 链路追踪（最后一公里，真出 span + OTLP 导出）** | `OtelTracingConfig`(starter) + `AdminOtelTracingConfig`(admin) | 关 | `customer-work.observability.otel.enabled=true`（starter）/ `admin.observability.otel.enabled=true`（admin），见 §6.13c |
+| **多租户行级隔离（tenant_id 强制过滤）** | `TenantContext` + `CustomerWorkTenantLineHandler`（starter）+ `TenantContextInterceptor`（admin） | 关 | `customer-work.tenant.enabled=true`（starter）/ `admin.tenant.enabled=true`（admin），见 §6.20 |
 | 运维就绪（健康/停机/巡检） | `SessionHealthIndicator` / `GracefulShutdownService` / `MaintenanceScheduler` | 开 | `/actuator/health` |
 | 模型多厂商 + 私有化兜底 / 重试 / **成本熔断** | `ModelConfig`（或 2.0 内置 `maxRetries`/`fallbackModel`）+ `ModelCostCircuitBreaker` | 开 | `model.provider`、`model.fallback.enabled`、`model.cost-control.enabled` |
 | MCP 接入 | `McpToolkitConfigurer` | 关 | `mcp.enabled=true` |
@@ -1462,6 +1463,41 @@ customer-admin-server：`spring.servlet.multipart.max-file-size`/`max-request-si
 - 配置：`admin.a2a.{enabled(false),agent-code,base-url(http://localhost:8082),version(1.0.0),description}`
 - 端点：`GET /.well-known/agent-card.json`（协议约定路径，不可改名）、`POST /a2a/jsonrpc`
 
+### 6.27 多租户行级隔离（B1 租户地基，默认关闭）
+
+共享库 + `tenant_id` 行级过滤，隔离强制点是 MyBatis-Plus 的 `TenantLineInnerInterceptor`。
+完整设计（逐表归属、忽略表判定依据、身份链路、已知约束）见 `docs/多租户架构设计.md`，这里只列用法。
+
+**开启**：`customer-work.tenant.enabled=true`（客服端）+ `admin.tenant.enabled=true`（后台）。
+默认关闭，单租户部署的行为与升级前完全一致——不挂拦截器、不装 Reactor 传播 Hook。
+
+**升级已有库**：客服端跑 `mysql/01-agent-scope-customer-work/customer-work-tenant-alter.sql`
+（27 张 cw_ 表加列 + 6 处唯一键重建，幂等可重复执行）；后台走 Flyway V49 自动执行。
+存量数据归入 `default` 租户，存量后台用户归入 `__platform__`。
+
+**租户身份来源**（三个入口各不相同）：
+
+| 入口 | 来源 | 配置 |
+|---|---|---|
+| 服务端接入方 | API Key → 租户映射 | `security.auth.tenant-keys.{key}: {租户ID}` |
+| H5 用户端 | 登录时带 `tenantCode`，登录后焊进 JWT | 前端 `?tenant=xxx` 或 `VITE_TENANT_CODE` |
+| 后台管理 | 登录用户的 `sys_user.tenant_id` | 运营方可在顶栏切换目标租户视角 |
+
+**后台租户管理**：`系统管理 → 租户管理`（权限点 `tenant:view/add/edit/delete`，仅运营方）。
+新建租户会自动初始化一个 `tenant_admin` 角色并授予除 `tenant:*` 外的全部权限点。
+冻结/退租只改状态不动数据，登录侧立即生效。
+
+**开发约定**（新增代码时必须遵守）：
+
+- 新增业务表一律带 `tenant_id`，不要往忽略清单加表；
+- 有意的跨租户查询走 `CrossTenantOperations.execute(...)`，它是可 grep 的白名单；
+- 缺租户上下文时持久层 **fail-closed 抛错**（`TenantContextMissingException`），
+  这是刻意的——静默返回别的租户的数据比一次 500 危险得多；
+- 无请求上下文的场景（定时任务、启动初始化）用 `TenantContext.runWith(租户, ...)` 显式指定。
+
+**已知限制**：客服端的字典 / 敏感词 / 限流规则三张配置表，新租户开通时不会自动复制平台默认值
+（admin 与客服端库之间没有直连通道），当前需要为新租户单独维护；平台词库批量下发属于运维能力，留待后续批次。
+
 ---
 
 ## 七、配置项总表
@@ -1482,7 +1518,8 @@ customer-admin-server：`spring.servlet.multipart.max-file-size`/`max-request-si
 | `observability` | trace-enabled(false), trace-file, tracing-enabled(false), studio.*, otel.{enabled(false),endpoint(http://localhost:4317),service-name(customer-work),sampler-ratio(1.0)}（见 §6.13c；admin 侧对应 `admin.observability.otel.*`，非本表 `customer-work.*` 范围，随 admin 自身配置文档见 §6.21） |
 | `human-approval` | enabled(true), guarded-tools([submitRefund]), timeout-seconds(0), timeout-action(escalate), store-mode(memory) |
 | `fact-log` | enabled(true), directory(./data/facts), max-file-mb(10), max-archived-files(5) |
-| `security` | auth.{enabled(false),header-name(X-API-Key),api-keys[]}, rate-limit.{enabled(false),requests-per-minute(120),algorithm(fixed-window),window-seconds(60),rule-enabled(false),store-mode(memory),refresh-enabled(true),refresh-interval-ms(60000)} |
+| `tenant` | enabled(false), column-name(tenant_id), ignored-tables[], auto-context-propagation(true)（见 §6.27；admin 侧对应 `admin.tenant.*`） |
+| `security` | auth.{enabled(false),header-name(X-API-Key),api-keys[],tenant-keys{}}, rate-limit.{enabled(false),requests-per-minute(120),algorithm(fixed-window),window-seconds(60),rule-enabled(false),store-mode(memory),refresh-enabled(true),refresh-interval-ms(60000)} |
 | `sensitive-word` | enabled(false), direction(BOTH), store-mode(memory), default-action(BLOCK), mask-char(*), inbound-safe-reply, outbound-safe-reply, refresh-enabled(true), refresh-interval-ms(60000), hit-log.{enabled(false),store-mode(memory),queue-capacity(2048),snippet-max-length(64)} |
 | `multi-agent` | enabled(true), mode(fanout), max-iters(6) |
 | `runtime` | shutdown-timeout-seconds(30), scheduler-enabled(false), scheduler-fixed-delay-ms(60000) |

--- a/docs/多租户架构设计.md
+++ b/docs/多租户架构设计.md
@@ -1,0 +1,156 @@
+# 多租户架构设计（B1 租户地基）
+
+本文是 B1 批次的设计定案，回答三个问题：**租户是什么、数据怎么不串、身份从哪来**。
+配额计费（B3）、按租户灰度（B4）建立在本文的 `tenant_id` 之上，不在本文范围。
+
+## 1. 租户模型
+
+隔离级别：**共享库 + `tenant_id` 行级过滤**（不做 schema-per-tenant）。
+
+`tenant_id` 为 `VARCHAR(64)`，三个保留值：
+
+| 值 | 含义 |
+|---|---|
+| `default` | 升级前的存量数据归属的默认租户，等价于"原来那个单租户系统" |
+| `__platform__` | 平台运营方自身。运营方后台用户、平台共享模型配置挂在此租户下 |
+| 其它 | 真实业务租户，由 `sys_tenant.tenant_code` 定义 |
+
+选 `VARCHAR` 而非 `BIGINT`：`tenant_id` 要出现在 API Key 映射、日志 MDC、指标标签、Nacos dataId 里，
+可读的编码（如 `acme`）比自增数字好排查，且与既有 `TenantResolver.DEFAULT_TENANT = "default"` 的口径衔接。
+
+### 生命周期
+
+`sys_tenant.status`：`ACTIVE`（正常）→ `SUSPENDED`（冻结，登录与 API 拒绝，数据保留）→ `TERMINATED`（退租，数据保留待导出/清理）。
+冻结与退租只改状态，不删数据——数据主权与导出属于 B6。
+
+## 2. 数据隔离
+
+### 2.1 强制机制
+
+MyBatis-Plus `TenantLineInnerInterceptor`（3.5.7）全局改写，两侧各挂一次：
+starter 的 `CustomerWorkPersistenceConfig`（独立 `customerWorkSqlSessionFactory`）与 admin 的 `MybatisPlusConfig`。
+
+选它而非在 Store SPI 逐个手工过滤的理由：
+
+- 一处配置覆盖 `SELECT/UPDATE/DELETE` 与 XML 手写 SQL，符合项目"防御式编程只保留一处"的规范；
+- **`INSERT` 由拦截器自动补 `tenant_id` 列与值**，因此已有的写入代码零改动——这是"加列"比"加忽略表"更省事的根本原因；
+- 全仓复杂 SQL 只有 3 个 XML（`OrderMapper` 的 `LEFT JOIN cw_user`、`AgentCallLogMapper` 的 `GROUP BY`、
+  admin 的 `ChatSessionStateQueryMapper`），改写面小、可逐个回归。
+
+### 2.2 逐表归属
+
+**原则：能加列的全加。** 忽略表清单越短越安全——漏加一张表就是一个串数据的口子，而多加一列 `tenant_id` 没有代价。
+关联表（`ai_agent_skill`、`sys_user_role` 等）同样加列，不靠"JOIN 主表天然隔离"这种需要每次推理的间接保证。
+
+| 类别 | 表 | 处理 |
+|---|---|---|
+| 客服端业务数据 | `cw_*` 全部 27 张 | 加 `tenant_id`，自动过滤 |
+| admin 配置与业务数据 | `ai_*` 除下方例外的全部、`sys_user`、`sys_role`、`sys_operation_log`、关联表 | 加 `tenant_id`，自动过滤 |
+| 平台级（忽略过滤） | `sys_permission`、`sys_menu_change_log`、`ai_system_tool`、`sys_tenant`、`flyway_schema_history` | 不加列，进忽略清单 |
+| 框架自建（忽略过滤） | `ai_chat_session_state` | 见 §4.1 |
+| 两级可见（忽略过滤） | `ai_model_config` | 见 §2.4 |
+
+平台级表的判定依据是"内容由平台定义、租户只读"：`sys_permission` 是权限点/菜单树的代码级定义，
+`ai_system_tool` 是代码里 `@Tool` 注册的工具目录（租户是否启用某工具走租户级的 `ai_agent_system_tool` 关联表）。
+
+### 2.3 唯一约束改造
+
+行级隔离后，原先的全局唯一键会阻止两个租户使用相同的业务标识，必须前置 `tenant_id`：
+
+| 表 | 原约束 | 改为 |
+|---|---|---|
+| `cw_user` | `(username)` | `(tenant_id, username)` |
+| `cw_knowledge` | `(title)` | `(tenant_id, title)` |
+| `cw_sensitive_word` | `(word)` | `(tenant_id, word)` |
+| `cw_rate_limit_rule` | `(rule_name)` | `(tenant_id, rule_name)` |
+| `cw_dict_type` | `(dict_type)` | `(tenant_id, dict_type)` |
+| `cw_dict_item` | `(dict_type, item_key)` | `(tenant_id, dict_type, item_key)` |
+
+不改的两个：`cw_chat_message.(message_id)` 是框架 `Msg.id` 的 UUID，全局唯一；
+`sys_user.(username)` **刻意保持全局唯一**——admin 只有一个登录入口，若允许跨租户重名，登录时无法判定归属租户，
+用户得先填租户编码才能登录。全局唯一换取登录体验，代价是租户不能自选已被占用的账号名，可接受。
+
+各表主键均为 `VARCHAR(64)` 业务号或自增 ID，天然全局唯一，不受影响。
+
+### 2.4 `ai_model_config` 为何破例
+
+该表存模型接入凭据（`api_key`）。若按普通租户级表处理，平台要为每个租户复制一份 key，
+则 key 轮换需批量更新 N 份，且租户管理员在自己的数据域里能读到平台凭据——这是真实的凭据泄露面。
+
+处理：加 `tenant_id` 但进忽略清单，由 Service 层显式做两级可见性：
+读取时 `tenant_id IN (当前租户, '__platform__')`，平台记录的 `api_key` 对租户视角脱敏；
+写入/删除时强制校验 `tenant_id = 当前租户`，租户改不动平台记录。
+
+**为什么不把两级做成拦截器的通用能力**：`TenantLineInnerInterceptor` 对 SELECT/UPDATE/DELETE 共用同一个
+`buildTableExpression`，一旦改成 `IN (租户, 平台)`，`UPDATE`/`DELETE` 也会放行到平台记录上，等于给租户开了越权写的口子。
+一张表的手工过滤，好过全局的越权风险。
+
+### 2.5 运营方的全局视角
+
+运营方需要跨租户看数据（租户列表、全局统计），而拦截器会强制把查询钉在某一个 `tenant_id` 上。
+解决办法是 MyBatis-Plus 的 `@InterceptorIgnore(tenantLine = "1")` / `InterceptorIgnoreHelper`：
+**跨租户查询走显式标注的专用 Mapper 方法**，且这些方法的调用入口必须先过运营方权限校验。
+
+不采用"TenantContext 塞特殊值代表全局"的做法——那会让"忘记设置上下文"与"故意查全局"在代码上无法区分，
+一处疏漏就是全量泄露。显式标注则是可 grep、可 review 的白名单。
+
+## 3. 租户身份从哪来
+
+现有 `TenantResolver` 从 `sessionId` 前缀猜租户，且**无分隔符时整个 sessionId 即租户**——
+现网每个会话都是一个独立"租户"，这个类只服务于记忆分文件落盘，不能作为安全边界，本批次不再让它参与鉴权链路。
+
+三个入口各自的权威来源：
+
+| 入口 | 来源 | 说明 |
+|---|---|---|
+| 服务端接入方 | API Key → tenant 映射 | `ApiKeyAuthWebFilter` 鉴权成功后把 key 绑定的 `tenant_id` 写入上下文 |
+| H5 用户端 | 登录态（token 内绑定） | 见下方说明 |
+| admin 后台 | 登录用户的 `sys_user.tenant_id` | 运营方为 `__platform__`，可显式切换目标租户 |
+
+**H5 的登录请求本身必须携带租户标识**（URL 参数或前端构建配置注入的 `tenantCode`），
+否则服务端无从判断该拿哪个租户的用户表校验密码。这不是设计妥协——任何 SaaS 的登录入口都需要租户线索。
+"不信任前端传参"约束的是**登录之后**：登录成功即把 `tenant_id` 焊进 token，后续请求一律从 token 取，
+忽略前端再传的任何租户参数。
+
+上下文载体 `TenantContext` 需双通道：客服端是 WebFlux（Reactor Context），admin 是 Spring MVC（ThreadLocal）。
+
+## 4. 已知约束
+
+### 4.1 框架自建表不受拦截器管辖
+
+`ai_chat_session_state` 由框架 `MysqlAgentStateStore` 直接持有 `DataSource` 读写，**绕过 MyBatis**，
+既加不了列也拦不住 SQL。它存的是对话历史与短期记忆，隔离只能靠 `session_id` 的 `{agentCode}:{uuid}` 命名——
+即租户间不共享 agentCode 时天然不串，共享 agentCode 时靠 uuid 不可猜。
+
+本项目自己的只读分页查询（`ChatSessionStateQueryMapper`）走 MyBatis，因此该表必须进忽略清单，
+否则拦截器会给它拼一个不存在的 `tenant_id` 列导致 SQL 报错。
+
+### 4.2 IM 渠道的用户身份串扰
+
+框架 issue #1966/#1764 的限制：多用户共享群场景下渠道侧用户身份可能串扰。
+本批次按"每租户独立机器人/群"部署来规避（`ai_channel_robot` 已加 `tenant_id`），共享群场景的风险在部署文档中声明。
+
+### 4.3 跨库同名表
+
+`cw_agent_call_log` / `cw_agent_call_segment` 在客服端库与 admin 库各有一份（admin 复用 starter 的 Mapper）。
+两边都要加列，且两侧拦截器都要生效，否则调用统计会串租户。
+
+## 5. 存量数据
+
+- `cw_*` 加列用 `NOT NULL DEFAULT 'default'`，存量行自动归入 `default` 租户，无需数据迁移脚本；
+- `sys_tenant` 种子插入 `default` 与 `__platform__` 两条记录；
+- 存量 `sys_user` 归入 `__platform__`（升级前的后台用户都是运营方）。
+
+客服端库无 Flyway（建表走 `SchemaInitializer` 的 `CREATE TABLE IF NOT EXISTS`，不执行 ALTER），
+因此存量库升级需要独立的 alter 脚本，放 `mysql/01-agent-scope-customer-work/`，与既有的
+`customer-work-user-avatar-alter.sql` 同一套路；admin 库走 Flyway，并按规范同步镜像到 `mysql/02-customer-admin/`。
+
+## 6. 租户开通时复制的种子
+
+以下数据平台有默认值、租户需要能自行修改，采取"开通租户时复制一份到该租户"而非两级可见：
+
+`sys_role`（内置角色）、`cw_dict_type` / `cw_dict_item`（内置字典）、`cw_sensitive_word`（平台底线词库）、
+`cw_rate_limit_rule`（默认限流规则）。
+
+代价是平台后续更新默认值不会传播到已开通租户；换来的是租户对自己配置的完全控制权，
+以及不必为这几张表引入 §2.4 那样的越权写风险。批量下发平台词库属于运维动作，留到 B6。

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS `agentscope_sessions` (
 --       本脚本用于 DBA 预审 / 受限权限环境。
 
 CREATE TABLE IF NOT EXISTS `cw_audit_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`          BIGINT AUTO_INCREMENT PRIMARY KEY,
     `event_type`  VARCHAR(64) NOT NULL COMMENT '事件类型: tool-call / final-answer / error',
     `agent_name`  VARCHAR(128) DEFAULT '' COMMENT 'Agent 名称',
@@ -46,7 +47,8 @@ CREATE TABLE IF NOT EXISTS `cw_audit_log` (
     `created_at`  TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '记录时间',
     INDEX `idx_audit_type` (`event_type`),
     INDEX `idx_audit_created` (`created_at`),
-    INDEX `idx_audit_agent` (`agent_name`)
+    INDEX `idx_audit_agent` (`agent_name`),
+    INDEX `idx_audit_log_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- =============================================================================
@@ -57,6 +59,7 @@ CREATE TABLE IF NOT EXISTS `cw_audit_log` (
 --       保证应用重启 / 多实例部署下审批单不丢失。
 
 CREATE TABLE IF NOT EXISTS `cw_approval` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`                        VARCHAR(64) PRIMARY KEY COMMENT '审批单号',
     `type`                      VARCHAR(32) NOT NULL COMMENT '审批类型：REFUND 等',
     `session_id`                VARCHAR(128) COMMENT '关联会话',
@@ -72,7 +75,8 @@ CREATE TABLE IF NOT EXISTS `cw_approval` (
     `execution_failure_reason`  TEXT COMMENT '下游执行失败原因',
     `execution_attempts`        INT DEFAULT 0 COMMENT '下游执行尝试次数',
     INDEX `idx_approval_status` (`status`),
-    INDEX `idx_approval_created` (`created_at_ms`)
+    INDEX `idx_approval_created` (`created_at_ms`),
+    INDEX `idx_approval_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- =============================================================================
@@ -83,9 +87,11 @@ CREATE TABLE IF NOT EXISTS `cw_approval` (
 --       中途重启可续填，用户无需从头重答。
 
 CREATE TABLE IF NOT EXISTS `cw_slot_filling_progress` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `progress_key`    VARCHAR(191) PRIMARY KEY COMMENT '收集进度键：sessionId:formName',
     `asking`          VARCHAR(64) COMMENT '当前追问的槽位名',
-    `collected_json`  TEXT COMMENT '已收集槽位值（JSON）'
+    `collected_json`  TEXT COMMENT '已收集槽位值（JSON）',
+    INDEX `idx_slot_filling_progress_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- =============================================================================
@@ -96,8 +102,10 @@ CREATE TABLE IF NOT EXISTS `cw_slot_filling_progress` (
 --       避免负载均衡到不同实例导致阶段状态"归零"回 GREETING。
 
 CREATE TABLE IF NOT EXISTS `cw_dialog_stage` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `session_id`  VARCHAR(191) PRIMARY KEY COMMENT '会话 ID',
-    `stage`       VARCHAR(24) NOT NULL COMMENT '当前对话阶段：GREETING/COLLECTING/PROCESSING/CONFIRMING/ESCALATED'
+    `stage`       VARCHAR(24) NOT NULL COMMENT '当前对话阶段：GREETING/COLLECTING/PROCESSING/CONFIRMING/ESCALATED',
+    INDEX `idx_dialog_stage_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- =============================================================================
@@ -110,6 +118,7 @@ CREATE TABLE IF NOT EXISTS `cw_dialog_stage` (
 --       坐席工作台轮询落到实例 B 也应查到最新状态。
 
 CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`                VARCHAR(64) PRIMARY KEY COMMENT '工单号',
     `session_id`        VARCHAR(128) COMMENT '关联会话',
     `reason`            TEXT COMMENT '转人工原因',
@@ -125,7 +134,8 @@ CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
     `emotion`           VARCHAR(32) COMMENT '用户情绪（LLM 分类，可空）',
     `suggested_assignees` TEXT COMMENT '推荐坐席列表 JSON（HITL 推荐，人工点选非自动派单，可空）',
     INDEX `idx_handoff_status` (`status`),
-    INDEX `idx_handoff_created` (`created_at_ms`)
+    INDEX `idx_handoff_created` (`created_at_ms`),
+    INDEX `idx_handoff_ticket_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- =============================================================================
@@ -137,13 +147,15 @@ CREATE TABLE IF NOT EXISTS `cw_handoff_ticket` (
 --       同一 message_id 重复提交按最新一次覆盖（用户改变主意允许更正）。
 
 CREATE TABLE IF NOT EXISTS `cw_message_feedback` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `message_id`     VARCHAR(64) PRIMARY KEY COMMENT '被反馈的消息ID',
     `session_id`     VARCHAR(128) COMMENT '所属会话',
     `type`           VARCHAR(8) NOT NULL COMMENT 'UP/DOWN',
     `comment`        TEXT COMMENT '文字说明',
     `created_at_ms`  BIGINT NOT NULL COMMENT '提交时间戳（毫秒，重复提交取最新）',
     INDEX `idx_feedback_session` (`session_id`),
-    INDEX `idx_feedback_type` (`type`)
+    INDEX `idx_feedback_type` (`type`),
+    INDEX `idx_message_feedback_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- =============================================================================
@@ -159,6 +171,7 @@ CREATE TABLE IF NOT EXISTS `cw_message_feedback` (
 
 -- 终端用户账户表（cw_user）：登录凭据以 BCrypt 哈希存储。
 CREATE TABLE IF NOT EXISTS `cw_user` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             VARCHAR(64) PRIMARY KEY COMMENT '用户ID',
     `username`       VARCHAR(64) NOT NULL COMMENT '用户名',
     `password_hash`  VARCHAR(100) NOT NULL COMMENT 'BCrypt 密码哈希',
@@ -167,11 +180,13 @@ CREATE TABLE IF NOT EXISTS `cw_user` (
     `status`         VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/DISABLED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
     `avatar_url`     VARCHAR(255) COMMENT '头像访问URL（相对路径，可为空）',
-    UNIQUE KEY `uk_user_username` (`username`)
+    UNIQUE KEY `uk_user_username` (`tenant_id`, `username`),
+    INDEX `idx_user_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 客服工单主表（cw_ticket）：完整生命周期状态机（AI_SERVING→WAITING_AGENT→PROCESSING→...→CLOSED）。
 CREATE TABLE IF NOT EXISTS `cw_ticket` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`              VARCHAR(64) PRIMARY KEY COMMENT '工单号',
     `session_id`      VARCHAR(128) NOT NULL COMMENT '关联会话',
     `user_id`         VARCHAR(64) NOT NULL COMMENT '发起用户',
@@ -193,11 +208,13 @@ CREATE TABLE IF NOT EXISTS `cw_ticket` (
     INDEX `idx_ticket_session` (`session_id`),
     INDEX `idx_ticket_user` (`user_id`, `created_at_ms`),
     INDEX `idx_ticket_status` (`status`, `updated_at_ms`),
-    INDEX `idx_ticket_assignee` (`assignee`, `status`)
+    INDEX `idx_ticket_assignee` (`assignee`, `status`),
+    INDEX `idx_ticket_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 工单事件轨迹表（cw_ticket_event）：每次状态流转一条，不可变审计。
 CREATE TABLE IF NOT EXISTS `cw_ticket_event` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '事件自增主键',
     `ticket_id`      VARCHAR(64) NOT NULL COMMENT '所属工单号',
     `event_type`     VARCHAR(32) NOT NULL COMMENT '事件类型',
@@ -207,11 +224,13 @@ CREATE TABLE IF NOT EXISTS `cw_ticket_event` (
     `actor_id`       VARCHAR(64) COMMENT '动作发起方标识',
     `note`           VARCHAR(500) COMMENT '备注',
     `created_at_ms`  BIGINT NOT NULL COMMENT '事件时间戳（毫秒）',
-    INDEX `idx_ticket_event` (`ticket_id`, `id`)
+    INDEX `idx_ticket_event` (`ticket_id`, `id`),
+    INDEX `idx_ticket_event_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 聊天消息留痕表（cw_chat_message）：会话/工单双维度，自增主键用于游标翻页。
 CREATE TABLE IF NOT EXISTS `cw_chat_message` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键（游标翻页）',
     `message_id`     VARCHAR(64) NOT NULL COMMENT '业务消息号 MSG-<uuid>',
     `session_id`     VARCHAR(128) NOT NULL COMMENT '所属会话',
@@ -222,11 +241,13 @@ CREATE TABLE IF NOT EXISTS `cw_chat_message` (
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
     UNIQUE KEY `uk_chat_message_id` (`message_id`),
     INDEX `idx_chat_session` (`session_id`, `id`),
-    INDEX `idx_chat_ticket` (`ticket_id`, `id`)
+    INDEX `idx_chat_ticket` (`ticket_id`, `id`),
+    INDEX `idx_chat_message_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 智能体调用主记录表（cw_agent_call_log）：每次调用一行，含分段耗时冗余汇总（MybatisAgentCallLogStore）。
 CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `request_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
     `user_id`        VARCHAR(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
@@ -257,11 +278,13 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_log` (
     INDEX `idx_call_username` (`username`),
     INDEX `idx_call_agent_code` (`agent_code`),
     INDEX `idx_call_session` (`session_id`),
-    INDEX `idx_call_start` (`start_time`)
+    INDEX `idx_call_start` (`start_time`),
+    INDEX `idx_agent_call_log_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 智能体调用分段明细表（cw_agent_call_segment）：一次调用的每段耗时一行（MybatisAgentCallLogStore）。
 CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `call_log_id`    BIGINT NOT NULL COMMENT '所属主记录ID',
     `seq`            INT NOT NULL COMMENT '调用内分段序号（从1起）',
@@ -275,7 +298,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
-    INDEX `idx_segment_call_log` (`call_log_id`, `seq`)
+    INDEX `idx_segment_call_log` (`call_log_id`, `seq`),
+    INDEX `idx_agent_call_segment_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- token 统计补列（2026-07-28）：CREATE TABLE IF NOT EXISTS 对已存在的表不加列，
@@ -289,6 +313,7 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
 
 -- 对话附件表（cw_chat_attachment）：上传附件落盘 + 落库，解析文本可追溯（MybatisAttachmentStore）。
 CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             VARCHAR(64) NOT NULL COMMENT '附件ID(UUID)',
     `session_id`     VARCHAR(128) NOT NULL DEFAULT '' COMMENT '会话ID',
     `message_id`     VARCHAR(64) NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）',
@@ -305,11 +330,13 @@ CREATE TABLE IF NOT EXISTS `cw_chat_attachment` (
     `created_at`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     PRIMARY KEY (`id`),
     INDEX `idx_cw_attachment_session` (`session_id`),
-    INDEX `idx_cw_attachment_created` (`created_at`)
+    INDEX `idx_cw_attachment_created` (`created_at`),
+    INDEX `idx_chat_attachment_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 商品表（cw_product）：JdbcProductBackend 演示表。
 CREATE TABLE IF NOT EXISTS `cw_product` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `product_id`   VARCHAR(32) PRIMARY KEY COMMENT '商品ID',
     `name`         VARCHAR(128) NOT NULL COMMENT '商品名称',
     `category`     VARCHAR(64) COMMENT '品类',
@@ -318,16 +345,18 @@ CREATE TABLE IF NOT EXISTS `cw_product` (
     `description`  VARCHAR(500) COMMENT '商品描述',
     `promotion`    VARCHAR(255) COMMENT '优惠活动',
     `status`       VARCHAR(16) NOT NULL DEFAULT 'ON_SALE' COMMENT 'ON_SALE/OFF_SALE',
-    INDEX `idx_product_category` (`category`)
+    INDEX `idx_product_category` (`category`),
+    INDEX `idx_product_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-INSERT IGNORE INTO `cw_product` (`product_id`, `name`, `category`, `price`, `stock`, `description`, `promotion`, `status`) VALUES
-('P001', '旗舰款无线降噪耳机', '耳机', 299.00, 100, '旗舰款无线降噪耳机，蓝牙 5.3，续航 30 小时，支持多点连接，颜色 黑/白，质保 1 年', '满 300 减 50；可叠加新人券 20 元；下单送收纳包', 'ON_SALE'),
-('P002', '运动防汗蓝牙耳机', '耳机', 199.00, 50, '运动防汗蓝牙耳机，IPX5 级防水，佩戴稳固，适合健身运动', '限时直降 30 元，晒单再返 10 元', 'ON_SALE'),
-('P003', '商务降噪头戴耳机', '耳机', 599.00, 0, '商务降噪头戴耳机，主动降噪，麦克风通话清晰，续航 40 小时', '', 'ON_SALE');
+INSERT IGNORE INTO `cw_product` (`tenant_id`, `product_id`, `name`, `category`, `price`, `stock`, `description`, `promotion`, `status`) VALUES
+('default', 'P001', '旗舰款无线降噪耳机', '耳机', 299.00, 100, '旗舰款无线降噪耳机，蓝牙 5.3，续航 30 小时，支持多点连接，颜色 黑/白，质保 1 年', '满 300 减 50；可叠加新人券 20 元；下单送收纳包', 'ON_SALE'),
+('default', 'P002', '运动防汗蓝牙耳机', '耳机', 199.00, 50, '运动防汗蓝牙耳机，IPX5 级防水，佩戴稳固，适合健身运动', '限时直降 30 元，晒单再返 10 元', 'ON_SALE'),
+('default', 'P003', '商务降噪头戴耳机', '耳机', 599.00, 0, '商务降噪头戴耳机，主动降噪，麦克风通话清晰，续航 40 小时', '', 'ON_SALE');
 
 -- 订单表（cw_order）：JdbcOrderBackend 演示表。种子含 Mock 示例订单，状态/金额/下单日期与 Mock 一致。
 CREATE TABLE IF NOT EXISTS `cw_order` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `order_id`         VARCHAR(32) PRIMARY KEY COMMENT '订单号',
     `user_id`          VARCHAR(64) NOT NULL COMMENT '下单用户',
     `product_id`       VARCHAR(32) NOT NULL COMMENT '商品ID',
@@ -337,17 +366,19 @@ CREATE TABLE IF NOT EXISTS `cw_order` (
     `receiver_addr`    VARCHAR(255) COMMENT '收货地址',
     `logistics_trace`  TEXT COMMENT '物流轨迹',
     `created_at_ms`    BIGINT NOT NULL COMMENT '下单时间戳（毫秒）',
-    INDEX `idx_order_user` (`user_id`, `created_at_ms`)
+    INDEX `idx_order_user` (`user_id`, `created_at_ms`),
+    INDEX `idx_order_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-INSERT IGNORE INTO `cw_order` (`order_id`, `user_id`, `product_id`, `product_name`, `amount`, `status`, `receiver_addr`, `logistics_trace`, `created_at_ms`) VALUES
-('20260613001', 'U-demo-1', 'P001', '旗舰款无线降噪耳机', 299.00, '已发货', '北京市朝阳区建国路 88 号', '[6-11 已揽收]→[6-12 到达分拨中心]→[6-13 派送中]。', 1781049600000),
-('20260613002', 'U-demo-1', 'P003', '商务降噪头戴耳机', 1599.00, '已签收', '上海市浦东新区世纪大道 100 号', '[5-18 已揽收]→[5-19 运输中]→[5-20 已签收]。', 1779235200000),
-('20260613003', 'U-demo-2', 'P002', '运动防汗蓝牙耳机', 199.00, '待发货', '广州市天河区体育西路 1 号', '[6-13 已下单，仓库备货中]', 1781308800000),
-('20260613004', 'U-demo-2', 'P001', '旗舰款无线降噪耳机', 299.00, '已退款', '深圳市南山区科技园路 5 号', '[6-08 已揽收]→[6-09 用户取消]→[6-10 已退款]', 1780876800000);
+INSERT IGNORE INTO `cw_order` (`tenant_id`, `order_id`, `user_id`, `product_id`, `product_name`, `amount`, `status`, `receiver_addr`, `logistics_trace`, `created_at_ms`) VALUES
+('default', '20260613001', 'U-demo-1', 'P001', '旗舰款无线降噪耳机', 299.00, '已发货', '北京市朝阳区建国路 88 号', '[6-11 已揽收]→[6-12 到达分拨中心]→[6-13 派送中]。', 1781049600000),
+('default', '20260613002', 'U-demo-1', 'P003', '商务降噪头戴耳机', 1599.00, '已签收', '上海市浦东新区世纪大道 100 号', '[5-18 已揽收]→[5-19 运输中]→[5-20 已签收]。', 1779235200000),
+('default', '20260613003', 'U-demo-2', 'P002', '运动防汗蓝牙耳机', 199.00, '待发货', '广州市天河区体育西路 1 号', '[6-13 已下单，仓库备货中]', 1781308800000),
+('default', '20260613004', 'U-demo-2', 'P001', '旗舰款无线降噪耳机', 299.00, '已退款', '深圳市南山区科技园路 5 号', '[6-08 已揽收]→[6-09 用户取消]→[6-10 已退款]', 1780876800000);
 
 -- 售后工单表（cw_refund）：JdbcAfterSalesBackend 演示表。退款/退货/换货共表，submitRefund 只落 PENDING 待人工复核（资金红线）。
 CREATE TABLE IF NOT EXISTS `cw_refund` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `refund_no`      VARCHAR(64) PRIMARY KEY COMMENT '售后工单号',
     `order_id`       VARCHAR(32) NOT NULL COMMENT '关联订单号',
     `type`           VARCHAR(16) NOT NULL COMMENT '类型：REFUND/RETURN/EXCHANGE',
@@ -356,24 +387,28 @@ CREATE TABLE IF NOT EXISTS `cw_refund` (
     `reason`         VARCHAR(500) COMMENT '诉求原因',
     `new_spec`       VARCHAR(128) COMMENT '换货目标规格',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_refund_order` (`order_id`, `created_at_ms`)
+    INDEX `idx_refund_order` (`order_id`, `created_at_ms`),
+    INDEX `idx_refund_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-INSERT IGNORE INTO `cw_refund` (`refund_no`, `order_id`, `type`, `status`, `amount`, `reason`, `new_spec`, `created_at_ms`) VALUES
-('RF-seed-20260613004', '20260613004', 'REFUND', 'APPROVED', 299.00, '七天无理由退款', NULL, 1781049600000);
+INSERT IGNORE INTO `cw_refund` (`tenant_id`, `refund_no`, `order_id`, `type`, `status`, `amount`, `reason`, `new_spec`, `created_at_ms`) VALUES
+('default', 'RF-seed-20260613004', '20260613004', 'REFUND', 'APPROVED', 299.00, '七天无理由退款', NULL, 1781049600000);
 
 -- 发票申请表（cw_invoice_request）：JdbcAfterSalesBackend 演示表。requestInvoice 真实落库。
 CREATE TABLE IF NOT EXISTS `cw_invoice_request` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '发票申请自增主键',
     `order_id`       VARCHAR(32) NOT NULL COMMENT '关联订单号',
     `invoice_title`  VARCHAR(255) NOT NULL COMMENT '发票抬头',
     `status`         VARCHAR(16) NOT NULL DEFAULT 'PENDING' COMMENT '状态：PENDING/ISSUED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_invoice_order` (`order_id`, `created_at_ms`)
+    INDEX `idx_invoice_order` (`order_id`, `created_at_ms`),
+    INDEX `idx_invoice_request_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 会员表（cw_member）：JdbcMemberBackend 演示表。种子 U-demo-1 与 Mock 数据一致（黄金会员/积分 1280）。
 CREATE TABLE IF NOT EXISTS `cw_member` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `member_id`        VARCHAR(64) PRIMARY KEY COMMENT '会员ID（对应用户ID）',
     `level`            VARCHAR(32) NOT NULL COMMENT '会员等级',
     `points`           INT NOT NULL DEFAULT 0 COMMENT '当前积分',
@@ -381,53 +416,61 @@ CREATE TABLE IF NOT EXISTS `cw_member` (
     `benefits`         VARCHAR(255) COMMENT '等级权益',
     `next_level`       VARCHAR(32) COMMENT '下一等级',
     `upgrade_gap`      DECIMAL(10,2) DEFAULT 0 COMMENT '升级所需再消费金额',
-    `phone`            VARCHAR(32) COMMENT '注册手机号'
+    `phone`            VARCHAR(32) COMMENT '注册手机号',
+    INDEX `idx_member_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-INSERT IGNORE INTO `cw_member` (`member_id`, `level`, `points`, `points_expiring`, `benefits`, `next_level`, `upgrade_gap`, `phone`) VALUES
-('U-demo-1', '黄金会员', 1280, 200, '免运费、专属客服、生日双倍积分', '铂金', 500.00, '138****0001'),
-('U-demo-2', '白银会员', 320, 0, '满额包邮、积分商城兑换', '黄金', 800.00, '139****0002');
+INSERT IGNORE INTO `cw_member` (`tenant_id`, `member_id`, `level`, `points`, `points_expiring`, `benefits`, `next_level`, `upgrade_gap`, `phone`) VALUES
+('default', 'U-demo-1', '黄金会员', 1280, 200, '免运费、专属客服、生日双倍积分', '铂金', 500.00, '138****0001'),
+('default', 'U-demo-2', '白银会员', 320, 0, '满额包邮、积分商城兑换', '黄金', 800.00, '139****0002');
 
 -- 会员账户问题处理日志表（cw_member_account_log）：JdbcMemberBackend 演示表。resolveAccountIssue 落一条处理日志。
 CREATE TABLE IF NOT EXISTS `cw_member_account_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '处理日志自增主键',
     `issue`          VARCHAR(255) NOT NULL COMMENT '账户问题描述',
     `handling`       VARCHAR(500) COMMENT '处置话术',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_account_log_created` (`created_at_ms`)
+    INDEX `idx_account_log_created` (`created_at_ms`),
+    INDEX `idx_member_account_log_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- 投诉工单表（cw_complaint）：JdbcComplaintBackend 演示表。种子 CP-seed-0001 支撑 queryComplaint 演示。
 CREATE TABLE IF NOT EXISTS `cw_complaint` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `complaint_no`   VARCHAR(64) PRIMARY KEY COMMENT '投诉工单号',
     `order_id`       VARCHAR(32) COMMENT '关联订单号（可空）',
     `content`        TEXT COMMENT '投诉内容',
     `status`         VARCHAR(16) NOT NULL COMMENT '状态：PROCESSING/RESOLVED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
-    INDEX `idx_complaint_order` (`order_id`, `created_at_ms`)
+    INDEX `idx_complaint_order` (`order_id`, `created_at_ms`),
+    INDEX `idx_complaint_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-INSERT IGNORE INTO `cw_complaint` (`complaint_no`, `order_id`, `content`, `status`, `created_at_ms`) VALUES
-('CP-seed-0001', '20260613002', '物流配送太慢，希望加快处理', 'PROCESSING', 1779235200000);
+INSERT IGNORE INTO `cw_complaint` (`tenant_id`, `complaint_no`, `order_id`, `content`, `status`, `created_at_ms`) VALUES
+('default', 'CP-seed-0001', '20260613002', '物流配送太慢，希望加快处理', 'PROCESSING', 1779235200000);
 
 -- 知识库 FAQ 表（cw_knowledge）：JdbcKnowledgeBackend 演示表。种子三条与 Mock 一致（退货/发票/运费），LIKE 关键词检索。
 CREATE TABLE IF NOT EXISTS `cw_knowledge` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`         BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '知识条目自增主键',
     `keyword`    VARCHAR(255) NOT NULL COMMENT '命中关键词（逗号分隔）',
     `title`      VARCHAR(255) NOT NULL COMMENT '条目标题',
     `content`    TEXT NOT NULL COMMENT '条目内容',
     `source`     VARCHAR(255) COMMENT '来源标注',
-    UNIQUE KEY `uk_knowledge_title` (`title`)
+    UNIQUE KEY `uk_knowledge_title` (`tenant_id`, `title`),
+    INDEX `idx_knowledge_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-INSERT IGNORE INTO `cw_knowledge` (`keyword`, `title`, `content`, `source`) VALUES
-('退货,退款,七天,无理由', '七天无理由退货政策', '支持七天无理由退货，商品需保持完好、不影响二次销售；定制类、生鲜类除外。', '《售后服务政策》第 3 条'),
-('发票,开票,报销', '发票开具规则', '支持开具电子普通发票与增值税专用发票，可在订单详情页自助申请，1-3 个工作日开具。', '《发票管理规则》第 1 条'),
-('运费,包邮,邮费', '运费说明', '单笔订单满 99 元包邮，偏远地区除外；退货运费由责任方承担。', '《运费说明》第 2 条');
+INSERT IGNORE INTO `cw_knowledge` (`tenant_id`, `keyword`, `title`, `content`, `source`) VALUES
+('default', '退货,退款,七天,无理由', '七天无理由退货政策', '支持七天无理由退货，商品需保持完好、不影响二次销售；定制类、生鲜类除外。', '《售后服务政策》第 3 条'),
+('default', '发票,开票,报销', '发票开具规则', '支持开具电子普通发票与增值税专用发票，可在订单详情页自助申请，1-3 个工作日开具。', '《发票管理规则》第 1 条'),
+('default', '运费,包邮,邮费', '运费说明', '单笔订单满 99 元包邮，偏远地区除外；退货运费由责任方承担。', '《运费说明》第 2 条');
 
 -- 敏感词表（SensitiveWordFilter / cw_sensitive_word）：智能路由中控"一次拦截"词库。
 -- 种子为脱敏占位词（非真实违禁词），覆盖 BLOCK/MASK/REVIEW 三种动作与多类目。
 CREATE TABLE IF NOT EXISTS `cw_sensitive_word` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `word`           VARCHAR(128) NOT NULL COMMENT '敏感词原词面',
     `category`       VARCHAR(32) NOT NULL COMMENT '类目: POLITICS/PORN/ABUSE/COMPETITOR/CUSTOM',
@@ -435,20 +478,22 @@ CREATE TABLE IF NOT EXISTS `cw_sensitive_word` (
     `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_sensitive_word` (`word`)
+    UNIQUE KEY `uk_sensitive_word` (`tenant_id`, `word`),
+    INDEX `idx_sensitive_word_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词表（一次拦截词库）';
 
-INSERT IGNORE INTO `cw_sensitive_word` (`word`, `category`, `action`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
-('测试敏感词A', 'CUSTOM', 'BLOCK', 1, 1779235200000, 1779235200000),
-('涉政占位', 'POLITICS', 'BLOCK', 1, 1779235200000, 1779235200000),
-('辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
-('竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
-('复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_sensitive_word` (`tenant_id`, `word`, `category`, `action`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', '测试敏感词A', 'CUSTOM', 'BLOCK', 1, 1779235200000, 1779235200000),
+('default', '涉政占位', 'POLITICS', 'BLOCK', 1, 1779235200000, 1779235200000),
+('default', '辱骂占位', 'ABUSE', 'BLOCK', 1, 1779235200000, 1779235200000),
+('default', '竞品XX', 'COMPETITOR', 'MASK', 1, 1779235200000, 1779235200000),
+('default', '复核占位', 'CUSTOM', 'REVIEW', 1, 1779235200000, 1779235200000);
 
 -- 敏感词命中日志表（AsyncSensitiveWordHitSink / cw_sensitive_word_hit_log）：后台"命中看板"的数据源。
 -- 仅当 customer-work.sensitive-word.hit-log.enabled=true 且 store-mode=jdbc 时写入。
 -- snippet 存用户/模型原文片段（已截断），属敏感数据，是否留存由使用方按合规要求决定，故整块默认关闭。
 CREATE TABLE IF NOT EXISTS `cw_sensitive_word_hit_log` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `direction`      VARCHAR(16) NOT NULL COMMENT '命中方向: INBOUND用户输入/OUTBOUND模型输出',
     `action`         VARCHAR(16) NOT NULL COMMENT '整体决策: BLOCK/MASK/REVIEW',
@@ -462,12 +507,14 @@ CREATE TABLE IF NOT EXISTS `cw_sensitive_word_hit_log` (
     `created_at_ms`  BIGINT COMMENT '命中时间戳（毫秒）',
     KEY `idx_hit_created` (`created_at_ms`),
     KEY `idx_hit_action` (`action`),
-    KEY `idx_hit_session` (`session_id`)
+    KEY `idx_hit_session` (`session_id`),
+    INDEX `idx_sensitive_word_hit_log_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词命中日志（后台看板数据源）';
 
 -- 限流规则表（RateLimitRuleProvider / cw_rate_limit_rule）：接入层限流的规则层，后台运营维护。
 -- 刻意不给种子：空表 = 无规则命中 = 回退 yml 全局兜底参数，与规则化之前行为完全一致。
 CREATE TABLE IF NOT EXISTS `cw_rate_limit_rule` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `rule_name`      VARCHAR(64) NOT NULL COMMENT '规则名（运营可读）',
     `path_prefix`    VARCHAR(128) NOT NULL COMMENT '匹配的请求路径前缀',
@@ -479,13 +526,15 @@ CREATE TABLE IF NOT EXISTS `cw_rate_limit_rule` (
     `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_rate_limit_rule_name` (`rule_name`),
-    KEY `idx_rate_limit_priority` (`priority`)
+    UNIQUE KEY `uk_rate_limit_rule_name` (`tenant_id`, `rule_name`),
+    KEY `idx_rate_limit_priority` (`priority`),
+    INDEX `idx_rate_limit_rule_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='限流规则表（接入层限流规则层）';
 
 -- 坐席库表（MybatisSeatAgentStore / cw_seat_agent）：智能路由中控"工单智能分配"的候选坐席池。
 -- skills 为逗号分隔技能标签串；seat_group 避开 SQL 保留字 group；种子为演示坐席（多技能/负载/在离线）。
 CREATE TABLE IF NOT EXISTS `cw_seat_agent` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             VARCHAR(64) PRIMARY KEY COMMENT '坐席ID',
     `name`           VARCHAR(64) NOT NULL COMMENT '坐席名',
     `skills`         VARCHAR(512) COMMENT '技能标签（逗号分隔，如 refund,invoice）',
@@ -495,15 +544,16 @@ CREATE TABLE IF NOT EXISTS `cw_seat_agent` (
     `seat_group`     VARCHAR(64) COMMENT '坐席分组',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    INDEX `idx_seat_online` (`online`)
+    INDEX `idx_seat_online` (`online`),
+    INDEX `idx_seat_agent_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='坐席库（智能分配候选坐席池）';
 
-INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current_load`, `online`, `seat_group`, `created_at_ms`, `updated_at_ms`) VALUES
-('SEAT-1001', '退款专员-小赵', 'refund,invoice', 5, 1, 1, 'aftersales', 1779235200000, 1779235200000),
-('SEAT-1002', '物流专员-小钱', 'logistics', 5, 3, 1, 'logistics', 1779235200000, 1779235200000),
-('SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
-('SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
-('SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_seat_agent` (`tenant_id`, `id`, `name`, `skills`, `max_load`, `current_load`, `online`, `seat_group`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', 'SEAT-1001', '退款专员-小赵', 'refund,invoice', 5, 1, 1, 'aftersales', 1779235200000, 1779235200000),
+('default', 'SEAT-1002', '物流专员-小钱', 'logistics', 5, 3, 1, 'logistics', 1779235200000, 1779235200000),
+('default', 'SEAT-1003', '投诉专员-小孙', 'complaint,refund', 4, 0, 1, 'complaint', 1779235200000, 1779235200000),
+('default', 'SEAT-1004', '综合坐席-小李', 'refund,logistics,complaint,invoice', 6, 5, 1, 'general', 1779235200000, 1779235200000),
+('default', 'SEAT-1005', '离线坐席-小周', 'refund', 5, 0, 0, 'aftersales', 1779235200000, 1779235200000);
 
 -- 人机切换工单智能分配增强列（cw_handoff_ticket 已在上文建表时含 category/required_skill/priority/emotion/suggested_assignees；
 -- 旧库存量表可手工执行下列 ALTER 补列，MySQL 无 ADD COLUMN IF NOT EXISTS，重复执行报 Duplicate column 可忽略）：
@@ -517,6 +567,7 @@ INSERT IGNORE INTO `cw_seat_agent` (`id`, `name`, `skills`, `max_load`, `current
 -- 数据字典（DictStore / cw_dict_type + cw_dict_item）：少量枚举型键值数据的统一落点，免于逐个建表。
 -- 后台管理系统"字典管理"页直连维护这两张表（单一数据真源，照内容风控先例不做双写同步）。
 CREATE TABLE IF NOT EXISTS `cw_dict_type` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `dict_type`      VARCHAR(64) NOT NULL COMMENT '字典类型编码（如 order_status）',
     `type_name`      VARCHAR(64) NOT NULL COMMENT '类型名称（展示用）',
@@ -524,10 +575,12 @@ CREATE TABLE IF NOT EXISTS `cw_dict_type` (
     `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_dict_type` (`dict_type`)
+    UNIQUE KEY `uk_dict_type` (`tenant_id`, `dict_type`),
+    INDEX `idx_dict_type_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典类型表';
 
 CREATE TABLE IF NOT EXISTS `cw_dict_item` (
+    `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
     `dict_type`      VARCHAR(64) NOT NULL COMMENT '所属字典类型编码',
     `item_key`       VARCHAR(128) NOT NULL COMMENT '字典项键（业务值）',
@@ -537,19 +590,20 @@ CREATE TABLE IF NOT EXISTS `cw_dict_item` (
     `remark`         VARCHAR(255) COMMENT '备注说明',
     `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
     `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
-    UNIQUE KEY `uk_dict_item` (`dict_type`, `item_key`),
-    KEY `idx_dict_item_type` (`dict_type`)
+    UNIQUE KEY `uk_dict_item` (`tenant_id`, `dict_type`, `item_key`),
+    KEY `idx_dict_item_type` (`dict_type`),
+    INDEX `idx_dict_item_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字典项表';
 
 -- 演示种子：订单状态（与 InMemoryDictStore 种子、后台订单页硬编码文案一致）。
-INSERT IGNORE INTO `cw_dict_type` (`dict_type`, `type_name`, `remark`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
-('order_status', '订单状态', '用户订单状态筛选项（与后端返回的中文文案一致）', 1, 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_dict_type` (`tenant_id`, `dict_type`, `type_name`, `remark`, `enabled`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', 'order_status', '订单状态', '用户订单状态筛选项（与后端返回的中文文案一致）', 1, 1779235200000, 1779235200000);
 
-INSERT IGNORE INTO `cw_dict_item` (`dict_type`, `item_key`, `item_label`, `sort`, `enabled`, `remark`, `created_at_ms`, `updated_at_ms`) VALUES
-('order_status', '待支付', '待支付', 1, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已支付', '已支付', 2, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '待发货', '待发货', 3, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已发货', '已发货', 4, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
-('order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);
+INSERT IGNORE INTO `cw_dict_item` (`tenant_id`, `dict_type`, `item_key`, `item_label`, `sort`, `enabled`, `remark`, `created_at_ms`, `updated_at_ms`) VALUES
+('default', 'order_status', '待支付', '待支付', 1, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已支付', '已支付', 2, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '待发货', '待发货', 3, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已发货', '已发货', 4, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
+('default', 'order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);

--- a/mysql/01-agent-scope-customer-work/customer-work-tenant-alter.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-tenant-alter.sql
@@ -1,0 +1,106 @@
+-- 首行强制 utf8mb4，避免走 stdin 管道时客户端字符集回退 latin1 把中文 COMMENT 字节级写坏（见 mysql/README.md）
+SET NAMES utf8mb4;
+
+-- ============================================================================
+-- 增量迁移：全部 cw_* 业务表增加 tenant_id（多租户行级隔离地基，B1 批次）
+-- 适用场景：已部署的 agent_scope_customer_work 库增量升级
+--          （全新建库直接跑 customer-work-schema.sql 即含租户列）。
+-- 存量数据：tenant_id 默认 'default'，即升级前的单租户系统整体归入 default 租户，无需数据搬迁。
+-- 幂等：加列/加索引走 information_schema 判定；唯一键重建先判存在再 DROP，可重复执行。
+--
+-- 为什么用游标遍历而不是逐表写 27 段 ALTER：cw_* 表还会增加，遍历式迁移对新表天然生效，
+-- 且避免了 54 段近乎重复的 PREPARE 块——那种长度反而让漏改某张表变得难以察觉。
+-- ============================================================================
+
+DROP PROCEDURE IF EXISTS `cw_add_tenant_column`;
+
+DELIMITER $$
+CREATE PROCEDURE `cw_add_tenant_column`()
+BEGIN
+    DECLARE v_done INT DEFAULT 0;
+    DECLARE v_table VARCHAR(64);
+    DECLARE cur CURSOR FOR
+        SELECT TABLE_NAME FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME LIKE 'cw\_%';
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = 1;
+
+    OPEN cur;
+    read_loop: LOOP
+        FETCH cur INTO v_table;
+        IF v_done = 1 THEN
+            LEAVE read_loop;
+        END IF;
+
+        -- 加租户列（已存在则跳过）
+        SET @col_exists := (
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = v_table AND COLUMN_NAME = 'tenant_id');
+        IF @col_exists = 0 THEN
+            SET @ddl := CONCAT('ALTER TABLE `', v_table,
+                '` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT ''default'' COMMENT ''租户ID（多租户行级隔离）''');
+            PREPARE stmt FROM @ddl;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+        END IF;
+
+        -- 加租户索引（已存在则跳过）；索引名与 customer-work-schema.sql 保持一致
+        SET @idx_name := CONCAT('idx_', SUBSTRING(v_table, 4), '_tenant');
+        SET @idx_exists := (
+            SELECT COUNT(*) FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = v_table AND INDEX_NAME = @idx_name);
+        IF @idx_exists = 0 THEN
+            SET @ddl := CONCAT('ALTER TABLE `', v_table, '` ADD INDEX `', @idx_name, '` (`tenant_id`)');
+            PREPARE stmt FROM @ddl;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+        END IF;
+    END LOOP;
+    CLOSE cur;
+END$$
+DELIMITER ;
+
+CALL `cw_add_tenant_column`();
+DROP PROCEDURE `cw_add_tenant_column`;
+
+-- ============================================================================
+-- 唯一键重建：原先全局唯一的业务标识改为租户内唯一，否则两个租户无法使用相同用户名/词条/字典键。
+-- cw_chat_message.uk_chat_message_id 刻意不动：它是框架 Msg.id 的 UUID，本就全局唯一。
+-- ============================================================================
+
+DROP PROCEDURE IF EXISTS `cw_rebuild_tenant_unique_key`;
+
+DELIMITER $$
+CREATE PROCEDURE `cw_rebuild_tenant_unique_key`(
+    IN p_table VARCHAR(64), IN p_index VARCHAR(64), IN p_columns VARCHAR(255))
+BEGIN
+    -- 已含 tenant_id 的唯一键说明本脚本跑过了，直接跳过
+    SET @already := (
+        SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = p_table
+          AND INDEX_NAME = p_index AND COLUMN_NAME = 'tenant_id');
+    IF @already = 0 THEN
+        SET @exists := (
+            SELECT COUNT(*) FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = p_table AND INDEX_NAME = p_index);
+        IF @exists > 0 THEN
+            SET @ddl := CONCAT('ALTER TABLE `', p_table, '` DROP INDEX `', p_index, '`');
+            PREPARE stmt FROM @ddl;
+            EXECUTE stmt;
+            DEALLOCATE PREPARE stmt;
+        END IF;
+        SET @ddl := CONCAT('ALTER TABLE `', p_table, '` ADD UNIQUE KEY `', p_index, '` (', p_columns, ')');
+        PREPARE stmt FROM @ddl;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+DELIMITER ;
+
+CALL `cw_rebuild_tenant_unique_key`('cw_user', 'uk_user_username', '`tenant_id`, `username`');
+CALL `cw_rebuild_tenant_unique_key`('cw_knowledge', 'uk_knowledge_title', '`tenant_id`, `title`');
+CALL `cw_rebuild_tenant_unique_key`('cw_sensitive_word', 'uk_sensitive_word', '`tenant_id`, `word`');
+CALL `cw_rebuild_tenant_unique_key`('cw_rate_limit_rule', 'uk_rate_limit_rule_name', '`tenant_id`, `rule_name`');
+CALL `cw_rebuild_tenant_unique_key`('cw_dict_type', 'uk_dict_type', '`tenant_id`, `dict_type`');
+CALL `cw_rebuild_tenant_unique_key`('cw_dict_item', 'uk_dict_item', '`tenant_id`, `dict_type`, `item_key`');
+
+DROP PROCEDURE `cw_rebuild_tenant_unique_key`;

--- a/mysql/02-customer-admin/49-V49__tenant_foundation.sql
+++ b/mysql/02-customer-admin/49-V49__tenant_foundation.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- B1 租户地基：租户主数据 + 全量业务表 tenant_id 行级隔离列
+--
+-- 设计依据见 docs/多租户架构设计.md：
+--   - 隔离级别 = 共享库 + tenant_id 行级过滤，强制点在 MyBatis-Plus TenantLineInnerInterceptor；
+--   - 原则是"能加列的全加"，忽略表清单越短越安全，故这里只排除三类平台级/框架自建表；
+--   - 存量数据归入 default 租户，存量后台用户归入 __platform__（升级前的后台用户都是运营方）。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `sys_tenant` (
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `tenant_code`    VARCHAR(64) NOT NULL COMMENT '租户编码（业务主键，出现在 API Key 映射/日志/指标标签里）',
+    `tenant_name`    VARCHAR(128) NOT NULL COMMENT '租户名称',
+    `status`         VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态：ACTIVE正常 / SUSPENDED冻结 / TERMINATED退租',
+    `contact_name`   VARCHAR(64) COMMENT '联系人',
+    `contact_phone`  VARCHAR(32) COMMENT '联系电话',
+    `contact_email`  VARCHAR(128) COMMENT '联系邮箱',
+    `remark`         VARCHAR(500) COMMENT '备注',
+    `expire_time`    DATETIME COMMENT '到期时间（空=不限期）',
+    `create_by`      BIGINT COMMENT '创建人ID',
+    `create_time`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`      BIGINT COMMENT '更新人ID',
+    `update_time`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`        TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    UNIQUE KEY `uk_sys_tenant_code` (`tenant_code`),
+    KEY `idx_sys_tenant_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户主数据';
+
+-- 两个保留租户：default 承接升级前的存量数据，__platform__ 是平台运营方自身
+INSERT INTO `sys_tenant` (`tenant_code`, `tenant_name`, `status`, `remark`)
+SELECT 'default', '默认租户', 'ACTIVE', '升级前的存量数据归属，等价于原单租户系统'
+WHERE NOT EXISTS (SELECT 1 FROM `sys_tenant` WHERE `tenant_code` = 'default');
+
+INSERT INTO `sys_tenant` (`tenant_code`, `tenant_name`, `status`, `remark`)
+SELECT '__platform__', '平台运营方', 'ACTIVE', '运营方自身，承载平台级共享配置与全局管理员'
+WHERE NOT EXISTS (SELECT 1 FROM `sys_tenant` WHERE `tenant_code` = '__platform__');
+
+-- ============================================================================
+-- 全量业务表加 tenant_id（34 张，Flyway 保证只执行一次故无需幂等判定）。
+--
+-- 未列入的 4 张即拦截器忽略清单（须与 TenantInterceptors.PLATFORM_LEVEL_TABLES 一致）：
+--   sys_permission        权限点/菜单树的代码级定义，平台统一，租户只读
+--   sys_menu_change_log   菜单变更审计，随 sys_permission 同属平台级
+--   ai_system_tool        代码里 @Tool 注册的工具目录（租户是否启用走租户级的 ai_agent_system_tool）
+--   ai_chat_session_state 框架 MysqlAgentStateStore 直接持 DataSource 读写，绕过 MyBatis，加了列也没人填
+--
+-- ai_model_config 在列——它要加列，只是因承载模型凭据而额外由 Service 层做两级可见性（见 §2.4）。
+-- 刻意用显式清单而非 information_schema 游标：本库无 DROP TABLE 历史，表集合确定，
+-- 而 DELIMITER/存储过程在本项目的 Flyway 迁移里尚无先例，不值得为省几十行去冒解析风险。
+-- ============================================================================
+
+ALTER TABLE `ai_agent` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_backup_model` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_backup_model_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_knowledge_base` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_knowledge_base_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_mcp` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_mcp_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_memory` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_memory_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_skill` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_skill_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_sub_agent` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_sub_agent_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_system_tool` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_system_tool_tenant` (`tenant_id`);
+ALTER TABLE `ai_agent_task` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_agent_task_tenant` (`tenant_id`);
+ALTER TABLE `ai_channel_binding` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_channel_binding_tenant` (`tenant_id`);
+ALTER TABLE `ai_channel_robot` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_channel_robot_tenant` (`tenant_id`);
+ALTER TABLE `ai_channel_session` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_channel_session_tenant` (`tenant_id`);
+ALTER TABLE `ai_chat_attachment` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_chat_attachment_tenant` (`tenant_id`);
+ALTER TABLE `ai_code_knowledge_chunk` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_code_knowledge_chunk_tenant` (`tenant_id`);
+ALTER TABLE `ai_code_knowledge_index` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_code_knowledge_index_tenant` (`tenant_id`);
+ALTER TABLE `ai_code_review_task` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_code_review_task_tenant` (`tenant_id`);
+ALTER TABLE `ai_coding_audit_log` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_coding_audit_log_tenant` (`tenant_id`);
+ALTER TABLE `ai_knowledge_base` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_knowledge_base_tenant` (`tenant_id`);
+ALTER TABLE `ai_mcp` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_mcp_tenant` (`tenant_id`);
+ALTER TABLE `ai_model_config` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_model_config_tenant` (`tenant_id`);
+ALTER TABLE `ai_project` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_project_tenant` (`tenant_id`);
+ALTER TABLE `ai_project_session` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_project_session_tenant` (`tenant_id`);
+ALTER TABLE `ai_scheduled_task` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_scheduled_task_tenant` (`tenant_id`);
+ALTER TABLE `ai_scheduled_task_run` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_scheduled_task_run_tenant` (`tenant_id`);
+ALTER TABLE `ai_site_message` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_site_message_tenant` (`tenant_id`);
+ALTER TABLE `ai_skill` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_skill_tenant` (`tenant_id`);
+ALTER TABLE `ai_skill_file` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_ai_skill_file_tenant` (`tenant_id`);
+ALTER TABLE `cw_agent_call_log` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_cw_agent_call_log_tenant` (`tenant_id`);
+ALTER TABLE `cw_agent_call_segment` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_cw_agent_call_segment_tenant` (`tenant_id`);
+ALTER TABLE `sys_operation_log` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_operation_log_tenant` (`tenant_id`);
+ALTER TABLE `sys_role` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_role_tenant` (`tenant_id`);
+ALTER TABLE `sys_role_permission` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_role_permission_tenant` (`tenant_id`);
+ALTER TABLE `sys_user` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_user_tenant` (`tenant_id`);
+ALTER TABLE `sys_user_role` ADD COLUMN `tenant_id` VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）', ADD INDEX `idx_sys_user_role_tenant` (`tenant_id`);
+
+-- ============================================================================
+-- 存量数据归属修正
+-- ============================================================================
+
+-- 升级前的后台用户/角色/权限关联都是运营方的，归入 __platform__；
+-- sys_user.username 刻意保持全局唯一（admin 只有一个登录入口，跨租户重名就无法定位归属租户），故不重建唯一键。
+UPDATE `sys_user` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+UPDATE `sys_role` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+UPDATE `sys_user_role` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+UPDATE `sys_role_permission` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+
+-- 存量模型配置转为平台共享（租户视角只读且 api_key 脱敏，见 docs/多租户架构设计.md §2.4）
+UPDATE `ai_model_config` SET `tenant_id` = '__platform__' WHERE `tenant_id` = 'default';
+
+-- ============================================================================
+-- 租户管理菜单与权限点（id 从 220 起，219 是 V46 字典管理占用的最后一个）
+--
+-- perm_code 一律以 tenant: 开头不是命名巧合：TenantProvisionService 正是按这个前缀
+-- 把租户管理权限从租户管理员角色里排除掉的。新增租户相关权限点务必沿用该前缀。
+-- 超管无需授权记录（AdminStpInterfaceImpl 对平台租户的 super_admin 直接放行全部权限点）。
+-- ============================================================================
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (220, 1, '租户管理', 'tenant:view', 1, '/system/tenant', 'OfficeBuilding', 'library', 9);
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (221, 220, '新增租户', 'tenant:add', 2, 1),
+    (222, 220, '编辑租户', 'tenant:edit', 2, 2),
+    (223, 220, '删除租户', 'tenant:delete', 2, 3);

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
              只钉 starter 会让 app-server / admin-server 运行期把 otel 解析回 1.31.0，与 starter 的
              编译版本对不上。 -->
         <opentelemetry.version>1.61.0</opentelemetry.version>
+        <!-- 多租户 ThreadLocal 跨线程传播（Reactor 自动上下文传播的 SPI 提供方）。
+             spring-boot-dependencies(3.2.5) 不托管这个坐标，必须显式钉版本；取值与
+             micrometer-observation:1.12.5 传递引入的版本一致，避免同一 classpath 上两个版本打架。 -->
+        <context-propagation.version>1.1.1</context-propagation.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
企业级 SaaS 路线图 **B1 批次**。把现有的"提示词级软隔离"（往 system prompt 尾部追加一句"不得泄露其它租户信息"）换成存储层强制隔离。

设计定案见 [docs/多租户架构设计.md](docs/多租户架构设计.md)，本文只列改动与验证。

## 隔离机制

| 组件 | 职责 |
|---|---|
| `TenantContext` | 全链路唯一真源（ThreadLocal），缺上下文时 `require()` 抛错 |
| `CustomerWorkTenantLineHandler` | MyBatis-Plus 过滤策略，租户值取自上下文，fail-closed |
| `TenantInterceptors` | 拦截器构建器，starter 与 admin 共用同一份忽略表清单 |
| `CrossTenantOperations` | 有意的跨租户操作白名单（登录、运营方全局查询），可 grep 可 review |

三个要点：

- **拦截器排在分页插件之前**：分页会先跑一次 count，租户条件晚拼会让 count 与数据页口径不一致。
- **INSERT 由拦截器自动补列补值**，所以已有写入代码零改动——这也是"能加列的全加、忽略清单越短越好"的根本原因。
- **Reactor 自动上下文传播**：WebFlux 主链路切到 boundedElastic 执行阻塞 JDBC 会丢 ThreadLocal，注册 `ThreadLocalAccessor` + `Hooks.enableAutomaticContextPropagation()` 在线程边界还原。Hook 是 JVM 全局的，故绑在多租户开关上。

## 数据层

- 客服端 **27 张 cw_ 表**加 `tenant_id` + 索引，**6 处唯一键**前置租户（`cw_user.username` 等原本全局唯一，多租户下会挡住两个租户用同一个用户名）。两份 schema 已同步，另附幂等 alter 脚本供存量库升级。
- admin 新增 `sys_tenant` 主数据与 ACTIVE/SUSPENDED/TERMINATED 三态生命周期，**34 张业务表**加列（V49，`mysql/02-customer-admin/` 镜像已同步）。
- 忽略清单只有 4 张：`sys_permission`、`sys_menu_change_log`（平台定义租户只读）、`ai_system_tool`（代码级工具目录）、`ai_chat_session_state`（框架 `MysqlAgentStateStore` 直接持 DataSource 读写，绕过 MyBatis）。`ai_model_config` 单独处理——它承载模型凭据，两级可见性由 Service 层做，避免拦截器的 `IN (租户, 平台)` 连带把 UPDATE/DELETE 也放行到平台记录上。

## 身份链路

| 入口 | 来源 |
|---|---|
| 服务端接入方 | API Key → 租户映射（Key 是唯一不可伪造的租户线索） |
| H5 用户端 | 登录带 `tenantCode`，成功即焊进 JWT，后续请求不再采信前端传参 |
| admin 后台 | 登录用户的 `sys_user.tenant_id`，运营方可切换目标租户视角 |

原有的 `TenantResolver` 从 sessionId 前缀猜租户、且无分隔符时整个 sessionId 即租户（现网等于每个会话一个"租户"），不再参与鉴权链路。

## 顺带修掉的两个问题

多租户使这两处从"没影响"变成"有影响"：

1. **超管特判只比 `role_code`** —— 租户可以自建角色，建一个叫 `super_admin` 的就能拿到含 `tenant:*` 在内的全部权限点。已限定为平台租户用户。
2. **权限查询若按视角租户进行**，运营方切到租户 X 后自己的角色（在 `__platform__`）一条都查不到，当场失去全部权限。已固定用**用户归属租户**查权限——权限属于"用户是谁"，与"在看哪个租户的数据"是两件事。

## 后台功能

`系统管理 → 租户管理`（权限点 `tenant:view/add/edit/delete`，两道防线：权限点在租户开通时被显式排除 + Service 层校验运营方身份）。新建租户自动初始化 `tenant_admin` 角色并授予除 `tenant:*` 外的全部权限点。顶栏租户切换器仅运营方可见。

## 兼容性

默认关闭（`customer-work.tenant.enabled` / `admin.tenant.enabled`）。关闭时不挂拦截器、不装全局 Hook，运行时行为与升级前完全一致。存量数据归 `default` 租户，存量后台用户归 `__platform__`。旧 JWT 无 tenant claim 时回落默认租户，不强制登出。

## 测试

starter **1150**(+14) / admin **732**(+11) / app 78 / channel 65 / gateway 1，全绿。前端 `vue-tsc -b && vite build` 两个模块均通过。

新增覆盖：上下文嵌套恢复与异常路径、fail-closed、忽略表大小写、跨租户豁免的嵌套安全（MyBatis-Plus 的 `clearIgnoreStrategy` 是无条件 remove，内层结束会清掉外层，已用深度计数兜住）、保留租户保护、编码不可变、生命周期与过期判定。

## 未验证 / 已知限制

- **迁移脚本未在真实 MySQL 上跑过**：本机 Docker 未启动，V49 与 alter 脚本只做了静态审查。合入前建议在临时库上灌一遍（`mysql/02-customer-admin/` 全量脚本 + 客服端 alter）。
- 客服端的字典 / 敏感词 / 限流规则三张配置表，新租户开通时不会自动复制平台默认值（admin 与客服端库之间没有直连通道），当前需单独维护；批量下发属运维能力，留待后续批次。
- 指标的 tenant 维度、租户级限流与配额分别属于 B5 收尾与 B2/B3。
