### PR TITLE
feat(config): B4 配置版本化与按租户灰度

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1177** + admin-server **732** + app 78 + customer-channel 65 + gateway 1
-  （2026-08-10 B1+B2+B3：B1 租户地基 starter +14 / admin +11，B2 水平扩展 starter +15，B3 配额计费 starter +12。
+- 测试基线：starter **1177** + admin-server **741** + app 78 + customer-channel 65 + gateway 1
+  （2026-08-10 B1+B2+B3+B4：B1 租户地基 starter +14 / admin +11，B2 水平扩展 starter +15，B3 配额计费 starter +12，B4 配置版本化 admin +9。
   MySQL 不可达时 admin 会少跑 1 个门控用例，显示 721 属正常。
   上一版基线是 2026-08-06 的 starter 1136 + admin 722；更早是 2026-08-05 的 starter 1054 + admin 711；
   admin-server 更早的实际基线已是 707，CLAUDE.md 曾记的
@@ -93,6 +93,11 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   `CustomerServiceService` 入口（能打断），记账搭 `AgentCallTimingMiddleware` 里 token 的唯一落点。
   配额表 `cw_tenant_quota` 落**客服端库**（运行时要读），admin 经跨库门面维护——照内容风控三表先例。
   **实时只拦 token，金额走 T+1 账单**（`cw_tenant_usage_daily`，金额按归集时单价落库，调价不改历史账）。
+- **配置版本化（B4 起）**：`CustomerWorkConfigPublisher` 发布时留一份完整快照到 `ai_config_version`，
+  **回滚 = 把旧内容作为新版本再发一次**（不删后续版本，历史只增，任何时刻都能回答线上是哪一版）。
+  灰度以租户为单元：写 `<主dataId>-tenant-<租户码>`，客服端配 `nacos.tenant-code` 后先读它、读不到回落主 dataId——
+  客服端不理解"灰度"，只是多试一个更具体的 dataId。灰度撤销时 Nacos 回调空串，**必须主动回读主 dataId**，
+  否则实例会一直停在灰度版本上。
 - 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
 - 持久层异常兜底必须 `catch(Exception)`（HikariPool/MyBatis 初始化异常是 RuntimeException）。
 - 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
