### PR TITLE
feat(billing): B3 配额与计费——租户 token 硬上限与账单归集

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1165** + admin-server **732** + app 78 + customer-channel 65 + gateway 1
-  （2026-08-10 B1+B2 合并后：B1 租户地基 starter +14 / admin +11，B2 水平扩展 starter +15。
+- 测试基线：starter **1177** + admin-server **732** + app 78 + customer-channel 65 + gateway 1
+  （2026-08-10 B1+B2+B3：B1 租户地基 starter +14 / admin +11，B2 水平扩展 starter +15，B3 配额计费 starter +12。
   MySQL 不可达时 admin 会少跑 1 个门控用例，显示 721 属正常。
   上一版基线是 2026-08-06 的 starter 1136 + admin 722；更早是 2026-08-05 的 starter 1054 + admin 711；
   admin-server 更早的实际基线已是 707，CLAUDE.md 曾记的
@@ -89,6 +89,10 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   两条约定：① Redis 实现失败一律**降级进程内**而非放行（保护性能力不能因基础设施故障消失）；
   ② 会话锁必须用 `RPermitExpirableSemaphore` 而非 `RLock`——加锁在 Reactor 链、释放在 `doFinally`，
   不保证同线程，RLock 会抛 `IllegalMonitorStateException`。K8s 清单见 `deploy/k8s/`。
+- **配额与计费（B3 起）**：租户 token 配额走 `TenantQuotaGuard`（starter），判定在
+  `CustomerServiceService` 入口（能打断），记账搭 `AgentCallTimingMiddleware` 里 token 的唯一落点。
+  配额表 `cw_tenant_quota` 落**客服端库**（运行时要读），admin 经跨库门面维护——照内容风控三表先例。
+  **实时只拦 token，金额走 T+1 账单**（`cw_tenant_usage_daily`，金额按归集时单价落库，调价不改历史账）。
 - 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
 - 持久层异常兜底必须 `catch(Exception)`（HikariPool/MyBatis 初始化异常是 RuntimeException）。
 - 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/BillingConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/BillingConfig.java
