### PR TITLE
docs(readme): 补齐 SaaS 化批次内容并修正章节编号

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   无需改框架代码（用法见 [全量参考 §6.9](docs/功能与配置全量参考.md)）。
 - **两套完整系统**：智能客服系统（AI 对话 + 用户工单 + 坐席协作）+ 后台管理系统（模型 / 提示词 / MCP / 渠道 /
   定时任务 / 工单工作台，改配置经 Nacos 热更新到运行中的客服应用，免重启）。
+- **多租户 SaaS 就绪（默认关闭）**：共享库 + `tenant_id` 行级隔离（MyBatis-Plus 拦截器全局改写，缺上下文 fail-closed），
+  配套租户配额与 T+1 计费账单、配置版本化与按租户灰度发布、多副本水平扩展（Redis 窗口计数 / 会话锁 + `deploy/k8s/` 清单）。
+  不开启时单租户部署行为与升级前完全一致，设计见 [多租户架构设计](docs/多租户架构设计.md)。
 
 ## 二、模块结构
 
@@ -53,6 +56,7 @@ flowchart LR
 
 > 附属目录：`mysql/` 建库脚本（业务库 / admin 库 / XXL-JOB 库）、`docker/` 中间件编排（MinIO / PaddleOCR /
 > [observability](docker/observability/README.md) 一键监控栈：Prometheus + Grafana + Alertmanager + Tempo + 钉钉告警）、
+> [deploy/k8s/](deploy/k8s/README.md) 多副本 K8s 清单（Deployment / HPA / PDB / 探针 / 优雅停机）、
 > `Dockerfile` + `docker-compose.yml` 一键起应用与依赖、`.github/workflows/ci.yml` CI。
 > starter 的代码分层与"作为依赖引入"的方式见 [全量参考 §九](docs/功能与配置全量参考.md)。
 
@@ -197,6 +201,8 @@ stateDiagram-v2
     end note
 ```
 
+## 四、能力地图
+
 细节（配置项、curl 示例、对应测试类）全部在 [功能与配置全量参考](docs/功能与配置全量参考.md)，此处只给地图：
 
 | 能力域 | 内容 | 全量参考 |
@@ -210,7 +216,8 @@ stateDiagram-v2
 | 模型层 | 多厂商（百炼/OpenAI/Anthropic/Gemini/Ollama）、私有化兜底、重试、成本熔断、token 告警 | §6.12~6.13b |
 | 安全与治理 | API Key 鉴权、限流（全局兜底 + 后台可维护的路径规则层）、敏感词内容风控（一次拦截/打码/复核 + 命中看板）、入站防注入围栏、敏感信息脱敏、Permission 三态权限、沙箱 | §6.14~6.14.2、§6.18 |
 | 可观测与运维 | Prometheus 业务指标、原生 Tracing、OTel 链路追踪（真出 span + OTLP 导出）、MDC 全链路日志、慢请求留证、合成监控、优雅停机、一键 Grafana/Tempo/Alertmanager 监控栈 | §6.13~6.13c |
-| 配置面 | Nacos 提示词/运行时配置热更新（后台 8082 改 → 客服 8080 免重启生效）、MCP / Higress / Studio 接入 | §6.15~6.17 |
+| 配置面 | Nacos 提示词/运行时配置热更新（后台 8082 改 → 客服 8080 免重启生效）、配置版本化快照 + 一键回滚 + 按租户灰度发布、MCP / Higress / Studio 接入 | §6.15~6.17、§6.30 |
+| 多租户 SaaS | 租户行级隔离（拦截器全局改写 + fail-closed）、租户管理与双视角权限、水平扩展（Redis 窗口计数 / 会话锁 + K8s 清单）、租户 token 配额 + T+1 计费账单 | §6.27~6.29 |
 | 数据飞轮 | 会话质检、坐席辅助、消息级点赞点踩、意图自动化评测（CI 可跑） | §6.11 末、§6.20 |
 | 后台管理系统 | RBAC 权限、模型/MCP/Skill/智能体配置、工作区聊天 + VibeCoding、渠道、定时任务(XXL-JOB)、工单工作台、内容风控、数据字典、开发者工具箱（HTTP/证书/cron/JWT/diff/格式互转/SQL 客户端等）、调用统计（token + 缓存命中率）、AI 编码助手 | §6.21 |
 
@@ -231,7 +238,7 @@ curl -X POST http://localhost:8080/api/customer/chat \
 ```
 
 - 启动后打开 **http://localhost:8080/swagger-ui.html** 在线调试全部接口。