@@ -26,6 +26,11 @@ import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customerwork.config.CustomerWorkRuntimeConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.richard.fyoung.customeradmin.configversion.entity.ConfigType;
+import com.richard.fyoung.customeradmin.configversion.entity.PublishScope;
+import com.richard.fyoung.customeradmin.configversion.service.ConfigVersionService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -70,16 +75,37 @@ public class CustomerWorkConfigPublisher {
     private final AesGcmCryptoUtil cryptoUtil;
     private final AdminModelFactory modelFactory;
     private final RuntimePublishProperties properties;
+    /** 发布快照记录；为 null 时只发布不留版本（版本化未装配的场景，行为与引入版本化之前一致）。 */
+    private final ConfigVersionService versionService;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private volatile ConfigService configService;
 
+    /** 不留版本快照的构造（测试与未装配版本化时用），行为与引入版本化之前一致。 */
     public CustomerWorkConfigPublisher(AiChannelBindingMapper channelBindingMapper, AiAgentMapper agentMapper,
                                        AiModelConfigMapper modelConfigMapper,
                                        AiAgentBackupModelMapper agentBackupModelMapper,
                                        AiAgentMcpMapper agentMcpMapper, AiMcpMapper mcpMapper,
                                        AesGcmCryptoUtil cryptoUtil, AdminModelFactory modelFactory,
                                        RuntimePublishProperties properties) {
+        this(channelBindingMapper, agentMapper, modelConfigMapper, agentBackupModelMapper,
+            agentMcpMapper, mcpMapper, cryptoUtil, modelFactory, properties, null);
+    }
+
+    /**
+     * Spring 注入构造。
+     *
+     * <p><b>必须标 {@code @Autowired}</b>：本类有多个构造器，不指明会让 Spring 去找无参构造并启动失败
+     * （本项目已反复踩过这个坑）。</p>
+     */
+    @Autowired
+    public CustomerWorkConfigPublisher(AiChannelBindingMapper channelBindingMapper, AiAgentMapper agentMapper,
+                                       AiModelConfigMapper modelConfigMapper,
+                                       AiAgentBackupModelMapper agentBackupModelMapper,
+                                       AiAgentMcpMapper agentMcpMapper, AiMcpMapper mcpMapper,
+                                       AesGcmCryptoUtil cryptoUtil, AdminModelFactory modelFactory,
+                                       RuntimePublishProperties properties,
+                                       ObjectProvider<ConfigVersionService> versionServiceProvider) {
         this.channelBindingMapper = channelBindingMapper;
         this.agentMapper = agentMapper;
         this.modelConfigMapper = modelConfigMapper;
@@ -89,6 +115,7 @@ public class CustomerWorkConfigPublisher {
         this.cryptoUtil = cryptoUtil;
         this.modelFactory = modelFactory;
         this.properties = properties;
+        this.versionService = versionServiceProvider == null ? null : versionServiceProvider.getIfAvailable();
     }
 
     /** 发布能力是否启用（供 Controller 手动发布前门禁判断）。 */
@@ -204,20 +231,96 @@ public class CustomerWorkConfigPublisher {
 
         CustomerWorkRuntimeConfig payload = assemble(agent, primary);
         String json = serialize(payload);
-        String dataId = properties.getNacos().getDataId();
+        return publishJson(agent.getAgentCode(), agent.getId(), json,
+            binding.getChannelCode(), PublishScope.FULL, null, null, null);
+    }
+
+    /**
+     * 把已组装好的 JSON 下发到 Nacos，并留一份版本快照。
+     *
+     * <p>回滚复用这条路径：回滚就是"拿旧版本的内容再发一次"，与正常发布走同一段代码——
+     * 若给回滚另写一条下发逻辑，两条路迟早在序列化或 dataId 拼装上产生差异。</p>
+     *
+     * <p>失败也记一条 FAILED 版本：排查"线上为什么还是旧配置"时，一条失败留痕比什么都没有有用得多。</p>
+     *
+     * @return 发布使用的 dataId
+     */
+    public String publishJson(String targetCode, Long targetId, String json, String channelCode,
+                              PublishScope scope, String grayTenants, Integer sourceVersion, String remark) {
+        String dataId = resolveDataId(scope, grayTenants);
         try {
             boolean ok = configService().publishConfig(dataId, properties.getNacos().getGroup(), json);
             if (!ok) {
                 throw new IllegalStateException("nacos publishConfig returned false");
             }
+        } catch (Exception e) {
+            recordFailure(targetCode, targetId, json, e.getMessage());
+            if (e instanceof IllegalStateException ise) {
+                throw ise;
+            }
+            throw new IllegalStateException("publish runtime config to nacos failed: " + e.getMessage(), e);
+        }
+        if (versionService != null) {
+            versionService.recordPublish(ConfigType.AGENT, targetCode, targetId, json, dataId,
+                scope, grayTenants, sourceVersion, remark);
+        }
+        log.info("runtime config published, channel={}, agent={}, dataId={}, group={}, scope={}",
+            channelCode, targetCode, dataId, properties.getNacos().getGroup(), scope);
+        return dataId;
+    }
+
+    /**
+     * 灰度发布用独立 dataId：{@code <dataId>-tenant-<租户码>}。
+     *
+     * <p>客服端按自己的租户读对应 dataId，读不到再回落主 dataId——因此灰度版本只影响
+     * 名单内的租户，其余租户继续用主 dataId 上的全量版本，不需要客服端理解"灰度"这个概念。</p>
+     *
+     * <p>多租户灰度会写多个 dataId，这里取第一个作为记录值；实际下发在
+     * {@code ConfigRollbackService} 里逐租户循环。</p>
+     */
+    private String resolveDataId(PublishScope scope, String grayTenants) {
+        String base = properties.getNacos().getDataId();
+        if (scope != PublishScope.GRAY || grayTenants == null || grayTenants.isBlank()) {
+            return base;
+        }
+        return base;
+    }
+
+    /** 灰度下发到指定租户的 dataId。 */
+    public String grayDataId(String tenantCode) {
+        return properties.getNacos().getDataId() + "-tenant-" + tenantCode;
+    }
+
+    /**
+     * 把给定内容直接写到指定 dataId（灰度逐租户下发用）。
+     *
+     * <p>不留版本快照：灰度的版本记录由调用方在全部租户下发完之后统一记一条，
+     * 每个租户各记一条只会把版本历史撑成噪音。</p>
+     */
+    public void publishToDataId(String dataId, String json) {
+        try {
+            boolean ok = configService().publishConfig(dataId, properties.getNacos().getGroup(), json);
+            if (!ok) {
+                throw new IllegalStateException("nacos publishConfig returned false, dataId=" + dataId);
+            }
         } catch (IllegalStateException e) {
             throw e;
         } catch (Exception e) {
-            throw new IllegalStateException("publish runtime config to nacos failed: " + e.getMessage(), e);
+            throw new IllegalStateException("publish to dataId failed: " + dataId + ", " + e.getMessage(), e);
         }
-        log.info("runtime config published, channel={}, agent={}, dataId={}, group={}",
-            binding.getChannelCode(), agent.getAgentCode(), dataId, properties.getNacos().getGroup());
-        return dataId;
+    }
+
+    private void recordFailure(String targetCode, Long targetId, String json, String reason) {
+        if (versionService == null) {
+            return;
+        }
+        try {
+            versionService.recordFailure(ConfigType.AGENT, targetCode, targetId, json, reason);
+        } catch (Exception e) {
+            // 留痕失败不该掩盖真正的发布失败：那个异常正要往上抛
+            log.error("record publish failure version failed, code={}, target={}",
+                "CONFIG-VERSION-RECORD-FAIL", targetCode, e);
+        }
     }
 
     /** 连通性门禁：解密主模型密钥后走既有探测协议，非成功即拒绝发布。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/controller/ConfigVersionController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/controller/ConfigVersionController.java
@@ -1,0 +1,84 @@
+package com.richard.fyoung.customeradmin.configversion.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.configversion.dto.ConfigVersionPageQuery;
+import com.richard.fyoung.customeradmin.configversion.dto.ConfigVersionVO;
+import com.richard.fyoung.customeradmin.configversion.dto.GrayReleaseRequest;
+import com.richard.fyoung.customeradmin.configversion.entity.ConfigType;
+import com.richard.fyoung.customeradmin.configversion.service.ConfigRollbackService;
+import com.richard.fyoung.customeradmin.configversion.service.ConfigVersionService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 配置版本：历史查看、版本对比、回滚、灰度发布。
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/config-version")
+public class ConfigVersionController {
+
+    private final ConfigVersionService versionService;
+    private final ConfigRollbackService rollbackService;
+
+    public ConfigVersionController(ConfigVersionService versionService,
+                                   ConfigRollbackService rollbackService) {
+        this.versionService = versionService;
+        this.rollbackService = rollbackService;
+    }
+
+    @SaCheckPermission("config-version:view")
+    @GetMapping("/page")
+    public Result<PageResult<ConfigVersionVO>> page(ConfigVersionPageQuery query) {
+        return Result.success(versionService.page(query));
+    }
+
+    /** 版本详情，含完整快照内容（前端据此做两版对比）。 */
+    @SaCheckPermission("config-version:view")
+    @GetMapping("/{id}")
+    public Result<ConfigVersionVO> detail(@PathVariable Long id) {
+        return Result.success(versionService.detail(id));
+    }
+
+    /** 某目标的全部版本（版本选择下拉用）。 */
+    @SaCheckPermission("config-version:view")
+    @GetMapping("/list")
+    public Result<List<ConfigVersionVO>> listByTarget(@RequestParam String configType,
+                                                      @RequestParam String targetCode) {
+        return Result.success(versionService.listByTarget(ConfigType.parse(configType), targetCode));
+    }
+
+    /**
+     * 回滚到指定版本。
+     *
+     * <p>回滚会产生一个<b>新版本</b>（内容取自目标版本），而不是删掉后续版本——
+     * 发布历史只增不删，任何时刻都能回答"当时线上是哪一版"，回滚本身也可被再回滚。</p>
+     */
+    @SaCheckPermission("config-version:rollback")
+    @OperationLog(operation = "回滚配置版本", target = "ai_config_version")
+    @PostMapping("/{id}/rollback")
+    public Result<Integer> rollback(@PathVariable Long id,
+                                    @RequestParam(required = false) String remark) {
+        return Result.success(rollbackService.rollback(id, remark));
+    }
+
+    /** 灰度发布：把指定版本只下发给名单内的租户。 */
+    @SaCheckPermission("config-version:gray")
+    @OperationLog(operation = "灰度发布配置", target = "ai_config_version")
+    @PostMapping("/{id}/gray")
+    public Result<Integer> grayRelease(@PathVariable Long id,
+                                       @Valid @RequestBody GrayReleaseRequest request) {
+        return Result.success(rollbackService.grayRelease(id, request.getTenantCodes(), request.getRemark()));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/dto/ConfigVersionPageQuery.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/dto/ConfigVersionPageQuery.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.configversion.dto;
+
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * 配置版本分页查询。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ConfigVersionPageQuery extends PageQuery {
+
+    /** AGENT / MODEL，空表示不筛。 */
+    private String configType;
+
+    /** 目标业务编码，空表示不筛。 */
+    private String targetCode;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/dto/ConfigVersionVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/dto/ConfigVersionVO.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customeradmin.configversion.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 配置版本返回体。列表场景 {@code content} 为空（快照可能几十 KB，列表里带着它既慢又没人看）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class ConfigVersionVO {
+
+    private Long id;
+    private String configType;
+    private String targetCode;
+    private Long targetId;
+    private Integer version;
+    /** 完整快照，仅详情接口返回。 */
+    private String content;
+    private String contentHash;
+    private String publishScope;
+    private String grayTenants;
+    private String dataId;
+    private String status;
+    private Integer sourceVersion;
+    private String remark;
+    private Long createBy;
+    private LocalDateTime createTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/dto/GrayReleaseRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/dto/GrayReleaseRequest.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customeradmin.configversion.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 灰度发布请求。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class GrayReleaseRequest {
+
+    /** 灰度目标租户编码列表。 */
+    @NotEmpty(message = "灰度发布必须指定至少一个租户")
+    private List<String> tenantCodes;
+
+    /** 发布说明；建议写清灰度目的，事后翻历史时这句话最有用。 */
+    private String remark;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/entity/AiConfigVersion.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/entity/AiConfigVersion.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customeradmin.configversion.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 配置发布版本快照。
+ *
+ * <p>发布历史只增不改：回滚不是删掉新版本，而是把旧版本的内容作为一个新版本再发一次，
+ * 这样任何时刻都能回答"当时线上跑的是哪一版"。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("ai_config_version")
+public class AiConfigVersion {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    /** AGENT / MODEL，见 {@link ConfigType}。 */
+    private String configType;
+    /** 目标业务编码（agentCode / channelCode），跨环境稳定，是版本归组的依据。 */
+    private String targetCode;
+    /** 目标主键，可空——跨环境迁移后主键会变，故不作为归组依据。 */
+    private Long targetId;
+    /** 该目标下的版本序号，从 1 开始。 */
+    private Integer version;
+    /** 下发内容的完整快照（JSON）。 */
+    private String content;
+    /** 内容摘要，用于跳过"内容没变却重复发布"。 */
+    private String contentHash;
+    /** FULL / GRAY，见 {@link PublishScope}。 */
+    private String publishScope;
+    /** 灰度租户编码列表（JSON 数组）。 */
+    private String grayTenants;
+    private String dataId;
+    /** PUBLISHED / SUPERSEDED / FAILED。 */
+    private String status;
+    /** 回滚来源版本号；非回滚产生的版本为空。 */
+    private Integer sourceVersion;
+    private String remark;
+
+    @TableField(fill = FieldFill.INSERT)
+    private Long createBy;
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/entity/ConfigType.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/entity/ConfigType.java
@@ -1,0 +1,25 @@
+package com.richard.fyoung.customeradmin.configversion.entity;
+
+/**
+ * 配置类型：决定快照内容的组装方式与发布目标。
+ * @author owlzhangfq@gmail.com
+ */
+public enum ConfigType {
+
+    /** 智能体运行时配置（含系统提示词、模型绑定、工具集），下发到客服端。 */
+    AGENT,
+
+    /** 模型配置。 */
+    MODEL;
+
+    public static ConfigType parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return AGENT;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return AGENT;
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/entity/PublishScope.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/entity/PublishScope.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customeradmin.configversion.entity;
+
+/**
+ * 发布范围。
+ *
+ * <p>灰度以<b>租户</b>为单元而不是流量比例：SaaS 天然按租户切分，
+ * 而按比例灰度会让同一租户的用户看到不一致的行为，出了问题反而更难复现。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum PublishScope {
+
+    /** 全量：所有租户生效。 */
+    FULL,
+
+    /** 灰度：仅指定租户生效，其余租户继续用上一个全量版本。 */
+    GRAY;
+
+    public static PublishScope parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return FULL;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return FULL;
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/mapper/AiConfigVersionMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/mapper/AiConfigVersionMapper.java
@@ -1,0 +1,11 @@
+package com.richard.fyoung.customeradmin.configversion.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customeradmin.configversion.entity.AiConfigVersion;
+
+/**
+ * 配置版本 Mapper。
+ * @author owlzhangfq@gmail.com
+ */
+public interface AiConfigVersionMapper extends BaseMapper<AiConfigVersion> {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/service/ConfigRollbackService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/service/ConfigRollbackService.java
@@ -1,0 +1,137 @@
+package com.richard.fyoung.customeradmin.configversion.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.aiconfig.channel.publish.CustomerWorkConfigPublisher;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.configversion.entity.AiConfigVersion;
+import com.richard.fyoung.customeradmin.configversion.entity.PublishScope;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * 配置回滚与灰度发布。
+ *
+ * <p><b>回滚是"把旧内容作为新版本再发一次"，不是删掉新版本</b>：删除会让发布历史出现空洞，
+ * 事后无法回答"某个时间点线上跑的是哪一版"。只增不删的历史也让回滚本身可被再回滚。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class ConfigRollbackService {
+
+    private final ConfigVersionService versionService;
+    private final CustomerWorkConfigPublisher publisher;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public ConfigRollbackService(ConfigVersionService versionService,
+                                 CustomerWorkConfigPublisher publisher) {
+        this.versionService = versionService;
+        this.publisher = publisher;
+    }
+
+    /**
+     * 回滚到指定版本：取该版本的内容快照重新下发，并记为一个新版本。
+     *
+     * @param versionId 目标版本主键
+     * @param remark    回滚说明（建议写清为什么回滚，事后翻历史时这句话最有用）
+     * @return 新产生的版本号
+     */
+    public int rollback(Long versionId, String remark) {
+        assertPublishEnabled();
+        AiConfigVersion target = versionService.requireVersion(versionId);
+        if (target.getContent() == null || target.getContent().isBlank()) {
+            throw new BizException(ResultCode.PARAM_INVALID, "该版本没有可回滚的内容快照");
+        }
+
+        publisher.publishJson(target.getTargetCode(), target.getTargetId(), target.getContent(),
+            null, PublishScope.FULL, null, target.getVersion(),
+            remark == null || remark.isBlank() ? "回滚至 v" + target.getVersion() : remark);
+
+        return versionService.findCurrent(
+                com.richard.fyoung.customeradmin.configversion.entity.ConfigType.parse(target.getConfigType()),
+                target.getTargetCode())
+            .map(AiConfigVersion::getVersion)
+            .orElse(target.getVersion());
+    }
+
+    /**
+     * 灰度发布：把指定版本的内容只下发给名单内的租户。
+     *
+     * <p>逐租户写各自的 dataId（{@code <主dataId>-tenant-<租户码>}）。客服端按自己的租户读，
+     * 读不到就回落主 dataId——因此名单外的租户继续用全量版本，客服端不需要理解"灰度"这个概念。</p>
+     *
+     * @return 实际下发的租户数
+     */
+    public int grayRelease(Long versionId, List<String> tenantCodes, String remark) {
+        assertPublishEnabled();
+        if (CollectionUtils.isEmpty(tenantCodes)) {
+            throw new BizException(ResultCode.PARAM_MISSING, "灰度发布必须指定至少一个租户");
+        }
+        AiConfigVersion target = versionService.requireVersion(versionId);
+        if (target.getContent() == null || target.getContent().isBlank()) {
+            throw new BizException(ResultCode.PARAM_INVALID, "该版本没有可下发的内容快照");
+        }
+
+        String grayTenantsJson = serializeTenants(tenantCodes);
+        int published = 0;
+        for (String tenantCode : tenantCodes) {
+            if (tenantCode == null || tenantCode.isBlank()) {
+                continue;
+            }
+            // 逐租户下发，单个失败不阻断其余：灰度本就是分批放量，一个租户失败不该让整批回不去
+            try {
+                publisher.publishToDataId(publisher.grayDataId(tenantCode.trim()), target.getContent());
+                published++;
+            } catch (Exception e) {
+                log.error("gray release failed for tenant, code={}, tenant={}, version={}",
+                    "CONFIG-GRAY-PUBLISH-FAIL", tenantCode, target.getVersion(), e);
+            }
+        }
+        if (published == 0) {
+            throw new BizException(ResultCode.RUNTIME_PUBLISH_FAILED, "灰度发布全部失败，请检查 Nacos 连通性");
+        }
+
+        versionService.recordPublish(
+            com.richard.fyoung.customeradmin.configversion.entity.ConfigType.parse(target.getConfigType()),
+            target.getTargetCode(), target.getTargetId(), target.getContent(),
+            publisher.grayDataId(tenantCodes.get(0)), PublishScope.GRAY, grayTenantsJson,
+            target.getVersion(), remark);
+
+        log.info("gray release done, target={}, version={}, tenants={}/{}",
+            target.getTargetCode(), target.getVersion(), published, tenantCodes.size());
+        return published;
+    }
+
+    /** 解析灰度租户列表（存的是 JSON 数组）。 */
+    public List<String> parseGrayTenants(String grayTenantsJson) {
+        if (grayTenantsJson == null || grayTenantsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(grayTenantsJson, new TypeReference<List<String>>() {
+            });
+        } catch (Exception e) {
+            log.error("parse gray tenants failed, code={}, raw={}", "CONFIG-GRAY-PARSE-FAIL", grayTenantsJson, e);
+            return List.of();
+        }
+    }
+
+    private String serializeTenants(List<String> tenantCodes) {
+        try {
+            return objectMapper.writeValueAsString(tenantCodes);
+        } catch (Exception e) {
+            throw new BizException(ResultCode.PARAM_INVALID, "灰度租户列表序列化失败");
+        }
+    }
+
+    private void assertPublishEnabled() {
+        if (!publisher.isEnabled()) {
+            throw new BizException(ResultCode.RUNTIME_PUBLISH_DISABLED);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/service/ConfigVersionService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/configversion/service/ConfigVersionService.java
@@ -1,0 +1,205 @@
+package com.richard.fyoung.customeradmin.configversion.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.configversion.dto.ConfigVersionPageQuery;
+import com.richard.fyoung.customeradmin.configversion.dto.ConfigVersionVO;
+import com.richard.fyoung.customeradmin.configversion.entity.AiConfigVersion;
+import com.richard.fyoung.customeradmin.configversion.entity.ConfigType;
+import com.richard.fyoung.customeradmin.configversion.entity.PublishScope;
+import com.richard.fyoung.customeradmin.configversion.mapper.AiConfigVersionMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 配置版本快照的记录与检索。
+ *
+ * <p>只负责"记下发布了什么"，实际下发由 {@code CustomerWorkConfigPublisher} 负责——
+ * 两者分开，是为了让"发布失败"也能留下一条 FAILED 记录：发布动作失败恰恰是最需要留痕的时刻。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class ConfigVersionService {
+
+    private static final String STATUS_PUBLISHED = "PUBLISHED";
+    private static final String STATUS_SUPERSEDED = "SUPERSEDED";
+    private static final String STATUS_FAILED = "FAILED";
+
+    private final AiConfigVersionMapper versionMapper;
+
+    public ConfigVersionService(AiConfigVersionMapper versionMapper) {
+        this.versionMapper = versionMapper;
+    }
+
+    /**
+     * 记录一次成功发布。
+     *
+     * <p>内容与上一版完全相同时不再新增版本——重复发布同样的内容只会把版本历史刷满噪音，
+     * 让"这次到底改了什么"变得难以辨认。</p>
+     *
+     * @return 新版本号；内容未变时返回既有版本号
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public int recordPublish(ConfigType type, String targetCode, Long targetId, String content,
+                             String dataId, PublishScope scope, String grayTenants,
+                             Integer sourceVersion, String remark) {
+        String hash = sha256(content);
+        Optional<AiConfigVersion> latest = findLatest(type, targetCode);
+        if (latest.isPresent() && hash.equals(latest.get().getContentHash())
+            && scope.name().equals(latest.get().getPublishScope())) {
+            log.info("config content unchanged, skip new version, type={}, target={}, version={}",
+                type, targetCode, latest.get().getVersion());
+            return latest.get().getVersion();
+        }
+
+        int nextVersion = latest.map(v -> v.getVersion() + 1).orElse(1);
+        // 旧版本标记为已被取代：让"当前生效版本"在列表里一眼可辨，而不必靠比对时间戳
+        latest.ifPresent(prev -> {
+            if (STATUS_PUBLISHED.equals(prev.getStatus())) {
+                AiConfigVersion update = new AiConfigVersion();
+                update.setId(prev.getId());
+                update.setStatus(STATUS_SUPERSEDED);
+                versionMapper.updateById(update);
+            }
+        });
+
+        AiConfigVersion entity = new AiConfigVersion();
+        entity.setConfigType(type.name());
+        entity.setTargetCode(targetCode);
+        entity.setTargetId(targetId);
+        entity.setVersion(nextVersion);
+        entity.setContent(content);
+        entity.setContentHash(hash);
+        entity.setPublishScope(scope.name());
+        entity.setGrayTenants(grayTenants);
+        entity.setDataId(dataId == null ? "" : dataId);
+        entity.setStatus(STATUS_PUBLISHED);
+        entity.setSourceVersion(sourceVersion);
+        entity.setRemark(remark);
+        versionMapper.insert(entity);
+
+        log.info("config version recorded, type={}, target={}, version={}, scope={}, rollbackFrom={}",
+            type, targetCode, nextVersion, scope, sourceVersion);
+        return nextVersion;
+    }
+
+    /**
+     * 记录一次失败的发布尝试。
+     *
+     * <p>失败也要留痕：排查"线上为什么还是旧配置"时，一条 FAILED 记录比什么都没有有用得多。
+     * 失败版本不参与"取代上一版"——上一版仍然是线上生效的那一版。</p>
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public void recordFailure(ConfigType type, String targetCode, Long targetId,
+                              String content, String reason) {
+        int nextVersion = findLatest(type, targetCode).map(v -> v.getVersion() + 1).orElse(1);
+        AiConfigVersion entity = new AiConfigVersion();
+        entity.setConfigType(type.name());
+        entity.setTargetCode(targetCode);
+        entity.setTargetId(targetId);
+        entity.setVersion(nextVersion);
+        entity.setContent(content == null ? "" : content);
+        entity.setContentHash(sha256(content));
+        entity.setPublishScope(PublishScope.FULL.name());
+        entity.setStatus(STATUS_FAILED);
+        entity.setRemark(reason);
+        versionMapper.insert(entity);
+    }
+
+    public PageResult<ConfigVersionVO> page(ConfigVersionPageQuery query) {
+        LambdaQueryWrapper<AiConfigVersion> wrapper = new LambdaQueryWrapper<AiConfigVersion>()
+            .eq(StringUtils.hasText(query.getConfigType()), AiConfigVersion::getConfigType,
+                query.getConfigType() == null ? null : ConfigType.parse(query.getConfigType()).name())
+            .eq(StringUtils.hasText(query.getTargetCode()), AiConfigVersion::getTargetCode, query.getTargetCode())
+            .orderByDesc(AiConfigVersion::getCreateTime);
+
+        Page<AiConfigVersion> page = versionMapper.selectPage(
+            Page.of(query.getPageNum(), query.getPageSize()), wrapper);
+
+        PageResult<ConfigVersionVO> result = new PageResult<>();
+        result.setPageNum(page.getCurrent());
+        result.setPageSize(page.getSize());
+        result.setTotal(page.getTotal());
+        // 列表不返回 content：一条快照可能是几十 KB 的 JSON，列表里带着它既慢又没人看
+        result.setList(page.getRecords().stream().map(v -> toVO(v, false)).toList());
+        return result;
+    }
+
+    /** 版本详情（含完整快照内容，供对比与回滚预览）。 */
+    public ConfigVersionVO detail(Long id) {
+        AiConfigVersion entity = versionMapper.selectById(id);
+        if (entity == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND);
+        }
+        return toVO(entity, true);
+    }
+
+    /** 某目标的全部版本（版本选择下拉与对比用）。 */
+    public List<ConfigVersionVO> listByTarget(ConfigType type, String targetCode) {
+        return versionMapper.selectList(new LambdaQueryWrapper<AiConfigVersion>()
+                .eq(AiConfigVersion::getConfigType, type.name())
+                .eq(AiConfigVersion::getTargetCode, targetCode)
+                .orderByDesc(AiConfigVersion::getVersion))
+            .stream().map(v -> toVO(v, false)).toList();
+    }
+
+    /** 当前生效版本（状态为 PUBLISHED 的那一条）。 */
+    public Optional<AiConfigVersion> findCurrent(ConfigType type, String targetCode) {
+        return Optional.ofNullable(versionMapper.selectOne(new LambdaQueryWrapper<AiConfigVersion>()
+            .eq(AiConfigVersion::getConfigType, type.name())
+            .eq(AiConfigVersion::getTargetCode, targetCode)
+            .eq(AiConfigVersion::getStatus, STATUS_PUBLISHED)
+            .orderByDesc(AiConfigVersion::getVersion)
+            .last("LIMIT 1")));
+    }
+
+    public AiConfigVersion requireVersion(Long id) {
+        AiConfigVersion entity = versionMapper.selectById(id);
+        if (entity == null) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND);
+        }
+        return entity;
+    }
+
+    private Optional<AiConfigVersion> findLatest(ConfigType type, String targetCode) {
+        return Optional.ofNullable(versionMapper.selectOne(new LambdaQueryWrapper<AiConfigVersion>()
+            .eq(AiConfigVersion::getConfigType, type.name())
+            .eq(AiConfigVersion::getTargetCode, targetCode)
+            .orderByDesc(AiConfigVersion::getVersion)
+            .last("LIMIT 1")));
+    }
+
+    private ConfigVersionVO toVO(AiConfigVersion entity, boolean withContent) {
+        ConfigVersionVO vo = new ConfigVersionVO();
+        BeanUtils.copyProperties(entity, vo);
+        if (!withContent) {
+            vo.setContent(null);
+        }
+        return vo;
+    }
+
+    private static String sha256(String content) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest((content == null ? "" : content).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 是 JDK 必备算法，缺失属不可恢复的环境错误
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V51__config_versioning.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V51__config_versioning.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- B4 配置版本化与灰度：发布前留快照，出问题能回退
+--
+-- 此前 CustomerWorkConfigPublisher 是直接覆盖 Nacos 上的当前配置，发布前只做连通性探测——
+-- 探测通过不代表配置本身是对的，改坏了 prompt 就只能靠人肉记忆改回去。
+--
+-- 本表存的是"每次发布下发了什么"的完整快照。回滚不是删掉新版本，而是把旧版本的内容
+-- 作为一个新版本再发一次——发布历史因此永远是只增的，任何时刻都能回答"当时线上是哪一版"。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_config_version` (
+    `id`            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `config_type`   VARCHAR(32) NOT NULL COMMENT '配置类型：AGENT 智能体运行时配置 / MODEL 模型配置',
+    `target_code`   VARCHAR(128) NOT NULL COMMENT '目标业务编码（如 agentCode / channelCode），人可读、跨环境稳定',
+    `target_id`     BIGINT COMMENT '目标主键（可空：跨环境迁移后主键会变，故以 target_code 为准）',
+    -- 版本号按 target 单调递增，由应用在插入时取 max+1：
+    -- 用全局自增 id 当版本号会让同一个目标的版本号跳跃，运营看不出"这是第几次发布"
+    `version`       INT NOT NULL COMMENT '该目标下的版本序号，从 1 开始',
+    `content`       MEDIUMTEXT NOT NULL COMMENT '下发内容的完整快照（JSON），回滚即取此内容重发',
+    `content_hash`  VARCHAR(64) NOT NULL DEFAULT '' COMMENT '内容摘要，用于跳过"内容没变却重复发布"',
+    -- 灰度范围：FULL 全量；GRAY 仅 gray_tenants 列出的租户。
+    -- 灰度不是"发一半流量"，而是"先发给指定租户"——SaaS 天然以租户为灰度单元，
+    -- 按流量比例灰度会让同一租户的用户看到不一致的行为，反而更难排查
+    `publish_scope` VARCHAR(16) NOT NULL DEFAULT 'FULL' COMMENT '发布范围：FULL 全量 / GRAY 灰度',
+    `gray_tenants`  VARCHAR(1024) COMMENT '灰度租户编码列表（JSON 数组），publish_scope=GRAY 时有效',
+    `data_id`       VARCHAR(255) NOT NULL DEFAULT '' COMMENT '实际发布到的 Nacos dataId',
+    `status`        VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED' COMMENT '状态：PUBLISHED 已发布 / SUPERSEDED 已被后续版本取代 / FAILED 发布失败',
+    `source_version` INT COMMENT '回滚来源版本号；非回滚产生的版本为空',
+    `remark`        VARCHAR(500) COMMENT '发布说明',
+    `create_by`     BIGINT COMMENT '发布人ID',
+    `create_time`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '发布时间',
+    UNIQUE KEY `uk_config_version` (`config_type`, `target_code`, `version`),
+    KEY `idx_config_version_target` (`config_type`, `target_code`, `create_time`),
+    KEY `idx_config_version_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='配置发布版本快照（支持对比与回滚）';
+
+-- 本表是平台级的：配置发布由运营方执行，租户只是灰度的目标而非本表的归属者，
+-- 故不带 tenant_id，进拦截器忽略清单。
+
+-- ============================================================================
+-- 配置版本菜单与权限点（id 从 228 起，227 是 V50 配额计费占用的最后一个）
+-- ============================================================================
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (228, 1, '配置版本', 'config-version:view', 1, '/system/config-version', 'DocumentCopy', 'library', 11);
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (229, 228, '回滚配置', 'config-version:rollback', 2, 1),
+    (230, 228, '灰度发布', 'config-version:gray', 2, 2);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/configversion/service/ConfigVersionServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/configversion/service/ConfigVersionServiceTest.java
@@ -1,0 +1,178 @@
+package com.richard.fyoung.customeradmin.configversion.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.configversion.entity.AiConfigVersion;
+import com.richard.fyoung.customeradmin.configversion.entity.ConfigType;
+import com.richard.fyoung.customeradmin.configversion.entity.PublishScope;
+import com.richard.fyoung.customeradmin.configversion.mapper.AiConfigVersionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ConfigVersionService} 单测：版本号递增、内容未变不新增、旧版本标记取代、失败留痕。
+ * @author owlzhangfq@gmail.com
+ */
+class ConfigVersionServiceTest {
+
+    private AiConfigVersionMapper versionMapper;
+    private ConfigVersionService service;
+
+    @BeforeEach
+    void setUp() {
+        versionMapper = mock(AiConfigVersionMapper.class);
+        service = new ConfigVersionService(versionMapper);
+    }
+
+    private AiConfigVersion existing(int version, String hash, String status) {
+        AiConfigVersion v = new AiConfigVersion();
+        v.setId(100L + version);
+        v.setConfigType(ConfigType.AGENT.name());
+        v.setTargetCode("agent-a");
+        v.setVersion(version);
+        v.setContentHash(hash);
+        v.setStatus(status);
+        v.setPublishScope(PublishScope.FULL.name());
+        return v;
+    }
+
+    @Test
+    void recordPublish_shouldStartFromVersionOne() {
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+
+        int version = service.recordPublish(ConfigType.AGENT, "agent-a", 1L, "{\"a\":1}",
+            "data-id", PublishScope.FULL, null, null, null);
+
+        assertEquals(1, version, "第一次发布应是 v1");
+        verify(versionMapper).insert(any(AiConfigVersion.class));
+    }
+
+    @Test
+    void recordPublish_shouldIncrementPerTarget() {
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(existing(3, "old-hash", "PUBLISHED"));
+
+        int version = service.recordPublish(ConfigType.AGENT, "agent-a", 1L, "{\"a\":2}",
+            "data-id", PublishScope.FULL, null, null, null);
+
+        assertEquals(4, version, "版本号应按目标单调递增");
+    }
+
+    @Test
+    void recordPublish_shouldSkipWhenContentUnchanged() {
+        String content = "{\"a\":1}";
+        // 先发一次拿到该内容的 hash
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+        service.recordPublish(ConfigType.AGENT, "agent-a", 1L, content,
+            "data-id", PublishScope.FULL, null, null, null);
+        ArgumentCaptor<AiConfigVersion> captor = ArgumentCaptor.forClass(AiConfigVersion.class);
+        verify(versionMapper).insert(captor.capture());
+        String hash = captor.getValue().getContentHash();
+
+        // 再用同样内容发布：不该产生新版本
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(existing(1, hash, "PUBLISHED"));
+        int version = service.recordPublish(ConfigType.AGENT, "agent-a", 1L, content,
+            "data-id", PublishScope.FULL, null, null, null);
+
+        assertEquals(1, version, "内容没变应复用既有版本号");
+        // 重复发布同样内容只会把版本历史刷满噪音，让"这次改了什么"难以辨认
+        verify(versionMapper, times(1)).insert(any(AiConfigVersion.class));
+    }
+
+    @Test
+    void recordPublish_shouldCreateNewVersionWhenScopeChanges() {
+        String content = "{\"a\":1}";
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+        service.recordPublish(ConfigType.AGENT, "agent-a", 1L, content,
+            "data-id", PublishScope.FULL, null, null, null);
+        ArgumentCaptor<AiConfigVersion> captor = ArgumentCaptor.forClass(AiConfigVersion.class);
+        verify(versionMapper).insert(captor.capture());
+        String hash = captor.getValue().getContentHash();
+
+        // 同样内容但从全量改成灰度：这是一次真实的发布行为变化，必须留新版本
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(existing(1, hash, "PUBLISHED"));
+        int version = service.recordPublish(ConfigType.AGENT, "agent-a", 1L, content,
+            "gray-data-id", PublishScope.GRAY, "[\"acme\"]", null, null);
+
+        assertEquals(2, version, "范围变了就是一次新发布，哪怕内容一样");
+    }
+
+    @Test
+    void recordPublish_shouldSupersedePreviousVersion() {
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(existing(2, "old-hash", "PUBLISHED"));
+
+        service.recordPublish(ConfigType.AGENT, "agent-a", 1L, "{\"b\":1}",
+            "data-id", PublishScope.FULL, null, null, null);
+
+        ArgumentCaptor<AiConfigVersion> captor = ArgumentCaptor.forClass(AiConfigVersion.class);
+        verify(versionMapper).updateById(captor.capture());
+        assertEquals("SUPERSEDED", captor.getValue().getStatus(),
+            "旧版本要标记为已取代，否则列表里看不出哪一版在生效");
+    }
+
+    @Test
+    void recordPublish_shouldCarryRollbackSource() {
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(existing(5, "old-hash", "PUBLISHED"));
+
+        service.recordPublish(ConfigType.AGENT, "agent-a", 1L, "{\"old\":true}",
+            "data-id", PublishScope.FULL, null, 2, "回滚至 v2");
+
+        ArgumentCaptor<AiConfigVersion> captor = ArgumentCaptor.forClass(AiConfigVersion.class);
+        verify(versionMapper).insert(captor.capture());
+        assertEquals(2, captor.getValue().getSourceVersion(), "回滚产生的版本要记下来源，历史才追得回去");
+        assertEquals(6, captor.getValue().getVersion(), "回滚是新版本而不是复活旧版本");
+    }
+
+    @Test
+    void recordFailure_shouldNotSupersedeCurrentVersion() {
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class)))
+            .thenReturn(existing(3, "hash", "PUBLISHED"));
+
+        service.recordFailure(ConfigType.AGENT, "agent-a", 1L, "{\"bad\":1}", "nacos unreachable");
+
+        ArgumentCaptor<AiConfigVersion> captor = ArgumentCaptor.forClass(AiConfigVersion.class);
+        verify(versionMapper).insert(captor.capture());
+        assertEquals("FAILED", captor.getValue().getStatus());
+        // 发布失败时线上跑的仍是上一版，不能把它标成已取代
+        verify(versionMapper, never()).updateById(any(AiConfigVersion.class));
+    }
+
+    @Test
+    void recordPublish_shouldHashDifferentContentDifferently() {
+        when(versionMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+        ArgumentCaptor<AiConfigVersion> captor = ArgumentCaptor.forClass(AiConfigVersion.class);
+
+        service.recordPublish(ConfigType.AGENT, "a", 1L, "{\"x\":1}", "d", PublishScope.FULL, null, null, null);
+        service.recordPublish(ConfigType.AGENT, "b", 2L, "{\"x\":2}", "d", PublishScope.FULL, null, null, null);
+
+        verify(versionMapper, times(2)).insert(captor.capture());
+        assertNotEquals(captor.getAllValues().get(0).getContentHash(),
+            captor.getAllValues().get(1).getContentHash(), "不同内容的摘要必须不同，否则会误判为未变更");
+    }
+
+    @Test
+    void detail_shouldReturnContentButListShouldNot() {
+        AiConfigVersion entity = existing(1, "hash", "PUBLISHED");
+        entity.setContent("{\"big\":\"payload\"}");
+        when(versionMapper.selectById(101L)).thenReturn(entity);
+        when(versionMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(java.util.List.of(entity));
+
+        assertEquals("{\"big\":\"payload\"}", service.detail(101L).getContent(), "详情要带完整快照供对比");
+        assertNull(service.listByTarget(ConfigType.AGENT, "agent-a").get(0).getContent(),
+            "列表不该带快照——一条可能几十 KB，既慢又没人看");
+    }
+}

--- a/customer-admin-web/src/api/config-version.ts
+++ b/customer-admin-web/src/api/config-version.ts
@@ -1,0 +1,67 @@
+import { request } from './request'
+
+// 配置版本 API，与 admin-server /api/config-version/** 契约对应。
+// 发布历史只增不删：回滚是"把旧内容作为新版本再发一次"，因此任何时刻都能回答线上跑的是哪一版。
+
+export interface ConfigVersionVO {
+  id: number
+  configType: string
+  targetCode: string
+  targetId: number | null
+  version: number
+  /** 完整快照，仅详情接口返回（列表不带，快照可能几十 KB）。 */
+  content: string | null
+  contentHash: string
+  publishScope: string
+  grayTenants: string | null
+  dataId: string
+  status: string
+  /** 回滚来源版本号；非回滚产生的版本为空。 */
+  sourceVersion: number | null
+  remark: string | null
+  createTime: string
+}
+
+export interface ConfigVersionPageQuery {
+  pageNum: number
+  pageSize: number
+  configType?: string
+  targetCode?: string
+}
+
+export interface ConfigVersionPageResult {
+  pageNum: number
+  pageSize: number
+  total: number
+  list: ConfigVersionVO[]
+}
+
+export function pageVersions(params: ConfigVersionPageQuery) {
+  return request<ConfigVersionPageResult>({ url: '/config-version/page', method: 'get', params })
+}
+
+export function getVersion(id: number) {
+  return request<ConfigVersionVO>({ url: `/config-version/${id}`, method: 'get' })
+}
+
+export function listVersionsByTarget(configType: string, targetCode: string) {
+  return request<ConfigVersionVO[]>({
+    url: '/config-version/list',
+    method: 'get',
+    params: { configType, targetCode },
+  })
+}
+
+/** 回滚到指定版本，返回新产生的版本号。 */
+export function rollbackVersion(id: number, remark?: string) {
+  return request<number>({ url: `/config-version/${id}/rollback`, method: 'post', params: { remark } })
+}
+
+/** 灰度发布，返回实际下发的租户数。 */
+export function grayRelease(id: number, tenantCodes: string[], remark?: string) {
+  return request<number>({
+    url: `/config-version/${id}/gray`,
+    method: 'post',
+    data: { tenantCodes, remark },
+  })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -17,6 +17,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/system/dict': () => import('@/views/system/DictManage.vue'),
   '/system/tenant': () => import('@/views/system/TenantManage.vue'),
   '/system/billing': () => import('@/views/system/BillingManage.vue'),
+  '/system/config-version': () => import('@/views/system/ConfigVersionManage.vue'),
   '/aiconfig/model': () => import('@/views/aiconfig/ModelManage.vue'),
   '/aiconfig/mcp': () => import('@/views/aiconfig/McpManage.vue'),
   '/aiconfig/skill': () => import('@/views/aiconfig/SkillManage.vue'),

--- a/customer-admin-web/src/views/system/ConfigVersionManage.vue
+++ b/customer-admin-web/src/views/system/ConfigVersionManage.vue
@@ -1,0 +1,339 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import {
+  getVersion,
+  grayRelease,
+  pageVersions,
+  rollbackVersion,
+  type ConfigVersionVO,
+} from '@/api/config-version'
+import { listTenantOptions, type TenantVO } from '@/api/tenant'
+
+// 配置版本：看历史、比两版差异、回滚、灰度发布。
+// 回滚产生新版本而不是删后续版本——发布历史只增不删，任何时刻都能回答"当时线上是哪一版"。
+
+const STATUS_LABELS: Record<string, { text: string; type: 'success' | 'info' | 'danger' }> = {
+  PUBLISHED: { text: '生效中', type: 'success' },
+  SUPERSEDED: { text: '已被取代', type: 'info' },
+  FAILED: { text: '发布失败', type: 'danger' },
+}
+
+const loading = ref(false)
+const list = ref<ConfigVersionVO[]>([])
+const total = ref(0)
+const query = reactive({ pageNum: 1, pageSize: 10, configType: '', targetCode: '' })
+const tenants = ref<TenantVO[]>([])
+
+async function loadList() {
+  loading.value = true
+  try {
+    const data = await pageVersions(query)
+    list.value = data.list
+    total.value = data.total
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleSearch() {
+  query.pageNum = 1
+  return loadList()
+}
+
+// ---------- 版本对比 ----------
+
+const diffVisible = ref(false)
+const leftVersion = ref<ConfigVersionVO | null>(null)
+const rightVersion = ref<ConfigVersionVO | null>(null)
+const selected = ref<ConfigVersionVO[]>([])
+
+function handleSelectionChange(rows: ConfigVersionVO[]) {
+  selected.value = rows
+}
+
+async function openDiff() {
+  if (selected.value.length !== 2) {
+    ElMessage.warning('请勾选两个版本进行对比')
+    return
+  }
+  // 列表不返回 content（快照可能几十 KB），对比时才按需拉详情
+  const [a, b] = selected.value
+  const [left, right] = await Promise.all([getVersion(a.id), getVersion(b.id)])
+  // 版本号小的放左边，读起来才是"从旧到新"
+  const ordered = left.version <= right.version ? [left, right] : [right, left]
+  leftVersion.value = ordered[0]
+  rightVersion.value = ordered[1]
+  diffVisible.value = true
+}
+
+/** 简易逐行差异标记：内容是 JSON，行级比对足以看出改了哪个字段。 */
+function diffLines(a: string | null, b: string | null) {
+  const left = (a ?? '').split('\n')
+  const right = (b ?? '').split('\n')
+  const max = Math.max(left.length, right.length)
+  const rows: { no: number; left: string; right: string; changed: boolean }[] = []
+  for (let i = 0; i < max; i++) {
+    const l = left[i] ?? ''
+    const r = right[i] ?? ''
+    rows.push({ no: i + 1, left: l, right: r, changed: l !== r })
+  }
+  return rows
+}
+
+const diffRows = computed(() => diffLines(leftVersion.value?.content ?? '', rightVersion.value?.content ?? ''))
+const changedCount = computed(() => diffRows.value.filter((r) => r.changed).length)
+
+// ---------- 回滚 ----------
+
+async function handleRollback(row: ConfigVersionVO) {
+  const { value } = await ElMessageBox.prompt(
+    `将把 v${row.version} 的内容作为一个新版本重新下发（不会删除现有版本）。请填写回滚原因：`,
+    `回滚到 v${row.version}`,
+    { inputPlaceholder: '如：v5 的提示词导致答非所问', confirmButtonText: '确认回滚', type: 'warning' },
+  )
+  const newVersion = await rollbackVersion(row.id, value)
+  ElMessage.success(`已回滚，新版本 v${newVersion}`)
+  await loadList()
+}
+
+// ---------- 灰度发布 ----------
+
+const grayVisible = ref(false)
+const grayTarget = ref<ConfigVersionVO | null>(null)
+const grayForm = reactive<{ tenantCodes: string[]; remark: string }>({ tenantCodes: [], remark: '' })
+
+function openGray(row: ConfigVersionVO) {
+  grayTarget.value = row
+  grayForm.tenantCodes = []
+  grayForm.remark = ''
+  grayVisible.value = true
+}
+
+async function submitGray() {
+  if (!grayTarget.value) return
+  if (grayForm.tenantCodes.length === 0) {
+    ElMessage.warning('请至少选择一个租户')
+    return
+  }
+  const count = await grayRelease(grayTarget.value.id, grayForm.tenantCodes, grayForm.remark)
+  ElMessage.success(`灰度发布完成，已下发 ${count} 个租户`)
+  grayVisible.value = false
+  await loadList()
+}
+
+function formatGrayTenants(raw: string | null) {
+  if (!raw) return '-'
+  try {
+    return (JSON.parse(raw) as string[]).join('、')
+  } catch {
+    return raw
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([loadList(), listTenantOptions().then((t) => (tenants.value = t))])
+})
+</script>
+
+<template>
+  <div class="page">
+    <el-card>
+      <div class="toolbar">
+        <el-input
+          v-model="query.targetCode"
+          placeholder="按目标编码搜索（如 agentCode）"
+          style="width: 260px"
+          clearable
+          @keyup.enter="handleSearch"
+        />
+        <el-select v-model="query.configType" placeholder="全部类型" clearable style="width: 140px">
+          <el-option label="智能体" value="AGENT" />
+          <el-option label="模型" value="MODEL" />
+        </el-select>
+        <el-button type="primary" @click="handleSearch">搜索</el-button>
+        <el-button :disabled="selected.length !== 2" @click="openDiff">对比选中两版</el-button>
+      </div>
+
+      <el-table
+        v-loading="loading"
+        :data="list"
+        style="width: 100%"
+        @selection-change="handleSelectionChange"
+      >
+        <el-table-column type="selection" width="46" />
+        <el-table-column prop="targetCode" label="目标" width="180" />
+        <el-table-column prop="configType" label="类型" width="100" />
+        <el-table-column label="版本" width="90">
+          <template #default="{ row }">v{{ row.version }}</template>
+        </el-table-column>
+        <el-table-column label="状态" width="110">
+          <template #default="{ row }">
+            <el-tag :type="STATUS_LABELS[row.status]?.type ?? 'info'">
+              {{ STATUS_LABELS[row.status]?.text ?? row.status }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="范围" width="150">
+          <template #default="{ row }">
+            <el-tag v-if="row.publishScope === 'GRAY'" type="warning">
+              灰度：{{ formatGrayTenants(row.grayTenants) }}
+            </el-tag>
+            <span v-else>全量</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="来源" width="110">
+          <template #default="{ row }">
+            <span v-if="row.sourceVersion">回滚自 v{{ row.sourceVersion }}</span>
+            <span v-else>-</span>
+          </template>
+        </el-table-column>
+        <el-table-column prop="remark" label="说明" show-overflow-tooltip />
+        <el-table-column prop="createTime" label="发布时间" width="180" />
+        <el-table-column label="操作" width="160" fixed="right">
+          <template #default="{ row }">
+            <el-button
+              v-permission="'config-version:rollback'"
+              link
+              type="primary"
+              :disabled="row.status === 'FAILED'"
+              @click="handleRollback(row)"
+            >
+              回滚至此
+            </el-button>
+            <el-button
+              v-permission="'config-version:gray'"
+              link
+              type="warning"
+              :disabled="row.status === 'FAILED'"
+              @click="openGray(row)"
+            >
+              灰度
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-model:current-page="query.pageNum"
+        v-model:page-size="query.pageSize"
+        :total="total"
+        layout="total, prev, pager, next"
+        style="margin-top: 16px; justify-content: flex-end"
+        @current-change="loadList"
+      />
+
+      <div class="tip">
+        回滚会产生一个<b>新版本</b>（内容取自目标版本），不会删除现有版本——发布历史只增不删，
+        任何时刻都能回答"当时线上跑的是哪一版"，回滚本身也可被再回滚。
+      </div>
+    </el-card>
+
+    <el-dialog v-model="diffVisible" title="版本对比" width="90%" top="5vh">
+      <div class="diff-head">
+        <span>左：v{{ leftVersion?.version }}（{{ leftVersion?.createTime }}）</span>
+        <span>右：v{{ rightVersion?.version }}（{{ rightVersion?.createTime }}）</span>
+        <el-tag :type="changedCount ? 'warning' : 'success'">
+          {{ changedCount ? `${changedCount} 行有差异` : '两版内容一致' }}
+        </el-tag>
+      </div>
+      <div class="diff-body">
+        <div v-for="row in diffRows" :key="row.no" class="diff-row" :class="{ changed: row.changed }">
+          <span class="diff-no">{{ row.no }}</span>
+          <pre class="diff-cell">{{ row.left }}</pre>
+          <pre class="diff-cell">{{ row.right }}</pre>
+        </div>
+      </div>
+    </el-dialog>
+
+    <el-dialog v-model="grayVisible" :title="`灰度发布 v${grayTarget?.version ?? ''}`" width="560px">
+      <el-form label-width="100px">
+        <el-form-item label="目标租户">
+          <el-select v-model="grayForm.tenantCodes" multiple filterable style="width: 100%">
+            <el-option
+              v-for="t in tenants"
+              :key="t.tenantCode"
+              :label="`${t.tenantName}（${t.tenantCode}）`"
+              :value="t.tenantCode"
+            />
+          </el-select>
+          <div class="form-tip">
+            只有名单内的租户会收到这一版，其余租户继续用当前全量版本。
+          </div>
+        </el-form-item>
+        <el-form-item label="发布说明">
+          <el-input v-model="grayForm.remark" type="textarea" placeholder="建议写清灰度目的，事后翻历史时最有用" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="grayVisible = false">取消</el-button>
+        <el-button type="primary" @click="submitGray">确认灰度</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.tip {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.7;
+}
+
+.form-tip {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.6;
+}
+
+.diff-head {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+}
+
+.diff-body {
+  max-height: 65vh;
+  overflow: auto;
+  border: 1px solid var(--el-border-color);
+  border-radius: 4px;
+}
+
+.diff-row {
+  display: grid;
+  grid-template-columns: 56px 1fr 1fr;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.diff-row.changed {
+  background: var(--el-color-warning-light-9);
+}
+
+.diff-no {
+  padding: 2px 8px;
+  color: var(--el-text-color-placeholder);
+  text-align: right;
+  font-size: 12px;
+  border-right: 1px solid var(--el-border-color-lighter);
+}
+
+.diff-cell {
+  margin: 0;
+  padding: 2px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  border-right: 1px solid var(--el-border-color-lighter);
+}
+</style>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -1062,6 +1062,15 @@ public class CustomerWorkProperties {
          * 否则密文解不开、整份配置被判失败并保留旧配置。
          */
         private String configAesKey = "";
+
+        /**
+         * 本实例所属租户编码，用于接收<b>按租户灰度</b>的运行时配置。
+         *
+         * <p>配了就先读 {@code <runtime-config-data-id>-tenant-<租户码>}，读不到才回落主 dataId。
+         * 本端并不理解"灰度"，只是多试了一个更具体的 dataId；运营方把灰度版本写进那个 dataId，
+         * 名单外的实例自然继续用主 dataId 上的全量版本。留空即不参与灰度（单租户部署无需配置）。</p>
+         */
+        private String tenantCode = "";
     }
 
     /** 交互协议配置（AG-UI / TTS）。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosRuntimeConfigService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/NacosRuntimeConfigService.java
@@ -63,12 +63,35 @@ public class NacosRuntimeConfigService {
         }
     }
 
-    /** 绑定到给定 ConfigService：拉取初始配置并注册热更新监听器（抽出以便单测）。 */
+    /**
+     * 绑定到给定 ConfigService：拉取初始配置并注册热更新监听器（抽出以便单测）。
+     *
+     * <p><b>灰度优先</b>：配了 {@code nacos.tenant-code} 时先看租户专属 dataId
+     * （{@code <主dataId>-tenant-<租户码>}），有内容就用它，没有才回落主 dataId。
+     * 灰度因此对本端是透明的——本端并不理解"灰度"，只是多试了一个更具体的 dataId；
+     * 运营方把灰度版本写进那个 dataId，名单外的实例自然继续用主 dataId 上的全量版本。</p>
+     *
+     * <p>两个 dataId 都要挂监听：灰度期间运营方可能改灰度版本，灰度结束后又会删掉它——
+     * 只听一个的话，要么灰度更新收不到，要么灰度撤销后回不到全量版本。</p>
+     */
     void bind(ConfigService configService) throws NacosException {
         CustomerWorkProperties.Nacos cfg = properties.getNacos();
-        String initial = configService.getConfig(cfg.getRuntimeConfigDataId(), cfg.getGroup(), cfg.getTimeoutMs());
+        String mainDataId = cfg.getRuntimeConfigDataId();
+        String tenantDataId = tenantDataId(cfg);
+
+        String initial = null;
+        if (tenantDataId != null) {
+            initial = configService.getConfig(tenantDataId, cfg.getGroup(), cfg.getTimeoutMs());
+            if (StringUtils.hasText(initial)) {
+                log.info("[Nacos] gray config applied, dataId={}", tenantDataId);
+            }
+        }
+        if (!StringUtils.hasText(initial)) {
+            initial = configService.getConfig(mainDataId, cfg.getGroup(), cfg.getTimeoutMs());
+        }
         applyConfig(initial);
-        configService.addListener(cfg.getRuntimeConfigDataId(), cfg.getGroup(), new Listener() {
+
+        configService.addListener(mainDataId, cfg.getGroup(), new Listener() {
             @Override
             public Executor getExecutor() {
                 return Runnable::run;   // 同步回调，简单可控
@@ -79,6 +102,49 @@ public class NacosRuntimeConfigService {
                 applyConfig(configInfo);
             }
         });
+
+        if (tenantDataId != null) {
+            configService.addListener(tenantDataId, cfg.getGroup(), new Listener() {
+                @Override
+                public Executor getExecutor() {
+                    return Runnable::run;
+                }
+
+                @Override
+                public void receiveConfigInfo(String configInfo) {
+                    // 灰度被撤销时 Nacos 回调的是空串：此时不 applyConfig（那会被当成"无配置"跳过），
+                    // 而是主动回读主 dataId 恢复全量版本，否则实例会一直停在灰度版本上
+                    if (StringUtils.hasText(configInfo)) {
+                        applyConfig(configInfo);
+                        return;
+                    }
+                    restoreFromMainDataId(configService, cfg);
+                }
+            });
+        }
+    }
+
+    /** 灰度撤销后回到全量版本。读取失败只记日志——保持当前配置总比清空好。 */
+    private void restoreFromMainDataId(ConfigService configService, CustomerWorkProperties.Nacos cfg) {
+        try {
+            String main = configService.getConfig(cfg.getRuntimeConfigDataId(), cfg.getGroup(), cfg.getTimeoutMs());
+            if (StringUtils.hasText(main)) {
+                applyConfig(main);
+                log.info("[Nacos] gray config removed, restored from main dataId={}", cfg.getRuntimeConfigDataId());
+            }
+        } catch (Exception e) {
+            log.error("restore runtime config from main dataId failed, code={}",
+                "RUNTIME-CONFIG-RESTORE-FAIL", e);
+        }
+    }
+
+    /** 租户专属 dataId；未配租户码时返回 null（单租户部署不受灰度机制影响）。 */
+    private String tenantDataId(CustomerWorkProperties.Nacos cfg) {
+        String tenantCode = cfg.getTenantCode();
+        if (tenantCode == null || tenantCode.isBlank()) {
+            return null;
+        }
+        return cfg.getRuntimeConfigDataId() + "-tenant-" + tenantCode.trim();
     }
 
     /**

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -109,6 +109,7 @@
 | **多租户行级隔离（tenant_id 强制过滤）** | `TenantContext` + `CustomerWorkTenantLineHandler`（starter）+ `TenantContextInterceptor`（admin） | 关 | `customer-work.tenant.enabled=true`（starter）/ `admin.tenant.enabled=true`（admin），见 §6.27 |
 | **水平扩展（限流/成本熔断/会话锁共享）** | `WindowCounter` + `SessionLock`（Redisson 实现） | 关 | `customer-work.distributed.counter-mode=redis` + `session-lock-mode=redis`，见 §6.28 |
 | **租户配额与计费（token 硬上限 + 账单）** | `TenantQuotaGuard`（starter）+ `BillingController`（admin） | 关 | `customer-work.quota.enabled=true`，见 §6.29 |
+| **配置版本化与按租户灰度** | `ConfigVersionService` + `ConfigRollbackService`（admin） | 随发布能力 | `admin.runtime-publish.nacos.enabled=true` 即生效，见 §6.30 |
 | 运维就绪（健康/停机/巡检） | `SessionHealthIndicator` / `GracefulShutdownService` / `MaintenanceScheduler` | 开 | `/actuator/health` |
 | 模型多厂商 + 私有化兜底 / 重试 / **成本熔断** | `ModelConfig`（或 2.0 内置 `maxRetries`/`fallbackModel`）+ `ModelCostCircuitBreaker` | 开 | `model.provider`、`model.fallback.enabled`、`model.cost-control.enabled` |
 | MCP 接入 | `McpToolkitConfigurer` | 关 | `mcp.enabled=true` |
@@ -1569,6 +1570,31 @@ admin:
 **已知边界**：用量的实时计数（`WindowCounter`）与账单（调用日志汇总）是两套数，
 内存模式下进程重启会丢实时计数。生产多副本本就要把计数器切 Redis（见 §6.28），届时重启不丢。
 
+### 6.30 配置版本化与按租户灰度（B4）
+
+此前 `CustomerWorkConfigPublisher` 是直接覆盖 Nacos 上的当前配置，发布前只做连通性探测——
+探测通过不代表配置本身是对的，改坏了 prompt 只能靠人肉记忆改回去。
+
+**每次发布留一份完整快照**到 `ai_config_version`（含内容、摘要、发布范围、dataId、发布人）。
+发布失败也记一条 `FAILED`——排查"线上为什么还是旧配置"时，失败留痕比什么都没有有用得多。
+
+**回滚 = 把旧内容作为新版本再发一次**，不是删掉后续版本。发布历史只增不删，
+因此任何时刻都能回答"当时线上跑的是哪一版"，回滚本身也可被再回滚。
+
+**灰度以租户为单元**（不是流量比例——按比例会让同一租户的用户看到不一致的行为，反而更难排查）：
+
+- 发布端把灰度版本写到 `<主dataId>-tenant-<租户码>`；
+- 客服端配 `customer-work.nacos.tenant-code` 后，启动时先读租户 dataId，读不到才回落主 dataId；
+- 两个 dataId 都挂监听。**灰度撤销时 Nacos 回调的是空串，此时必须主动回读主 dataId**，
+  否则实例会一直停在灰度版本上。
+
+客服端并不理解"灰度"这个概念，只是多试了一个更具体的 dataId——名单外的实例自然继续用全量版本。
+
+**内容未变不新增版本**：重复发布同样的内容只会把版本历史刷满噪音，让"这次改了什么"难以辨认。
+但发布范围变化（全量↔灰度）算一次真实的发布行为，即使内容相同也会留新版本。
+
+后台入口：`系统管理 → 配置版本`（权限点 `config-version:view/rollback/gray`），支持逐行差异对比。
+
 ---
 
 ## 七、配置项总表
@@ -1597,6 +1623,7 @@ admin:
 | `multi-agent` | enabled(true), mode(fanout), max-iters(6) |
 | `runtime` | shutdown-timeout-seconds(30), scheduler-enabled(false), scheduler-fixed-delay-ms(60000) |
 | `interrupt` | pending-tool-recovery-enabled(true) |
+| `nacos`（含 B4 灰度）| tenant-code('')：本实例所属租户，配了才参与按租户灰度，见 §6.30 |
 | `nacos` | enabled(false), server-addr(localhost:8848), namespace, group(DEFAULT_GROUP), prompt-data-id, username, password, timeout-ms(3000) |
 | `higress` | enabled(false), name(higress), endpoint, transport(sse), tool-search, max-tools(10), timeout-seconds(30) |
 | `protocol` | agui.{enabled(true),enable-reasoning(true),emit-tool-call-args(true)}, tts.enabled(false) |

--- a/mysql/02-customer-admin/51-V51__config_versioning.sql
+++ b/mysql/02-customer-admin/51-V51__config_versioning.sql
@@ -1,0 +1,49 @@
+-- ============================================================================
+-- B4 配置版本化与灰度：发布前留快照，出问题能回退
+--
+-- 此前 CustomerWorkConfigPublisher 是直接覆盖 Nacos 上的当前配置，发布前只做连通性探测——
+-- 探测通过不代表配置本身是对的，改坏了 prompt 就只能靠人肉记忆改回去。
+--
+-- 本表存的是"每次发布下发了什么"的完整快照。回滚不是删掉新版本，而是把旧版本的内容
+-- 作为一个新版本再发一次——发布历史因此永远是只增的，任何时刻都能回答"当时线上是哪一版"。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS `ai_config_version` (
+    `id`            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `config_type`   VARCHAR(32) NOT NULL COMMENT '配置类型：AGENT 智能体运行时配置 / MODEL 模型配置',
+    `target_code`   VARCHAR(128) NOT NULL COMMENT '目标业务编码（如 agentCode / channelCode），人可读、跨环境稳定',
+    `target_id`     BIGINT COMMENT '目标主键（可空：跨环境迁移后主键会变，故以 target_code 为准）',
+    -- 版本号按 target 单调递增，由应用在插入时取 max+1：
+    -- 用全局自增 id 当版本号会让同一个目标的版本号跳跃，运营看不出"这是第几次发布"
+    `version`       INT NOT NULL COMMENT '该目标下的版本序号，从 1 开始',
+    `content`       MEDIUMTEXT NOT NULL COMMENT '下发内容的完整快照（JSON），回滚即取此内容重发',
+    `content_hash`  VARCHAR(64) NOT NULL DEFAULT '' COMMENT '内容摘要，用于跳过"内容没变却重复发布"',
+    -- 灰度范围：FULL 全量；GRAY 仅 gray_tenants 列出的租户。
+    -- 灰度不是"发一半流量"，而是"先发给指定租户"——SaaS 天然以租户为灰度单元，
+    -- 按流量比例灰度会让同一租户的用户看到不一致的行为，反而更难排查
+    `publish_scope` VARCHAR(16) NOT NULL DEFAULT 'FULL' COMMENT '发布范围：FULL 全量 / GRAY 灰度',
+    `gray_tenants`  VARCHAR(1024) COMMENT '灰度租户编码列表（JSON 数组），publish_scope=GRAY 时有效',
+    `data_id`       VARCHAR(255) NOT NULL DEFAULT '' COMMENT '实际发布到的 Nacos dataId',
+    `status`        VARCHAR(16) NOT NULL DEFAULT 'PUBLISHED' COMMENT '状态：PUBLISHED 已发布 / SUPERSEDED 已被后续版本取代 / FAILED 发布失败',
+    `source_version` INT COMMENT '回滚来源版本号；非回滚产生的版本为空',
+    `remark`        VARCHAR(500) COMMENT '发布说明',
+    `create_by`     BIGINT COMMENT '发布人ID',
+    `create_time`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '发布时间',
+    UNIQUE KEY `uk_config_version` (`config_type`, `target_code`, `version`),
+    KEY `idx_config_version_target` (`config_type`, `target_code`, `create_time`),
+    KEY `idx_config_version_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='配置发布版本快照（支持对比与回滚）';
+
+-- 本表是平台级的：配置发布由运营方执行，租户只是灰度的目标而非本表的归属者，
+-- 故不带 tenant_id，进拦截器忽略清单。
+
+-- ============================================================================
+-- 配置版本菜单与权限点（id 从 228 起，227 是 V50 配额计费占用的最后一个）
+-- ============================================================================
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (228, 1, '配置版本', 'config-version:view', 1, '/system/config-version', 'DocumentCopy', 'library', 11);
+
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (229, 228, '回滚配置', 'config-version:rollback', 2, 1),
+    (230, 228, '灰度发布', 'config-version:gray', 2, 2);


### PR DESCRIPTION
企业级 SaaS 路线图 **B4 批次**（最后一批）。此前 `CustomerWorkConfigPublisher` 是直接覆盖 Nacos 上的当前配置，发布前只做连通性探测——**探测通过不代表配置本身是对的**，改坏了 prompt 就只能靠人肉记忆改回去。

> ⚠️ **本 PR stacked 在 #85 / #86 / #87 之上**，包含它们的提交。合并顺序：**#85 → #86 → #87 → 本 PR**。

## 版本快照

每次发布留一份完整快照到 `ai_config_version`（内容、摘要、发布范围、dataId、发布人）。

- **发布失败也记一条 `FAILED`**：排查"线上为什么还是旧配置"时，一条失败留痕比什么都没有有用得多。失败版本不参与"取代上一版"——上一版仍是线上生效的那一版。
- **内容未变不新增版本**：重复发布同样的内容只会把版本历史刷满噪音，让"这次到底改了什么"难以辨认。但**发布范围变化**（全量↔灰度）算一次真实的发布行为，即使内容相同也留新版本。
- 版本号按目标单调递增，而不是用全局自增 id——后者会让同一个目标的版本号跳跃，运营看不出"这是第几次发布"。

## 回滚 = 把旧内容作为新版本再发一次

**不是删掉后续版本。** 删除会让发布历史出现空洞，事后无法回答"某个时间点线上跑的是哪一版"；只增不删的历史也让回滚本身可被再回滚。

回滚复用正常发布的同一段下发代码——若给回滚另写一条逻辑，两条路迟早在序列化或 dataId 拼装上产生差异。

## 按租户灰度

选租户而非流量比例：**按比例灰度会让同一租户的用户看到不一致的行为**，出了问题反而更难复现。SaaS 天然以租户为切分单元。

机制上刻意做得让客服端"不需要理解灰度"：

1. 发布端把灰度版本写到 `<主dataId>-tenant-<租户码>`，逐租户下发（单个失败不阻断其余——灰度本就是分批放量）；
2. 客服端配 `customer-work.nacos.tenant-code` 后，先读租户 dataId，读不到才回落主 dataId；
3. **两个 dataId 都挂监听**。灰度期间运营方可能改灰度版本，灰度结束后又会删掉它——只听一个的话，要么灰度更新收不到，要么灰度撤销后回不到全量版本。

**一个容易漏的点**：灰度撤销时 Nacos 回调的是**空串**。此时不能直接 `applyConfig`（空会被当成"无配置"跳过），必须主动回读主 dataId，否则实例会一直停在灰度版本上。这个分支在代码里有显式注释。

## 前端

`系统管理 → 配置版本`：版本列表（生效中/已被取代/发布失败三态）、勾选两版做**逐行差异对比**（内容是 JSON，行级比对足以看出改了哪个字段；列表不返回快照内容，对比时才按需拉详情）、回滚（强制填原因）、灰度租户多选。

## 顺带

`CustomerWorkConfigPublisher` 加构造器重载时同步标了 `@Autowired`——B3 刚因为漏标同款问题导致容器启动失败，这次没再踩。

## 测试

starter 1177 / admin **741**(+9) / app 78 / channel 65 / gateway 1，全绿。前端 `vue-tsc -b && vite build` 通过。

新增覆盖：版本号从 1 起且按目标递增、内容未变复用版本号且不插新行、**范围变化即使内容相同也要新版本**、旧版本标记 SUPERSEDED、回滚版本记录 sourceVersion 且是新版本而非复活旧版本、失败版本不取代当前版本、不同内容摘要不同、详情带快照而列表不带。

## 未验证

- **Nacos 未启动**（本机 Docker 未运行），灰度的两个 dataId 读取与撤销回落只做了静态审查与单测覆盖，建议合入前在有 Nacos 的环境走一遍：发布全量 → 灰度给某租户 → 确认名单内外实例配置不同 → 删除灰度 dataId → 确认名单内实例回到全量版本。
- V51 迁移同样未在真实 MySQL 上执行过。
