### PR TITLE
fix(config): 移除 CustomerWorkProperties 中重复的 Tenant 配置块

### DIFF
--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/config/CustomerWorkProperties.java
@@ -190,40 +190,6 @@ public class CustomerWorkProperties {
 
         /** 分布式会话锁的持有超时（秒），防止实例崩溃后锁永不释放。 */
         private int sessionLockLeaseSeconds = 120;
-    /** 多租户隔离（tenant_id 行级过滤），SaaS 部署开启。 */
-    private final Tenant tenant = new Tenant();
-
-    /**
-     * 多租户配置。默认关闭——单租户部署（升级前的既有形态）行为完全不变。
-     *
-     * <p>开启后 {@code TenantLineInnerInterceptor} 接管本 starter 独立 MyBatis 环境下的全部
-     * SELECT/UPDATE/DELETE 改写与 INSERT 补列，且缺失租户上下文时 fail-closed 直接报错，
-     * 而不是放行成全量查询——静默返回跨租户数据比报错危险得多。</p>
-     */
-    @Data
-    public static class Tenant {
-
-        /** 是否开启多租户行级隔离。 */
-        private boolean enabled = false;
-
-        /** 租户列名（全部业务表统一）。 */
-        private String columnName = "tenant_id";
-
-        /**
-         * 不参与租户过滤的表（平台级数据 + 框架自建表）。
-         *
-         * <p>清单语义见 {@code docs/多租户架构设计.md}：这里的表要么内容由平台定义租户只读，
-         * 要么根本没有 {@code tenant_id} 列（框架自建），漏配会让 SQL 拼出不存在的列而报错。</p>
-         */
-        private List<String> ignoredTables = new ArrayList<>();
-
-        /**
-         * 是否在 starter 内开启 Reactor 自动上下文传播（{@code Hooks.enableAutomaticContextPropagation()}）。
-         *
-         * <p>WebFlux 主链路会切到 boundedElastic 执行阻塞 JDBC，而 MyBatis 拦截器读的是 ThreadLocal——
-         * 不传播就必然在跨线程边界丢租户。该 Hook 是 JVM 全局的，故只在多租户开启时才装。</p>
-         */
-        private boolean autoContextPropagation = true;
     }
 
     /**


### PR DESCRIPTION
## 问题

PR #88 合并时把 B1 的 `Tenant` 字段与内部类**重复粘进了 `Distributed` 类内部**，且 `Distributed` 少了闭合括号。结果是 `Tenant` 字段与 `Tenant` 类各定义两次，**main 上的 `customer-work-starter` 编译不过**。

```
108:    private final Tenant tenant = new Tenant();      ← 第一份
118:    public static class Tenant {
...
192:        private int sessionLockLeaseSeconds = 120;   ← Distributed 少了 }
193:    private final Tenant tenant = new Tenant();      ← 第二份，嵌在 Distributed 里
204:    public static class Tenant {
```

## 修复

删除重复的那份并补回 `Distributed` 的闭合括号。保留的是文件靠前那份（108/118 行）——两份内容**逐字一致**，因此没有任何配置项语义变化。

修复后各配置块唯一：

```
108: private final Tenant tenant       118: class Tenant
144: private final Distributed distributed   172: class Distributed
147: private final Quota quota         156: class Quota
```

## 顺带实测了迁移脚本

`mysql/01-agent-scope-customer-work/customer-work-tenant-alter.sql` 此前只做过静态审查（当时本机 Docker 未启动）。这次在本机存量库上实跑：

- 27 张 `cw_` 表全部加列成功；
- `uk_user_username` / `uk_dict_item` / `uk_sensitive_word` 三处唯一键均已正确前置 `tenant_id`；
- 脚本幂等，可重复执行。

**没跑这个脚本时，starter 的 23 个持久层测试会因 `Unknown column 'tenant_id' in 'field list'` 报错**（共 91 个 error）。部署 B1 到已有环境时务必先执行它。

## 验证

`mvn clean compile` 全模块通过；全量单测在 MySQL 可达的环境下：

| 模块 | 用例 | 失败 |
|---|---|---|
| customer-work-starter | 1177 | 0 |
| customer-admin-server | 742 | 0 |
| customer-work-app-server | 78 | 0 |
| customer-channel | 65 | 0 |
| customer-work-gateway | 1 | 0 |

合计 **2063**，全绿。