### PR TITLE
feat(scaling): B2 水平扩展——限流/成本熔断/会话锁切跨实例共享

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,10 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1136** + admin-server **722** + app 78 + customer-channel 65 + gateway 1
-  （2026-08-06 feature/devtoolbox-expansion 实测，该分支给开发者工具箱补了 cron/JWT/diff/格式互转四项
-  与 AES 两端对齐，starter +82 / admin +11。上一版基线是 2026-08-05 的 starter 1054 + admin 711；
+- 测试基线：starter **1151** + admin-server **722** + app 78 + customer-channel 65 + gateway 1
+  （2026-08-10 feature/distributed-scaling 实测，B2 水平扩展：starter +15（窗口计数/会话锁）。
+  MySQL 不可达时 admin 会少跑 1 个门控用例，显示 721 属正常。
+  上一版基线是 2026-08-06 的 starter 1136 + admin 722；更早是 2026-08-05 的 starter 1054 + admin 711；
   admin-server 更早的实际基线已是 707，CLAUDE.md 曾记的
   701 系陈旧数字。starter 已按下方规则排除 2 个环境门控测试。此前 feature/sink-common-to-starter 把 admin
   十项通用能力下沉 starter：核心逻辑测试随迁，故 starter +226 / admin −106，admin 侧只保留薄壳职责测试；
@@ -75,6 +76,11 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   让 main 的 CI 从 PR #65 起连红 6 次（表现为 `Table 'customer_admin.cw_agent_call_log' doesn't exist`）。
 - **迁移脚本里不要写库名前缀**（`INSERT INTO \`customer_admin\`.\`xxx\``）：脚本执行时已经 USE 到目标库，
   写死库名会让脚本换库不可用，验证/多环境时甚至串库写到别的库去。V14 踩过。