-- 跑测试（无需 API Key，任何环境全绿）：`mvn test` ——当前基线 **2002 个**（starter 1136 + admin-server 722 +
+- 跑测试（无需 API Key，任何环境全绿）：`mvn test` ——当前基线 **2065 个**（starter 1180 + admin-server 741 +
   app 78 + customer-channel 65 + gateway 1），外部依赖（Redis/MySQL/Nacos/百炼/OCR/MinIO）不可达的用例自动跳过。
 - 环境要求、前端启动、构建坑位速查见 [新人必读](docs/新人必读.md)。
 
@@ -244,7 +251,8 @@ timeline
     已完成 · 2.0 迁移 : RC4 首轮迁移（rc2.0 分支存档） : 2.0.0 GA 全量迁移 + Harness 新能力补齐
     已完成 · 生产化 : HITL 审批闭环 + 人机切换工单 : 用户工单系统（JWT + WS 双通道 + 7 态状态机） : 后台管理系统 + Nacos 配置热更新 : 真实业务后端 jdbc + 附件解析 OCR : Nacos 注册发现 + SCG 网关 + XXL-JOB
     已完成 · 平台化 : 内容风控（敏感词 + 限流）+ 数据字典 + 开发者工具箱 : 十项通用能力薄壳化下沉 starter : OTel 链路追踪 + 一键 Grafana / Tempo 监控栈 : 登录态 Redis 持久化 + streamEvents 流式重构
-    规划中 · 扩展点 : A2A Agent Card 注册发现 : RocketMQ 异步消息 : Training 数据飞轮（RM Gallery / Trinity-RFT） : 后台 AI 编码助手 P1~P3 演进
+    已完成 · SaaS 化 : 多租户行级隔离 + 租户管理双视角 : 水平扩展（Redis 计数 / 会话锁 + K8s 清单） : 租户配额 + T+1 计费账单 : 配置版本化 + 按租户灰度 : starter 按域拆分治理
+    规划中 · 扩展点 : 租户安全合规（审计归档 / 退租数据导出） : A2A Agent Card 注册发现 : RocketMQ 异步消息 : Training 数据飞轮（RM Gallery / Trinity-RFT） : 后台 AI 编码助手 P1~P3 演进
 ```
 
 规划中的能力框架均已提供扩展点（保留为"配置即用"，不硬编入以保证开箱即用）：
@@ -266,6 +274,7 @@ timeline
 | 15 分钟跑起来、看懂结构、知道改哪里 | [docs/新人必读.md](docs/新人必读.md) |
 | 功能总表、配置项、接口速查、各功能用法与测试 | [docs/功能与配置全量参考.md](docs/功能与配置全量参考.md) |
 | 架构原理、时序图、UML 类图、扩展点 | [docs/详细技术文档.md](docs/详细技术文档.md) |
+| 多租户隔离模型、逐表归属、身份链路 | [docs/多租户架构设计.md](docs/多租户架构设计.md) |
 | 全部接口的请求 / 响应示例（生产调用方视角） | [docs/生产接口使用手册.md](docs/生产接口使用手册.md) |
 | 生产部署步骤、环境变量、建表、灰度回滚 | [docs/部署手册.md](docs/部署手册.md) |
 | 1.x→2.0 API 映射、RC4→GA 变更、issue 核对 | [docs/MIGRATION-2.0.md](docs/MIGRATION-2.0.md) |

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -1500,10 +1500,8 @@ customer-admin-server：`spring.servlet.multipart.max-file-size`/`max-request-si
 
 **已知限制**：客服端的字典 / 敏感词 / 限流规则三张配置表，新租户开通时不会自动复制平台默认值
 （admin 与客服端库之间没有直连通道），当前需要为新租户单独维护；平台词库批量下发属于运维能力，留待后续批次。
-### 6.28 水平扩展：限流 / 成本熔断 / 会话锁的跨实例共享（默认关闭）
-=======
 
-### 6.27 水平扩展：限流 / 成本熔断 / 会话锁的跨实例共享（默认关闭）
+### 6.28 水平扩展：限流 / 成本熔断 / 会话锁的跨实例共享（默认关闭）
 
 单实例部署下进程内实现更快也更简单，所以默认不变。**多副本部署必须切**，否则扩容会同时
 放大配额、打乱会话——这不是性能优化，是正确性问题。