@@ -1,0 +1,29 @@
+package com.richard.fyoung.customeradmin.billing.config;
+
+import com.richard.fyoung.customeradmin.billing.schedule.UsageAggregationDriver;
+import com.richard.fyoung.customeradmin.billing.service.UsageAggregationService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 计费装配：用量归集驱动仅在显式开启时才起线程。
+ *
+ * <p>默认关闭。多副本部署下开启前要知悉：每个副本都会跑自己的归集循环。
+ * 归集是幂等的（同一天重跑覆盖），并发不会算错数，只是白白重复扫日志；
+ * 要严格互斥可在 {@code UsageAggregationDriver} 外面套 {@code DistributedLockExecutor}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class BillingConfig {
+
+    @Bean(destroyMethod = "stop")
+    @ConditionalOnProperty(prefix = "admin.billing.aggregation", name = "enabled", havingValue = "true")
+    public UsageAggregationDriver usageAggregationDriver(
+        UsageAggregationService aggregationService,
+        @Value("${admin.billing.aggregation.interval-ms:21600000}") long intervalMs,
+        @Value("${admin.billing.aggregation.backfill-days:3}") int backfillDays) {
+        return new UsageAggregationDriver(aggregationService, intervalMs, backfillDays);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/QuotaGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/QuotaGatewayFactory.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customeradmin.billing.config;
+
+import com.richard.fyoung.customeradmin.billing.jdbc.QuotaGateway;
+import com.richard.fyoung.customerwork.gateway.CrossDbGateway;
+import com.richard.fyoung.customerwork.quota.mapper.TenantQuotaMapper;
+
+import java.util.List;
+
+/**
+ * 把客服端库的跨库环境装配成配额门面。
+ *
+ * <p>{@link TenantQuotaMapper} 没有自己的 XML（配额只用 BaseMapper 的 CRUD），故走接口注册。</p>
+ * @author owlzhangfq@gmail.com
+ */
+final class QuotaGatewayFactory {
+
+    static final List<Class<?>> MAPPER_CLASSES = List.of(TenantQuotaMapper.class);
+
+    static final List<String> MAPPER_XML_LOCATIONS = List.of();
+
+    private QuotaGatewayFactory() {
+    }
+
+    static QuotaGateway build(CrossDbGateway gateway) {
+        return new QuotaGateway(gateway.getMapper(TenantQuotaMapper.class));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/QuotaGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/QuotaGatewayProvider.java
@@ -1,0 +1,68 @@
+package com.richard.fyoung.customeradmin.billing.config;
+
+import com.richard.fyoung.customeradmin.billing.jdbc.QuotaGateway;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.contentguard.config.ContentGuardProperties;
+import com.richard.fyoung.customerwork.gateway.CrossDbConnectionSettings;
+import com.richard.fyoung.customerwork.gateway.CrossDbGatewayProvider;
+import com.richard.fyoung.customerwork.gateway.CrossDbGateways;
+import com.richard.fyoung.customerwork.gateway.CrossDbUnavailableException;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * 客服端库配额门面的惰性提供者。
+ *
+ * <p>连接参数复用 {@link ContentGuardProperties}——配额表与内容风控三表在同一个客服端库，
+ * 再配一套连接参数只会多一处要同步维护的配置。连接池另建（各自 3 连接）而不是共用：
+ * 池子共用会让后台配额操作与词库维护互相排队，两者都是低频操作，多一个小池的代价可以忽略。</p>
+ *
+ * <p>惰性建连，<b>绝不在 admin 启动期触碰客服端库</b>：后台不该因为客服端库没起来就启动不了。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class QuotaGatewayProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(QuotaGatewayProvider.class);
+
+    private static final String POOL_NAME = "tenant-quota-pool";
+    private static final int MAX_POOL_SIZE = 3;
+
+    private final ContentGuardProperties properties;
+    private final CrossDbGatewayProvider<QuotaGateway> delegate;
+
+    public QuotaGatewayProvider(ContentGuardProperties properties) {
+        this.properties = properties;
+        this.delegate = CrossDbGateways.lazy(this::connectionSettings,
+            QuotaGatewayFactory.MAPPER_CLASSES,
+            QuotaGatewayFactory.MAPPER_XML_LOCATIONS,
+            QuotaGatewayFactory::build);
+    }
+
+    /** 取门面（惰性构建 + 探测 + 缓存）；库不可达抛明确业务异常。 */
+    public QuotaGateway get() {
+        try {
+            return delegate.get();
+        } catch (CrossDbUnavailableException e) {
+            log.error("quota datasource unavailable, code={}, url={}",
+                "QUOTA-DS-UNAVAILABLE", properties.jdbcUrl(), e);
+            throw new BizException(ResultCode.CUSTOMER_WORK_UNAVAILABLE,
+                "客服端库不可达（租户配额存放于此）：" + e.rootMessage());
+        }
+    }
+
+    private CrossDbConnectionSettings connectionSettings() {
+        return CrossDbConnectionSettings.builder(POOL_NAME, properties.jdbcUrl())
+            .credentials(properties.getUsername(), properties.getPassword())
+            .maximumPoolSize(MAX_POOL_SIZE)
+            .build();
+    }
+
+    @PreDestroy
+    public void close() {
+        delegate.close();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/controller/BillingController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/controller/BillingController.java
@@ -1,0 +1,156 @@
+package com.richard.fyoung.customeradmin.billing.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.billing.dto.TenantQuotaSaveRequest;
+import com.richard.fyoung.customeradmin.billing.dto.TenantQuotaVO;
+import com.richard.fyoung.customeradmin.billing.dto.UsageAggregate;
+import com.richard.fyoung.customeradmin.billing.entity.AiModelPrice;
+import com.richard.fyoung.customeradmin.billing.service.BillingReportService;
+import com.richard.fyoung.customeradmin.billing.service.ModelPriceAdminService;
+import com.richard.fyoung.customeradmin.billing.service.TenantQuotaService;
+import com.richard.fyoung.customeradmin.billing.service.UsageAggregationService;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 配额与计费：租户配额维护、模型单价维护、账单报表、手工归集。
+ *
+ * <p>权限分层：账单明细（{@code billing:view}）租户管理员也能看自己那份；
+ * 配额与单价的编辑、以及全平台总览是运营方专属，额外校验一次身份——
+ * 全租户消费明细泄露的是全体客户名单与用量，不能只靠权限点配置正确。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/billing")
+public class BillingController {
+
+    private final TenantQuotaService quotaService;
+    private final ModelPriceAdminService priceService;
+    private final BillingReportService reportService;
+    private final UsageAggregationService aggregationService;
+
+    public BillingController(TenantQuotaService quotaService,
+                             ModelPriceAdminService priceService,
+                             BillingReportService reportService,
+                             UsageAggregationService aggregationService) {
+        this.quotaService = quotaService;
+        this.priceService = priceService;
+        this.reportService = reportService;
+        this.aggregationService = aggregationService;
+    }
+
+    // ---------- 租户配额 ----------
+
+    @SaCheckPermission("billing:view")
+    @GetMapping("/quota")
+    public Result<List<TenantQuotaVO>> listQuota(@RequestParam String tenantId) {
+        assertPlatformOperator();
+        return Result.success(quotaService.listByTenant(tenantId));
+    }
+
+    @SaCheckPermission("billing:quota-edit")
+    @OperationLog(operation = "保存租户配额", target = "cw_tenant_quota")
+    @PostMapping("/quota")
+    public Result<Void> saveQuota(@Valid @RequestBody TenantQuotaSaveRequest request) {
+        assertPlatformOperator();
+        quotaService.save(request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("billing:quota-edit")
+    @OperationLog(operation = "删除租户配额", target = "cw_tenant_quota")
+    @DeleteMapping("/quota")
+    public Result<Void> deleteQuota(@RequestParam String tenantId, @RequestParam String period) {
+        assertPlatformOperator();
+        quotaService.delete(tenantId, period);
+        return Result.success();
+    }
+
+    // ---------- 模型单价 ----------
+
+    @SaCheckPermission("billing:view")
+    @GetMapping("/price")
+    public Result<List<AiModelPrice>> listPrice() {
+        assertPlatformOperator();
+        return Result.success(priceService.list());
+    }
+
+    @SaCheckPermission("billing:price-edit")
+    @OperationLog(operation = "新增模型单价", target = "ai_model_price")
+    @PostMapping("/price")
+    public Result<Long> createPrice(@Valid @RequestBody AiModelPrice request) {
+        assertPlatformOperator();
+        return Result.success(priceService.create(request));
+    }
+
+    @SaCheckPermission("billing:price-edit")
+    @OperationLog(operation = "删除模型单价", target = "ai_model_price")
+    @DeleteMapping("/price/{id}")
+    public Result<Void> deletePrice(@PathVariable Long id) {
+        assertPlatformOperator();
+        priceService.delete(id);
+        return Result.success();
+    }
+
+    // ---------- 账单 ----------
+
+    /** 单租户账单：不传 tenantId 时取当前视角租户，租户管理员看到的恒是自己那份。 */
+    @SaCheckPermission("billing:view")
+    @GetMapping("/bill")
+    public Result<List<UsageAggregate>> tenantBill(
+        @RequestParam(required = false) String tenantId,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        // 指定别的租户属于跨租户读，必须是运营方
+        if (tenantId != null && !tenantId.isBlank() && !tenantId.equals(TenantSession.effectiveTenant())) {
+            assertPlatformOperator();
+        }
+        return Result.success(reportService.tenantBill(tenantId, from, to));
+    }
+
+    /** 全平台账单总览（运营方专属）。 */
+    @SaCheckPermission("billing:view")
+    @GetMapping("/overview")
+    public Result<List<UsageAggregate>> platformOverview(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        assertPlatformOperator();
+        return Result.success(reportService.platformOverview(from, to));
+    }
+
+    /**
+     * 手工触发用量归集（补数据用）。
+     *
+     * <p>归集可重复执行：同一天再跑一次就覆盖，因此补数据只要重跑对应日期。</p>
+     */
+    @SaCheckPermission("billing:export")
+    @OperationLog(operation = "手工归集用量", target = "cw_tenant_usage_daily")
+    @PostMapping("/aggregate")
+    public Result<Integer> aggregate(
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        assertPlatformOperator();
+        return Result.success(aggregationService.aggregate(date));
+    }
+
+    private void assertPlatformOperator() {
+        if (!TenantSession.isPlatformOperator()) {
+            throw new BizException(ResultCode.TENANT_VIEW_FORBIDDEN);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/dto/TenantQuotaSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/dto/TenantQuotaSaveRequest.java
@@ -1,0 +1,39 @@
+package com.richard.fyoung.customeradmin.billing.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 租户配额新增/编辑请求（按 tenantId + period 覆盖）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class TenantQuotaSaveRequest {
+
+    @NotBlank(message = "租户不能为空")
+    private String tenantId;
+
+    /** DAILY / MONTHLY。 */
+    @NotBlank(message = "周期不能为空")
+    private String period;
+
+    /** token 上限，0 = 不限。 */
+    @Min(value = 0, message = "token 上限不能为负")
+    private Long tokenLimit;
+
+    /** 金额上限（元），0 = 不限；实时链路只拦 token，金额走 T+1 账单告警。 */
+    private BigDecimal amountLimit;
+
+    /** BLOCK / DEGRADE / WARN。 */
+    private String exceedAction;
+
+    @Min(value = 0, message = "预警阈值不能为负")
+    @Max(value = 100, message = "预警阈值不能超过 100")
+    private Integer warnPercent;
+
+    private Boolean enabled;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/dto/TenantQuotaVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/dto/TenantQuotaVO.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customeradmin.billing.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 租户配额返回体。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class TenantQuotaVO {
+
+    private String tenantId;
+    private String period;
+    private Long tokenLimit;
+    private BigDecimal amountLimit;
+    private String exceedAction;
+    private Integer warnPercent;
+    private Boolean enabled;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/dto/UsageAggregate.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/dto/UsageAggregate.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customeradmin.billing.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 用量聚合结果：既承接"从调用日志汇总"，也承接"按区间汇总账单"。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class UsageAggregate {
+
+    private String tenantId;
+    private LocalDate statDate;
+    private String provider;
+    private String modelName;
+    private Long callCount;
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long cachedTokens;
+    private Long totalTokens;
+    /** 从调用日志汇总时为空（金额由归集服务按单价算出后回填）。 */
+    private BigDecimal amount;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/entity/AiModelPrice.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/entity/AiModelPrice.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customeradmin.billing.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 模型单价。
+ *
+ * <p>单价按「元/百万 token」存：各厂商官网报价本身就是这个口径，照抄不用换算；
+ * 若按「元/token」存，小数位多到 DECIMAL 精度与可读性都难兼顾。</p>
+ *
+ * <p><b>调价插新行而不是改旧行</b>：{@code effective_from} 让历史账单按当时的价格算得回去。
+ * 改旧行会让已出账的数字在下次查询时悄悄变掉。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_model_price")
+public class AiModelPrice {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String provider;
+    private String modelName;
+    /** 输入单价（元/百万 token）。 */
+    private BigDecimal inputPrice;
+    /** 输出单价（元/百万 token）。 */
+    private BigDecimal outputPrice;
+    /** 缓存命中输入单价（元/百万 token），各厂商折扣不同故单列而非按比例算。 */
+    private BigDecimal cachedPrice;
+    private String currency;
+    private LocalDateTime effectiveFrom;
+    private String remark;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private Long updateBy;
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    @TableLogic
+    private Integer deleted;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/entity/CwTenantUsageDaily.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/entity/CwTenantUsageDaily.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customeradmin.billing.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 租户日用量归集：账单与报表的数据源。
+ *
+ * <p>金额在归集时按当日单价算好落库，而不是查询时实时算——单价会变，
+ * 实时算会让历史账单随调价而变动，对不上已经出过的账。</p>
+ *
+ * <p>本表参与租户自动过滤：租户管理员看自己的用量，运营方跨租户查询走
+ * {@code CrossTenantOperations}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_tenant_usage_daily")
+public class CwTenantUsageDaily {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String tenantId;
+    private LocalDate statDate;
+    private String provider;
+    private String modelName;
+    private Long callCount;
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long cachedTokens;
+    private Long totalTokens;
+    private BigDecimal amount;
+    private String currency;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/jdbc/QuotaGateway.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/jdbc/QuotaGateway.java
@@ -1,0 +1,13 @@
+package com.richard.fyoung.customeradmin.billing.jdbc;
+
+import com.richard.fyoung.customerwork.quota.mapper.TenantQuotaMapper;
+
+/**
+ * 客服端库上的配额数据门面。
+ *
+ * <p>配额表落在客服端库（运行时要读它来拦模型调用），后台通过跨库门面维护——
+ * 与内容风控三表同一套路，见 {@code ContentGuardGateway}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record QuotaGateway(TenantQuotaMapper quotaMapper) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/mapper/AiModelPriceMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/mapper/AiModelPriceMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.billing.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.billing.entity.AiModelPrice;
+
+/**
+ * 模型单价 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiModelPriceMapper extends BaseMapper<AiModelPrice> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/mapper/CwTenantUsageDailyMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/mapper/CwTenantUsageDailyMapper.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customeradmin.billing.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.billing.dto.UsageAggregate;
+import com.richard.fyoung.customeradmin.billing.entity.CwTenantUsageDaily;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 租户日用量 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface CwTenantUsageDailyMapper extends BaseMapper<CwTenantUsageDaily> {
+
+    /**
+     * 从调用日志汇总某一天的用量（按租户 + 模型分组），供归集任务写入本表。
+     *
+     * <p>数据源是 {@code cw_agent_call_log}——那才是每次调用的原始记录，
+     * 本表只是它的按日汇总视图。</p>
+     */
+    List<UsageAggregate> aggregateFromCallLog(@Param("statDate") LocalDate statDate);
+
+    /** 按租户与日期区间汇总（账单报表用）。 */
+    List<UsageAggregate> sumByTenantAndRange(@Param("tenantId") String tenantId,
+                                             @Param("from") LocalDate from,
+                                             @Param("to") LocalDate to);
+
+    /** 跨租户汇总（运营方账单总览）。 */
+    List<UsageAggregate> sumGroupByTenant(@Param("from") LocalDate from, @Param("to") LocalDate to);
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/schedule/UsageAggregationDriver.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/schedule/UsageAggregationDriver.java
@@ -1,0 +1,80 @@
+package com.richard.fyoung.customeradmin.billing.schedule;
+
+import com.richard.fyoung.customeradmin.billing.service.UsageAggregationService;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 用量归集的周期驱动（自带守护线程）。
+ *
+ * <p><b>为什么不用 {@code @Scheduled}</b>：admin 至今没开 {@code @EnableScheduling}，
+ * 为一个归集任务打开全局调度会把容器里所有带 {@code @Scheduled} 的 Bean 一并激活，
+ * 影响面远大于收益——这个判断在 {@code SensitiveWordRefreshTask} 上已经下过一次，这里沿用。</p>
+ *
+ * <p><b>为什么是固定间隔而不是 cron</b>：归集幂等（同一天重跑就是覆盖），多跑几次只是多扫一遍日志，
+ * 不会算错数。用固定间隔就不必引入 cron 解析，也天然容忍实例重启——重启后下一轮照跑，
+ * 不会像"每天 02:00"那样错过就得等一整天。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class UsageAggregationDriver {
+
+    private static final Logger log = LoggerFactory.getLogger(UsageAggregationDriver.class);
+
+    private static final String THREAD_NAME = "admin-usage-aggregation";
+
+    /** 间隔下限：配置填得过小会把原始日志表反复全扫。 */
+    private static final long MIN_INTERVAL_MS = TimeUnit.MINUTES.toMillis(10);
+
+    private final UsageAggregationService aggregationService;
+    private final long intervalMs;
+    private final int backfillDays;
+    private final Thread worker;
+    private volatile boolean running = true;
+
+    public UsageAggregationDriver(UsageAggregationService aggregationService, long intervalMs, int backfillDays) {
+        this.aggregationService = aggregationService;
+        this.intervalMs = Math.max(MIN_INTERVAL_MS, intervalMs);
+        this.backfillDays = Math.max(1, backfillDays);
+        this.worker = new Thread(this::loop, THREAD_NAME);
+        this.worker.setDaemon(true);
+        this.worker.start();
+        log.info("usage aggregation driver started, intervalMs={}, backfillDays={}",
+            this.intervalMs, this.backfillDays);
+    }
+
+    private void loop() {
+        while (running) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(intervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            runOnce();
+        }
+    }
+
+    /** 归集 T-1 起的若干天：回溯是为了兜住任务失败或实例停机造成的空洞。 */
+    void runOnce() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        for (int i = 0; i < backfillDays; i++) {
+            LocalDate target = yesterday.minusDays(i);
+            try {
+                aggregationService.aggregate(target);
+            } catch (Exception e) {
+                // 单日失败不阻断其余日期：一天算不出来不该连带让整周的账都补不上
+                log.error("usage aggregation failed, code={}, date={}", "BILLING-AGGREGATE-FAIL", target, e);
+            }
+        }
+    }
+
+    public void stop() {
+        running = false;
+        worker.interrupt();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/BillingReportService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/BillingReportService.java
@@ -1,0 +1,54 @@
+package com.richard.fyoung.customeradmin.billing.service;
+
+import com.richard.fyoung.customeradmin.billing.dto.UsageAggregate;
+import com.richard.fyoung.customeradmin.billing.mapper.CwTenantUsageDailyMapper;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.tenant.CrossTenantOperations;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 账单报表：按租户 / 按区间聚合 token 与金额。
+ *
+ * <p>数据源是归集表 {@code cw_tenant_usage_daily}，不是原始调用日志——金额在归集时就按当日单价
+ * 算好落库了，查询时重算会让历史账单随调价而变动。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class BillingReportService {
+
+    private final CwTenantUsageDailyMapper usageMapper;
+
+    public BillingReportService(CwTenantUsageDailyMapper usageMapper) {
+        this.usageMapper = usageMapper;
+    }
+
+    /**
+     * 单租户账单明细（按模型分组）。
+     *
+     * <p>不传租户时取当前视角租户：运营方切到某租户就看那个租户的账，
+     * 租户管理员则恒等于自己——一套接口两种身份都成立。</p>
+     */
+    public List<UsageAggregate> tenantBill(String tenantId, LocalDate from, LocalDate to) {
+        String target = tenantId == null || tenantId.isBlank() ? TenantSession.effectiveTenant() : tenantId;
+        if (target == null) {
+            return List.of();
+        }
+        // 显式按 tenantId 查，跨租户豁免：运营方查别的租户时，当前上下文并不是目标租户
+        return CrossTenantOperations.execute(
+            () -> usageMapper.sumByTenantAndRange(target, from, to));
+    }
+
+    /**
+     * 全租户账单总览（运营方专属）。
+     *
+     * <p>调用方必须先校验运营方身份——这是跨租户读，一旦被租户管理员调到就是全体客户的消费明细泄露。</p>
+     */
+    public List<UsageAggregate> platformOverview(LocalDate from, LocalDate to) {
+        return CrossTenantOperations.execute(() -> usageMapper.sumGroupByTenant(from, to));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/ModelPriceAdminService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/ModelPriceAdminService.java
@@ -1,0 +1,54 @@
+package com.richard.fyoung.customeradmin.billing.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.billing.entity.AiModelPrice;
+import com.richard.fyoung.customeradmin.billing.mapper.AiModelPriceMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 模型单价维护。
+ *
+ * <p><b>只增不改</b>：调价插一条新的生效记录，旧记录留着让历史账单算得回去。
+ * 因此这里没有 update——真要改错录的价，删掉那条再插新的。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class ModelPriceAdminService {
+
+    private final AiModelPriceMapper priceMapper;
+
+    public ModelPriceAdminService(AiModelPriceMapper priceMapper) {
+        this.priceMapper = priceMapper;
+    }
+
+    public List<AiModelPrice> list() {
+        return priceMapper.selectList(new LambdaQueryWrapper<AiModelPrice>()
+            .orderByAsc(AiModelPrice::getProvider)
+            .orderByAsc(AiModelPrice::getModelName)
+            .orderByDesc(AiModelPrice::getEffectiveFrom));
+    }
+
+    public Long create(AiModelPrice request) {
+        request.setId(null);
+        if (request.getEffectiveFrom() == null) {
+            request.setEffectiveFrom(LocalDateTime.now());
+        }
+        if (request.getCurrency() == null || request.getCurrency().isBlank()) {
+            request.setCurrency("CNY");
+        }
+        priceMapper.insert(request);
+        log.info("model price created, provider={}, model={}, effectiveFrom={}",
+            request.getProvider(), request.getModelName(), request.getEffectiveFrom());
+        return request.getId();
+    }
+
+    public void delete(Long id) {
+        priceMapper.deleteById(id);
+        log.info("model price deleted, id={}", id);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/ModelPriceService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/ModelPriceService.java
@@ -1,0 +1,92 @@
+package com.richard.fyoung.customeradmin.billing.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.billing.entity.AiModelPrice;
+import com.richard.fyoung.customeradmin.billing.mapper.AiModelPriceMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * token → 金额换算。
+ *
+ * <p>取价规则：同一 {@code (provider, model)} 下取<b>生效时间不晚于结算时刻的最新一条</b>。
+ * 调价插新行而不改旧行，历史账单据此算得回去。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class ModelPriceService {
+
+    /** 单价按「元/百万 token」存，换算时除以这个基数。 */
+    private static final BigDecimal MILLION = new BigDecimal("1000000");
+
+    /** 金额保留 4 位小数：单次调用的费用常在厘以下，保留 2 位会把大量小额调用抹成 0。 */
+    private static final int AMOUNT_SCALE = 4;
+
+    private final AiModelPriceMapper priceMapper;
+
+    public ModelPriceService(AiModelPriceMapper priceMapper) {
+        this.priceMapper = priceMapper;
+    }
+
+    /**
+     * 按 token 用量算金额。
+     *
+     * <p>缓存命中的 token 是 {@code inputTokens} 的子集，按缓存价单独计，
+     * 剩下的部分才按输入价计——重复计一次会把账单虚高。</p>
+     *
+     * @return 金额（元）；查不到单价时返回 0 并打日志，不抛异常——
+     *         计费算不出来不该阻断归集任务，缺价这件事由日志和"金额为 0"的异常报表暴露
+     */
+    public BigDecimal calculate(String provider, String modelName,
+                                long inputTokens, long outputTokens, long cachedTokens,
+                                LocalDateTime settleAt) {
+        AiModelPrice price = findEffectivePrice(provider, modelName, settleAt);
+        if (price == null) {
+            log.error("model price not found, code={}, provider={}, model={}",
+                "BILLING-PRICE-MISSING", provider, modelName);
+            return BigDecimal.ZERO.setScale(AMOUNT_SCALE, RoundingMode.HALF_UP);
+        }
+        long cached = Math.max(0, Math.min(cachedTokens, inputTokens));
+        long uncachedInput = Math.max(0, inputTokens - cached);
+
+        BigDecimal amount = multiply(uncachedInput, price.getInputPrice())
+            .add(multiply(outputTokens, price.getOutputPrice()))
+            .add(multiply(cached, price.getCachedPrice()));
+        return amount.setScale(AMOUNT_SCALE, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 查生效单价：provider 为空时只按模型名匹配。
+     *
+     * <p>日志里没有 provider（{@code cw_agent_call_log} 只记 agent 信息），
+     * 归集时传空是常态，因此这里必须容忍。</p>
+     */
+    public AiModelPrice findEffectivePrice(String provider, String modelName, LocalDateTime settleAt) {
+        if (modelName == null || modelName.isBlank()) {
+            return null;
+        }
+        LambdaQueryWrapper<AiModelPrice> wrapper = new LambdaQueryWrapper<AiModelPrice>()
+            .eq(AiModelPrice::getModelName, modelName)
+            .le(AiModelPrice::getEffectiveFrom, settleAt == null ? LocalDateTime.now() : settleAt)
+            .orderByDesc(AiModelPrice::getEffectiveFrom);
+        if (provider != null && !provider.isBlank()) {
+            wrapper.eq(AiModelPrice::getProvider, provider);
+        }
+        List<AiModelPrice> candidates = priceMapper.selectList(wrapper);
+        return candidates.isEmpty() ? null : candidates.get(0);
+    }
+
+    private BigDecimal multiply(long tokens, BigDecimal pricePerMillion) {
+        if (tokens <= 0 || pricePerMillion == null) {
+            return BigDecimal.ZERO;
+        }
+        return pricePerMillion.multiply(BigDecimal.valueOf(tokens))
+            .divide(MILLION, AMOUNT_SCALE + 2, RoundingMode.HALF_UP);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/TenantQuotaService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/TenantQuotaService.java
@@ -1,0 +1,73 @@
+package com.richard.fyoung.customeradmin.billing.service;
+
+import com.richard.fyoung.customeradmin.billing.config.QuotaGatewayProvider;
+import com.richard.fyoung.customeradmin.billing.dto.TenantQuotaSaveRequest;
+import com.richard.fyoung.customeradmin.billing.dto.TenantQuotaVO;
+import com.richard.fyoung.customerwork.quota.MybatisTenantQuotaStore;
+import com.richard.fyoung.customerwork.quota.QuotaExceedAction;
+import com.richard.fyoung.customerwork.quota.QuotaPeriod;
+import com.richard.fyoung.customerwork.quota.TenantQuota;
+import com.richard.fyoung.customerwork.quota.TenantQuotaStore;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 后台的租户配额维护：直接读写客服端库的 {@code cw_tenant_quota}，客服端轮询/实时读取即生效。
+ *
+ * <p>复用 starter 的 {@link MybatisTenantQuotaStore} 而不是重写一套 CRUD——同一张表、同一套语义，
+ * 重写只会多出一份要同步维护的代码（照内容风控"写侧复用 starter Mapper"的先例）。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class TenantQuotaService {
+
+    private final QuotaGatewayProvider gatewayProvider;
+
+    public TenantQuotaService(QuotaGatewayProvider gatewayProvider) {
+        this.gatewayProvider = gatewayProvider;
+    }
+
+    /** 每次取新的 Store：门面本身是惰性缓存的，这里只是把它包成 Store 语义，无额外开销。 */
+    private TenantQuotaStore store() {
+        return new MybatisTenantQuotaStore(gatewayProvider.get().quotaMapper());
+    }
+
+    public List<TenantQuotaVO> listByTenant(String tenantId) {
+        return store().findByTenant(tenantId).stream().map(TenantQuotaService::toVO).toList();
+    }
+
+    public void save(TenantQuotaSaveRequest request) {
+        TenantQuota quota = new TenantQuota(
+            request.getTenantId(),
+            QuotaPeriod.parse(request.getPeriod()),
+            request.getTokenLimit() == null ? 0L : request.getTokenLimit(),
+            request.getAmountLimit() == null ? BigDecimal.ZERO : request.getAmountLimit(),
+            QuotaExceedAction.parse(request.getExceedAction()),
+            request.getWarnPercent() == null ? 80 : request.getWarnPercent(),
+            request.getEnabled() == null || request.getEnabled());
+        store().save(quota);
+        log.info("tenant quota saved, tenant={}, period={}, tokenLimit={}, action={}",
+            quota.tenantId(), quota.period(), quota.tokenLimit(), quota.exceedAction());
+    }
+
+    public void delete(String tenantId, String period) {
+        store().delete(tenantId, QuotaPeriod.parse(period));
+        log.info("tenant quota deleted, tenant={}, period={}", tenantId, period);
+    }
+
+    private static TenantQuotaVO toVO(TenantQuota quota) {
+        TenantQuotaVO vo = new TenantQuotaVO();
+        vo.setTenantId(quota.tenantId());
+        vo.setPeriod(quota.period().name());
+        vo.setTokenLimit(quota.tokenLimit());
+        vo.setAmountLimit(quota.amountLimit());
+        vo.setExceedAction(quota.exceedAction().name());
+        vo.setWarnPercent(quota.warnPercent());
+        vo.setEnabled(quota.enabled());
+        return vo;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/UsageAggregationService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/service/UsageAggregationService.java
@@ -1,0 +1,110 @@
+package com.richard.fyoung.customeradmin.billing.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.billing.dto.UsageAggregate;
+import com.richard.fyoung.customeradmin.billing.entity.CwTenantUsageDaily;
+import com.richard.fyoung.customeradmin.billing.mapper.CwTenantUsageDailyMapper;
+import com.richard.fyoung.customerwork.tenant.CrossTenantOperations;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 用量归集：把 {@code cw_agent_call_log} 的原始调用记录按「租户 + 日期 + 模型」汇总进
+ * {@code cw_tenant_usage_daily}，并按当日单价算好金额。
+ *
+ * <p><b>为什么要落一张汇总表而不是查询时实时聚合</b>：账单要能对得上——单价会调整，
+ * 实时聚合会让历史账单随调价而变动；且原始日志量级远大于汇总，按月出账时全表扫不可接受。</p>
+ *
+ * <p>归集可重复执行（同一天再跑一次就覆盖），因此补数据只要重跑对应日期即可。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class UsageAggregationService {
+
+    private final CwTenantUsageDailyMapper usageMapper;
+    private final ModelPriceService priceService;
+
+    public UsageAggregationService(CwTenantUsageDailyMapper usageMapper, ModelPriceService priceService) {
+        this.usageMapper = usageMapper;
+        this.priceService = priceService;
+    }
+
+    /**
+     * 归集指定日期的用量。
+     *
+     * <p>整段跑在跨租户豁免下：归集本身就是要覆盖所有租户，
+     * 若按当前上下文过滤，就只会汇总到某一个租户的数据。</p>
+     *
+     * @return 写入的记录数
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public int aggregate(LocalDate statDate) {
+        LocalDate target = statDate == null ? LocalDate.now().minusDays(1) : statDate;
+        List<UsageAggregate> rows = CrossTenantOperations.execute(
+            () -> usageMapper.aggregateFromCallLog(target));
+        if (rows.isEmpty()) {
+            log.info("usage aggregation found no data, date={}", target);
+            return 0;
+        }
+
+        // 按当日 23:59:59 取价：同一天内调价的情况按当日最终价结算，避免同一天出现两种价格
+        LocalDateTime settleAt = target.atTime(23, 59, 59);
+        int written = 0;
+        for (UsageAggregate row : rows) {
+            written += upsert(row, target, settleAt);
+        }
+        log.info("usage aggregation done, date={}, rows={}", target, written);
+        return written;
+    }
+
+    private int upsert(UsageAggregate row, LocalDate statDate, LocalDateTime settleAt) {
+        String tenantId = row.getTenantId() == null || row.getTenantId().isBlank()
+            ? TenantContext.DEFAULT : row.getTenantId();
+        String provider = row.getProvider() == null ? "" : row.getProvider();
+        String modelName = row.getModelName() == null ? "" : row.getModelName();
+
+        BigDecimal amount = priceService.calculate(provider, modelName,
+            nullToZero(row.getInputTokens()), nullToZero(row.getOutputTokens()),
+            nullToZero(row.getCachedTokens()), settleAt);
+
+        // 归集结果本身跨租户，写入时要切到对应租户的上下文，让拦截器补出正确的 tenant_id
+        return TenantContext.callWith(tenantId, () -> {
+            CwTenantUsageDaily existing = usageMapper.selectOne(new LambdaQueryWrapper<CwTenantUsageDaily>()
+                .eq(CwTenantUsageDaily::getStatDate, statDate)
+                .eq(CwTenantUsageDaily::getProvider, provider)
+                .eq(CwTenantUsageDaily::getModelName, modelName));
+
+            CwTenantUsageDaily entity = existing == null ? new CwTenantUsageDaily() : existing;
+            entity.setTenantId(tenantId);
+            entity.setStatDate(statDate);
+            entity.setProvider(provider);
+            entity.setModelName(modelName);
+            entity.setCallCount(nullToZero(row.getCallCount()));
+            entity.setInputTokens(nullToZero(row.getInputTokens()));
+            entity.setOutputTokens(nullToZero(row.getOutputTokens()));
+            entity.setCachedTokens(nullToZero(row.getCachedTokens()));
+            entity.setTotalTokens(nullToZero(row.getTotalTokens()));
+            entity.setAmount(amount);
+            entity.setCurrency("CNY");
+
+            if (existing == null) {
+                usageMapper.insert(entity);
+            } else {
+                usageMapper.updateById(entity);
+            }
+            return 1;
+        });
+    }
+
+    private long nullToZero(Long value) {
+        return value == null ? 0L : value;
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V50__tenant_quota_billing.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V50__tenant_quota_billing.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- B3 配额与计费：模型单价表 + 租户配额 + 用量归集
+--
+-- 成本治理此前只能回答"花了多少 token"，这批补上"谁花的、值多少钱、超了怎么办"。
+-- 本迁移建两张 admin 库的表：
+--   ai_model_price         单价（token → 金额的换算依据，按生效时间留历史）
+--   cw_tenant_usage_daily  日用量归集（账单与报表的数据源，由定时任务从调用日志汇总）
+--
+-- 配额表 cw_tenant_quota **不在这里**：它要被客服端运行时读取（拦在模型调用之前），
+-- 按内容风控三表的先例落在客服端库、由 starter 定义 Mapper，admin 复用同一套 Mapper 管理，
+-- 见 customer-work-schema.sql。跨库放两份或让客服端反查 admin 库都不如沿用既有模式。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_model_price` (
+    `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `provider`        VARCHAR(64) NOT NULL COMMENT '模型厂商，如 dashscope/openai',
+    `model_name`      VARCHAR(128) NOT NULL COMMENT '模型名，如 qwen-max',
+    -- 单价用「每百万 token」而非「每 token」：后者小数位太多，DECIMAL 精度与可读性都难兼顾，
+    -- 且各厂商官网报价本身就是按百万 token 计的，照抄不用换算，少一层出错机会
+    `input_price`     DECIMAL(16,6) NOT NULL DEFAULT 0 COMMENT '输入单价（元/百万 token）',
+    `output_price`    DECIMAL(16,6) NOT NULL DEFAULT 0 COMMENT '输出单价（元/百万 token）',
+    -- 命中缓存的输入 token 通常按折扣价计，单独一列而不是按比例算：折扣比例各厂商不同且会变
+    `cached_price`    DECIMAL(16,6) NOT NULL DEFAULT 0 COMMENT '缓存命中输入单价（元/百万 token）',
+    `currency`        VARCHAR(8) NOT NULL DEFAULT 'CNY' COMMENT '币种',
+    `effective_from`  DATETIME NOT NULL COMMENT '生效时间；调价不改旧行而是插新行，历史账单才算得回去',
+    `remark`          VARCHAR(255) COMMENT '备注',
+    `create_by`       BIGINT COMMENT '创建人ID',
+    `create_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`       BIGINT COMMENT '更新人ID',
+    `update_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`         TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    KEY `idx_model_price_lookup` (`provider`, `model_name`, `effective_from`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型单价（按生效时间留历史，供账单回溯）';
+
+-- 单价是平台统一定义的（租户不该也不能自己定价），故不带 tenant_id，进拦截器忽略清单
+
+CREATE TABLE IF NOT EXISTS `cw_tenant_usage_daily` (
+    `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `tenant_id`       VARCHAR(64) NOT NULL COMMENT '租户ID',
+    `stat_date`       DATE NOT NULL COMMENT '统计日期（自然日）',
+    `provider`        VARCHAR(64) NOT NULL DEFAULT '' COMMENT '模型厂商',
+    `model_name`      VARCHAR(128) NOT NULL DEFAULT '' COMMENT '模型名',
+    `call_count`      BIGINT NOT NULL DEFAULT 0 COMMENT '调用次数',
+    `input_tokens`    BIGINT NOT NULL DEFAULT 0 COMMENT '输入 token',
+    `output_tokens`   BIGINT NOT NULL DEFAULT 0 COMMENT '输出 token',
+    `cached_tokens`   BIGINT NOT NULL DEFAULT 0 COMMENT '缓存命中输入 token（input 的子集）',
+    `total_tokens`    BIGINT NOT NULL DEFAULT 0 COMMENT '总 token',
+    -- 金额在归集时按当日单价算好落库，而不是查询时实时算：
+    -- 单价会变，实时算会让历史账单随调价而变动，对不上已出账的数
+    `amount`          DECIMAL(16,4) NOT NULL DEFAULT 0 COMMENT '金额（元，按归集时点的单价结算）',
+    `currency`        VARCHAR(8) NOT NULL DEFAULT 'CNY' COMMENT '币种',
+    `create_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    UNIQUE KEY `uk_tenant_usage_daily` (`tenant_id`, `stat_date`, `provider`, `model_name`),
+    KEY `idx_usage_daily_date` (`stat_date`),
+    KEY `idx_usage_daily_tenant` (`tenant_id`, `stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户日用量归集（账单与报表数据源）';
+
+-- ============================================================================
+-- 配额与计费菜单权限点（id 从 224 起，223 是 V49 租户管理占用的最后一个）
+--
+-- 与 tenant: 前缀同理走 billing: 前缀：TenantProvisionService 排除的是 tenant:，
+-- 计费同属平台专属，这里显式列出以便将来一并纳入排除规则。
+-- ============================================================================
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (224, 1, '配额与计费', 'billing:view', 1, '/system/billing', 'Wallet', 'library', 10);
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (225, 224, '编辑配额', 'billing:quota-edit', 2, 1),
+    (226, 224, '编辑单价', 'billing:price-edit', 2, 2),
+    (227, 224, '导出账单', 'billing:export', 2, 3);
+
+-- 演示单价种子：与项目默认模型对齐（数值为示意，上线前按厂商实际报价维护）
+INSERT INTO `ai_model_price` (`provider`, `model_name`, `input_price`, `output_price`, `cached_price`, `currency`, `effective_from`, `remark`)
+SELECT 'dashscope', 'qwen-max', 2.400000, 9.600000, 0.480000, 'CNY', '2026-01-01 00:00:00', '示意价格，上线前按厂商实际报价维护'
+WHERE NOT EXISTS (SELECT 1 FROM `ai_model_price` WHERE `provider` = 'dashscope' AND `model_name` = 'qwen-max');

--- a/customer-admin-server/src/main/resources/mapper/CwTenantUsageDailyMapper.xml
+++ b/customer-admin-server/src/main/resources/mapper/CwTenantUsageDailyMapper.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!--
+  租户用量归集与账单聚合。
+
+  模型名取自 cw_agent_call_segment.name（kind='MODEL' 的分段名就是模型名）——
+  cw_agent_call_log 本身只记 agent_code/agent_name，不含模型信息，token 也是分段级更准。
+  provider 日志里没有，归集时留空，单价按 model_name 匹配。
+
+  注意：这几条 SQL 都会被租户拦截器改写。归集任务与运营方总览是刻意跨租户的，
+  调用方必须包 CrossTenantOperations，否则只会汇总到当前上下文那一个租户。
+-->
+<mapper namespace="com.richard.fyoung.customeradmin.billing.mapper.CwTenantUsageDailyMapper">
+
+    <select id="aggregateFromCallLog" resultType="com.richard.fyoung.customeradmin.billing.dto.UsageAggregate">
+        SELECT
+            l.tenant_id                              AS tenantId,
+            s.name                                   AS modelName,
+            COUNT(DISTINCT l.id)                     AS callCount,
+            COALESCE(SUM(s.input_tokens), 0)         AS inputTokens,
+            COALESCE(SUM(s.output_tokens), 0)        AS outputTokens,
+            COALESCE(SUM(s.cached_tokens), 0)        AS cachedTokens,
+            COALESCE(SUM(s.input_tokens), 0) + COALESCE(SUM(s.output_tokens), 0) AS totalTokens
+        FROM cw_agent_call_log l
+        INNER JOIN cw_agent_call_segment s ON s.call_log_id = l.id AND s.kind = 'MODEL'
+        WHERE l.created_at &gt;= #{statDate}
+          AND l.created_at &lt; DATE_ADD(#{statDate}, INTERVAL 1 DAY)
+        GROUP BY l.tenant_id, s.name
+    </select>
+
+    <select id="sumByTenantAndRange" resultType="com.richard.fyoung.customeradmin.billing.dto.UsageAggregate">
+        SELECT
+            tenant_id                 AS tenantId,
+            provider                  AS provider,
+            model_name                AS modelName,
+            COALESCE(SUM(call_count), 0)    AS callCount,
+            COALESCE(SUM(input_tokens), 0)  AS inputTokens,
+            COALESCE(SUM(output_tokens), 0) AS outputTokens,
+            COALESCE(SUM(cached_tokens), 0) AS cachedTokens,
+            COALESCE(SUM(total_tokens), 0)  AS totalTokens,
+            COALESCE(SUM(amount), 0)        AS amount
+        FROM cw_tenant_usage_daily
+        WHERE tenant_id = #{tenantId}
+          AND stat_date BETWEEN #{from} AND #{to}
+        GROUP BY tenant_id, provider, model_name
+        ORDER BY amount DESC
+    </select>
+
+    <select id="sumGroupByTenant" resultType="com.richard.fyoung.customeradmin.billing.dto.UsageAggregate">
+        SELECT
+            tenant_id                 AS tenantId,
+            COALESCE(SUM(call_count), 0)    AS callCount,
+            COALESCE(SUM(input_tokens), 0)  AS inputTokens,
+            COALESCE(SUM(output_tokens), 0) AS outputTokens,
+            COALESCE(SUM(cached_tokens), 0) AS cachedTokens,
+            COALESCE(SUM(total_tokens), 0)  AS totalTokens,
+            COALESCE(SUM(amount), 0)        AS amount
+        FROM cw_tenant_usage_daily
+        WHERE stat_date BETWEEN #{from} AND #{to}
+        GROUP BY tenant_id
+        ORDER BY amount DESC
+    </select>
+
+</mapper>

--- a/customer-admin-web/src/api/billing.ts
+++ b/customer-admin-web/src/api/billing.ts
@@ -1,0 +1,86 @@
+import { request } from './request'
+
+// 配额与计费 API，与 admin-server /api/billing/** 契约对应。
+// 配额落在客服端库（运行时要读它拦模型调用），单价与用量归集在 admin 库。
+
+export interface TenantQuotaVO {
+  tenantId: string
+  period: string
+  tokenLimit: number
+  amountLimit: number
+  exceedAction: string
+  warnPercent: number
+  enabled: boolean
+}
+
+export interface TenantQuotaSaveRequest {
+  tenantId: string
+  period: string
+  tokenLimit?: number
+  amountLimit?: number
+  exceedAction?: string
+  warnPercent?: number
+  enabled?: boolean
+}
+
+export interface ModelPriceVO {
+  id: number
+  provider: string
+  modelName: string
+  /** 单价口径是「元/百万 token」，与各厂商官网报价一致。 */
+  inputPrice: number
+  outputPrice: number
+  cachedPrice: number
+  currency: string
+  effectiveFrom: string
+  remark: string | null
+}
+
+export interface UsageAggregate {
+  tenantId: string
+  provider: string | null
+  modelName: string | null
+  callCount: number
+  inputTokens: number
+  outputTokens: number
+  cachedTokens: number
+  totalTokens: number
+  amount: number
+}
+
+export function listQuota(tenantId: string) {
+  return request<TenantQuotaVO[]>({ url: '/billing/quota', method: 'get', params: { tenantId } })
+}
+
+export function saveQuota(data: TenantQuotaSaveRequest) {
+  return request<void>({ url: '/billing/quota', method: 'post', data })
+}
+
+export function deleteQuota(tenantId: string, period: string) {
+  return request<void>({ url: '/billing/quota', method: 'delete', params: { tenantId, period } })
+}
+
+export function listPrice() {
+  return request<ModelPriceVO[]>({ url: '/billing/price', method: 'get' })
+}
+
+export function createPrice(data: Partial<ModelPriceVO>) {
+  return request<number>({ url: '/billing/price', method: 'post', data })
+}
+
+export function deletePrice(id: number) {
+  return request<void>({ url: `/billing/price/${id}`, method: 'delete' })
+}
+
+export function fetchTenantBill(params: { tenantId?: string; from: string; to: string }) {
+  return request<UsageAggregate[]>({ url: '/billing/bill', method: 'get', params })
+}
+
+export function fetchPlatformOverview(params: { from: string; to: string }) {
+  return request<UsageAggregate[]>({ url: '/billing/overview', method: 'get', params })
+}
+
+/** 手工触发归集（补数据用，幂等：同一天重跑就是覆盖）。 */
+export function triggerAggregate(date?: string) {
+  return request<number>({ url: '/billing/aggregate', method: 'post', params: { date } })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -16,6 +16,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/login-image': () => import('@/views/system/LoginImageManage.vue'),
   '/system/dict': () => import('@/views/system/DictManage.vue'),
   '/system/tenant': () => import('@/views/system/TenantManage.vue'),
+  '/system/billing': () => import('@/views/system/BillingManage.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),

--- a/customer-admin-web/src/views/system/BillingManage.vue
+++ b/customer-admin-web/src/views/system/BillingManage.vue
@@ -1,0 +1,463 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import {
+  createPrice,
+  deletePrice,
+  deleteQuota,
+  fetchPlatformOverview,
+  fetchTenantBill,
+  listPrice,
+  listQuota,
+  saveQuota,
+  triggerAggregate,
+  type ModelPriceVO,
+  type TenantQuotaSaveRequest,
+  type TenantQuotaVO,
+  type UsageAggregate,
+} from '@/api/billing'
+import { listTenantOptions, type TenantVO } from '@/api/tenant'
+
+// 配额与计费：平台运营方专属。三块内容各自独立，用 tab 分开而不是堆在一页——
+// 配额是"管上限"、单价是"管口径"、账单是"看结果"，同时看的场景很少。
+
+const PERIOD_LABELS: Record<string, string> = { DAILY: '按日', MONTHLY: '按月' }
+const ACTION_LABELS: Record<string, string> = {
+  BLOCK: '拦截',
+  DEGRADE: '降级备用模型',
+  WARN: '仅告警',
+}
+
+const activeTab = ref('quota')
+const tenants = ref<TenantVO[]>([])
+
+async function loadTenants() {
+  tenants.value = await listTenantOptions()
+}
+
+// ---------- 配额 ----------
+
+const quotaTenant = ref('')
+const quotaLoading = ref(false)
+const quotas = ref<TenantQuotaVO[]>([])
+
+async function loadQuota() {
+  if (!quotaTenant.value) return
+  quotaLoading.value = true
+  try {
+    quotas.value = await listQuota(quotaTenant.value)
+  } finally {
+    quotaLoading.value = false
+  }
+}
+
+const quotaDialogVisible = ref(false)
+const quotaForm = reactive<TenantQuotaSaveRequest>({
+  tenantId: '',
+  period: 'MONTHLY',
+  tokenLimit: 0,
+  amountLimit: 0,
+  exceedAction: 'BLOCK',
+  warnPercent: 80,
+  enabled: true,
+})
+
+function openQuotaDialog(row?: TenantQuotaVO) {
+  Object.assign(quotaForm, row ?? {
+    tenantId: quotaTenant.value,
+    period: 'MONTHLY',
+    tokenLimit: 0,
+    amountLimit: 0,
+    exceedAction: 'BLOCK',
+    warnPercent: 80,
+    enabled: true,
+  })
+  quotaForm.tenantId = row?.tenantId ?? quotaTenant.value
+  quotaDialogVisible.value = true
+}
+
+async function submitQuota() {
+  if (!quotaForm.tenantId) {
+    ElMessage.warning('请先选择租户')
+    return
+  }
+  await saveQuota(quotaForm)
+  ElMessage.success('配额已保存')
+  quotaDialogVisible.value = false
+  await loadQuota()
+}
+
+async function removeQuota(row: TenantQuotaVO) {
+  await ElMessageBox.confirm(
+    `确认删除租户「${row.tenantId}」的${PERIOD_LABELS[row.period] ?? row.period}配额？删除后该周期不再限额。`,
+    '删除确认',
+    { type: 'warning' },
+  )
+  await deleteQuota(row.tenantId, row.period)
+  ElMessage.success('配额已删除')
+  await loadQuota()
+}
+
+// ---------- 单价 ----------
+
+const priceLoading = ref(false)
+const prices = ref<ModelPriceVO[]>([])
+
+async function loadPrice() {
+  priceLoading.value = true
+  try {
+    prices.value = await listPrice()
+  } finally {
+    priceLoading.value = false
+  }
+}
+
+const priceDialogVisible = ref(false)
+const priceForm = reactive<Partial<ModelPriceVO>>({
+  provider: 'dashscope',
+  modelName: '',
+  inputPrice: 0,
+  outputPrice: 0,
+  cachedPrice: 0,
+  currency: 'CNY',
+  effectiveFrom: '',
+  remark: '',
+})
+
+function openPriceDialog() {
+  Object.assign(priceForm, {
+    provider: 'dashscope',
+    modelName: '',
+    inputPrice: 0,
+    outputPrice: 0,
+    cachedPrice: 0,
+    currency: 'CNY',
+    effectiveFrom: '',
+    remark: '',
+  })
+  priceDialogVisible.value = true
+}
+
+async function submitPrice() {
+  if (!priceForm.modelName) {
+    ElMessage.warning('请填写模型名')
+    return
+  }
+  await createPrice(priceForm)
+  ElMessage.success('单价已新增')
+  priceDialogVisible.value = false
+  await loadPrice()
+}
+
+async function removePrice(row: ModelPriceVO) {
+  await ElMessageBox.confirm(
+    `确认删除 ${row.provider}/${row.modelName} 自 ${row.effectiveFrom} 起的单价？` +
+      '历史账单已按当时价格结算落库，删除不影响已出的账。',
+    '删除确认',
+    { type: 'warning' },
+  )
+  await deletePrice(row.id)
+  ElMessage.success('单价已删除')
+  await loadPrice()
+}
+
+// ---------- 账单 ----------
+
+const billLoading = ref(false)
+const billRange = ref<[string, string]>(['', ''])
+const billTenant = ref('')
+const billRows = ref<UsageAggregate[]>([])
+const overviewRows = ref<UsageAggregate[]>([])
+
+function defaultRange(): [string, string] {
+  const now = new Date()
+  const first = new Date(now.getFullYear(), now.getMonth(), 1)
+  const fmt = (d: Date) => d.toISOString().slice(0, 10)
+  return [fmt(first), fmt(now)]
+}
+
+async function loadBill() {
+  const [from, to] = billRange.value
+  if (!from || !to) {
+    ElMessage.warning('请选择日期区间')
+    return
+  }
+  billLoading.value = true
+  try {
+    if (billTenant.value) {
+      billRows.value = await fetchTenantBill({ tenantId: billTenant.value, from, to })
+      overviewRows.value = []
+    } else {
+      overviewRows.value = await fetchPlatformOverview({ from, to })
+      billRows.value = []
+    }
+  } finally {
+    billLoading.value = false
+  }
+}
+
+async function handleAggregate() {
+  await ElMessageBox.confirm(
+    '将重新归集最近的用量数据（幂等，重复执行只是覆盖）。用于补数据或验证配置。',
+    '手工归集',
+    { type: 'info' },
+  )
+  const count = await triggerAggregate()
+  ElMessage.success(`归集完成，写入 ${count} 条`)
+  await loadBill()
+}
+
+onMounted(async () => {
+  billRange.value = defaultRange()
+  await loadTenants()
+  await Promise.all([loadPrice(), loadBill()])
+})
+</script>
+
+<template>
+  <div class="page">
+    <el-card>
+      <el-tabs v-model="activeTab">
+        <!-- 配额 -->
+        <el-tab-pane label="租户配额" name="quota">
+          <div class="toolbar">
+            <el-select
+              v-model="quotaTenant"
+              placeholder="选择租户"
+              style="width: 260px"
+              filterable
+              @change="loadQuota"
+            >
+              <el-option
+                v-for="t in tenants"
+                :key="t.tenantCode"
+                :label="`${t.tenantName}（${t.tenantCode}）`"
+                :value="t.tenantCode"
+              />
+            </el-select>
+            <el-button
+              v-permission="'billing:quota-edit'"
+              type="primary"
+              :disabled="!quotaTenant"
+              @click="openQuotaDialog()"
+            >
+              新增配额
+            </el-button>
+          </div>
+
+          <el-table v-loading="quotaLoading" :data="quotas" style="width: 100%">
+            <el-table-column label="周期" width="100">
+              <template #default="{ row }">{{ PERIOD_LABELS[row.period] ?? row.period }}</template>
+            </el-table-column>
+            <el-table-column label="token 上限" width="160">
+              <template #default="{ row }">
+                {{ row.tokenLimit > 0 ? row.tokenLimit.toLocaleString() : '不限' }}
+              </template>
+            </el-table-column>
+            <el-table-column label="金额上限（元）" width="150">
+              <template #default="{ row }">
+                {{ row.amountLimit > 0 ? row.amountLimit : '不限' }}
+              </template>
+            </el-table-column>
+            <el-table-column label="超额处置" width="150">
+              <template #default="{ row }">
+                <el-tag :type="row.exceedAction === 'BLOCK' ? 'danger' : 'warning'">
+                  {{ ACTION_LABELS[row.exceedAction] ?? row.exceedAction }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="warnPercent" label="预警阈值(%)" width="120" />
+            <el-table-column label="状态" width="90">
+              <template #default="{ row }">
+                <el-tag :type="row.enabled ? 'success' : 'info'">{{ row.enabled ? '启用' : '停用' }}</el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="操作" width="150" fixed="right">
+              <template #default="{ row }">
+                <el-button v-permission="'billing:quota-edit'" link type="primary" @click="openQuotaDialog(row)">
+                  编辑
+                </el-button>
+                <el-button v-permission="'billing:quota-edit'" link type="danger" @click="removeQuota(row)">
+                  删除
+                </el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+          <div class="tip">
+            实时链路只按 token 拦截；金额上限走 T+1 账单预警——实时算金额需要客服端持有单价表，
+            跨库依赖不值当，而 token 本就是成本的直接驱动。
+          </div>
+        </el-tab-pane>
+
+        <!-- 单价 -->
+        <el-tab-pane label="模型单价" name="price">
+          <div class="toolbar">
+            <el-button v-permission="'billing:price-edit'" type="primary" @click="openPriceDialog">
+              新增单价
+            </el-button>
+            <span class="tip">调价请新增一条生效记录，不要改旧记录——历史账单要按当时的价格算得回去。</span>
+          </div>
+
+          <el-table v-loading="priceLoading" :data="prices" style="width: 100%">
+            <el-table-column prop="provider" label="厂商" width="130" />
+            <el-table-column prop="modelName" label="模型" width="180" />
+            <el-table-column prop="inputPrice" label="输入价（元/百万token）" width="190" />
+            <el-table-column prop="outputPrice" label="输出价（元/百万token）" width="190" />
+            <el-table-column prop="cachedPrice" label="缓存价（元/百万token）" width="190" />
+            <el-table-column prop="effectiveFrom" label="生效时间" width="180" />
+            <el-table-column prop="remark" label="备注" show-overflow-tooltip />
+            <el-table-column label="操作" width="90" fixed="right">
+              <template #default="{ row }">
+                <el-button v-permission="'billing:price-edit'" link type="danger" @click="removePrice(row)">
+                  删除
+                </el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-tab-pane>
+
+        <!-- 账单 -->
+        <el-tab-pane label="账单报表" name="bill">
+          <div class="toolbar">
+            <el-date-picker
+              v-model="billRange"
+              type="daterange"
+              value-format="YYYY-MM-DD"
+              start-placeholder="开始日期"
+              end-placeholder="结束日期"
+              style="width: 260px"
+            />
+            <el-select v-model="billTenant" placeholder="全部租户（总览）" style="width: 260px" clearable filterable>
+              <el-option
+                v-for="t in tenants"
+                :key="t.tenantCode"
+                :label="`${t.tenantName}（${t.tenantCode}）`"
+                :value="t.tenantCode"
+              />
+            </el-select>
+            <el-button type="primary" @click="loadBill">查询</el-button>
+            <el-button v-permission="'billing:export'" @click="handleAggregate">手工归集</el-button>
+          </div>
+
+          <!-- 选了租户看按模型明细，没选看按租户总览 -->
+          <el-table v-if="billTenant" v-loading="billLoading" :data="billRows" style="width: 100%">
+            <el-table-column prop="modelName" label="模型" width="200" />
+            <el-table-column prop="callCount" label="调用次数" width="120" />
+            <el-table-column prop="inputTokens" label="输入 token" width="140" />
+            <el-table-column prop="outputTokens" label="输出 token" width="140" />
+            <el-table-column prop="cachedTokens" label="缓存 token" width="140" />
+            <el-table-column prop="totalTokens" label="总 token" width="140" />
+            <el-table-column prop="amount" label="金额（元）" width="140" />
+          </el-table>
+
+          <el-table v-else v-loading="billLoading" :data="overviewRows" style="width: 100%">
+            <el-table-column prop="tenantId" label="租户" width="200" />
+            <el-table-column prop="callCount" label="调用次数" width="120" />
+            <el-table-column prop="totalTokens" label="总 token" width="160" />
+            <el-table-column prop="amount" label="金额（元）" width="160" />
+          </el-table>
+
+          <div class="tip">
+            账单来自日归集表，默认 T+1；金额按归集当时的单价结算落库，之后调价不会改动已出的账。
+          </div>
+        </el-tab-pane>
+      </el-tabs>
+    </el-card>
+
+    <el-dialog v-model="quotaDialogVisible" title="租户配额" width="520px">
+      <el-form :model="quotaForm" label-width="130px">
+        <el-form-item label="租户">
+          <el-input v-model="quotaForm.tenantId" disabled />
+        </el-form-item>
+        <el-form-item label="周期">
+          <el-select v-model="quotaForm.period" style="width: 100%">
+            <el-option label="按日" value="DAILY" />
+            <el-option label="按月" value="MONTHLY" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="token 上限">
+          <el-input-number v-model="quotaForm.tokenLimit!" :min="0" :step="10000" style="width: 100%" />
+          <div class="form-tip">0 表示不限</div>
+        </el-form-item>
+        <el-form-item label="金额上限（元）">
+          <el-input-number v-model="quotaForm.amountLimit!" :min="0" :precision="2" style="width: 100%" />
+          <div class="form-tip">0 表示不限；金额维度走 T+1 账单预警，不参与实时拦截</div>
+        </el-form-item>
+        <el-form-item label="超额处置">
+          <el-select v-model="quotaForm.exceedAction" style="width: 100%">
+            <el-option label="拦截（拒绝后续调用）" value="BLOCK" />
+            <el-option label="降级到备用模型" value="DEGRADE" />
+            <el-option label="仅告警" value="WARN" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="预警阈值(%)">
+          <el-input-number v-model="quotaForm.warnPercent!" :min="0" :max="100" style="width: 100%" />
+        </el-form-item>
+        <el-form-item label="启用">
+          <el-switch v-model="quotaForm.enabled!" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="quotaDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submitQuota">确定</el-button>
+      </template>
+    </el-dialog>
+
+    <el-dialog v-model="priceDialogVisible" title="新增模型单价" width="520px">
+      <el-form :model="priceForm" label-width="150px">
+        <el-form-item label="厂商">
+          <el-input v-model="priceForm.provider!" placeholder="如 dashscope" />
+        </el-form-item>
+        <el-form-item label="模型名">
+          <el-input v-model="priceForm.modelName!" placeholder="如 qwen-max" />
+        </el-form-item>
+        <el-form-item label="输入价（元/百万）">
+          <el-input-number v-model="priceForm.inputPrice!" :min="0" :precision="6" style="width: 100%" />
+        </el-form-item>
+        <el-form-item label="输出价（元/百万）">
+          <el-input-number v-model="priceForm.outputPrice!" :min="0" :precision="6" style="width: 100%" />
+        </el-form-item>
+        <el-form-item label="缓存价（元/百万）">
+          <el-input-number v-model="priceForm.cachedPrice!" :min="0" :precision="6" style="width: 100%" />
+        </el-form-item>
+        <el-form-item label="生效时间">
+          <el-date-picker
+            v-model="priceForm.effectiveFrom!"
+            type="datetime"
+            value-format="YYYY-MM-DDTHH:mm:ss"
+            placeholder="留空表示立即生效"
+            style="width: 100%"
+          />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="priceForm.remark!" type="textarea" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="priceDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submitPrice">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.tip {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.7;
+}
+
+.form-tip {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/calllog/AgentCallTimingMiddleware.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.calllog;
 
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.observability.MdcContextLifter;
+import com.richard.fyoung.customerwork.quota.TenantQuotaGuard;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
@@ -21,6 +22,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
@@ -71,14 +73,33 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
     /** 可为 null：未接入 Micrometer 时降级为只落库、不出指标（与 ObservabilityMiddleware 同款可选注入）。 */
     private final MeterRegistry meterRegistry;
 
+    /** 可为 null：配额未装配时不记账（配额默认关闭）。 */
+    private final TenantQuotaGuard quotaGuard;
+
     public AgentCallTimingMiddleware(CustomerWorkProperties properties,
                                      ToolKindRegistry toolKindRegistry,
                                      AgentCallRecordSink sink,
                                      ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this(properties, toolKindRegistry, sink, meterRegistryProvider, null);
+    }
+
+    /**
+     * Spring 注入构造。
+     *
+     * <p><b>必须标 {@code @Autowired}</b>：本类有多个构造器，不指明的话 Spring 会去找无参构造并因此启动失败。
+     * 这个坑在本项目已经踩过一轮（PR #68 一次修了 5 处），加构造器时务必同步标注。</p>
+     */
+    @Autowired
+    public AgentCallTimingMiddleware(CustomerWorkProperties properties,
+                                     ToolKindRegistry toolKindRegistry,
+                                     AgentCallRecordSink sink,
+                                     ObjectProvider<MeterRegistry> meterRegistryProvider,
+                                     ObjectProvider<TenantQuotaGuard> quotaGuardProvider) {
         this.enabled = properties.getCallLog().isEnabled();
         this.toolKindRegistry = toolKindRegistry;
         this.sink = sink;
         this.meterRegistry = meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable();
+        this.quotaGuard = quotaGuardProvider == null ? null : quotaGuardProvider.getIfAvailable();
     }
 
     @Override
@@ -253,9 +274,32 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
             // 分段结算是 token 的唯一落点（三态终止各只走一次，CAS 保证不重复），指标在此同步累加，
             // 与落库口径天然一致；工具段 usage 恒为 null，不产生指标
             recordTokens(inputTokens, outputTokens);
+            // 配额记账搭同一趟车：token 的落点只此一处，记在别处迟早与落库口径漂移
+            recordQuotaUsage(inputTokens, outputTokens);
         } catch (Exception e) {
             log.error("agent call segment collect failed, code={}, kind={}, name={}",
                 "CALLLOG-SEGMENT-FAIL", kind, name, e);
+        }
+    }
+
+    /**
+     * 把本段 token 计入当前租户的配额用量。
+     *
+     * <p>配额未装配或未开启时是空操作。异常吞掉不上抛：记账失败不该让一次成功的对话变成失败——
+     * 少记一段的代价远小于误伤用户请求，且超限判定下一次调用就会补上。</p>
+     */
+    private void recordQuotaUsage(Long inputTokens, Long outputTokens) {
+        if (quotaGuard == null) {
+            return;
+        }
+        long total = (inputTokens == null ? 0L : inputTokens) + (outputTokens == null ? 0L : outputTokens);
+        if (total <= 0) {
+            return;
+        }
+        try {
+            quotaGuard.record(null, total);
+        } catch (Exception e) {
+            log.error("quota usage record failed, code={}", "QUOTA-RECORD-FAIL", e);
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -143,6 +143,25 @@ public class CustomerWorkProperties {
     /** 水平扩展：把进程内的计数与串行锁换成跨实例共享实现。 */
     private final Distributed distributed = new Distributed();
 
+    /** 租户 token 配额（成本治理的硬上限）。 */
+    private final Quota quota = new Quota();
+
+    /**
+     * 租户配额配置。默认关闭——没配配额时行为与引入配额之前完全一致。
+     *
+     * <p>只判 token 不判金额：金额需要单价表（在 admin 库），让客服端跨库反查只为算一个
+     * 实时金额并不划算；token 本就是成本的直接驱动。金额维度走 T+1 账单与预警。</p>
+     */
+    @Data
+    public static class Quota {
+
+        /** 是否开启配额判定。关闭时 Guard 一律放行，也不记账。 */
+        private boolean enabled = false;
+
+        /** 配额存储：{@code memory} 进程内 / {@code jdbc} 落 {@code cw_tenant_quota}。 */
+        private String storeMode = "memory";
+    }
+
     /**
      * 水平扩展配置。默认全 memory——单实例部署下进程内实现更快也更简单，
      * 多副本部署才需要切 redis，否则限流与成本配额会被放大成实例数倍。

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/InMemoryTenantQuotaStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/InMemoryTenantQuotaStore.java
@@ -1,0 +1,44 @@
+package com.richard.fyoung.customerwork.quota;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 进程内配额存储（默认实现，单测与未接库时用）。
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemoryTenantQuotaStore implements TenantQuotaStore {
+
+    private final Map<String, TenantQuota> quotas = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<TenantQuota> find(String tenantId, QuotaPeriod period) {
+        return Optional.ofNullable(quotas.get(key(tenantId, period)));
+    }
+
+    @Override
+    public List<TenantQuota> findByTenant(String tenantId) {
+        List<TenantQuota> result = new ArrayList<>();
+        for (QuotaPeriod period : QuotaPeriod.values()) {
+            find(tenantId, period).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    @Override
+    public void save(TenantQuota quota) {
+        quotas.put(key(quota.tenantId(), quota.period()), quota);
+    }
+
+    @Override
+    public void delete(String tenantId, QuotaPeriod period) {
+        quotas.remove(key(tenantId, period));
+    }
+
+    private String key(String tenantId, QuotaPeriod period) {
+        return tenantId + ":" + period.name();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/MybatisTenantQuotaStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/MybatisTenantQuotaStore.java
@@ -1,0 +1,88 @@
+package com.richard.fyoung.customerwork.quota;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customerwork.quota.entity.TenantQuotaDO;
+import com.richard.fyoung.customerwork.quota.mapper.TenantQuotaMapper;
+import com.richard.fyoung.customerwork.tenant.CrossTenantOperations;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 配额的 MyBatis-Plus 实现。
+ *
+ * <p>查询走 {@link CrossTenantOperations}：配额判定发生在请求链路上，那时上下文里的租户
+ * 正是要判定的对象，本该能自动过滤到。但配额也会被<b>运营方跨租户读写</b>（后台配额度、
+ * 定时任务批量核对），两种调用方都用同一个 Store，让 Store 自己按显式 tenantId 取数
+ * 比让调用方各自记得切上下文更不容易出错。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisTenantQuotaStore implements TenantQuotaStore {
+
+    private final TenantQuotaMapper mapper;
+
+    public MybatisTenantQuotaStore(TenantQuotaMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<TenantQuota> find(String tenantId, QuotaPeriod period) {
+        TenantQuotaDO row = CrossTenantOperations.execute(() -> mapper.selectOne(
+            new LambdaQueryWrapper<TenantQuotaDO>()
+                .eq(TenantQuotaDO::getTenantId, tenantId)
+                .eq(TenantQuotaDO::getPeriod, period.name())));
+        return Optional.ofNullable(row).map(MybatisTenantQuotaStore::toDomain);
+    }
+
+    @Override
+    public List<TenantQuota> findByTenant(String tenantId) {
+        List<TenantQuotaDO> rows = CrossTenantOperations.execute(() -> mapper.selectList(
+            new LambdaQueryWrapper<TenantQuotaDO>().eq(TenantQuotaDO::getTenantId, tenantId)));
+        return rows.stream().map(MybatisTenantQuotaStore::toDomain).toList();
+    }
+
+    @Override
+    public void save(TenantQuota quota) {
+        long now = System.currentTimeMillis();
+        CrossTenantOperations.run(() -> {
+            TenantQuotaDO existing = mapper.selectOne(new LambdaQueryWrapper<TenantQuotaDO>()
+                .eq(TenantQuotaDO::getTenantId, quota.tenantId())
+                .eq(TenantQuotaDO::getPeriod, quota.period().name()));
+
+            TenantQuotaDO row = existing == null ? new TenantQuotaDO() : existing;
+            row.setTenantId(quota.tenantId());
+            row.setPeriod(quota.period().name());
+            row.setTokenLimit(quota.tokenLimit());
+            row.setAmountLimit(quota.amountLimit() == null ? BigDecimal.ZERO : quota.amountLimit());
+            row.setExceedAction(quota.exceedAction().name());
+            row.setWarnPercent(quota.warnPercent());
+            row.setEnabled(quota.enabled() ? 1 : 0);
+            row.setUpdatedAtMs(now);
+            if (existing == null) {
+                row.setCreatedAtMs(now);
+                mapper.insert(row);
+            } else {
+                mapper.updateById(row);
+            }
+        });
+    }
+
+    @Override
+    public void delete(String tenantId, QuotaPeriod period) {
+        CrossTenantOperations.run(() -> mapper.delete(new LambdaQueryWrapper<TenantQuotaDO>()
+            .eq(TenantQuotaDO::getTenantId, tenantId)
+            .eq(TenantQuotaDO::getPeriod, period.name())));
+    }
+
+    private static TenantQuota toDomain(TenantQuotaDO row) {
+        return new TenantQuota(
+            row.getTenantId(),
+            QuotaPeriod.parse(row.getPeriod()),
+            row.getTokenLimit() == null ? 0L : row.getTokenLimit(),
+            row.getAmountLimit() == null ? BigDecimal.ZERO : row.getAmountLimit(),
+            QuotaExceedAction.parse(row.getExceedAction()),
+            row.getWarnPercent() == null ? 0 : row.getWarnPercent(),
+            row.getEnabled() == null || row.getEnabled() == 1);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/QuotaDecision.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/QuotaDecision.java
@@ -1,0 +1,36 @@
+package com.richard.fyoung.customerwork.quota;
+
+/**
+ * 配额判定结果。
+ *
+ * @param allowed 是否放行
+ * @param action  超额时的处置方式（放行时为 null）
+ * @param used    判定时的已用量
+ * @param limit   判定时的上限
+ * @param period  触发的周期（放行时为 null）
+ * @author owlzhangfq@gmail.com
+ */
+public record QuotaDecision(boolean allowed,
+                            QuotaExceedAction action,
+                            long used,
+                            long limit,
+                            QuotaPeriod period) {
+
+    public static QuotaDecision allow() {
+        return new QuotaDecision(true, null, 0L, 0L, null);
+    }
+
+    public static QuotaDecision exceeded(TenantQuota quota, long used) {
+        return new QuotaDecision(false, quota.exceedAction(), used, quota.tokenLimit(), quota.period());
+    }
+
+    /** 是否应当拒绝本次调用（WARN 只记录不拦，DEGRADE 由调用方换模型而非拒绝）。 */
+    public boolean shouldBlock() {
+        return !allowed && action == QuotaExceedAction.BLOCK;
+    }
+
+    /** 是否应当降级到备用模型。 */
+    public boolean shouldDegrade() {
+        return !allowed && action == QuotaExceedAction.DEGRADE;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/QuotaExceedAction.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/QuotaExceedAction.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.quota;
+
+/**
+ * 配额超额后的处置方式。
+ *
+ * <p>默认 {@link #BLOCK}：配额的意义就是硬上限。"软上限"该用
+ * {@code warn_percent} 预警阈值表达，而不是让超额后继续花钱。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum QuotaExceedAction {
+
+    /** 拦截：拒绝后续模型调用。拦得住成本，代价是服务中断。 */
+    BLOCK,
+
+    /**
+     * 降级：改用备用（更便宜的）模型继续服务。
+     *
+     * <p>保住了服务可用性，但成本只是变慢不是停住——适合"宁可答得差也不能不答"的场景，
+     * 不适合用来兜住真正的预算红线。</p>
+     */
+    DEGRADE,
+
+    /** 仅告警：不拦不降级，只记录。用于观察期或内部租户。 */
+    WARN;
+
+    /** 宽松解析：脏值按 BLOCK 兜底（fail-closed，宁可误拦也不放任花钱）。 */
+    public static QuotaExceedAction parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return BLOCK;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return BLOCK;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/QuotaPeriod.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/QuotaPeriod.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customerwork.quota;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 配额周期。
+ *
+ * <p>周期键（如 {@code 2026-08}）参与实时计数的 Redis key，因此必须是<b>自然日/自然月对齐</b>的，
+ * 不能用"距今 N 秒"的滚动窗口——账单是按自然月出的，滚动窗口算出来的数对不上账。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum QuotaPeriod {
+
+    DAILY(DateTimeFormatter.ofPattern("yyyy-MM-dd"), 2 * 24 * 3600),
+    MONTHLY(DateTimeFormatter.ofPattern("yyyy-MM"), 40 * 24 * 3600);
+
+    private final DateTimeFormatter keyFormatter;
+
+    /** 计数键的存活时长（秒）：略大于一个周期，让跨周期的计数自然过期而不必显式清理。 */
+    private final int retentionSeconds;
+
+    QuotaPeriod(DateTimeFormatter keyFormatter, int retentionSeconds) {
+        this.keyFormatter = keyFormatter;
+        this.retentionSeconds = retentionSeconds;
+    }
+
+    /** 指定日期所属周期的键，如 {@code 2026-08-10}（日）或 {@code 2026-08}（月）。 */
+    public String periodKey(LocalDate date) {
+        return keyFormatter.format(date);
+    }
+
+    public int retentionSeconds() {
+        return retentionSeconds;
+    }
+
+    /** 该周期的起始日（用于按周期聚合日用量）。 */
+    public LocalDate startOf(LocalDate date) {
+        return this == DAILY ? date : date.withDayOfMonth(1);
+    }
+
+    /** 宽松解析：库里存的是字符串，脏值按月周期兜底（范围更大，不会误拦）。 */
+    public static QuotaPeriod parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return MONTHLY;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return MONTHLY;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuota.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuota.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.quota;
+
+import java.math.BigDecimal;
+
+/**
+ * 租户配额（领域模型）。
+ *
+ * @param tenantId     租户 ID
+ * @param period       周期
+ * @param tokenLimit   token 上限，0 = 不限
+ * @param amountLimit  金额上限（元），0 = 不限；实时链路只拦 token，金额走 T+1 账单告警
+ * @param exceedAction 超额处置
+ * @param warnPercent  预警阈值（用量百分比）
+ * @param enabled      是否启用
+ * @author owlzhangfq@gmail.com
+ */
+public record TenantQuota(String tenantId,
+                          QuotaPeriod period,
+                          long tokenLimit,
+                          BigDecimal amountLimit,
+                          QuotaExceedAction exceedAction,
+                          int warnPercent,
+                          boolean enabled) {
+
+    /** 是否设置了 token 上限（0 表示不限，不参与判定）。 */
+    public boolean hasTokenLimit() {
+        return tokenLimit > 0;
+    }
+
+    /** 达到预警线但尚未超限。 */
+    public boolean shouldWarn(long used) {
+        if (!hasTokenLimit() || warnPercent <= 0) {
+            return false;
+        }
+        return used >= tokenLimit * warnPercent / 100L && used < tokenLimit;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuotaConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuotaConfig.java
@@ -1,0 +1,58 @@
+package com.richard.fyoung.customerwork.quota;
+
+import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.counter.WindowCounter;
+import com.richard.fyoung.customerwork.quota.mapper.TenantQuotaMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 租户配额装配：Store 按 {@code store-mode} 选实现，Guard 按 {@code enabled} 决定是否真的拦。
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class TenantQuotaConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantQuotaConfig.class);
+
+    private static final String MODE_JDBC = "jdbc";
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TenantQuotaStore tenantQuotaStore(CustomerWorkProperties properties,
+                                             ObjectProvider<TenantQuotaMapper> mapperProvider) {
+        CustomerWorkProperties.Quota cfg = properties.getQuota();
+        if (!MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode())) {
+            return new InMemoryTenantQuotaStore();
+        }
+        TenantQuotaMapper mapper = mapperProvider.getIfAvailable();
+        if (mapper == null) {
+            // 配了 jdbc 却没有 Mapper（持久层未装配），让位给内存实现而不是启动失败：
+            // 配额是旁路保护，不该拖垮主链路可启动性；配置没生效由 error 日志暴露
+            log.error("quota store-mode=jdbc but TenantQuotaMapper unavailable, fallback to in-memory, code={}",
+                "QUOTA-MAPPER-MISSING");
+            return new InMemoryTenantQuotaStore();
+        }
+        log.info("tenant quota store ready (jdbc)");
+        return new MybatisTenantQuotaStore(mapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TenantQuotaGuard tenantQuotaGuard(CustomerWorkProperties properties,
+                                             TenantQuotaStore quotaStore,
+                                             ObjectProvider<WindowCounter> counterProvider) {
+        WindowCounter counter = counterProvider.getIfAvailable();
+        boolean enabled = properties.getQuota().isEnabled();
+        if (enabled) {
+            log.info("tenant quota guard enabled, storeMode={}", properties.getQuota().getStoreMode());
+        }
+        return new TenantQuotaGuard(quotaStore,
+            counter == null ? new InMemoryWindowCounter() : counter, enabled);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuotaGuard.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuotaGuard.java
@@ -1,0 +1,118 @@
+package com.richard.fyoung.customerwork.quota;
+
+import com.richard.fyoung.customerwork.counter.WindowCounter;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 租户 token 配额的实时判定与记账。
+ *
+ * <p><b>只判 token，不判金额</b>：金额需要单价表，而单价在 admin 库；让客服端跨库反查
+ * 只为算一个实时金额并不划算。token 本就是成本的直接驱动，拦住 token 就拦住了钱。
+ * 金额维度走 T+1 账单与预警（{@code cw_tenant_usage_daily}），两者分工明确。</p>
+ *
+ * <p><b>用量计数与账单是两套数</b>：这里用 {@link WindowCounter} 做实时累加（快、可跨实例共享），
+ * 账单以 {@code cw_agent_call_log} 汇总为准（准、可对账）。二者在进程重启且计数器为内存模式时
+ * 会短暂不一致——这是刻意取舍：实时链路要的是"快到能拦在调用前"，对账要的是"一分不差"，
+ * 用同一份数据满足不了两个目标。生产多副本本就要把计数器切到 Redis，届时重启不丢。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class TenantQuotaGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantQuotaGuard.class);
+
+    private static final String KEY_PREFIX = "quota:";
+
+    private final TenantQuotaStore quotaStore;
+    private final WindowCounter counter;
+    private final boolean enabled;
+
+    public TenantQuotaGuard(TenantQuotaStore quotaStore, WindowCounter counter, boolean enabled) {
+        this.quotaStore = quotaStore;
+        this.counter = counter;
+        this.enabled = enabled;
+    }
+
+    /**
+     * 模型调用前的配额判定。
+     *
+     * <p>先判后记：本次预估用量不计入判定基数——预估值本就不准，用它去卡边界会让
+     * "刚好卡在限额上"的请求随预估误差随机通过或失败。实际用量在调用后由
+     * {@link #record(String, long)} 补记。</p>
+     *
+     * @param tenantId 租户；为空时取当前上下文
+     * @return 判定结果，调用方据此决定放行 / 拒绝 / 降级
+     */
+    public QuotaDecision check(String tenantId) {
+        if (!enabled) {
+            return QuotaDecision.allow();
+        }
+        String tenant = resolveTenant(tenantId);
+        if (tenant == null) {
+            // 没有租户上下文说明不在多租户链路上（如内部任务），配额无从谈起，放行
+            return QuotaDecision.allow();
+        }
+
+        for (QuotaPeriod period : QuotaPeriod.values()) {
+            Optional<TenantQuota> configured = quotaStore.find(tenant, period);
+            if (configured.isEmpty()) {
+                continue;
+            }
+            TenantQuota quota = configured.get();
+            if (!quota.enabled() || !quota.hasTokenLimit()) {
+                continue;
+            }
+            long used = counter.current(counterKey(tenant, period), period.retentionSeconds());
+            if (used >= quota.tokenLimit()) {
+                log.error("tenant token quota exceeded, code={}, tenant={}, period={}, used={}, limit={}, action={}",
+                    "QUOTA-TOKEN-EXCEEDED", tenant, period, used, quota.tokenLimit(), quota.exceedAction());
+                return QuotaDecision.exceeded(quota, used);
+            }
+            if (quota.shouldWarn(used)) {
+                log.info("tenant token quota warning, tenant={}, period={}, used={}, limit={}",
+                    tenant, period, used, quota.tokenLimit());
+            }
+        }
+        return QuotaDecision.allow();
+    }
+
+    /**
+     * 记录实际用量（模型调用之后）。
+     *
+     * <p>两个周期各记一份：日配额与月配额是独立的上限，不能共用一个计数。</p>
+     */
+    public void record(String tenantId, long tokens) {
+        if (!enabled || tokens <= 0) {
+            return;
+        }
+        String tenant = resolveTenant(tenantId);
+        if (tenant == null) {
+            return;
+        }
+        for (QuotaPeriod period : QuotaPeriod.values()) {
+            counter.increment(counterKey(tenant, period), tokens, period.retentionSeconds());
+        }
+    }
+
+    /** 当前周期已用量（后台展示"额度用了多少"用）。 */
+    public long currentUsage(String tenantId, QuotaPeriod period) {
+        String tenant = resolveTenant(tenantId);
+        return tenant == null ? 0L : counter.current(counterKey(tenant, period), period.retentionSeconds());
+    }
+
+    /** 计数键含周期标识（如 {@code quota:acme:MONTHLY:2026-08}），跨周期自然归零，无需显式重置。 */
+    private String counterKey(String tenantId, QuotaPeriod period) {
+        return KEY_PREFIX + tenantId + ":" + period.name() + ":" + period.periodKey(LocalDate.now());
+    }
+
+    private String resolveTenant(String tenantId) {
+        if (tenantId != null && !tenantId.isBlank()) {
+            return tenantId;
+        }
+        return TenantContext.get();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuotaStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/TenantQuotaStore.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.quota;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 租户配额存储 SPI（第 9 次套用 Store SPI 模式：接口 + InMemory 默认 + MyBatis-Plus 实现）。
+ * @author owlzhangfq@gmail.com
+ */
+public interface TenantQuotaStore {
+
+    /** 查某租户某周期的配额；未配置返回 empty（= 不限）。 */
+    Optional<TenantQuota> find(String tenantId, QuotaPeriod period);
+
+    /** 某租户的全部周期配额。 */
+    List<TenantQuota> findByTenant(String tenantId);
+
+    /** 保存或更新（按 tenantId + period 唯一）。 */
+    void save(TenantQuota quota);
+
+    /** 删除某租户某周期的配额。 */
+    void delete(String tenantId, QuotaPeriod period);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/entity/TenantQuotaDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/entity/TenantQuotaDO.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.quota.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * 租户配额持久化对象（贫血 DO，对应 {@code cw_tenant_quota}）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_tenant_quota")
+public class TenantQuotaDO {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /**
+     * 归属租户。
+     *
+     * <p>本表在租户拦截器的忽略清单外（正常参与过滤），但仍显式持有该字段：
+     * 运营方跨租户配额度时要读到"这条配额属于谁"，靠拦截器自动补值读不出来。</p>
+     */
+    private String tenantId;
+    private String period;
+    private Long tokenLimit;
+    private BigDecimal amountLimit;
+    private String exceedAction;
+    private Integer warnPercent;
+    private Integer enabled;
+    private String remark;
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/mapper/TenantQuotaMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/quota/mapper/TenantQuotaMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customerwork.quota.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.quota.entity.TenantQuotaDO;
+
+/**
+ * 租户配额 Mapper（starter 定义，admin 复用同一套做后台管理——照内容风控三表的先例）。
+ * @author owlzhangfq@gmail.com
+ */
+public interface TenantQuotaMapper extends BaseMapper<TenantQuotaDO> {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/service/CustomerServiceService.java
@@ -5,8 +5,12 @@ import com.richard.fyoung.customerwork.calllog.AgentCallMeta;
 import com.richard.fyoung.customerwork.calllog.AgentCallSessionType;
 import com.richard.fyoung.customerwork.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.dto.IntentResult;
+import com.richard.fyoung.customerwork.counter.InMemoryWindowCounter;
 import com.richard.fyoung.customerwork.lock.InMemorySessionLock;
 import com.richard.fyoung.customerwork.lock.SessionLock;
+import com.richard.fyoung.customerwork.quota.InMemoryTenantQuotaStore;
+import com.richard.fyoung.customerwork.quota.QuotaDecision;
+import com.richard.fyoung.customerwork.quota.TenantQuotaGuard;
 import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordFilter;
 import com.richard.fyoung.customerwork.sensitiveword.SensitiveWordStreamGuard;
 import io.agentscope.core.ReActAgent;
@@ -55,6 +59,15 @@ public class CustomerServiceService {
     public static final String FALLBACK_REPLY =
         "抱歉，系统繁忙，已为您记录问题，建议稍后再试或转人工坐席。";
 
+    /**
+     * 配额超限时的回复文本。
+     *
+     * <p>与 {@link #FALLBACK_REPLY} 分开：前者是"系统故障"，用户重试有意义；
+     * 配额超限重试无用，措辞必须让人知道该去找谁。</p>
+     */
+    public static final String QUOTA_EXCEEDED_REPLY =
+        "本期服务额度已用尽，请联系管理员提升额度后再试。";
+
     /** 进程内热 Agent 缓存上限：超过则按 LRU 淘汰最久未用的会话，避免无界缓存导致 OOM。 */
     private static final int MAX_HOT_AGENTS = 1000;
 
@@ -96,6 +109,15 @@ public class CustomerServiceService {
     private SessionLock sessionLock = new InMemorySessionLock(0);
 
     /**
+     * 租户配额判定；未装配时是一个恒放行的实例（配额默认关闭，行为与引入配额前一致）。
+     *
+     * <p>判定放在入口而不是 token 采集中间件里：那个中间件的既定原则是"只读透传、绝不打断主链路"，
+     * 而配额拦截恰恰要打断。记账则复用中间件里 token 的唯一落点，两边各就各位。</p>
+     */
+    private TenantQuotaGuard quotaGuard =
+        new TenantQuotaGuard(new InMemoryTenantQuotaStore(), new InMemoryWindowCounter(), false);
+
+    /**
      * 会话最后活跃时间戳（用于超时清理）：sessionId -> lastActivityMs。
      */
     private final ConcurrentHashMap<String, Long> sessionActivity = new ConcurrentHashMap<>();
@@ -107,13 +129,18 @@ public class CustomerServiceService {
                                   CustomerWorkProperties properties,
                                   ObjectProvider<MeterRegistry> meterRegistryProvider,
                                   ObjectProvider<SensitiveWordFilter> sensitiveWordFilterProvider,
-                                  ObjectProvider<SessionLock> sessionLockProvider) {
+                                  ObjectProvider<SessionLock> sessionLockProvider,
+                                  ObjectProvider<TenantQuotaGuard> quotaGuardProvider) {
         this(agentFactory, sessionStateManager, properties);
         this.meterRegistry = meterRegistryProvider.getIfAvailable();
         this.sensitiveWordFilter = sensitiveWordFilterProvider.getIfAvailable();
         SessionLock provided = sessionLockProvider == null ? null : sessionLockProvider.getIfAvailable();
         if (provided != null) {
             this.sessionLock = provided;
+        }
+        TenantQuotaGuard guard = quotaGuardProvider == null ? null : quotaGuardProvider.getIfAvailable();
+        if (guard != null) {
+            this.quotaGuard = guard;
         }
     }
 
@@ -190,6 +217,10 @@ public class CustomerServiceService {
      */
     public Mono<String> chat(String sessionId, String userText) {
         log.info("[session {}] received user message: {}", sessionId, userText);
+        QuotaDecision quota = quotaGuard.check(null);
+        if (quota.shouldBlock()) {
+            return Mono.just(QUOTA_EXCEEDED_REPLY);
+        }
         touchSession(sessionId);
         ReActAgent agent = resolveAgent(sessionId);
         RuntimeContext ctx = agentFactory.contextFor(sessionId);
@@ -221,6 +252,10 @@ public class CustomerServiceService {
      */
     public Flux<String> chatStream(String sessionId, String userText) {
         log.info("[session {}] received user message (stream): {}", sessionId, userText);
+        QuotaDecision quota = quotaGuard.check(null);
+        if (quota.shouldBlock()) {
+            return Flux.just(QUOTA_EXCEEDED_REPLY);
+        }
         touchSession(sessionId);
         ReActAgent agent = resolveAgent(sessionId);
         RuntimeContext ctx = agentFactory.contextFor(sessionId);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantInterceptors.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tenant/TenantInterceptors.java
@@ -32,6 +32,11 @@ public final class TenantInterceptors {
         "ai_system_tool",
         "ai_chat_session_state",
         "ai_model_config",
+        // 单价由平台统一定义，租户不该也不能自己定价，故无 tenant_id 列
+        "ai_model_price",
+        // 配额带 tenant_id 但刻意不自动过滤：运营方要跨租户配额度，而租户管理员
+        // 本就不该看到自己的额度设置。访问控制由 Controller 的运营方校验负责
+        "sys_tenant_quota",
         "flyway_schema_history");
 
     private TenantInterceptors() {

--- a/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
+++ b/customer-work-starter/src/main/resources/customerwork/schema/customer-work-schema.sql
@@ -535,3 +535,23 @@ INSERT IGNORE INTO `cw_dict_item` (`tenant_id`, `dict_type`, `item_key`, `item_l
 ('default', 'order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
 ('default', 'order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
 ('default', 'order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);
+
+-- 租户配额表（MybatisTenantQuotaStore / cw_tenant_quota）：B3 成本治理的硬上限。
+-- 落在客服端库而非 admin 库：它要被运行时读取（拦在模型调用之前），照内容风控三表的先例
+-- 由 starter 定义 Mapper、admin 复用同一套 Mapper 管理，避免跨库反查或两处各存一份。
+-- 刻意不给种子：空表 = 无配额 = 不拦，与引入配额之前行为完全一致。
+CREATE TABLE IF NOT EXISTS `cw_tenant_quota` (
+    `tenant_id`      VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `period`         VARCHAR(16) NOT NULL COMMENT '周期: DAILY 日 / MONTHLY 月',
+    `token_limit`    BIGINT NOT NULL DEFAULT 0 COMMENT 'token 上限，0=不限',
+    `amount_limit`   DECIMAL(16,4) NOT NULL DEFAULT 0 COMMENT '金额上限（元），0=不限；实时链路只拦 token，金额走 T+1 账单告警',
+    `exceed_action`  VARCHAR(16) NOT NULL DEFAULT 'BLOCK' COMMENT '超额处置: BLOCK 拦截 / DEGRADE 降级备用模型 / WARN 仅告警',
+    `warn_percent`   INT NOT NULL DEFAULT 80 COMMENT '预警阈值（用量百分比），达到即告警但不拦',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `remark`         VARCHAR(255) COMMENT '备注',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_tenant_quota` (`tenant_id`, `period`),
+    INDEX `idx_tenant_quota_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='租户配额（每租户每周期一条）';

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/quota/TenantQuotaGuardTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/quota/TenantQuotaGuardTest.java
@@ -1,0 +1,149 @@
+package com.richard.fyoung.customerwork.quota;
+
+import com.richard.fyoung.customerwork.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 租户配额判定单测：关闭时放行、无配额放行、超限按策略处置、日月两周期独立、跨租户不串。
+ * @author owlzhangfq@gmail.com
+ */
+class TenantQuotaGuardTest {
+
+    private final InMemoryTenantQuotaStore store = new InMemoryTenantQuotaStore();
+    private final InMemoryWindowCounter counter = new InMemoryWindowCounter();
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private TenantQuotaGuard guard(boolean enabled) {
+        return new TenantQuotaGuard(store, counter, enabled);
+    }
+
+    private TenantQuota quota(String tenant, QuotaPeriod period, long limit, QuotaExceedAction action) {
+        return new TenantQuota(tenant, period, limit, BigDecimal.ZERO, action, 80, true);
+    }
+
+    @Test
+    void check_shouldAllow_whenDisabled() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 1, QuotaExceedAction.BLOCK));
+        TenantQuotaGuard g = guard(false);
+        g.record("acme", 1000);
+        assertTrue(g.check("acme").allowed(), "配额关闭时一律放行，且不记账");
+    }
+
+    @Test
+    void check_shouldAllow_whenNoQuotaConfigured() {
+        assertTrue(guard(true).check("no-quota-tenant").allowed(), "没配配额等于不限");
+    }
+
+    @Test
+    void check_shouldAllow_whenNoTenantContext() {
+        // 内部任务、启动初始化等链路没有租户，配额无从谈起
+        assertTrue(guard(true).check(null).allowed(), "无租户上下文应放行而不是报错");
+    }
+
+    @Test
+    void check_shouldBlock_whenTokenLimitReached() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 100, QuotaExceedAction.BLOCK));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 100);
+
+        QuotaDecision decision = g.check("acme");
+        assertFalse(decision.allowed(), "达到上限应拒绝");
+        assertTrue(decision.shouldBlock(), "BLOCK 策略应拦截");
+        assertFalse(decision.shouldDegrade(), "BLOCK 策略不是降级");
+        assertEquals(QuotaPeriod.DAILY, decision.period(), "应指出是哪个周期触发的");
+    }
+
+    @Test
+    void check_shouldDegrade_whenActionIsDegrade() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 10, QuotaExceedAction.DEGRADE));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 10);
+
+        QuotaDecision decision = g.check("acme");
+        assertTrue(decision.shouldDegrade(), "DEGRADE 策略应降级");
+        assertFalse(decision.shouldBlock(), "降级不等于拦截——服务要继续，只是换个便宜模型");
+    }
+
+    @Test
+    void check_shouldNotBlock_whenActionIsWarn() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 10, QuotaExceedAction.WARN));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 100);
+
+        QuotaDecision decision = g.check("acme");
+        assertFalse(decision.allowed(), "超限事实要如实反映");
+        assertFalse(decision.shouldBlock(), "WARN 只记录不拦");
+        assertFalse(decision.shouldDegrade(), "WARN 也不降级");
+    }
+
+    @Test
+    void record_shouldCountDailyAndMonthlyIndependently() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 1000, QuotaExceedAction.BLOCK));
+        store.save(quota("acme", QuotaPeriod.MONTHLY, 100, QuotaExceedAction.BLOCK));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 100);
+
+        // 日额度还剩很多，但月额度已满——两个周期是独立上限，不能共用一份计数
+        assertFalse(g.check("acme").allowed(), "月配额触顶就该拦，哪怕日配额还很富余");
+        assertEquals(100L, g.currentUsage("acme", QuotaPeriod.DAILY), "日用量应独立计数");
+        assertEquals(100L, g.currentUsage("acme", QuotaPeriod.MONTHLY), "月用量应独立计数");
+    }
+
+    @Test
+    void record_shouldIsolateTenants() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 100, QuotaExceedAction.BLOCK));
+        store.save(quota("other", QuotaPeriod.DAILY, 100, QuotaExceedAction.BLOCK));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 100);
+
+        assertFalse(g.check("acme").allowed(), "用超的租户应被拦");
+        assertTrue(g.check("other").allowed(), "另一个租户的额度不该被消耗");
+    }
+
+    @Test
+    void check_shouldFallBackToTenantContext() {
+        store.save(quota("ctx-tenant", QuotaPeriod.DAILY, 10, QuotaExceedAction.BLOCK));
+        TenantQuotaGuard g = guard(true);
+        TenantContext.set("ctx-tenant");
+        g.record(null, 10);
+
+        assertFalse(g.check(null).allowed(), "未显式传租户时应取当前上下文");
+    }
+
+    @Test
+    void check_shouldIgnoreDisabledQuota() {
+        store.save(new TenantQuota("acme", QuotaPeriod.DAILY, 1, BigDecimal.ZERO,
+            QuotaExceedAction.BLOCK, 80, false));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 100);
+        assertTrue(g.check("acme").allowed(), "停用的配额不参与判定");
+    }
+
+    @Test
+    void check_shouldIgnoreZeroLimit() {
+        store.save(quota("acme", QuotaPeriod.DAILY, 0, QuotaExceedAction.BLOCK));
+        TenantQuotaGuard g = guard(true);
+        g.record("acme", 100);
+        assertTrue(g.check("acme").allowed(), "上限 0 表示不限，而非一点额度都不给");
+    }
+
+    @Test
+    void shouldWarn_shouldTriggerBeforeLimit() {
+        TenantQuota q = quota("acme", QuotaPeriod.DAILY, 100, QuotaExceedAction.BLOCK);
+        assertFalse(q.shouldWarn(79), "未到阈值不预警");
+        assertTrue(q.shouldWarn(80), "达到 80% 应预警");
+        assertFalse(q.shouldWarn(100), "已超限就不是预警而是拦截了");
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -108,6 +108,7 @@
 | **OTel 链路追踪（最后一公里，真出 span + OTLP 导出）** | `OtelTracingConfig`(starter) + `AdminOtelTracingConfig`(admin) | 关 | `customer-work.observability.otel.enabled=true`（starter）/ `admin.observability.otel.enabled=true`（admin），见 §6.13c |
 | **多租户行级隔离（tenant_id 强制过滤）** | `TenantContext` + `CustomerWorkTenantLineHandler`（starter）+ `TenantContextInterceptor`（admin） | 关 | `customer-work.tenant.enabled=true`（starter）/ `admin.tenant.enabled=true`（admin），见 §6.27 |
 | **水平扩展（限流/成本熔断/会话锁共享）** | `WindowCounter` + `SessionLock`（Redisson 实现） | 关 | `customer-work.distributed.counter-mode=redis` + `session-lock-mode=redis`，见 §6.28 |
+| **租户配额与计费（token 硬上限 + 账单）** | `TenantQuotaGuard`（starter）+ `BillingController`（admin） | 关 | `customer-work.quota.enabled=true`，见 §6.29 |
 | 运维就绪（健康/停机/巡检） | `SessionHealthIndicator` / `GracefulShutdownService` / `MaintenanceScheduler` | 开 | `/actuator/health` |
 | 模型多厂商 + 私有化兜底 / 重试 / **成本熔断** | `ModelConfig`（或 2.0 内置 `maxRetries`/`fallbackModel`）+ `ModelCostCircuitBreaker` | 开 | `model.provider`、`model.fallback.enabled`、`model.cost-control.enabled` |
 | MCP 接入 | `McpToolkitConfigurer` | 关 | `mcp.enabled=true` |
@@ -1530,6 +1531,44 @@ Redis 连接复用 `customer-work.distributed-lock.redis.*`，不用再配一套
 K8s 多副本清单见 `deploy/k8s/`（含 Deployment / Service / HPA / PDB / 探针 / 优雅停机），
 其 ConfigMap 已把上述三项全部切成 Redis。
 
+### 6.29 租户配额与计费（B3，默认关闭）
+
+成本治理此前只能回答"花了多少 token"，这批补上"谁花的、值多少钱、超了怎么办"。
+
+**三张表的分工**：`cw_tenant_quota`（配额，落**客服端库**——运行时要读它拦模型调用，
+照内容风控三表先例由 starter 定义 Mapper、admin 经跨库门面维护）、`ai_model_price`（单价，admin 库）、
+`cw_tenant_usage_daily`（日用量归集，admin 库，账单数据源）。
+
+```yaml
+customer-work:
+  quota:
+    enabled: true
+    store-mode: jdbc     # memory 进程内 / jdbc 落 cw_tenant_quota
+admin:
+  billing:
+    aggregation:
+      enabled: true      # 用量归集守护线程
+      interval-ms: 21600000   # 6 小时跑一次（归集幂等，多跑只是多扫一遍日志）
+      backfill-days: 3        # 回溯天数，兜住任务失败/实例停机造成的空洞
+```
+
+**实时只拦 token，金额走 T+1 账单**：实时算金额需要客服端持有单价表（在 admin 库），
+跨库反查只为算一个实时值不划算；而 token 本就是成本的直接驱动，拦住 token 就拦住了钱。
+金额维度体现在账单与预警里。
+
+**判定与记账分处两地**：判定在 `CustomerServiceService` 入口（那里能打断链路），
+记账搭 `AgentCallTimingMiddleware` 里 token 的唯一落点（记在别处迟早与落库口径漂移）。
+后者的既定原则是"只读透传、绝不打断主链路"，所以判定不能放它那儿。
+
+**超额三态**：`BLOCK` 拦截（默认，配额的意义就是硬上限）/ `DEGRADE` 降级到备用模型 /
+`WARN` 仅告警。软上限该用 `warn_percent` 预警阈值表达，而不是让超额后继续花钱。
+
+**账单口径**：金额在归集时按当日单价算好落库，不是查询时实时算——单价会变，
+实时算会让历史账单随调价而变动，对不上已经出过的账。调价请新增一条生效记录而不是改旧记录。
+
+**已知边界**：用量的实时计数（`WindowCounter`）与账单（调用日志汇总）是两套数，
+内存模式下进程重启会丢实时计数。生产多副本本就要把计数器切 Redis（见 §6.28），届时重启不丢。
+
 ---
 
 ## 七、配置项总表
@@ -1552,6 +1591,7 @@ K8s 多副本清单见 `deploy/k8s/`（含 Deployment / Service / HPA / PDB / �
 | `fact-log` | enabled(true), directory(./data/facts), max-file-mb(10), max-archived-files(5) |
 | `tenant` | enabled(false), column-name(tenant_id), ignored-tables[], auto-context-propagation(true)（见 §6.27；admin 侧对应 `admin.tenant.*`） |
 | `distributed` | counter-mode(memory), counter-key-prefix(cw:counter:), session-lock-mode(memory), session-lock-wait-seconds(10), session-lock-lease-seconds(120)（见 §6.28，Redis 连接复用 `distributed-lock.redis.*`） |
+| `quota` | enabled(false), store-mode(memory)（见 §6.29；admin 侧归集对应 `admin.billing.aggregation.*`） |
 | `security` | auth.{enabled(false),header-name(X-API-Key),api-keys[],tenant-keys{}}, rate-limit.{enabled(false),requests-per-minute(120),algorithm(fixed-window),window-seconds(60),rule-enabled(false),store-mode(memory),refresh-enabled(true),refresh-interval-ms(60000)} |
 | `sensitive-word` | enabled(false), direction(BOTH), store-mode(memory), default-action(BLOCK), mask-char(*), inbound-safe-reply, outbound-safe-reply, refresh-enabled(true), refresh-interval-ms(60000), hit-log.{enabled(false),store-mode(memory),queue-capacity(2048),snippet-max-length(64)} |
 | `multi-agent` | enabled(true), mode(fanout), max-iters(6) |

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -607,3 +607,23 @@ INSERT IGNORE INTO `cw_dict_item` (`tenant_id`, `dict_type`, `item_key`, `item_l
 ('default', 'order_status', '已签收', '已签收', 5, 1, NULL, 1779235200000, 1779235200000),
 ('default', 'order_status', '已取消', '已取消', 6, 1, NULL, 1779235200000, 1779235200000),
 ('default', 'order_status', '已退款', '已退款', 7, 1, NULL, 1779235200000, 1779235200000);
+
+-- 租户配额表（MybatisTenantQuotaStore / cw_tenant_quota）：B3 成本治理的硬上限。
+-- 落在客服端库而非 admin 库：它要被运行时读取（拦在模型调用之前），照内容风控三表的先例
+-- 由 starter 定义 Mapper、admin 复用同一套 Mapper 管理，避免跨库反查或两处各存一份。
+-- 刻意不给种子：空表 = 无配额 = 不拦，与引入配额之前行为完全一致。
+CREATE TABLE IF NOT EXISTS `cw_tenant_quota` (
+    `tenant_id`      VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `period`         VARCHAR(16) NOT NULL COMMENT '周期: DAILY 日 / MONTHLY 月',
+    `token_limit`    BIGINT NOT NULL DEFAULT 0 COMMENT 'token 上限，0=不限',
+    `amount_limit`   DECIMAL(16,4) NOT NULL DEFAULT 0 COMMENT '金额上限（元），0=不限；实时链路只拦 token，金额走 T+1 账单告警',
+    `exceed_action`  VARCHAR(16) NOT NULL DEFAULT 'BLOCK' COMMENT '超额处置: BLOCK 拦截 / DEGRADE 降级备用模型 / WARN 仅告警',
+    `warn_percent`   INT NOT NULL DEFAULT 80 COMMENT '预警阈值（用量百分比），达到即告警但不拦',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `remark`         VARCHAR(255) COMMENT '备注',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_tenant_quota` (`tenant_id`, `period`),
+    INDEX `idx_tenant_quota_tenant` (`tenant_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT='租户配额（每租户每周期一条）';

--- a/mysql/02-customer-admin/50-V50__tenant_quota_billing.sql
+++ b/mysql/02-customer-admin/50-V50__tenant_quota_billing.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- B3 配额与计费：模型单价表 + 租户配额 + 用量归集
+--
+-- 成本治理此前只能回答"花了多少 token"，这批补上"谁花的、值多少钱、超了怎么办"。
+-- 本迁移建两张 admin 库的表：
+--   ai_model_price         单价（token → 金额的换算依据，按生效时间留历史）
+--   cw_tenant_usage_daily  日用量归集（账单与报表的数据源，由定时任务从调用日志汇总）
+--
+-- 配额表 cw_tenant_quota **不在这里**：它要被客服端运行时读取（拦在模型调用之前），
+-- 按内容风控三表的先例落在客服端库、由 starter 定义 Mapper，admin 复用同一套 Mapper 管理，
+-- 见 customer-work-schema.sql。跨库放两份或让客服端反查 admin 库都不如沿用既有模式。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_model_price` (
+    `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `provider`        VARCHAR(64) NOT NULL COMMENT '模型厂商，如 dashscope/openai',
+    `model_name`      VARCHAR(128) NOT NULL COMMENT '模型名，如 qwen-max',
+    -- 单价用「每百万 token」而非「每 token」：后者小数位太多，DECIMAL 精度与可读性都难兼顾，
+    -- 且各厂商官网报价本身就是按百万 token 计的，照抄不用换算，少一层出错机会
+    `input_price`     DECIMAL(16,6) NOT NULL DEFAULT 0 COMMENT '输入单价（元/百万 token）',
+    `output_price`    DECIMAL(16,6) NOT NULL DEFAULT 0 COMMENT '输出单价（元/百万 token）',
+    -- 命中缓存的输入 token 通常按折扣价计，单独一列而不是按比例算：折扣比例各厂商不同且会变
+    `cached_price`    DECIMAL(16,6) NOT NULL DEFAULT 0 COMMENT '缓存命中输入单价（元/百万 token）',
+    `currency`        VARCHAR(8) NOT NULL DEFAULT 'CNY' COMMENT '币种',
+    `effective_from`  DATETIME NOT NULL COMMENT '生效时间；调价不改旧行而是插新行，历史账单才算得回去',
+    `remark`          VARCHAR(255) COMMENT '备注',
+    `create_by`       BIGINT COMMENT '创建人ID',
+    `create_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_by`       BIGINT COMMENT '更新人ID',
+    `update_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted`         TINYINT NOT NULL DEFAULT 0 COMMENT '逻辑删除：0正常 / 1删除',
+    KEY `idx_model_price_lookup` (`provider`, `model_name`, `effective_from`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型单价（按生效时间留历史，供账单回溯）';
+
+-- 单价是平台统一定义的（租户不该也不能自己定价），故不带 tenant_id，进拦截器忽略清单
+
+CREATE TABLE IF NOT EXISTS `cw_tenant_usage_daily` (
+    `id`              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `tenant_id`       VARCHAR(64) NOT NULL COMMENT '租户ID',
+    `stat_date`       DATE NOT NULL COMMENT '统计日期（自然日）',
+    `provider`        VARCHAR(64) NOT NULL DEFAULT '' COMMENT '模型厂商',
+    `model_name`      VARCHAR(128) NOT NULL DEFAULT '' COMMENT '模型名',
+    `call_count`      BIGINT NOT NULL DEFAULT 0 COMMENT '调用次数',
+    `input_tokens`    BIGINT NOT NULL DEFAULT 0 COMMENT '输入 token',
+    `output_tokens`   BIGINT NOT NULL DEFAULT 0 COMMENT '输出 token',
+    `cached_tokens`   BIGINT NOT NULL DEFAULT 0 COMMENT '缓存命中输入 token（input 的子集）',
+    `total_tokens`    BIGINT NOT NULL DEFAULT 0 COMMENT '总 token',
+    -- 金额在归集时按当日单价算好落库，而不是查询时实时算：
+    -- 单价会变，实时算会让历史账单随调价而变动，对不上已出账的数
+    `amount`          DECIMAL(16,4) NOT NULL DEFAULT 0 COMMENT '金额（元，按归集时点的单价结算）',
+    `currency`        VARCHAR(8) NOT NULL DEFAULT 'CNY' COMMENT '币种',
+    `create_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_time`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    UNIQUE KEY `uk_tenant_usage_daily` (`tenant_id`, `stat_date`, `provider`, `model_name`),
+    KEY `idx_usage_daily_date` (`stat_date`),
+    KEY `idx_usage_daily_tenant` (`tenant_id`, `stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户日用量归集（账单与报表数据源）';
+
+-- ============================================================================
+-- 配额与计费菜单权限点（id 从 224 起，223 是 V49 租户管理占用的最后一个）
+--
+-- 与 tenant: 前缀同理走 billing: 前缀：TenantProvisionService 排除的是 tenant:，
+-- 计费同属平台专属，这里显式列出以便将来一并纳入排除规则。
+-- ============================================================================
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (224, 1, '配额与计费', 'billing:view', 1, '/system/billing', 'Wallet', 'library', 10);
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (225, 224, '编辑配额', 'billing:quota-edit', 2, 1),
+    (226, 224, '编辑单价', 'billing:price-edit', 2, 2),
+    (227, 224, '导出账单', 'billing:export', 2, 3);
+
+-- 演示单价种子：与项目默认模型对齐（数值为示意，上线前按厂商实际报价维护）
+INSERT INTO `ai_model_price` (`provider`, `model_name`, `input_price`, `output_price`, `cached_price`, `currency`, `effective_from`, `remark`)
+SELECT 'dashscope', 'qwen-max', 2.400000, 9.600000, 0.480000, 'CNY', '2026-01-01 00:00:00', '示意价格，上线前按厂商实际报价维护'
+WHERE NOT EXISTS (SELECT 1 FROM `ai_model_price` WHERE `provider` = 'dashscope' AND `model_name` = 'qwen-max');


### PR DESCRIPTION
企业级 SaaS 路线图 **B3 批次**。成本治理此前只能回答"花了多少 token"，这批补上"谁花的、值多少钱、超了怎么办"。

> ⚠️ **本 PR stacked 在 #85（B1 租户地基）和 #86（B2 分布式化）之上**，包含它们的提交。合并顺序：**#85 → #86 → 本 PR**。

## 三张表各就各位

| 表 | 位置 | 为什么在这 |
|---|---|---|
| `cw_tenant_quota` | **客服端库** | 运行时要读它拦模型调用。照内容风控三表先例：starter 定义 Mapper，admin 经跨库门面维护——比让客服端反查 admin 库或两处各存一份都干净 |
| `ai_model_price` | admin 库 | 只有出账用得上。按 `effective_from` 留历史，**调价插新行不改旧行**，历史账单才算得回去 |
| `cw_tenant_usage_daily` | admin 库 | 账单数据源，由归集任务从 `cw_agent_call_log` 汇总 |

单价口径是「元/百万 token」——各厂商官网报价就是这个口径，照抄不用换算；按「元/token」存则小数位多到精度与可读性难兼顾。缓存命中 token 单独一列而非按比例算：折扣各厂商不同且会变。

## 实时只拦 token，金额走 T+1

实时算金额需要客服端持有单价表（在 admin 库），跨库反查只为算一个实时值不划算；而 token 本就是成本的直接驱动，**拦住 token 就拦住了钱**。金额维度体现在账单与预警里，两者分工明确。

金额在**归集时按当日单价算好落库**，查询时不重算——否则调价会让已经出过的账在下次查询时悄悄变掉。

## 判定与记账分处两地

- **判定**在 `CustomerServiceService.chat/chatStream` 入口——那里能打断链路并返回明确提示。
- **记账**搭 `AgentCallTimingMiddleware` 里 token 的唯一落点（三态终止各只走一次、CAS 保证不重复），记在别处迟早与落库口径漂移。

之所以不把判定也放中间件：它的既定原则是"只读透传事件、绝不打断主链路"，而配额拦截恰恰要打断。

超额三态：`BLOCK` 拦截（默认——配额的意义就是硬上限）/ `DEGRADE` 降级备用模型 / `WARN` 仅告警。软上限该用 `warn_percent` 预警阈值表达，而不是让超额后继续花钱。

## 归集任务的两个选择

- **用自带守护线程而非 `@Scheduled`**：admin 刻意没开 `@EnableScheduling`，为一个归集任务打开全局调度会把容器里所有带 `@Scheduled` 的 Bean 一并激活——这个判断 `SensitiveWordRefreshTask` 已经下过一次，这里沿用。
- **固定间隔而非 cron**：归集幂等（同一天重跑就是覆盖），多跑只是多扫一遍日志；且重启后下一轮照跑，不会像"每天 02:00"那样错过就得等一整天。

## 顺带

`AgentCallTimingMiddleware` 加构造器后缺 `@Autowired` 导致容器启动失败——本项目第 6 次踩这个坑（PR #68 曾一次修 5 处）。已修并在类注释里写明。

## 一个值得注意的发现

`ModelCostCircuitBreaker.tryConsume(...)` **在生产代码里没有任何调用点**——全仓只有测试调用它。也就是说"模型成本熔断"这个能力一直是死代码，`docs/生产就绪评估.md` 里"进程内 AtomicLong 计数（prod 基线默认未开启）"的表述掩盖了"它压根没接进链路"这个事实。

本 PR 没有顺手接它（那是独立的行为变更，应当单独评估阈值与降级策略），但 B3 的配额链路可以视为它的正确形态：判定在能打断的地方、记账在 token 唯一落点。**建议后续要么把它接进链路，要么删掉。**

## 测试

starter **1177**(+12) / admin 732 / app 78 / channel 65 / gateway 1，全绿。前端 `vue-tsc -b && vite build` 通过。

新增覆盖：配额关闭/未配置/无租户上下文均放行、BLOCK 与 DEGRADE 的区别（降级不等于拦截）、WARN 不拦、**日月两周期独立计数**（月满日空也要拦）、跨租户额度不互相消耗、上下文回退、停用配额与 0 上限不参与判定、预警阈值边界。

## 未验证

- **MySQL 未启动**（本机 Docker 未运行），V50 迁移与跨库门面只做了静态审查。
- 归集 SQL 依赖 `cw_agent_call_segment.name` 作为模型名（调用日志本身不记模型信息），建议合入前用真实数据核对一次归集结果与原始日志的口径是否一致。