+- **水平扩展（B2 起）**：限流与成本熔断共用 `WindowCounter` SPI、会话串行锁走 `SessionLock` SPI，
+  默认进程内，多副本部署切 `customer-work.distributed.{counter-mode,session-lock-mode}=redis`。
+  两条约定：① Redis 实现失败一律**降级进程内**而非放行（保护性能力不能因基础设施故障消失）；
+  ② 会话锁必须用 `RPermitExpirableSemaphore` 而非 `RLock`——加锁在 Reactor 链、释放在 `doFinally`，
+  不保证同线程，RLock 会抛 `IllegalMonitorStateException`。K8s 清单见 `deploy/k8s/`。
 - 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
 - 持久层异常兜底必须 `catch(Exception)`（HikariPool/MyBatis 初始化异常是 RuntimeException）。
 - 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -104,6 +104,39 @@ public class CustomerWorkProperties {
     /** 分布式锁（跨实例互斥场景，如后台管理并发写操作互斥），基于 Redisson。 */
     private final DistributedLock distributedLock = new DistributedLock();
 
+    /** 水平扩展：把进程内的计数与串行锁换成跨实例共享实现。 */
+    private final Distributed distributed = new Distributed();
+
+    /**
+     * 水平扩展配置。默认全 memory——单实例部署下进程内实现更快也更简单，
+     * 多副本部署才需要切 redis，否则限流与成本配额会被放大成实例数倍。
+     *
+     * <p>Redis 连接复用 {@code customer-work.distributed-lock.redis.*}，不再单独配一套。</p>
+     */
+    @Data
+    public static class Distributed {
+
+        /** 限流与成本熔断的窗口计数实现：{@code memory} 进程内 / {@code redis} 跨实例共享。 */
+        private String counterMode = "memory";
+
+        /** Redis 计数键前缀，多套环境共用一个 Redis 时用它隔离。 */
+        private String counterKeyPrefix = "cw:counter:";
+
+        /**
+         * 会话串行锁实现：{@code memory} 进程内信号量 / {@code redis} 分布式锁。
+         *
+         * <p>进程内锁要求网关按会话做 sticky 路由才成立；一旦同一会话可能落到不同实例，
+         * 必须切 redis，否则同一会话的并发请求会同时进入模型调用，历史被交叉写坏。</p>
+         */
+        private String sessionLockMode = "memory";
+
+        /** 分布式会话锁的最长等待时间（秒），等不到即按繁忙拒绝，避免请求线程无限堆积。 */
+        private int sessionLockWaitSeconds = 10;
+
+        /** 分布式会话锁的持有超时（秒），防止实例崩溃后锁永不释放。 */
+        private int sessionLockLeaseSeconds = 120;
+    }
+
     /**
      * 会话总结建议配置。默认关闭。
      *

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/InMemoryWindowCounter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/InMemoryWindowCounter.java
@@ -1,0 +1,127 @@
+package com.richard.fyoung.customerwork.counter;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 进程内窗口计数（默认实现）。
+ *
+ * <p>单实例部署下这就是正确答案；多实例部署下每个实例各算各的，等于把配额放大成 N 倍，
+ * 此时应换 {@link RedissonWindowCounter}。行为与改造前 {@code RateLimitWebFilter} 内嵌的
+ * 计数逻辑逐字等价——包括窗口自带到期时刻、按到期时刻清扫（不能按"是否等于当前窗口序号"判断，
+ * 否则窗口大小不同的规则会互相误删对方的有效窗口）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemoryWindowCounter implements WindowCounter {
+
+    /** 跟踪的计数键上限，超过则清扫过期窗口，避免 Map 无界增长导致内存泄漏。 */
+    private static final int MAX_TRACKED_KEYS = 100_000;
+
+    private final Map<String, Object> windows = new ConcurrentHashMap<>();
+
+    @Override
+    public long increment(String key, long delta, int windowSeconds) {
+        FixedWindow window = fixedWindow(key, windowSeconds);
+        if (windows.size() > MAX_TRACKED_KEYS) {
+            evictExpiredFixedWindows(System.currentTimeMillis());
+        }
+        return window.count.addAndGet(delta);
+    }
+
+    @Override
+    public void decrement(String key, long delta, int windowSeconds) {
+        Object existing = windows.get(key);
+        if (existing instanceof FixedWindow fw) {
+            fw.count.addAndGet(-delta);
+        }
+    }
+
+    @Override
+    public long current(String key, int windowSeconds) {
+        Object existing = windows.get(key);
+        if (!(existing instanceof FixedWindow fw)) {
+            return 0L;
+        }
+        // 窗口已过期即视为 0：只读路径不负责滚动窗口，否则读操作会产生写副作用
+        return fw.expireAtMs <= System.currentTimeMillis() ? 0L : fw.count.get();
+    }
+
+    @Override
+    public boolean tryAcquireSliding(String key, int limit, int windowSeconds) {
+        long now = System.currentTimeMillis();
+        long windowMs = windowSeconds * 1000L;
+        long windowStart = now - windowMs;
+        SlidingWindow sw = (SlidingWindow) windows.compute(key, (k, existing) -> {
+            SlidingWindow w = existing instanceof SlidingWindow s ? s : new SlidingWindow(windowMs);
+            synchronized (w.timestamps) {
+                Iterator<Long> it = w.timestamps.iterator();
+                while (it.hasNext() && it.next() < windowStart) {
+                    it.remove();
+                }
+            }
+            return w;
+        });
+        if (windows.size() > MAX_TRACKED_KEYS) {
+            evictEmptySlidingWindows(now);
+        }
+        synchronized (sw.timestamps) {
+            if (sw.timestamps.size() >= limit) {
+                return false;
+            }
+            sw.timestamps.addLast(now);
+            return true;
+        }
+    }
+
+    private FixedWindow fixedWindow(String key, int windowSeconds) {
+        long windowMs = windowSeconds * 1000L;
+        long currentWindow = System.currentTimeMillis() / windowMs;
+        return (FixedWindow) windows.compute(key, (k, w) -> {
+            if (!(w instanceof FixedWindow fw) || fw.window != currentWindow) {
+                return new FixedWindow(currentWindow, (currentWindow + 1) * windowMs);
+            }
+            return w;
+        });
+    }
+
+    private void evictExpiredFixedWindows(long now) {
+        windows.entrySet().removeIf(e ->
+            e.getValue() instanceof FixedWindow fw && fw.expireAtMs <= now);
+    }
+
+    private void evictEmptySlidingWindows(long now) {
+        windows.entrySet().removeIf(e -> {
+            if (!(e.getValue() instanceof SlidingWindow sw)) {
+                return false;
+            }
+            synchronized (sw.timestamps) {
+                return sw.timestamps.isEmpty() || sw.timestamps.peekFirst() < now - sw.windowMs;
+            }
+        });
+    }
+
+    /** 固定时间窗内的计数（自带到期时刻，供跨窗口大小安全清扫）。 */
+    private static final class FixedWindow {
+        private final long window;
+        private final long expireAtMs;
+        private final AtomicLong count = new AtomicLong();
+
+        FixedWindow(long window, long expireAtMs) {
+            this.window = window;
+            this.expireAtMs = expireAtMs;
+        }
+    }
+
+    /** 滑动时间窗：记录每个请求的时间戳，过期出队（自带窗口大小，供跨规则安全清扫）。 */
+    private static final class SlidingWindow {
+        private final ArrayDeque<Long> timestamps = new ArrayDeque<>();
+        private final long windowMs;
+
+        SlidingWindow(long windowMs) {
+            this.windowMs = windowMs;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/RedissonWindowCounter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/RedissonWindowCounter.java
@@ -1,0 +1,134 @@
+package com.richard.fyoung.customerwork.counter;
+
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 基于 Redis 的跨实例窗口计数（多副本部署时的正确实现）。
+ *
+ * <p><b>计数用 Lua 脚本原子执行</b>：分布式限流最怕"查完再写"的竞态——N 个实例同时读到未超限、
+ * 各自放行一个请求，配额照样被击穿。把判断与写入放进一次 Redis 调用才有意义。</p>
+ *
+ * <p><b>Redis 不可达时降级到进程内计数，而不是直接放行</b>：限流与成本熔断都是保护性能力，
+ * 基础设施故障时全放行等于保护完全消失；退回单机配额虽然总量会放大成 N 倍，
+ * 但仍拦得住单实例上的失控流量。降级只打一次 error 日志，不逐请求刷屏。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class RedissonWindowCounter implements WindowCounter {
+
+    private static final Logger log = LoggerFactory.getLogger(RedissonWindowCounter.class);
+
+    /**
+     * 固定窗口累加：首次写入时才设过期，避免每次请求都重置 TTL 把窗口无限延长。
+     * 返回累加后的值。
+     */
+    private static final String FIXED_WINDOW_SCRIPT =
+        "local v = redis.call('INCRBY', KEYS[1], ARGV[1]) "
+            + "if v == tonumber(ARGV[1]) then redis.call('PEXPIRE', KEYS[1], ARGV[2]) end "
+            + "return v";
+
+    /**
+     * 滑动窗口取用：先清窗口外的旧记录，再判是否已达上限，未达才写入本次时刻。
+     * 超限时刻意不写入——持续打压若仍记录，窗口会永远不恢复。
+     */
+    private static final String SLIDING_WINDOW_SCRIPT =
+        "redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1]) "
+            + "local count = redis.call('ZCARD', KEYS[1]) "
+            + "if count >= tonumber(ARGV[2]) then return 0 end "
+            + "redis.call('ZADD', KEYS[1], ARGV[3], ARGV[4]) "
+            + "redis.call('PEXPIRE', KEYS[1], ARGV[5]) "
+            + "return 1";
+
+    private final RedissonClient redisson;
+    private final String keyPrefix;
+
+    /** Redis 不可达时的降级去处；同时也是"多实例配额被放大"这一已知代价的承担者。 */
+    private final WindowCounter fallback;
+
+    /** 降级日志只打一次：Redis 抖动时逐请求打 error 会把日志刷爆，反而淹没真正的问题。 */
+    private volatile boolean degradedLogged = false;
+
+    public RedissonWindowCounter(RedissonClient redisson, String keyPrefix, WindowCounter fallback) {
+        this.redisson = redisson;
+        this.keyPrefix = keyPrefix == null || keyPrefix.isBlank() ? "cw:counter:" : keyPrefix;
+        this.fallback = fallback == null ? new InMemoryWindowCounter() : fallback;
+    }
+
+    @Override
+    public long increment(String key, long delta, int windowSeconds) {
+        long windowMs = windowSeconds * 1000L;
+        String redisKey = fixedWindowKey(key, windowMs);
+        try {
+            Long value = eval(FIXED_WINDOW_SCRIPT, RScript.ReturnType.INTEGER, List.of(redisKey),
+                String.valueOf(delta), String.valueOf(windowMs * 2));
+            return value == null ? delta : value;
+        } catch (Exception e) {
+            logDegraded(e);
+            return fallback.increment(key, delta, windowSeconds);
+        }
+    }
+
+    @Override
+    public void decrement(String key, long delta, int windowSeconds) {
+        long windowMs = windowSeconds * 1000L;
+        try {
+            redisson.getAtomicLong(fixedWindowKey(key, windowMs)).addAndGet(-delta);
+        } catch (Exception e) {
+            logDegraded(e);
+            fallback.decrement(key, delta, windowSeconds);
+        }
+    }
+
+    @Override
+    public long current(String key, int windowSeconds) {
+        long windowMs = windowSeconds * 1000L;
+        try {
+            return redisson.getAtomicLong(fixedWindowKey(key, windowMs)).get();
+        } catch (Exception e) {
+            logDegraded(e);
+            return fallback.current(key, windowSeconds);
+        }
+    }
+
+    @Override
+    public boolean tryAcquireSliding(String key, int limit, int windowSeconds) {
+        long now = System.currentTimeMillis();
+        long windowMs = windowSeconds * 1000L;
+        // member 必须唯一，否则同一毫秒内的两个请求会被 ZADD 当成同一个成员覆盖掉一个
+        String member = now + "-" + ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+        try {
+            Long allowed = eval(SLIDING_WINDOW_SCRIPT, RScript.ReturnType.INTEGER, List.of(keyPrefix + key),
+                String.valueOf(now - windowMs), String.valueOf(limit),
+                String.valueOf(now), member, String.valueOf(windowMs * 2));
+            return allowed != null && allowed == 1L;
+        } catch (Exception e) {
+            logDegraded(e);
+            return fallback.tryAcquireSliding(key, limit, windowSeconds);
+        }
+    }
+
+    /** 固定窗口的键带窗口序号：窗口滚动即换键，天然避免跨窗口累加，过期由 TTL 兜底回收。 */
+    private String fixedWindowKey(String key, long windowMs) {
+        return keyPrefix + key + ":" + (System.currentTimeMillis() / windowMs);
+    }
+
+    private Long eval(String script, RScript.ReturnType returnType, List<Object> keys, String... args) {
+        return redisson.getScript(StringCodec.INSTANCE)
+            .eval(RScript.Mode.READ_WRITE, script, returnType, keys, (Object[]) args);
+    }
+
+    private void logDegraded(Exception e) {
+        if (degradedLogged) {
+            return;
+        }
+        degradedLogged = true;
+        log.error("distributed window counter unavailable, degraded to in-process counting, code={}",
+            "COUNTER-REDIS-DEGRADED", e);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/WindowCounter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/WindowCounter.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customerwork.counter;
+
+/**
+ * 时间窗口计数器 SPI：接入层限流与模型成本熔断共用。
+ *
+ * <p>两者本来就是同一件事——在一个时间窗内累加、判断是否越过阈值。此前各自实现了一套进程内计数，
+ * 多实例部署时配额被放大 N 倍（N 个实例各算各的）。抽成 SPI 后换一个实现就同时解决两处。</p>
+ *
+ * <p>实现须保证：窗口滚动由实现内部负责（调用方只给窗口长度，不管窗口边界），
+ * 且计数键在窗口结束后能自行回收，不留无界增长。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface WindowCounter {
+
+    /**
+     * 固定窗口累加并返回累加后的值。
+     *
+     * @param key           计数键（调用方保证语义唯一，如 {@code ratelimit:key:xxx}）
+     * @param delta         本次增量
+     * @param windowSeconds 窗口长度（秒）
+     * @return 当前窗口累加后的总量
+     */
+    long increment(String key, long delta, int windowSeconds);
+
+    /**
+     * 回退固定窗口的计数（越过阈值后把本次增量退回去，避免被拒的请求仍占额度）。
+     *
+     * <p>不保证与 {@link #increment} 严格原子成对：并发下允许短暂的计数虚高，
+     * 这对"防成本失控"的目的是安全方向的偏差。</p>
+     */
+    void decrement(String key, long delta, int windowSeconds);
+
+    /** 只读当前窗口累计值，不产生任何计数副作用。 */
+    long current(String key, int windowSeconds);
+
+    /**
+     * 滑动窗口取用一次配额。
+     *
+     * <p>与固定窗口分开是因为语义不同：滑动窗口要记录每次请求的时刻，而不是往一个数上加。
+     * 超限时不得记录本次请求，否则持续打压会让窗口永远不恢复。</p>
+     *
+     * @return true=放行（已记录本次），false=超限（未记录）
+     */
+    boolean tryAcquireSliding(String key, int limit, int windowSeconds);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/WindowCounterConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/counter/WindowCounterConfig.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customerwork.counter;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 窗口计数器装配：按 {@code customer-work.distributed.counter-mode} 选实现。
+ *
+ * <p>下游可声明自己的 {@link WindowCounter} Bean 覆盖（如换成 Bucket4j），与 starter 其它 SPI 一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class WindowCounterConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(WindowCounterConfig.class);
+
+    private static final String MODE_REDIS = "redis";
+
+    @Bean
+    @ConditionalOnMissingBean
+    public WindowCounter windowCounter(CustomerWorkProperties properties,
+                                       ObjectProvider<RedissonClient> redissonProvider) {
+        CustomerWorkProperties.Distributed cfg = properties.getDistributed();
+        InMemoryWindowCounter inMemory = new InMemoryWindowCounter();
+        if (!MODE_REDIS.equalsIgnoreCase(cfg.getCounterMode())) {
+            return inMemory;
+        }
+        RedissonClient redisson = redissonProvider.getIfAvailable();
+        if (redisson == null) {
+            // 配了 redis 却没有客户端可用，说明装配缺了一环。这里让位给进程内实现而不是启动失败：
+            // 限流/熔断是旁路保护，不该拖垮主链路的可启动性；配置没生效这件事由 error 日志暴露。
+            log.error("counter-mode=redis but no RedissonClient available, fallback to in-memory, code={}",
+                "COUNTER-REDIS-CLIENT-MISSING");
+            return inMemory;
+        }
+        log.info("distributed window counter enabled, prefix={}", cfg.getCounterKeyPrefix());
+        return new RedissonWindowCounter(redisson, cfg.getCounterKeyPrefix(), inMemory);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/DistributedLockConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/DistributedLockConfig.java
@@ -5,6 +5,8 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.redisson.config.SingleServerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +23,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class DistributedLockConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(DistributedLockConfig.class);
+
+    private static final String MODE_REDIS = "redis";
+
     @Bean(destroyMethod = "shutdown")
     @ConditionalOnMissingBean
     public RedissonClient redissonClient(CustomerWorkProperties properties) {
@@ -31,6 +37,26 @@ public class DistributedLockConfig {
     @ConditionalOnMissingBean
     public DistributedLockExecutor distributedLockExecutor(RedissonClient redissonClient) {
         return new RedissonDistributedLockExecutor(redissonClient);
+    }
+
+    /**
+     * 会话串行锁：按 {@code customer-work.distributed.session-lock-mode} 选实现。
+     *
+     * <p>默认进程内——它只在网关按会话 sticky 路由时才正确，但那正是当前部署形态；
+     * 切 redis 后即使同一会话落到不同实例也能互斥。</p>
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public SessionLock sessionLock(CustomerWorkProperties properties, RedissonClient redissonClient) {
+        CustomerWorkProperties.Distributed cfg = properties.getDistributed();
+        InMemorySessionLock inMemory = new InMemorySessionLock(cfg.getSessionLockWaitSeconds());
+        if (!MODE_REDIS.equalsIgnoreCase(cfg.getSessionLockMode())) {
+            return inMemory;
+        }
+        log.info("distributed session lock enabled, waitSeconds={}, leaseSeconds={}",
+            cfg.getSessionLockWaitSeconds(), cfg.getSessionLockLeaseSeconds());
+        return new RedissonSessionLock(redissonClient, "cw:sessionlock:",
+            cfg.getSessionLockWaitSeconds(), cfg.getSessionLockLeaseSeconds(), inMemory);
     }
 
     /**

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/InMemorySessionLock.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/InMemorySessionLock.java
@@ -1,0 +1,71 @@
+package com.richard.fyoung.customerwork.lock;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 进程内会话串行锁（默认实现，等价于改造前 {@code CustomerServiceService} 内嵌的 Semaphore）。
+ *
+ * <p>相比原实现补了一件事：<b>锁对象按等待者计数回收</b>。原来每见一个新 sessionId 就往
+ * Map 里放一个 Semaphore 且永不移除，长期运行会把会话数累积成内存泄漏。这里在最后一个
+ * 使用者释放时把条目摘掉，用 compute 保证"计数归零"与"移除"是同一次原子操作，
+ * 不会与正在进入的请求擦身而过。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemorySessionLock implements SessionLock {
+
+    private final Map<String, Entry> locks = new ConcurrentHashMap<>();
+    private final long waitSeconds;
+
+    public InMemorySessionLock(long waitSeconds) {
+        this.waitSeconds = waitSeconds <= 0 ? Long.MAX_VALUE : waitSeconds;
+    }
+
+    @Override
+    public Releasable acquire(String sessionId) {
+        Entry entry = locks.compute(sessionId, (k, existing) -> {
+            Entry e = existing == null ? new Entry() : existing;
+            e.users++;
+            return e;
+        });
+        try {
+            if (waitSeconds == Long.MAX_VALUE) {
+                entry.semaphore.acquire();
+            } else if (!entry.semaphore.tryAcquire(waitSeconds, TimeUnit.SECONDS)) {
+                releaseEntry(sessionId);
+                throw new SessionLockTimeoutException(sessionId);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            releaseEntry(sessionId);
+            throw new SessionLockTimeoutException(sessionId);
+        }
+        return () -> {
+            entry.semaphore.release();
+            releaseEntry(sessionId);
+        };
+    }
+
+    /** 使用者计数减一，归零即摘除条目（与 acquire 的 compute 互斥，不会漏删或误删）。 */
+    private void releaseEntry(String sessionId) {
+        locks.compute(sessionId, (k, existing) -> {
+            if (existing == null) {
+                return null;
+            }
+            existing.users--;
+            return existing.users <= 0 ? null : existing;
+        });
+    }
+
+    /** 当前跟踪的会话数（测试用，用于验证锁对象确实被回收）。 */
+    int trackedSessions() {
+        return locks.size();
+    }
+
+    private static final class Entry {
+        private final Semaphore semaphore = new Semaphore(1);
+        private int users;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/RedissonSessionLock.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/RedissonSessionLock.java
@@ -1,0 +1,88 @@
+package com.richard.fyoung.customerwork.lock;
+
+import org.redisson.api.RPermitExpirableSemaphore;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 跨实例的会话串行锁（多副本部署用）。
+ *
+ * <p><b>为什么用 {@code RPermitExpirableSemaphore} 而不是 {@code RLock}</b>：Redisson 的 RLock 是
+ * 线程绑定的可重入锁，解锁时校验持有线程。而本项目在 Reactor 链里加锁、在 {@code doFinally} 里释放，
+ * 两者不保证同一线程，用 RLock 会在释放时抛 IllegalMonitorStateException。
+ * PermitExpirableSemaphore 的 acquire 返回一个 permitId，释放只认这个 id 不认线程，正好匹配。</p>
+ *
+ * <p>lease 时间是硬保险：实例崩溃时锁不会永久留在 Redis 里把整个会话卡死。
+ * 它必须显著大于单次对话的最长处理时间，否则长响应会在处理中途失去互斥保护。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class RedissonSessionLock implements SessionLock {
+
+    private static final Logger log = LoggerFactory.getLogger(RedissonSessionLock.class);
+
+    private final RedissonClient redisson;
+    private final String keyPrefix;
+    private final long waitSeconds;
+    private final long leaseSeconds;
+
+    /** Redis 不可达时的降级去处：退回单实例串行，总比完全没有互斥好。 */
+    private final SessionLock fallback;
+
+    private volatile boolean degradedLogged = false;
+
+    public RedissonSessionLock(RedissonClient redisson, String keyPrefix,
+                               long waitSeconds, long leaseSeconds, SessionLock fallback) {
+        this.redisson = redisson;
+        this.keyPrefix = keyPrefix == null || keyPrefix.isBlank() ? "cw:sessionlock:" : keyPrefix;
+        this.waitSeconds = waitSeconds <= 0 ? 10 : waitSeconds;
+        this.leaseSeconds = leaseSeconds <= 0 ? 120 : leaseSeconds;
+        this.fallback = fallback == null ? new InMemorySessionLock(waitSeconds) : fallback;
+    }
+
+    @Override
+    public Releasable acquire(String sessionId) {
+        RPermitExpirableSemaphore semaphore;
+        String permitId;
+        try {
+            semaphore = redisson.getPermitExpirableSemaphore(keyPrefix + sessionId);
+            // 幂等：已存在则不改动。permits=1 即互斥
+            semaphore.trySetPermits(1);
+            permitId = semaphore.tryAcquire(waitSeconds, leaseSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SessionLockTimeoutException(sessionId);
+        } catch (Exception e) {
+            logDegraded(e);
+            return fallback.acquire(sessionId);
+        }
+        if (permitId == null) {
+            throw new SessionLockTimeoutException(sessionId);
+        }
+        return () -> releaseQuietly(semaphore, permitId, sessionId);
+    }
+
+    /**
+     * 释放失败不上抛：这里跑在 {@code doFinally} 里，抛出去只会掩盖真正的业务异常。
+     * 而且 lease 到期后锁会自动释放，最坏情况是多占用一小段时间，不会永久卡死。
+     */
+    private void releaseQuietly(RPermitExpirableSemaphore semaphore, String permitId, String sessionId) {
+        try {
+            semaphore.release(permitId);
+        } catch (Exception e) {
+            log.error("release session lock failed, code={}, sessionId={}", "SESSION-LOCK-RELEASE-FAIL",
+                sessionId, e);
+        }
+    }
+
+    private void logDegraded(Exception e) {
+        if (degradedLogged) {
+            return;
+        }
+        degradedLogged = true;
+        log.error("distributed session lock unavailable, degraded to in-process lock, code={}",
+            "SESSION-LOCK-REDIS-DEGRADED", e);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/SessionLock.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/SessionLock.java
@@ -1,0 +1,29 @@
+package com.richard.fyoung.customerwork.lock;
+
+/**
+ * 会话级串行锁 SPI：同一会话的请求串行执行，防止并发写 StateStore 把对话历史交叉覆盖。
+ *
+ * <p>进程内实现要求网关按会话做 sticky 路由才成立；一旦同一会话可能落到不同实例
+ * （扩缩容、滚动发布、网关配置疏漏），就必须换分布式实现。</p>
+ *
+ * <p><b>释放必须与线程无关</b>：调用方在 Reactor 链里获取锁，而释放发生在 {@code doFinally}，
+ * 两者不保证同一线程。因此本接口返回一个释放句柄，而不是依赖"谁加锁谁解锁"的线程绑定语义——
+ * Redisson 的 {@code RLock} 正是绑定线程的，直接用会在跨线程释放时抛 IllegalMonitorStateException。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface SessionLock {
+
+    /**
+     * 获取会话锁，阻塞直到成功或超时。
+     *
+     * <p>调用方负责在弹性线程池（boundedElastic）上调用，不要阻塞 Netty 事件循环。</p>
+     *
+     * @return 释放句柄；获取失败时抛 {@link SessionLockTimeoutException}
+     */
+    Releasable acquire(String sessionId);
+
+    /** 释放句柄：持有释放所需的全部信息（如 Redisson 的 permitId），与获取时的线程无关。 */
+    interface Releasable {
+        void release();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/SessionLockTimeoutException.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/lock/SessionLockTimeoutException.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customerwork.lock;
+
+/**
+ * 会话锁在等待时限内未获取到：同一会话有请求正在处理中。
+ *
+ * <p>调用方应转成"请稍候再试"这类业务提示，而不是当系统故障处理——
+ * 它恰恰说明串行保护在起作用。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class SessionLockTimeoutException extends RuntimeException {
+
+    public SessionLockTimeoutException(String sessionId) {
+        super("acquire session lock timeout, sessionId=" + sessionId);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/ModelCostCircuitBreaker.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/ModelCostCircuitBreaker.java
@@ -1,12 +1,13 @@
 package com.richard.fyoung.customerwork.observability;
 
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.counter.WindowCounter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 模型成本熔断器（P2：防止 token 消耗超预算打爆成本）。
@@ -23,6 +24,10 @@ import java.util.concurrent.atomic.AtomicLong;
  * 不可用则返回 false，由调用方决定降级策略（如返回兜底回复、降级到更便宜的模型）。</p>
  *
  * <p>仅在 {@code model.cost-control.enabled=true} 时生效；默认关闭。</p>
+ *
+ * <p>计数走 {@link WindowCounter}：默认进程内，多副本部署把
+ * {@code customer-work.distributed.counter-mode} 切成 {@code redis} 才是真正的成本上限——
+ * 否则每个实例各有一份配额，实际花销是配置值的实例数倍，"熔断"形同虚设。</p>
  * @author owlzhangfq@gmail.com
  */
 @Component
@@ -30,17 +35,15 @@ public class ModelCostCircuitBreaker {
 
     private static final Logger log = LoggerFactory.getLogger(ModelCostCircuitBreaker.class);
 
+    private static final String MINUTE_KEY = "modelcost:minute";
+    private static final String HOUR_KEY = "modelcost:hour";
+    private static final int MINUTE_WINDOW_SECONDS = 60;
+    private static final int HOUR_WINDOW_SECONDS = 3600;
+
     private final boolean enabled;
     private final int maxTokensPerMinute;
     private final int maxTokensPerHour;
-
-    /** 当前分钟窗口的 token 消耗（分钟时间戳 -> 累计 token）。 */
-    private final AtomicLong currentMinuteTokens = new AtomicLong(0);
-    private volatile long currentMinuteTimestamp = currentMinute();
-
-    /** 当前小时窗口的 token 消耗（小时时间戳 -> 累计 token）。 */
-    private final AtomicLong currentHourTokens = new AtomicLong(0);
-    private volatile long currentHourTimestamp = currentHour();
+    private final WindowCounter counter;
 
     /**
      * Spring 注入构造：读取 {@code model.cost-control.*} 配置。
@@ -50,10 +53,18 @@ public class ModelCostCircuitBreaker {
      * {@code model.cost-control.enabled=true} 空转。</p>
      */
     @Autowired
-    public ModelCostCircuitBreaker(CustomerWorkProperties properties) {
+    public ModelCostCircuitBreaker(CustomerWorkProperties properties,
+                                   ObjectProvider<WindowCounter> counterProvider) {
         this.enabled = properties.getModel().getCostControl().isEnabled();
         this.maxTokensPerMinute = properties.getModel().getCostControl().getMaxTokensPerMinute();
         this.maxTokensPerHour = properties.getModel().getCostControl().getMaxTokensPerHour();
+        WindowCounter provided = counterProvider == null ? null : counterProvider.getIfAvailable();
+        this.counter = provided == null ? new InMemoryWindowCounter() : provided;
+    }
+
+    /** 便捷构造：进程内计数。单实例部署与测试用这个即可，多副本请走带 {@link WindowCounter} 的构造。 */
+    public ModelCostCircuitBreaker(CustomerWorkProperties properties) {
+        this(properties, (ObjectProvider<WindowCounter>) null);
     }
 
     /** 无参构造（禁用状态，兼容测试）。 */
@@ -61,6 +72,7 @@ public class ModelCostCircuitBreaker {
         this.enabled = false;
         this.maxTokensPerMinute = 0;
         this.maxTokensPerHour = 0;
+        this.counter = new InMemoryWindowCounter();
     }
 
     /**
@@ -74,36 +86,22 @@ public class ModelCostCircuitBreaker {
             return true;
         }
 
-        // 滚动分钟窗口
-        long nowMin = currentMinute();
-        if (nowMin != currentMinuteTimestamp) {
-            currentMinuteTimestamp = nowMin;
-            currentMinuteTokens.set(0);
-        }
-
-        // 滚动小时窗口
-        long nowHour = currentHour();
-        if (nowHour != currentHourTimestamp) {
-            currentHourTimestamp = nowHour;
-            currentHourTokens.set(0);
-        }
-
-        // 检查分钟限额
-        long minuteAfter = currentMinuteTokens.addAndGet(tokenCount);
+        // 窗口滚动由计数器实现负责：键自带窗口序号，跨窗口自然归零，不需要在这里比对时间戳
+        long minuteAfter = counter.increment(MINUTE_KEY, tokenCount, MINUTE_WINDOW_SECONDS);
         if (minuteAfter > maxTokensPerMinute) {
-            log.warn("[CostCircuit] minute limit exceeded: consumed={}, limit={}",
-                minuteAfter, maxTokensPerMinute);
-            currentMinuteTokens.addAndGet(-tokenCount); // 回滚
+            log.error("model cost minute limit exceeded, code={}, consumed={}, limit={}",
+                "MODEL-COST-MINUTE-LIMIT", minuteAfter, maxTokensPerMinute);
+            counter.decrement(MINUTE_KEY, tokenCount, MINUTE_WINDOW_SECONDS);
             return false;
         }
 
-        // 检查小时限额
-        long hourAfter = currentHourTokens.addAndGet(tokenCount);
+        long hourAfter = counter.increment(HOUR_KEY, tokenCount, HOUR_WINDOW_SECONDS);
         if (hourAfter > maxTokensPerHour) {
-            log.warn("[CostCircuit] hour limit exceeded: consumed={}, limit={}",
-                hourAfter, maxTokensPerHour);
-            currentHourTokens.addAndGet(-tokenCount); // 回滚
-            currentMinuteTokens.addAndGet(-tokenCount); // 回滚分钟窗口
+            log.error("model cost hour limit exceeded, code={}, consumed={}, limit={}",
+                "MODEL-COST-HOUR-LIMIT", hourAfter, maxTokensPerHour);
+            counter.decrement(HOUR_KEY, tokenCount, HOUR_WINDOW_SECONDS);
+            // 分钟窗口的增量也要退回：这次请求整体被拒，不该占用任何一个窗口的额度
+            counter.decrement(MINUTE_KEY, tokenCount, MINUTE_WINDOW_SECONDS);
             return false;
         }
 
@@ -115,25 +113,16 @@ public class ModelCostCircuitBreaker {
         if (!enabled) {
             return false;
         }
-        return currentMinuteTokens.get() >= maxTokensPerMinute
-            || currentHourTokens.get() >= maxTokensPerHour;
+        return getMinuteTokens() >= maxTokensPerMinute || getHourTokens() >= maxTokensPerHour;
     }
 
     /** 当前分钟已消耗 token 数（测试用）。 */
     long getMinuteTokens() {
-        return currentMinuteTokens.get();
+        return counter.current(MINUTE_KEY, MINUTE_WINDOW_SECONDS);
     }
 
     /** 当前小时已消耗 token 数（测试用）。 */
     long getHourTokens() {
-        return currentHourTokens.get();
-    }
-
-    private long currentMinute() {
-        return System.currentTimeMillis() / 60_000L;
-    }
-
-    private long currentHour() {
-        return System.currentTimeMillis() / 3_600_000L;
+        return counter.current(HOUR_KEY, HOUR_WINDOW_SECONDS);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/RateLimitWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/security/RateLimitWebFilter.java
@@ -1,11 +1,14 @@
 package com.richard.fyoung.customerwork.security;
 
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.counter.WindowCounter;
 import com.richard.fyoung.customerwork.security.ratelimit.RateLimitAlgorithm;
 import com.richard.fyoung.customerwork.security.ratelimit.RateLimitDimension;
 import com.richard.fyoung.customerwork.security.ratelimit.RateLimitRule;
 import com.richard.fyoung.customerwork.security.ratelimit.RateLimitRuleProvider;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -14,12 +17,6 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
-
-import java.util.ArrayDeque;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 限流过滤器（接入层安全，支持固定窗口与滑动窗口算法）。
@@ -35,29 +32,40 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p>健康检查与 Actuator 端点放行；超限返回 429。算法两选：<b>fixed-window</b> 实现最省但窗口边界
  * 最坏放过 2 倍瞬时流量；<b>sliding-window</b> 无边界突刺，代价是每个计数键要留时间戳队列。</p>
  *
- * <p>采用进程内计数；分布式部署应换成基于 Redis 的分布式限流（如 Bucket4j + Redis），
- * 本实现接口不变、可平滑替换。</p>
+ * <p>计数交给 {@link WindowCounter}：默认进程内，多副本部署把
+ * {@code customer-work.distributed.counter-mode} 切成 {@code redis} 即变成跨实例共享配额——
+ * 否则 N 个实例各算各的，等于把限额放大成 N 倍。</p>
  * @author owlzhangfq@gmail.com
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 20)
 public class RateLimitWebFilter implements WebFilter {
 
-    /** 进程内跟踪的客户端窗口数量上限，超过则清扫过期窗口，避免 Map 无界增长导致内存泄漏。 */
-    private static final int MAX_TRACKED_CLIENTS = 100_000;
-
     /** 全局兜底层的固定窗口大小（秒）：与规则化之前的"每分钟"语义保持一致。 */
     private static final int DEFAULT_WINDOW_SECONDS = 60;
+
+    /** 计数键前缀：与成本熔断共用同一个计数器实现，靠前缀分隔命名空间。 */
+    private static final String KEY_PREFIX = "ratelimit:";
 
     private final CustomerWorkProperties properties;
     /** 规则快照提供者；规则功能未装配时为 null，此时只走全局兜底层。 */
     private final RateLimitRuleProvider ruleProvider;
-    private final Map<String, Object> windows = new ConcurrentHashMap<>();
+    private final WindowCounter counter;
 
+    /** 便捷构造：进程内计数。多副本部署走带 {@link WindowCounter} 的构造。 */
     public RateLimitWebFilter(CustomerWorkProperties properties,
                               ObjectProvider<RateLimitRuleProvider> ruleProviderProvider) {
+        this(properties, ruleProviderProvider, null);
+    }
+
+    @Autowired
+    public RateLimitWebFilter(CustomerWorkProperties properties,
+                              ObjectProvider<RateLimitRuleProvider> ruleProviderProvider,
+                              ObjectProvider<WindowCounter> counterProvider) {
         this.properties = properties;
         this.ruleProvider = ruleProviderProvider == null ? null : ruleProviderProvider.getIfAvailable();
+        WindowCounter provided = counterProvider == null ? null : counterProvider.getIfAvailable();
+        this.counter = provided == null ? new InMemoryWindowCounter() : provided;
     }
 
     @Override
@@ -101,78 +109,14 @@ public class RateLimitWebFilter implements WebFilter {
         return allowFixed(clientId, limit, DEFAULT_WINDOW_SECONDS);
     }
 
-    /**
-     * 固定时间窗：同一窗口内累计请求数不超过 limit。
-     *
-     * <p>窗口序号按 {@code now / windowMs} 算，不同规则可以有不同窗口大小；每个窗口自带到期时刻，
-     * 清扫时只按到期时刻判断——<b>不能</b>按"是否等于当前窗口序号"判断，那样窗口大小不同的规则
-     * 会互相把对方的有效窗口误删。</p>
-     */
+    /** 固定时间窗：同一窗口内累计请求数不超过 limit。窗口滚动与键回收由计数器实现负责。 */
     boolean allowFixed(String clientId, int limit, int windowSeconds) {
-        long windowMs = windowSeconds * 1000L;
-        long now = System.currentTimeMillis();
-        long currentWindow = now / windowMs;
-        FixedWindow window = (FixedWindow) windows.compute(clientId, (k, w) -> {
-            if (w == null || ((FixedWindow) w).window != currentWindow) {
-                return new FixedWindow(currentWindow, (currentWindow + 1) * windowMs);
-            }
-            return w;
-        });
-        // 跟踪的客户端过多时，清扫掉已到期的窗口，防止 Map 无界增长
-        if (windows.size() > MAX_TRACKED_CLIENTS) {
-            evictExpiredFixedWindows(now);
-        }
-        return window.count.incrementAndGet() <= limit;
+        return counter.increment(KEY_PREFIX + clientId, 1L, windowSeconds) <= limit;
     }
 
-    /**
-     * 滑动时间窗：在最近 windowSeconds 秒内的请求数不超过 limit。
-     * 用 ArrayDeque 记录每个请求的时间戳，过期出队，当前队列长度即为窗口内请求数。
-     */
+    /** 滑动时间窗：最近 windowSeconds 秒内的请求数不超过 limit。 */
     boolean allowSliding(String clientId, int limit, int windowSeconds) {
-        long now = System.currentTimeMillis();
-        long windowMs = windowSeconds * 1000L;
-        long windowStart = now - windowMs;
-        SlidingWindow sw = (SlidingWindow) windows.compute(clientId, (k, existing) -> {
-            SlidingWindow w = existing == null ? new SlidingWindow(windowMs) : (SlidingWindow) existing;
-            // 清除窗口外的过期时间戳
-            synchronized (w.timestamps) {
-                Iterator<Long> it = w.timestamps.iterator();
-                while (it.hasNext() && it.next() < windowStart) {
-                    it.remove();
-                }
-            }
-            return w;
-        });
-        // 跟踪的客户端过多时，清扫空窗口
-        if (windows.size() > MAX_TRACKED_CLIENTS) {
-            evictEmptySlidingWindows(now);
-        }
-        synchronized (sw.timestamps) {
-            if (sw.timestamps.size() >= limit) {
-                return false;
-            }
-            sw.timestamps.addLast(now);
-            return true;
-        }
-    }
-
-    /** 移除已到期的固定窗口（按窗口自带的到期时刻，跨规则安全）。 */
-    private void evictExpiredFixedWindows(long now) {
-        windows.entrySet().removeIf(e ->
-            e.getValue() instanceof FixedWindow fw && fw.expireAtMs <= now);
-    }
-
-    /** 移除已空或整体过期的滑动窗口（按窗口自带的窗口大小判断，跨规则安全）。 */
-    private void evictEmptySlidingWindows(long now) {
-        windows.entrySet().removeIf(e -> {
-            if (!(e.getValue() instanceof SlidingWindow sw)) {
-                return false;
-            }
-            synchronized (sw.timestamps) {
-                return sw.timestamps.isEmpty() || sw.timestamps.peekFirst() < now - sw.windowMs;
-            }
-        });
+        return counter.tryAcquireSliding(KEY_PREFIX + clientId, limit, windowSeconds);
     }
 
     /** 统一入口：按配置选择算法。 */
@@ -205,27 +149,5 @@ public class RateLimitWebFilter implements WebFilter {
 
     private boolean isExempt(String path) {
         return path.startsWith("/actuator") || path.equals("/api/customer/health");
-    }
-
-    /** 固定时间窗内的计数（自带到期时刻，供跨规则安全清扫）。 */
-    private static final class FixedWindow {
-        private final long window;
-        private final long expireAtMs;
-        private final AtomicInteger count = new AtomicInteger();
-
-        FixedWindow(long window, long expireAtMs) {
-            this.window = window;
-            this.expireAtMs = expireAtMs;
-        }
-    }
-
-    /** 滑动时间窗：记录每个请求的时间戳，过期出队（自带窗口大小，供跨规则安全清扫）。 */
-    private static final class SlidingWindow {
-        private final ArrayDeque<Long> timestamps = new ArrayDeque<>();
-        private final long windowMs;
-
-        SlidingWindow(long windowMs) {
-            this.windowMs = windowMs;
-        }
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
@@ -5,6 +5,8 @@ import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
 import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.dto.IntentResult;
+import com.richard.fyoung.customerwork.lock.InMemorySessionLock;
+import com.richard.fyoung.customerwork.lock.SessionLock;
 import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordFilter;
 import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordStreamGuard;
 import io.agentscope.core.ReActAgent;
@@ -87,9 +89,11 @@ public class CustomerServiceService {
 
     /**
      * 会话级并发锁：同一 sessionId 的请求串行执行，防止并发写状态导致状态冲突 / 覆盖。
-     * 锁对象在 sessionId 首次使用时懒创建，进程内有效。
+     *
+     * <p>默认进程内（要求网关按会话 sticky 路由）；多副本部署把
+     * {@code customer-work.distributed.session-lock-mode} 切成 {@code redis} 即跨实例互斥。</p>
      */
-    private final ConcurrentHashMap<String, java.util.concurrent.Semaphore> sessionLocks = new ConcurrentHashMap<>();
+    private SessionLock sessionLock = new InMemorySessionLock(0);
 
     /**
      * 会话最后活跃时间戳（用于超时清理）：sessionId -> lastActivityMs。
@@ -102,10 +106,15 @@ public class CustomerServiceService {
                                   SessionStateManager sessionStateManager,
                                   CustomerWorkProperties properties,
                                   ObjectProvider<MeterRegistry> meterRegistryProvider,
-                                  ObjectProvider<SensitiveWordFilter> sensitiveWordFilterProvider) {
+                                  ObjectProvider<SensitiveWordFilter> sensitiveWordFilterProvider,
+                                  ObjectProvider<SessionLock> sessionLockProvider) {
         this(agentFactory, sessionStateManager, properties);
         this.meterRegistry = meterRegistryProvider.getIfAvailable();
         this.sensitiveWordFilter = sensitiveWordFilterProvider.getIfAvailable();
+        SessionLock provided = sessionLockProvider == null ? null : sessionLockProvider.getIfAvailable();
+        if (provided != null) {
+            this.sessionLock = provided;
+        }
     }
 
     /** 无指标构造（单测 / 未接入 Micrometer 场景）；properties 为空时使用默认配置。 */
@@ -333,10 +342,15 @@ public class CustomerServiceService {
         return true;
     }
 
-    /** 主动结束并清理会话：移除热缓存、删除持久化状态、清理会话锁。 */
+    /**
+     * 主动结束并清理会话：移除热缓存、删除持久化状态。
+     *
+     * <p>不再显式清理会话锁——锁对象由 {@link SessionLock} 实现自行回收
+     * （进程内实现按使用者计数摘除，分布式实现靠 lease 过期），
+     * 这里若强行清理反而可能把正在使用中的锁摘掉。</p>
+     */
     public void endSession(String sessionId) {
         sessionAgents.remove(sessionId);
-        sessionLocks.remove(sessionId);
         sessionActivity.remove(sessionId);
         try {
             RuntimeContext ctx = agentFactory.contextFor(sessionId);
@@ -351,7 +365,7 @@ public class CustomerServiceService {
     /**
      * 热配置刷新：清空进程内热 Agent 缓存，使下一次会话请求按最新配置（提示词/MCP/maxIters）重建 Agent。
      *
-     * <p>只清热缓存，<b>不动</b> {@code AgentStateStore}（会话短期状态）与 {@code sessionLocks}（会话锁）：
+     * <p>只清热缓存，<b>不动</b> {@code AgentStateStore}（会话短期状态）与 {@code SessionLock}（会话锁）：
      * "淘汰即重建、状态从 StateStore 恢复"是既有 LRU 淘汰路径已验证的行为，热更新复用同一路径即可，不会
      * 丢失任何进行中会话的上下文。模型链的热替换走 {@code MutableDelegatingModel#swap}，与本方法互补
      * （模型链是共享单例，无需重建 Agent 即生效；提示词/MCP/maxIters 绑定在 Agent 上，需重建）。</p>
@@ -427,28 +441,20 @@ public class CustomerServiceService {
      * 在 boundedElastic 上获取锁并执行，不阻塞 Netty 事件循环线程。
      */
     private <T> Mono<T> withSessionLock(String sessionId, Supplier<Mono<T>> supplier) {
-        java.util.concurrent.Semaphore lock = sessionLocks.computeIfAbsent(sessionId, k -> new java.util.concurrent.Semaphore(1));
-        return Mono.fromCallable(() -> {
-                lock.acquire();
-                return true;
-            })
+        return Mono.fromCallable(() -> sessionLock.acquire(sessionId))
             .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic())
-            .flatMap(ignored -> supplier.get())
-            .doFinally(signal -> lock.release());
+            .flatMap(releasable -> supplier.get()
+                // 释放挂在内层：doFinally 只有拿到锁之后才注册，避免获取失败时误释放别人的锁
+                .doFinally(signal -> releasable.release()));
     }
 
     /**
      * 会话级锁包装（Flux）：同 {@link #withSessionLock}，用于流式输出。
      */
     private <T> Flux<T> withSessionLockFlux(String sessionId, Flux<T> flux) {
-        java.util.concurrent.Semaphore lock = sessionLocks.computeIfAbsent(sessionId, k -> new java.util.concurrent.Semaphore(1));
-        return Mono.fromCallable(() -> {
-                lock.acquire();
-                return true;
-            })
+        return Mono.fromCallable(() -> sessionLock.acquire(sessionId))
             .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic())
-            .flatMapMany(ignored -> flux)
-            .doFinally(signal -> lock.release());
+            .flatMapMany(releasable -> flux.doFinally(signal -> releasable.release()));
     }
 
     private Msg toUserMsg(String userText) {

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/counter/InMemoryWindowCounterTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/counter/InMemoryWindowCounterTest.java
@@ -1,0 +1,72 @@
+package com.richard.fyoung.customerwork.counter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 进程内窗口计数单测：固定窗口累加/回退/只读，滑动窗口取用与超限不记录。
+ * @author owlzhangfq@gmail.com
+ */
+class InMemoryWindowCounterTest {
+
+    private final InMemoryWindowCounter counter = new InMemoryWindowCounter();
+
+    @Test
+    void increment_shouldAccumulateWithinWindow() {
+        assertEquals(5L, counter.increment("k", 5, 60), "首次累加应返回增量本身");
+        assertEquals(8L, counter.increment("k", 3, 60), "同窗口内应继续累加");
+    }
+
+    @Test
+    void decrement_shouldRollBackIncrement() {
+        counter.increment("k", 10, 60);
+        counter.decrement("k", 10, 60);
+        assertEquals(0L, counter.current("k", 60), "被拒的请求不应继续占用额度");
+    }
+
+    @Test
+    void current_shouldReturnZeroForUnknownKey() {
+        assertEquals(0L, counter.current("never-used", 60), "没用过的键读出来必须是 0，不能是 null 或异常");
+    }
+
+    @Test
+    void current_shouldNotCreateWindow() {
+        counter.current("read-only", 60);
+        assertEquals(3L, counter.increment("read-only", 3, 60),
+            "只读路径不得产生写副作用，否则首次累加会读到被污染的基数");
+    }
+
+    @Test
+    void increment_shouldIsolateDifferentKeys() {
+        counter.increment("a", 100, 60);
+        assertEquals(1L, counter.increment("b", 1, 60), "不同键的计数不能串");
+    }
+
+    @Test
+    void tryAcquireSliding_shouldRejectBeyondLimit() {
+        assertTrue(counter.tryAcquireSliding("s", 2, 60), "第 1 次应放行");
+        assertTrue(counter.tryAcquireSliding("s", 2, 60), "第 2 次应放行");
+        assertFalse(counter.tryAcquireSliding("s", 2, 60), "达到上限后应拒绝");
+    }
+
+    @Test
+    void tryAcquireSliding_shouldNotRecordRejectedRequests() {
+        counter.tryAcquireSliding("s", 1, 60);
+        counter.tryAcquireSliding("s", 1, 60);
+        counter.tryAcquireSliding("s", 1, 60);
+        // 被拒的请求若也记录，持续打压会让窗口永远填满、再也恢复不了
+        assertFalse(counter.tryAcquireSliding("s", 2, 60) && counter.tryAcquireSliding("s", 2, 60),
+            "窗口内应只留下 1 条已放行记录，配额提到 2 后只能再放行 1 次");
+    }
+
+    @Test
+    void tryAcquireSliding_shouldReleaseAfterWindowPasses() throws InterruptedException {
+        assertTrue(counter.tryAcquireSliding("s", 1, 1), "窗口内第 1 次放行");
+        assertFalse(counter.tryAcquireSliding("s", 1, 1), "窗口内第 2 次拒绝");
+        Thread.sleep(1100);
+        assertTrue(counter.tryAcquireSliding("s", 1, 1), "窗口滑过后应恢复放行");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/lock/InMemorySessionLockTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/lock/InMemorySessionLockTest.java
@@ -1,0 +1,108 @@
+package com.richard.fyoung.customerwork.lock;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 进程内会话锁单测：同会话互斥、不同会话并行、等待超时、锁对象按使用者计数回收。
+ * @author owlzhangfq@gmail.com
+ */
+class InMemorySessionLockTest {
+
+    @Test
+    void acquire_shouldSerializeSameSession() throws Exception {
+        InMemorySessionLock lock = new InMemorySessionLock(5);
+        SessionLock.Releasable first = lock.acquire("s1");
+
+        AtomicBoolean secondEntered = new AtomicBoolean(false);
+        CountDownLatch started = new CountDownLatch(1);
+        Thread t = new Thread(() -> {
+            started.countDown();
+            SessionLock.Releasable second = lock.acquire("s1");
+            secondEntered.set(true);
+            second.release();
+        });
+        t.start();
+        started.await();
+        Thread.sleep(100);
+
+        assertFalse(secondEntered.get(), "同一会话的第二个请求必须等前一个释放");
+        first.release();
+        t.join(2000);
+        assertTrue(secondEntered.get(), "前一个释放后第二个应立即进入");
+    }
+
+    @Test
+    void acquire_shouldNotBlockDifferentSessions() {
+        InMemorySessionLock lock = new InMemorySessionLock(1);
+        SessionLock.Releasable a = lock.acquire("s1");
+        SessionLock.Releasable b = lock.acquire("s2");
+        a.release();
+        b.release();
+        // 不同会话互不阻塞：若实现退化成全局锁，上面第二次 acquire 会等到超时抛异常
+    }
+
+    @Test
+    void acquire_shouldTimeoutWhenHeldTooLong() {
+        InMemorySessionLock lock = new InMemorySessionLock(1);
+        lock.acquire("s1");
+        assertThrows(SessionLockTimeoutException.class, () -> lock.acquire("s1"),
+            "等不到锁应抛超时而不是无限阻塞，否则请求线程会堆积到耗尽");
+    }
+
+    @Test
+    void release_shouldEvictLockEntry() {
+        InMemorySessionLock lock = new InMemorySessionLock(5);
+        SessionLock.Releasable r1 = lock.acquire("s1");
+        SessionLock.Releasable r2 = lock.acquire("s2");
+        assertEquals(2, lock.trackedSessions(), "持有期间锁对象应存在");
+
+        r1.release();
+        r2.release();
+        // 改造前每见一个新 sessionId 就留一个 Semaphore 且永不移除，长跑必然堆成内存泄漏
+        assertEquals(0, lock.trackedSessions(), "全部释放后锁对象应被回收");
+    }
+
+    @Test
+    void acquire_shouldEvictEntryOnTimeout() {
+        InMemorySessionLock lock = new InMemorySessionLock(1);
+        SessionLock.Releasable held = lock.acquire("s1");
+        assertThrows(SessionLockTimeoutException.class, () -> lock.acquire("s1"));
+        held.release();
+        assertEquals(0, lock.trackedSessions(), "超时失败的等待者也要把自己的计数退掉，否则条目永远回收不掉");
+    }
+
+    @Test
+    void acquire_shouldSupportSequentialReuse() throws Exception {
+        InMemorySessionLock lock = new InMemorySessionLock(5);
+        for (int i = 0; i < 3; i++) {
+            SessionLock.Releasable r = lock.acquire("s1");
+            r.release();
+        }
+        assertEquals(0, lock.trackedSessions(), "反复获取释放不应残留条目");
+        assertTrue(lock.acquire("s1") != null, "条目被回收后仍应能重新获取");
+    }
+
+    @Test
+    void unlimitedWait_shouldBlockUntilReleased() throws Exception {
+        InMemorySessionLock lock = new InMemorySessionLock(0);
+        SessionLock.Releasable first = lock.acquire("s1");
+        CountDownLatch acquired = new CountDownLatch(1);
+        Thread t = new Thread(() -> {
+            lock.acquire("s1").release();
+            acquired.countDown();
+        });
+        t.start();
+        assertFalse(acquired.await(200, TimeUnit.MILLISECONDS), "waitSeconds<=0 表示不限等待，不应提前超时");
+        first.release();
+        assertTrue(acquired.await(2, TimeUnit.SECONDS), "释放后应能拿到");
+    }
+}

--- a/deploy/k8s/00-namespace.yaml
+++ b/deploy/k8s/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: customer-work
+  labels:
+    app.kubernetes.io/part-of: customer-work

--- a/deploy/k8s/10-configmap.yaml
+++ b/deploy/k8s/10-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: customer-work-config
+  namespace: customer-work
+data:
+  SPRING_PROFILES_ACTIVE: "prod"
+
+  # ---- 外部依赖地址（按实际部署填写）----
+  MYSQL_HOST: "mysql.customer-work.svc.cluster.local"
+  MYSQL_PORT: "3306"
+  REDIS_HOST: "redis.customer-work.svc.cluster.local"
+  REDIS_PORT: "6379"
+  NACOS_SERVER_ADDR: "nacos.customer-work.svc.cluster.local:8848"
+
+  # ---- 多副本必须项 ----
+  # 三个进程内实现切成 Redis 共享：不切就等于每个副本各有一份配额、各锁各的会话。
+  # 详见 deploy/k8s/README.md「多副本的前提」。
+  CUSTOMER_WORK_DISTRIBUTED_COUNTERMODE: "redis"
+  CUSTOMER_WORK_DISTRIBUTED_SESSIONLOCKMODE: "redis"
+  # 会话锁的持有超时要显著大于单次对话的最长处理时间，否则长响应会在处理中途失去互斥保护
+  CUSTOMER_WORK_DISTRIBUTED_SESSIONLOCKLEASESECONDS: "120"
+  CUSTOMER_WORK_DISTRIBUTED_SESSIONLOCKWAITSECONDS: "10"
+
+  # ---- 健康探针 ----
+  # liveness/readiness 分离端点默认关闭，K8s 探针要用就得显式开
+  MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED: "true"
+  MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,info,metrics,prometheus"
+
+  # ---- 优雅停机 ----
+  # 必须小于 Deployment 的 terminationGracePeriodSeconds，否则处理中的对话会被 SIGKILL 打断
+  CUSTOMER_WORK_RUNTIME_SHUTDOWNTIMEOUTSECONDS: "30"

--- a/deploy/k8s/20-secret.example.yaml
+++ b/deploy/k8s/20-secret.example.yaml
@@ -1,0 +1,18 @@
+# 模板文件：不要把真实密钥提交进仓库。
+# 生产建议用 External Secrets Operator / Vault / 云厂商 KMS 注入，
+# 或用 kubectl create secret 命令行创建（见 deploy/k8s/README.md）。
+apiVersion: v1
+kind: Secret
+metadata:
+  name: customer-work-secret
+  namespace: customer-work
+type: Opaque
+stringData:
+  DASHSCOPE_API_KEY: "REPLACE_ME"
+  MYSQL_PASSWORD: "REPLACE_ME"
+  REDIS_PASSWORD: "REPLACE_ME"
+  # 终端用户登录态 JWT 签名密钥；不覆盖会退到开发默认值，等于任何人都能伪造登录态
+  CW_USER_JWT_SECRET: "REPLACE_ME"
+  # 后台敏感字段加解密密钥
+  ADMIN_AES_SECRET_KEY: "REPLACE_ME"
+  ADMIN_MYSQL_PASSWORD: "REPLACE_ME"

--- a/deploy/k8s/30-app-server.yaml
+++ b/deploy/k8s/30-app-server.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: customer-work-app
+  namespace: customer-work
+  labels:
+    app: customer-work-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: customer-work-app
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: customer-work-app
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8080"
+    spec:
+      # 必须大于应用自身的 shutdown-timeout-seconds（ConfigMap 里是 30），
+      # 否则正在处理的对话会在优雅停机走完之前被 SIGKILL 打断
+      terminationGracePeriodSeconds: 45
+      containers:
+        - name: app
+          image: customer-work/app-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: customer-work-config
+            - secretRef:
+                name: customer-work-secret
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          # 启动探针单独设，给 JVM + Spring 上下文足够的启动时间；
+          # 没有它就得把 liveness 的 initialDelay 调得很大，那会让运行期的故障检测跟着变迟钝
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            periodSeconds: 5
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                # 先让 Service 摘掉本 Pod 的 endpoint，再开始停机，避免摘流量与停机竞争
+                # 导致的少量 502（K8s 的 endpoint 更新与 SIGTERM 是并行发生的）
+                command: ["sh", "-c", "sleep 5"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: customer-work-app
+  namespace: customer-work
+  labels:
+    app: customer-work-app
+spec:
+  type: ClusterIP
+  selector:
+    app: customer-work-app
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+# 滚动发布/节点驱逐时至少保留一个可用副本
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: customer-work-app
+  namespace: customer-work
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: customer-work-app

--- a/deploy/k8s/40-admin-server.yaml
+++ b/deploy/k8s/40-admin-server.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: customer-admin-server
+  namespace: customer-work
+  labels:
+    app: customer-admin-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: customer-admin-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: customer-admin-server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "8082"
+    spec:
+      terminationGracePeriodSeconds: 45
+      containers:
+        - name: admin
+          image: customer-work/admin-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8082
+          envFrom:
+            - configMapRef:
+                name: customer-work-config
+            - secretRef:
+                name: customer-work-secret
+          env:
+            # 后台登录态存 Redis，多副本才不会因为落到别的实例而被要求重新登录；
+            # Redis 不可达时后台登录 fail-closed（见 AdminSaTokenDaoConfig），这是刻意的
+            - name: ADMIN_REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: customer-work-config
+                  key: REDIS_HOST
+            - name: ADMIN_REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: customer-work-config
+                  key: REDIS_PORT
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            periodSeconds: 5
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: customer-admin-server
+  namespace: customer-work
+  labels:
+    app: customer-admin-server
+spec:
+  type: ClusterIP
+  selector:
+    app: customer-admin-server
+  ports:
+    - name: http
+      port: 8082
+      targetPort: http
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: customer-admin-server
+  namespace: customer-work
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: customer-admin-server

--- a/deploy/k8s/50-hpa.yaml
+++ b/deploy/k8s/50-hpa.yaml
@@ -1,0 +1,79 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: customer-work-app
+  namespace: customer-work
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: customer-work-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      # 缩容放慢：对话是长连接型负载，缩太快会把正在处理的会话连带打断，
+      # 而扩容代价远低于误伤用户请求
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: customer-admin-server
+  namespace: customer-work
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: customer-admin-server
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+
+# ---------------------------------------------------------------------------
+# 更贴合负载的伸缩依据（需先装 Prometheus Adapter）
+#
+# 对话服务的瓶颈通常是"等模型响应"而不是 CPU：一个副本可能 CPU 只有 20% 却已经把
+# 可用连接吃满。CPU 指标在这种负载下会明显滞后，真正该看的是在途请求数。
+# 装了 adapter 后把下面这段加进上面的 metrics 列表即可：
+#
+#   - type: Pods
+#     pods:
+#       metric:
+#         name: http_server_requests_active   # 由 Micrometer 暴露，经 adapter 转成自定义指标
+#       target:
+#         type: AverageValue
+#         averageValue: "20"
+# ---------------------------------------------------------------------------

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,57 @@
+# Kubernetes 部署清单
+
+多副本部署的最小可用清单。按序号顺序 apply 即可：
+
+```bash
+kubectl apply -f deploy/k8s/00-namespace.yaml
+kubectl apply -f deploy/k8s/10-configmap.yaml
+# 先按下方说明改好真实密钥再 apply
+kubectl apply -f deploy/k8s/20-secret.example.yaml
+kubectl apply -f deploy/k8s/30-app-server.yaml
+kubectl apply -f deploy/k8s/40-admin-server.yaml
+kubectl apply -f deploy/k8s/50-hpa.yaml
+```
+
+## 多副本的前提（不做就等于没扩容）
+
+单副本能跑不代表多副本正确。以下三项默认是进程内实现，`10-configmap.yaml` 里已全部切成 Redis，
+**改成多副本前务必确认它们生效**，否则会出现"扩容后配额翻倍、同一会话历史被写坏"这类问题：
+
+| 能力 | 进程内的后果 | 配置项 |
+|---|---|---|
+| 限流 | N 个副本各算各的，实际放行量是配置值的 N 倍 | `customer-work.distributed.counter-mode=redis` |
+| 成本熔断 | 同上，token 预算被放大 N 倍，"熔断"形同虚设 | 同上（与限流共用计数器） |
+| 会话串行锁 | 同一会话的并发请求落到不同副本，对话历史交叉覆盖 | `customer-work.distributed.session-lock-mode=redis` |
+
+会话锁切到 Redis 后，网关不再需要按会话做 sticky 路由——这正是能水平扩缩容的前提。
+
+## 依赖的外部服务
+
+清单只覆盖应用本身。MySQL / Redis / Nacos / XXL-JOB 按各自的运维方式部署（云托管或独立 StatefulSet），
+在 `10-configmap.yaml` 与 `20-secret.example.yaml` 里填地址与凭据。
+
+## 密钥
+
+`20-secret.example.yaml` 是**模板**，不要直接把真实密钥提交进仓库。生产建议用
+外部密钥管理（External Secrets Operator / Vault / 云厂商 KMS）注入，或至少：
+
+```bash
+kubectl create secret generic customer-work-secret -n customer-work \
+  --from-literal=DASHSCOPE_API_KEY='真实值' \
+  --from-literal=MYSQL_PASSWORD='真实值' \
+  --from-literal=REDIS_PASSWORD='真实值' \
+  --from-literal=CW_USER_JWT_SECRET='真实值' \
+  --from-literal=ADMIN_AES_SECRET_KEY='真实值'
+```
+
+## HPA 的伸缩依据
+
+默认按 CPU 70% / 内存 80% 伸缩。对话服务的实际瓶颈通常是**等待模型响应**而非 CPU——
+真正贴合负载的指标是并发请求数或队列深度，那需要 Prometheus Adapter 提供自定义指标
+（`50-hpa.yaml` 末尾附了示例，装了 adapter 再启用）。CPU/内存只是在没有 adapter 时的兜底依据。
+
+## 滚动发布与优雅停机
+
+`terminationGracePeriodSeconds` 与应用的 `customer-work.runtime.shutdown-timeout-seconds`（默认 30）
+需要匹配：K8s 的宽限期必须**大于**应用自身的停机超时，否则正在处理的对话会被 SIGKILL 打断。
+当前设为 45 秒，改应用配置时记得同步这里。

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -106,6 +106,7 @@
 | **合成监控（主动探活）** | `SyntheticMonitor` | 关 | `synthetic-monitor.enabled=true`（真实链路探测，指标 `customerwork.synthetic.probe`） |
 | 原生 Tracing | `TracingConfig` | 关 | `observability.tracing-enabled=true` |
 | **OTel 链路追踪（最后一公里，真出 span + OTLP 导出）** | `OtelTracingConfig`(starter) + `AdminOtelTracingConfig`(admin) | 关 | `customer-work.observability.otel.enabled=true`（starter）/ `admin.observability.otel.enabled=true`（admin），见 §6.13c |
+| **水平扩展（限流/成本熔断/会话锁共享）** | `WindowCounter` + `SessionLock`（Redisson 实现） | 关 | `customer-work.distributed.counter-mode=redis` + `session-lock-mode=redis`，见 §6.27 |
 | 运维就绪（健康/停机/巡检） | `SessionHealthIndicator` / `GracefulShutdownService` / `MaintenanceScheduler` | 开 | `/actuator/health` |
 | 模型多厂商 + 私有化兜底 / 重试 / **成本熔断** | `ModelConfig`（或 2.0 内置 `maxRetries`/`fallbackModel`）+ `ModelCostCircuitBreaker` | 开 | `model.provider`、`model.fallback.enabled`、`model.cost-control.enabled` |
 | MCP 接入 | `McpToolkitConfigurer` | 关 | `mcp.enabled=true` |
@@ -1462,6 +1463,38 @@ customer-admin-server：`spring.servlet.multipart.max-file-size`/`max-request-si
 - 配置：`admin.a2a.{enabled(false),agent-code,base-url(http://localhost:8082),version(1.0.0),description}`
 - 端点：`GET /.well-known/agent-card.json`（协议约定路径，不可改名）、`POST /a2a/jsonrpc`
 
+### 6.27 水平扩展：限流 / 成本熔断 / 会话锁的跨实例共享（默认关闭）
+
+单实例部署下进程内实现更快也更简单，所以默认不变。**多副本部署必须切**，否则扩容会同时
+放大配额、打乱会话——这不是性能优化，是正确性问题。
+
+```yaml
+customer-work:
+  distributed:
+    counter-mode: redis        # 限流 + 成本熔断共用的窗口计数
+    session-lock-mode: redis   # 会话串行锁
+    session-lock-wait-seconds: 10    # 等不到即按繁忙拒绝，避免请求线程堆积
+    session-lock-lease-seconds: 120  # 持有超时，防实例崩溃后锁永不释放
+```
+
+Redis 连接复用 `customer-work.distributed-lock.redis.*`，不用再配一套。
+
+**三个实现细节**（改造时容易踩）：
+
+- **计数用 Lua 脚本原子执行**。分布式限流最怕"查完再写"的竞态：N 个实例同时读到未超限、
+  各自放行一个，配额照样击穿。判断与写入必须在一次 Redis 调用里完成。
+- **会话锁用 `RPermitExpirableSemaphore` 而不是 `RLock`**。RLock 是线程绑定的，解锁校验持有线程；
+  而本项目在 Reactor 链里加锁、在 `doFinally` 释放，两者不保证同一线程，用 RLock 会抛
+  `IllegalMonitorStateException`。PermitExpirableSemaphore 的释放只认 permitId 不认线程。
+- **lease 时间必须显著大于单次对话的最长处理时间**，否则长响应会在处理中途失去互斥保护。
+
+**Redis 不可达时降级为进程内实现**，而不是直接放行。保护性能力在基础设施故障时全放行等于保护消失；
+退回单机配额虽然总量放大成 N 倍，但仍拦得住单实例上的失控流量。降级只打一次 error 日志（`COUNTER-REDIS-DEGRADED`
+/ `SESSION-LOCK-REDIS-DEGRADED`），不逐请求刷屏。
+
+K8s 多副本清单见 `deploy/k8s/`（含 Deployment / Service / HPA / PDB / 探针 / 优雅停机），
+其 ConfigMap 已把上述三项全部切成 Redis。
+
 ---
 
 ## 七、配置项总表
@@ -1482,6 +1515,7 @@ customer-admin-server：`spring.servlet.multipart.max-file-size`/`max-request-si
 | `observability` | trace-enabled(false), trace-file, tracing-enabled(false), studio.*, otel.{enabled(false),endpoint(http://localhost:4317),service-name(customer-work),sampler-ratio(1.0)}（见 §6.13c；admin 侧对应 `admin.observability.otel.*`，非本表 `customer-work.*` 范围，随 admin 自身配置文档见 §6.21） |
 | `human-approval` | enabled(true), guarded-tools([submitRefund]), timeout-seconds(0), timeout-action(escalate), store-mode(memory) |
 | `fact-log` | enabled(true), directory(./data/facts), max-file-mb(10), max-archived-files(5) |
+| `distributed` | counter-mode(memory), counter-key-prefix(cw:counter:), session-lock-mode(memory), session-lock-wait-seconds(10), session-lock-lease-seconds(120)（见 §6.27，Redis 连接复用 `distributed-lock.redis.*`） |
 | `security` | auth.{enabled(false),header-name(X-API-Key),api-keys[]}, rate-limit.{enabled(false),requests-per-minute(120),algorithm(fixed-window),window-seconds(60),rule-enabled(false),store-mode(memory),refresh-enabled(true),refresh-interval-ms(60000)} |
 | `sensitive-word` | enabled(false), direction(BOTH), store-mode(memory), default-action(BLOCK), mask-char(*), inbound-safe-reply, outbound-safe-reply, refresh-enabled(true), refresh-interval-ms(60000), hit-log.{enabled(false),store-mode(memory),queue-capacity(2048),snippet-max-length(64)} |
 | `multi-agent` | enabled(true), mode(fanout), max-iters(6) |

--- a/docs/生产就绪评估.md
+++ b/docs/生产就绪评估.md
@@ -95,13 +95,21 @@ GitHub 上可能尚未关闭）：
 | 应用层：Actuator 暴露面 | 默认 `application.yml`（尤其 `customer-channel`）为方便调试暴露了全部管理端点（`exposure.include: "*"`） | prod 两处 yml 均收敛为 `management.endpoints.web.exposure.include: health,prometheus`，`health.show-details: when-authorized` |
 | 应用层：鉴权默认值 | `security.auth.enabled` 非 prod 环境默认 `false`，容易在生产忘记显式开启 | prod yml 翻转默认值为 `${AUTH_ENABLED:true}`（fail-safe：忘记设置环境变量时默认拦截而非放行） |
 
-### 多实例部署注意事项（诚实声明：以下能力当前实现是进程内统计/存储）
+### 多实例部署注意事项
 
-| 组件 | 现状 | 多实例影响 | 应对 |
+下面三项**默认仍是进程内实现**（单实例部署下更快也更简单），多副本部署必须切成共享实现，
+否则"扩容"会同时放大配额、打乱会话。切换只改配置，代码无需改动。
+
+| 组件 | 默认实现 | 不切的后果 | 切换方式 |
 |---|---|---|---|
-| `security.rate-limit` 限流 | 进程内计数器 | N 实例横向扩容 = 实际总配额被放大为 N 倍 | 需要全局精确限流时在网关层（Higress 等）做全局限流，或改造为 Redis 计数 |
-| `model.cost-control` 模型成本熔断 | 进程内 `AtomicLong` 计数（本项目 prod 基线默认未开启） | 同上，按实例数放大 | 同上；开启前需评估是否要求全局精确 |
-| `CustomerServiceService` 会话级串行锁 | 进程内 `Semaphore`（`ConcurrentHashMap<sessionId, Semaphore>`） | 只在同一实例内生效，同一 `sessionId` 的并发请求若被负载均衡到不同实例，锁不能跨实例互斥 | 生产建议网关层为同一 `sessionId` 配置会话粘性路由（sticky session），不依赖跨实例分布式锁 |
+| `security.rate-limit` 限流 | 进程内窗口计数 | N 实例横向扩容 = 实际总配额被放大为 N 倍 | `customer-work.distributed.counter-mode: redis` |
+| `model.cost-control` 模型成本熔断 | 同上（与限流共用 `WindowCounter`） | 同上，token 预算按实例数放大，"熔断"形同虚设 | 同上（一个开关同时管两处） |
+| `CustomerServiceService` 会话级串行锁 | 进程内 `Semaphore` | 只在同一实例内生效，同一 `sessionId` 的并发请求落到不同实例就没有互斥，对话历史会被交叉覆盖 | `customer-work.distributed.session-lock-mode: redis`；切换后网关不再需要 sticky 路由 |
+
+三者的 Redis 实现在 Redis 不可达时**降级为进程内计数/加锁**而非直接放行：保护性能力在基础设施故障时
+全放行等于保护消失，退回单机配额虽会放大成 N 倍，但仍拦得住单实例上的失控流量。降级只打一次 error 日志。
+
+K8s 多副本清单见 `deploy/k8s/`，其 ConfigMap 已把上述三项全部切成 Redis。
 | `PendingApprovalService` / `SlotFillingService` / `DialogStageService` | 均已提供 `store-mode=jdbc` 可插拔实现（见上表） | 切 jdbc 后可跨实例共享，问题已解决 | 生产按上表配置 `store-mode: jdbc` |
 | `ComplaintBackend`（投诉工单） | 默认 `MockComplaintBackend` 进程内 `Map`；已提供 `MybatisComplaintBackend`（落库 `cw_complaint`，经 `ComplaintMapper`）作为 `customer-work.tool-backend.mode=jdbc` 时的可插拔实现，问题已解决 | 生产按 `customer-work.tool-backend.mode: jdbc` 配置即可跨实例共享，无需自行对接工单系统 |
 

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -307,11 +307,15 @@ customer-work:
 
 ## 七、多实例部署注意事项
 
-以下三条是**代码现状的诚实边界**(进程内实现),横向扩容前必须知悉:
+以下三项默认是**进程内实现**(单实例下更快也更简单),横向扩容前必须逐条切换,否则"扩容"会同时放大配额、打乱会话:
 
-1. **限流与成本熔断是进程内计数器**:`security.rate-limit` 与 `model.cost-control`(prod 基线未开启)在 N 个实例下实际总配额被放大为 N 倍。需要全局精确限流时在网关层(Higress 等)做,不要依赖应用层配置。
-2. **会话级串行锁是进程内 Semaphore**:`CustomerServiceService` 对同一 `sessionId` 的并发请求排队执行以避免状态覆盖,但只在同一实例内生效。**生产必须在网关层为 sessionId 配置会话粘性路由(sticky session)**——这比引入跨实例分布式锁省事且可靠。
+1. **限流与成本熔断**:默认进程内计数,N 个实例下实际总配额被放大为 N 倍。多副本部署设 `customer-work.distributed.counter-mode: redis`,两者共用同一个计数器实现,一个开关同时生效。
+2. **会话级串行锁**:默认进程内 Semaphore,只在同一实例内生效,同一 `sessionId` 的并发请求落到不同实例就没有互斥,对话历史会被交叉覆盖。两种做法二选一——网关层为 sessionId 配置会话粘性路由(sticky session),**或**设 `customer-work.distributed.session-lock-mode: redis`(切了之后不再依赖 sticky,才能真正自由扩缩容)。
 3. **审批 / 槽位 / 对话阶段已切 jdbc,跨实例安全**:三者共享状态落 MySQL,应用重启、多实例路由均不受影响——前提是[第三节](#三数据库初始化)的表已建好。
+
+Redis 连接复用 `customer-work.distributed-lock.redis.*`。三者的 Redis 实现在 **Redis 不可达时降级为进程内**而非直接放行:保护性能力在基础设施故障时全放行等于保护消失,退回单机配额仍拦得住单实例上的失控流量。
+
+**Kubernetes 部署**:`deploy/k8s/` 提供了 Deployment / Service / HPA / PDB / 探针 / 优雅停机的完整清单,其 ConfigMap 已把上述三项全部切成 Redis。注意 `terminationGracePeriodSeconds`(45)必须大于应用的 `runtime.shutdown-timeout-seconds`(30),否则处理中的对话会被 SIGKILL 打断。
 
 ## 八、安全暴露面收口
 


### PR DESCRIPTION
企业级 SaaS 路线图 **B2 批次**。三个进程内实现此前把水平扩展的责任外推给了网关（"生产必须配 sticky session"），本批把它们变成可切换的共享实现。

**默认仍是进程内**——单实例部署下更快也更简单，行为与改造前完全一致。多副本部署切一个开关即可。

## 窗口计数（限流 + 成本熔断）

两者本来就是同一件事：在一个时间窗内累加、判断是否越过阈值。此前各自实现了一套进程内计数，抽成 `WindowCounter` SPI 后换一个实现同时解决两处。

- `InMemoryWindowCounter` 与改造前逐字等价（窗口自带到期时刻、按到期时刻清扫——不能按"是否等于当前窗口序号"判断，那样窗口大小不同的规则会互相误删）。**既有 20 个测试未改一行全部通过**，可作为行为等价的证据。
- `RedissonWindowCounter` 用 **Lua 脚本原子执行**。分布式限流最怕"查完再写"的竞态：N 个实例同时读到未超限、各自放行一个，配额照样被击穿。判断与写入必须在一次 Redis 调用里完成。

## 会话串行锁

- 新增 `SessionLock` SPI，返回**与线程无关的释放句柄**。
- Redis 实现刻意用 `RPermitExpirableSemaphore` 而不是 `RLock`：RLock 是线程绑定的可重入锁、解锁校验持有线程，而本项目在 Reactor 链里加锁、在 `doFinally` 里释放，两者不保证同一线程，用 RLock 会抛 `IllegalMonitorStateException`。PermitExpirableSemaphore 的释放只认 permitId。
- **顺带修掉一个进程内实现的内存泄漏**：原来每见一个新 sessionId 就往 Map 里放一个 Semaphore 且永不移除，长期运行会把会话数累积成泄漏。现按使用者计数回收（用 `compute` 保证"计数归零"与"移除"原子），`endSession` 也不再需要手工清理——手工清理反而可能摘掉正在使用中的锁。

## 故障时的取向

Redis 不可达时三者一律**降级为进程内实现，而不是直接放行**。保护性能力在基础设施故障时全放行等于保护完全消失；退回单机配额虽然总量会放大成 N 倍，但仍拦得住单实例上的失控流量。降级只打一次 error 日志（`COUNTER-REDIS-DEGRADED` / `SESSION-LOCK-REDIS-DEGRADED`），不逐请求刷屏。

## K8s 清单（`deploy/k8s/`）

Deployment(2 副本) / Service / HPA / PDB / startup+liveness+readiness 三探针 / preStop 优雅停机。几个有意为之的细节：

- ConfigMap 已把上述三项**全部切成 Redis**——多副本却不切，等于扩容的同时放大配额、打乱会话。
- `terminationGracePeriodSeconds`(45) 必须大于应用的 `runtime.shutdown-timeout-seconds`(30)，否则处理中的对话会被 SIGKILL 打断。
- startupProbe 单独设，给 JVM + Spring 上下文足够启动时间；没有它就得把 liveness 的 initialDelay 调大，那会让运行期的故障检测跟着变迟钝。
- HPA 默认按 CPU/内存，但注释里说明了这只是兜底：对话服务的真实瓶颈是**等模型响应**而非 CPU，一个副本可能 CPU 只有 20% 却已把连接吃满。附了 Prometheus Adapter 自定义指标的配置示例。
- 缩容 `stabilizationWindowSeconds` 设 300：对话是长连接型负载，缩太快会打断正在处理的会话，而扩容代价远低于误伤请求。

## 顺带

`ModelCostCircuitBreaker` 原来用 `log.warn`，项目规范只用 info/error，一并改成带错误码的 error。

## 测试

starter **1151**(+15) / admin 722 / app 78 / channel 65 / gateway 1，全绿。

新增覆盖：固定窗口累加/回退/只读无副作用/键隔离、滑动窗口超限不记录（被拒也记录会导致持续打压下窗口永不恢复）与窗口滑过后恢复、会话锁同会话互斥/不同会话并行/等待超时/**锁对象回收**（含超时路径也要退计数，否则条目永远回收不掉）。

## 未验证

Redis 实现（`RedissonWindowCounter` / `RedissonSessionLock`）**未在真实 Redis 上跑过** —— 本机 Docker 未启动。Lua 脚本与 Redisson API 用法经静态审查，但建议合入前在有 Redis 的环境跑一次双实例验证：两个实例共用一个 Redis，确认限流总量不翻倍、同一会话在两实例间互斥。