@@ -1534,41 +1532,6 @@ Redis 连接复用 `customer-work.distributed-lock.redis.*`，不用再配一套
 
 K8s 多副本清单见 `deploy/k8s/`（含 Deployment / Service / HPA / PDB / 探针 / 优雅停机），
 其 ConfigMap 已把上述三项全部切成 Redis。
-=======
-### 6.27 多租户行级隔离（B1 租户地基，默认关闭）
-
-共享库 + `tenant_id` 行级过滤，隔离强制点是 MyBatis-Plus 的 `TenantLineInnerInterceptor`。
-完整设计（逐表归属、忽略表判定依据、身份链路、已知约束）见 `docs/多租户架构设计.md`，这里只列用法。
-
-**开启**：`customer-work.tenant.enabled=true`（客服端）+ `admin.tenant.enabled=true`（后台）。
-默认关闭，单租户部署的行为与升级前完全一致——不挂拦截器、不装 Reactor 传播 Hook。
-
-**升级已有库**：客服端跑 `mysql/01-agent-scope-customer-work/customer-work-tenant-alter.sql`
-（27 张 cw_ 表加列 + 6 处唯一键重建，幂等可重复执行）；后台走 Flyway V49 自动执行。
-存量数据归入 `default` 租户，存量后台用户归入 `__platform__`。
-
-**租户身份来源**（三个入口各不相同）：
-
-| 入口 | 来源 | 配置 |
-|---|---|---|
-| 服务端接入方 | API Key → 租户映射 | `security.auth.tenant-keys.{key}: {租户ID}` |
-| H5 用户端 | 登录时带 `tenantCode`，登录后焊进 JWT | 前端 `?tenant=xxx` 或 `VITE_TENANT_CODE` |
-| 后台管理 | 登录用户的 `sys_user.tenant_id` | 运营方可在顶栏切换目标租户视角 |
-
-**后台租户管理**：`系统管理 → 租户管理`（权限点 `tenant:view/add/edit/delete`，仅运营方）。
-新建租户会自动初始化一个 `tenant_admin` 角色并授予除 `tenant:*` 外的全部权限点。
-冻结/退租只改状态不动数据，登录侧立即生效。
-
-**开发约定**（新增代码时必须遵守）：
-
-- 新增业务表一律带 `tenant_id`，不要往忽略清单加表；
-- 有意的跨租户查询走 `CrossTenantOperations.execute(...)`，它是可 grep 的白名单；
-- 缺租户上下文时持久层 **fail-closed 抛错**（`TenantContextMissingException`），
-  这是刻意的——静默返回别的租户的数据比一次 500 危险得多；
-- 无请求上下文的场景（定时任务、启动初始化）用 `TenantContext.runWith(租户, ...)` 显式指定。
-
-**已知限制**：客服端的字典 / 敏感词 / 限流规则三张配置表，新租户开通时不会自动复制平台默认值
-（admin 与客服端库之间没有直连通道），当前需要为新租户单独维护；平台词库批量下发属于运维能力，留待后续批次。
 
 ### 6.29 租户配额与计费（B3，默认关闭）
 


### PR DESCRIPTION
## 改动内容

**README.md**（对齐 B1~B4 与 PR #90 后的实际进展）：
- 第一节新增「多租户 SaaS 就绪」要点（行级隔离 fail-closed / 配额计费 / 按租户灰度 / 水平扩展），链接 docs/多租户架构设计.md
- 能力地图新增「多租户 SaaS」行（§6.27~6.29），「配置面」行补配置版本化 + 灰度（§6.30）
- 测试基线 2002 → **2065**（starter 1180 + admin-server 741，与 CLAUDE.md 一致）
- Roadmap 时间线补「已完成 · SaaS 化」阶段；规划中补租户安全合规
- 附属目录补 deploy/k8s/；文档地图补多租户架构设计
- 修正章节编号断档（原「三」直接跳「五」，能力地图表升为独立第四节）

**docs/功能与配置全量参考.md**：
- 清理 B1/B2 并行合入遗留的合并冲突残留：两行裸 `=======`、§6.27 多租户整段重复、水平扩展段头编号错乱
- 现在 §6.26~6.30 编号连续且各只出现一次（§6.29 内「见 §6.28」引用随之恢复正确）

## 验证
- 纯文档改动，无代码变更
- `grep -n '^=======\|<<<<<<<\|>>>>>>>'` 全量参考无残留；§6.26~6.30 标题唯一且有序