### PR TITLE
fix: VibeCoding 会话产出物落 MinIO，修复临时目录被清理即丢失

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/VibeCodingWorkspaceConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/VibeCodingWorkspaceConfig.java
@@ -1,0 +1,44 @@
+package com.richard.fyoung.customeradmin.config;
+
+import com.richard.fyoung.customeradmin.workspace.runtime.SessionWorkspaceStorage;
+import com.richard.fyoung.customerwork.data.attachment.MinioAttachmentFileStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * VibeCoding 会话工作区持久化装配。
+ *
+ * <p>复用 starter 的 {@link MinioAttachmentFileStorage}（同一套惰性 bucket 语义），但指向<b>独立 bucket</b>——
+ * 产出物与聊天附件的生命周期和备份策略不同，混在一个桶里运维不好切分。构造不连网，
+ * MinIO 不可达不影响 admin 启动。</p>
+ *
+ * <p>{@code enabled=false} 时返回 {@code null}（NullBean），使用侧的 {@code ObjectProvider#getIfAvailable}
+ * 拿到 null 后跳过持久化，产出物仅存于本地临时目录。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class VibeCodingWorkspaceConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(VibeCodingWorkspaceConfig.class);
+
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+
+    @Bean
+    @ConditionalOnMissingBean(SessionWorkspaceStorage.class)
+    public SessionWorkspaceStorage sessionWorkspaceStorage(VibeCodingWorkspaceProperties properties) {
+        if (!properties.isEnabled()) {
+            log.info("vibecoding workspace persistence disabled (产出物仅存本地临时目录，会随清理丢失)");
+            return null;
+        }
+        log.info("vibecoding workspace persistence: minio (endpoint={}, bucket={}, prefix={}, maxArchiveMb={})",
+            properties.getEndpoint(), properties.getBucket(), properties.getPrefix(), properties.getMaxArchiveMb());
+        MinioAttachmentFileStorage storage = new MinioAttachmentFileStorage(
+            properties.getEndpoint(), properties.getAccessKey(), properties.getSecretKey(),
+            properties.getBucket(), properties.isAutoCreateBucket());
+        return new SessionWorkspaceStorage(storage, properties.getPrefix(),
+            properties.getMaxArchiveMb() * BYTES_PER_MB);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/VibeCodingWorkspaceProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/VibeCodingWorkspaceProperties.java
@@ -1,0 +1,38 @@
+package com.richard.fyoung.customeradmin.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * VibeCoding 会话工作区持久化配置（对象存储，独立 bucket）。
+ *
+ * <p>会话产出物是用户生成的代码，工作区本身落在系统临时目录（会被 OS 清理），故必须有权威副本。
+ * 单独一个 bucket 而不是复用附件桶：产出物的生命周期、容量特征与备份策略都和聊天附件不同。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "admin.vibecoding.workspace")
+public class VibeCodingWorkspaceProperties {
+
+    /**
+     * 是否启用工作区持久化。关闭后产出物只存在于本地临时目录，
+     * 会随 OS 清理 / 容器销毁丢失——仅在明确不需要保留产出物时才关。
+     */
+    private boolean enabled = true;
+    private String endpoint = "http://localhost:9000";
+    private String accessKey = "minioadmin";
+    private String secretKey = "minioadmin";
+    /** 存放会话工作区归档的 bucket。 */
+    private String bucket = "customer-admin-vibecoding";
+    /** 对象 key 前缀，实际 key = {prefix}{agentCode}/{sessionId}.tar.gz。 */
+    private String prefix = "workspaces/";
+    /** bucket 不存在时是否自动创建。 */
+    private boolean autoCreateBucket = true;
+    /**
+     * 单个会话归档的大小上限（MB）：归档在内存里构建，不封顶会被一个巨大的工作区打爆。
+     * 超限时跳过保存并记 error（产出物仍在本地，但不再有权威副本，需要运维介入）。
+     */
+    private int maxArchiveMb = 100;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -186,6 +186,8 @@ public class AdminAgentInstanceFactory {
     private final IndirectInjectionGuardMiddleware indirectInjectionGuardMiddleware;
     /** 后台委派任务仓储（落 MySQL），挂到每个 HarnessAgent 上接管 {@code agent_spawn} 的异步任务。 */
     private final TaskRepository taskRepository;
+    /** VibeCoding 会话工作区持久化；未启用时为 null（产出物仅存本地临时目录）。 */
+    private final SessionWorkspaceStorage sessionWorkspaceStorage;
 
     /**
      * {@code agentCode -> ToolSourceInfo}：{@link #build} 每次重建都会覆盖写入，天然跟着
@@ -213,9 +215,13 @@ public class AdminAgentInstanceFactory {
                                       KnowledgeRetrievalService knowledgeRetrievalService,
                                       ObjectProvider<SensitiveWordMiddleware> sensitiveWordMiddlewareProvider,
                                       IndirectInjectionGuardMiddleware indirectInjectionGuardMiddleware,
-                                      TaskRepository taskRepository) {
+                                      TaskRepository taskRepository,
+                                      ObjectProvider<SessionWorkspaceStorage> sessionWorkspaceStorageProvider) {
         this.indirectInjectionGuardMiddleware = indirectInjectionGuardMiddleware;
         this.taskRepository = taskRepository;
+        // 容错 null provider：单测直传 null 依赖构造本类验证路径防御逻辑（同 CustomerServiceAgentFactory 的 meterRegistry 手法）
+        this.sessionWorkspaceStorage = sessionWorkspaceStorageProvider == null
+            ? null : sessionWorkspaceStorageProvider.getIfAvailable();
         this.agentMapper = agentMapper;
         this.agentMcpMapper = agentMcpMapper;
         this.agentSkillMapper = agentSkillMapper;
@@ -681,7 +687,29 @@ public class AdminAgentInstanceFactory {
             log.error("[workspace] create session workspace dir failed, code={}, agentCode={}, sessionId={}",
                 "SESSION_WORKSPACE_INIT_ERROR", agentCode, safeSession, e);
         }
+        // 恢复权威副本：工作区落在系统临时目录（会被 OS 清理）、容器化部署更是一销毁就没了，
+        // 而会话产出物是用户生成的代码、不是可重建的派生物。本方法是所有会话级功能解析路径的公共入口，
+        // 挂在这里能覆盖 stream / files / file-content / rollback 全部链路。
+        // 仅在本地目录为空时真正拉取（见 SessionWorkspaceStorage#hydrate），故重复调用无额外开销。
+        if (sessionWorkspaceStorage != null) {
+            sessionWorkspaceStorage.hydrate(agentCode, safeSession, workspace);
+        }
         return workspace;
+    }
+
+    /**
+     * 把会话工作区保存回权威存储（对象存储）。产出物写入之后必须调用一次，否则本地临时目录一被清理就丢。
+     *
+     * <p>调用点覆盖三条会造成写入的链路：对话轮次结束、手工保存文件、一键回滚。
+     * 未启用持久化时静默跳过；失败只记 error，不打断主链路（见 {@link SessionWorkspaceStorage#persist}）。</p>
+     */
+    public void persistSessionWorkspace(String agentCode, String sessionId) {
+        if (sessionWorkspaceStorage == null) {
+            return;
+        }
+        String safeSession = requireSafeSessionId(sessionId);
+        sessionWorkspaceStorage.persist(agentCode, safeSession,
+            Path.of(WORKSPACE_ROOT, agentCode, "sessions", safeSession).normalize());
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/SessionWorkspaceStorage.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/SessionWorkspaceStorage.java
@@ -1,0 +1,200 @@
+package com.richard.fyoung.customeradmin.workspace.runtime;
+
+import com.richard.fyoung.customerwork.data.attachment.AttachmentFileStorage;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Comparator;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * VibeCoding 会话工作区的权威存储：整棵目录树打成 tar.gz 存进对象存储，一个会话一个对象。
+ *
+ * <p><b>为什么需要它</b>：会话产出物（生成的代码）此前只存在于磁盘一份，而工作区已移出项目目录、
+ * 落在系统临时目录下（见 {@code RuntimeWorkDir}），会被 OS 定期清理；容器化部署时更是容器一销毁就没了。
+ * 产出物是用户在会话里生成的代码，<b>不是可重建的派生物</b>，必须有权威副本。</p>
+ *
+ * <p><b>为什么整棵树打包而不是逐文件同步</b>：{@code .git} 必须一起同步——{@code GitWorkspaceService#ensureRepo}
+ * 见到没有 {@code .git} 就用当前内容建新基线，只同步业务文件的话，恢复后"本轮变更"diff 会变空、
+ * 一键回滚会回滚到"已修改"状态，两个功能静默失效。而 {@code .git} 动辄上百个小对象，逐个传既慢又难保证
+ * 一致性；打成单个归档则天然原子、且 tar 能保住可执行位（脚本与 git 钩子需要）。</p>
+ *
+ * <p><b>已知限制</b>：恢复以"本地目录为空"为触发条件，多副本部署时 A 副本持有本地旧副本、B 副本更新了
+ * 对象存储，A 不会重新拉取。当前 admin 为单实例部署，如需多副本请配会话粘滞或引入版本号比对。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class SessionWorkspaceStorage {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionWorkspaceStorage.class);
+
+    private final AttachmentFileStorage fileStorage;
+    private final String keyPrefix;
+    private final long maxArchiveBytes;
+
+    /**
+     * @param fileStorage     对象存储（VibeCoding 专用实例，独立 bucket）
+     * @param keyPrefix       对象 key 前缀
+     * @param maxArchiveBytes 归档大小上限：归档在内存里构建，不封顶会被一个巨大的工作区打爆
+     */
+    public SessionWorkspaceStorage(AttachmentFileStorage fileStorage, String keyPrefix, long maxArchiveBytes) {
+        this.fileStorage = fileStorage;
+        this.keyPrefix = keyPrefix == null || keyPrefix.isBlank() ? ""
+            : (keyPrefix.endsWith("/") ? keyPrefix : keyPrefix + "/");
+        this.maxArchiveBytes = maxArchiveBytes;
+    }
+
+    /**
+     * 恢复：对象存储 → 本地工作区。<b>仅当本地工作区不存在或为空时</b>执行，避免覆盖本进程刚写出的内容。
+     *
+     * <p>不抛异常——恢复失败退化为"从空工作区开始"，不该让整个会话打不开。</p>
+     */
+    public void hydrate(String agentCode, String sessionId, Path workspace) {
+        try {
+            if (!isEmptyDir(workspace)) {
+                return;
+            }
+            byte[] archive;
+            try {
+                archive = fileStorage.read(objectKey(agentCode, sessionId));
+            } catch (Exception e) {
+                // 对象不存在是常态（新会话），不记 error 免得刷屏
+                return;
+            }
+            extractTo(archive, workspace);
+            log.info("vibecoding workspace hydrated, agentCode={}, sessionId={}, bytes={}",
+                agentCode, sessionId, archive.length);
+        } catch (Exception e) {
+            log.error("hydrate vibecoding workspace failed, code={}, agentCode={}, sessionId={}",
+                "VIBECODING-WORKSPACE-HYDRATE-FAIL", agentCode, sessionId, e);
+        }
+    }
+
+    /**
+     * 保存：本地工作区 → 对象存储（整树覆盖）。
+     *
+     * <p>不抛异常——保存失败不该打断对话主链路，但会记 error（这是产出物唯一的持久化路径，失败必须可见）。</p>
+     */
+    public void persist(String agentCode, String sessionId, Path workspace) {
+        try {
+            if (!Files.isDirectory(workspace)) {
+                return;
+            }
+            byte[] archive = archive(workspace);
+            if (archive.length > maxArchiveBytes) {
+                log.error("vibecoding workspace too large to persist, code={}, agentCode={}, sessionId={}, bytes={}, limit={}",
+                    "VIBECODING-WORKSPACE-TOO-LARGE", agentCode, sessionId, archive.length, maxArchiveBytes);
+                return;
+            }
+            fileStorage.storeAt(objectKey(agentCode, sessionId), archive);
+            log.info("vibecoding workspace persisted, agentCode={}, sessionId={}, bytes={}",
+                agentCode, sessionId, archive.length);
+        } catch (Exception e) {
+            log.error("persist vibecoding workspace failed, code={}, agentCode={}, sessionId={}",
+                "VIBECODING-WORKSPACE-PERSIST-FAIL", agentCode, sessionId, e);
+        }
+    }
+
+    /** 对象 key：{@code {prefix}{agentCode}/{sessionId}.tar.gz}，一个会话恒定一个对象。 */
+    String objectKey(String agentCode, String sessionId) {
+        return keyPrefix + agentCode + "/" + sessionId + ".tar.gz";
+    }
+
+    /** 目录不存在或没有任何条目时视为空。 */
+    private static boolean isEmptyDir(Path dir) throws IOException {
+        if (!Files.isDirectory(dir)) {
+            return true;
+        }
+        try (var entries = Files.list(dir)) {
+            return entries.findAny().isEmpty();
+        }
+    }
+
+    /** 把整棵目录树打成 tar.gz（保留相对路径与可执行位；符号链接按其指向的普通文件写入）。 */
+    byte[] archive(Path workspace) throws IOException {
+        Path root = workspace.toAbsolutePath().normalize();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(out);
+             TarArchiveOutputStream tar = new TarArchiveOutputStream(gzip)) {
+            // 路径可能超过 tar 头部 100 字节的历史限制（.git 下的深层对象目录很容易超），用 POSIX 扩展头
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+            Files.walkFileTree(root, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (!attrs.isRegularFile()) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    String name = root.relativize(file).toString();
+                    TarArchiveEntry entry = new TarArchiveEntry(file.toFile(), name);
+                    entry.setSize(attrs.size());
+                    tar.putArchiveEntry(entry);
+                    Files.copy(file, tar);
+                    tar.closeArchiveEntry();
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException e) {
+                    // 单个文件读不到（临时文件被删/权限）不该让整次归档失败
+                    log.error("skip unreadable file while archiving workspace, code={}, file={}",
+                        "VIBECODING-WORKSPACE-ARCHIVE-SKIP", file, e);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * 解包到目标目录（先清空，保证与归档完全一致）。
+     *
+     * <p>逐条目校验解出的路径必须仍落在目标目录内——归档内容虽由本服务自己产生，但对象存储里的
+     * 数据可能被篡改，{@code ../} 条目会写到工作区之外（tar slip）。</p>
+     */
+    void extractTo(byte[] archive, Path workspace) throws IOException {
+        Path root = workspace.toAbsolutePath().normalize();
+        deleteRecursively(root);
+        Files.createDirectories(root);
+        try (TarArchiveInputStream tar = new TarArchiveInputStream(
+                new GZIPInputStream(new ByteArrayInputStream(archive)))) {
+            TarArchiveEntry entry;
+            while ((entry = tar.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                Path target = root.resolve(entry.getName()).normalize();
+                if (!target.startsWith(root)) {
+                    log.error("skip tar entry escaping workspace, code={}, entry={}",
+                        "VIBECODING-WORKSPACE-TAR-SLIP", entry.getName());
+                    continue;
+                }
+                Files.createDirectories(target.getParent());
+                Files.copy(tar, target);
+            }
+        }
+    }
+
+    /** 递归删除目录（不存在则跳过）。 */
+    private static void deleteRecursively(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try (var paths = Files.walk(dir)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.delete(path);
+            }
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
@@ -218,6 +218,9 @@ public class VibeCodingService {
             auditService.applyUsage(audit, usageTotal.get());
             auditService.applyChangedFiles(audit, changedPaths(initialSnapshot, snapshot(sessionWorkspace)));
             auditService.finish(audit, signal == SignalType.ON_COMPLETE ? null : "VIBECODING_STREAM_" + signal.name());
+            // 产出物落权威存储：工作区在系统临时目录，不保存的话 OS 一清理 / 容器一销毁本轮生成的代码就没了。
+            // 放在 doFinally 而非 onComplete——用户中途取消时本轮已写出的文件同样要保住。
+            agentInstanceFactory.persistSessionWorkspace(agentCode, safeSession);
         });
     }
 
@@ -345,6 +348,8 @@ public class VibeCodingService {
             auditService.applyChangedFiles(audit, affected);
             log.info("[workspace] session rolled back, agentCode={}, sessionId={}, restored={}, deleted={}",
                 agentCode, safeSession, result.restoredFiles().size(), result.deletedFiles().size());
+            // 回滚同样是写操作：不保存的话权威副本仍是回滚前的状态，下次恢复会把已撤销的改动又拉回来
+            agentInstanceFactory.persistSessionWorkspace(agentCode, safeSession);
             auditService.finish(audit, (String) null);
             return result;
         } catch (RuntimeException e) {
@@ -389,6 +394,7 @@ public class VibeCodingService {
                 log.error("[workspace] save file content failed, agentCode={}, sessionId={}, path={}", agentCode, sessionId, relativePath, e);
                 throw new BizException(ResultCode.SYSTEM_ERROR, "文件保存失败: " + relativePath);
             }
+            agentInstanceFactory.persistSessionWorkspace(agentCode, sessionId);
             auditService.finish(audit, (String) null);
         } catch (RuntimeException e) {
             auditService.finish(audit, e);

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -250,6 +250,20 @@ admin:
     # 自定义时每个角色 name/type(PLAN|CODING|REVIEW)/prompt 均可配。role-timeout-seconds 为 PLAN/REVIEW
     # 角色单次一次性模型调用超时。
     role-timeout-seconds: ${ADMIN_COLLAB_ROLE_TIMEOUT_SECONDS:60}
+  vibecoding:
+    workspace:
+      # 会话工作区（VibeCoding 产出物）持久化到 MinIO：工作区本身落在系统临时目录、会被 OS 清理，
+      # 而产出物是用户在会话里生成的代码、不是可重建的派生物，必须有权威副本。
+      # 整棵目录树（含 .git，回滚与变更 diff 依赖它）打成 tar.gz，一个会话一个对象。
+      enabled: ${ADMIN_VIBECODING_WORKSPACE_PERSIST:true}
+      endpoint: ${MINIO_ENDPOINT:http://localhost:9000}
+      access-key: ${MINIO_ACCESS_KEY:minioadmin}
+      secret-key: ${MINIO_SECRET_KEY:minioadmin}
+      bucket: ${ADMIN_VIBECODING_BUCKET:customer-admin-vibecoding}
+      prefix: ${ADMIN_VIBECODING_PREFIX:workspaces/}
+      auto-create-bucket: ${ADMIN_VIBECODING_AUTO_CREATE_BUCKET:true}
+      # 归档在内存里构建，超过上限跳过保存并记 error
+      max-archive-mb: ${ADMIN_VIBECODING_MAX_ARCHIVE_MB:100}
   knowledge:
     # 代码知识库（P3-2 降级版）：DashScope 真实 Embedding + MySQL 向量 + 应用层余弦相似度。
     # Key 从 ai_model_config 的 dashscope 行借用（AES 解密），缺失即 fast fail。

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentServiceTest.java
@@ -275,6 +275,11 @@ class ChatAttachmentServiceTest {
         }
 
         @Override
+        public void storeAt(String storagePath, byte[] data) {
+            objects.put(storagePath, data);
+        }
+
+        @Override
         public byte[] read(String storagePath) throws java.io.IOException {
             byte[] data = objects.get(storagePath);
             if (data == null) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
@@ -28,7 +28,7 @@ class AdminAgentInstanceFactoryTest {
     private AdminAgentInstanceFactory newFactoryForPathTest() {
         return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-            null);
+            null, null);
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SessionWorkspaceStorageTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SessionWorkspaceStorageTest.java
@@ -1,0 +1,190 @@
+package com.richard.fyoung.customeradmin.workspace.runtime;
+
+import com.richard.fyoung.customerwork.data.attachment.AttachmentFileStorage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link SessionWorkspaceStorage} 单测：整树往返、{@code .git} 一并保住、空目录才恢复、
+ * 超限跳过、tar slip 拦截。
+ *
+ * <p>{@code .git} 那条是本类的重点——{@code GitWorkspaceService#ensureRepo} 见不到 {@code .git}
+ * 就会用当前内容建新基线，只同步业务文件的话"本轮变更"diff 会变空、一键回滚会回滚到已修改状态。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class SessionWorkspaceStorageTest {
+
+    private static final long BIG_ENOUGH = 100L * 1024 * 1024;
+
+    @Test
+    void persistThenHydrate_shouldRoundTripWholeTree(@TempDir Path tmp) throws Exception {
+        InMemoryObjectStore store = new InMemoryObjectStore();
+        SessionWorkspaceStorage storage = new SessionWorkspaceStorage(store, "workspaces/", BIG_ENOUGH);
+
+        Path src = Files.createDirectories(tmp.resolve("src-ws"));
+        Files.writeString(src.resolve("pom.xml"), "<project/>", StandardCharsets.UTF_8);
+        Files.createDirectories(src.resolve("src/main/java/com/demo"));
+        Files.writeString(src.resolve("src/main/java/com/demo/App.java"), "class App {}", StandardCharsets.UTF_8);
+
+        storage.persist("coder", "sess-1", src);
+
+        Path restored = tmp.resolve("restored-ws");
+        storage.hydrate("coder", "sess-1", restored);
+
+        assertEquals("<project/>", Files.readString(restored.resolve("pom.xml"), StandardCharsets.UTF_8));
+        assertEquals("class App {}",
+            Files.readString(restored.resolve("src/main/java/com/demo/App.java"), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void persistThenHydrate_shouldPreserveGitDir(@TempDir Path tmp) throws Exception {
+        InMemoryObjectStore store = new InMemoryObjectStore();
+        SessionWorkspaceStorage storage = new SessionWorkspaceStorage(store, "workspaces/", BIG_ENOUGH);
+
+        Path src = Files.createDirectories(tmp.resolve("src-ws"));
+        Files.writeString(src.resolve("a.txt"), "hello", StandardCharsets.UTF_8);
+        // 模拟 git 仓库：objects 目录路径很深，同时验证长路径不被 tar 头部长度限制截断
+        Path deep = src.resolve(".git/objects/ab/cdef0123456789abcdef0123456789abcdef01");
+        Files.createDirectories(deep.getParent());
+        Files.write(deep, new byte[] {1, 2, 3});
+        Files.writeString(src.resolve(".git/HEAD"), "ref: refs/heads/master\n", StandardCharsets.UTF_8);
+
+        storage.persist("coder", "sess-git", src);
+        Path restored = tmp.resolve("restored-ws");
+        storage.hydrate("coder", "sess-git", restored);
+
+        assertTrue(Files.isDirectory(restored.resolve(".git")), ".git 必须一并恢复，否则回滚与变更 diff 失效");
+        assertEquals("ref: refs/heads/master\n",
+            Files.readString(restored.resolve(".git/HEAD"), StandardCharsets.UTF_8));
+        assertArrayEquals(new byte[] {1, 2, 3},
+            Files.readAllBytes(restored.resolve(".git/objects/ab/cdef0123456789abcdef0123456789abcdef01")));
+    }
+
+    @Test
+    void hydrate_shouldSkip_whenLocalWorkspaceNotEmpty(@TempDir Path tmp) throws Exception {
+        InMemoryObjectStore store = new InMemoryObjectStore();
+        SessionWorkspaceStorage storage = new SessionWorkspaceStorage(store, "workspaces/", BIG_ENOUGH);
+
+        Path src = Files.createDirectories(tmp.resolve("src-ws"));
+        Files.writeString(src.resolve("a.txt"), "远端旧内容", StandardCharsets.UTF_8);
+        storage.persist("coder", "sess-2", src);
+
+        // 本地已有内容：不能被远端覆盖（否则本进程刚写出的产出物会被旧副本顶掉）
+        Path local = Files.createDirectories(tmp.resolve("local-ws"));
+        Files.writeString(local.resolve("a.txt"), "本地新内容", StandardCharsets.UTF_8);
+        storage.hydrate("coder", "sess-2", local);
+
+        assertEquals("本地新内容", Files.readString(local.resolve("a.txt"), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void hydrate_shouldDoNothing_whenObjectAbsent(@TempDir Path tmp) {
+        SessionWorkspaceStorage storage =
+            new SessionWorkspaceStorage(new InMemoryObjectStore(), "workspaces/", BIG_ENOUGH);
+
+        Path fresh = tmp.resolve("brand-new");
+        storage.hydrate("coder", "never-saved", fresh);
+
+        // 新会话没有权威副本是常态，不该抛异常、也不该造出内容
+        assertFalse(Files.exists(fresh.resolve("anything")));
+    }
+
+    @Test
+    void persist_shouldSkip_whenArchiveExceedsLimit(@TempDir Path tmp) throws Exception {
+        InMemoryObjectStore store = new InMemoryObjectStore();
+        SessionWorkspaceStorage storage = new SessionWorkspaceStorage(store, "workspaces/", 64);
+
+        Path src = Files.createDirectories(tmp.resolve("src-ws"));
+        // 随机字节，避免被 gzip 压到限额以下
+        byte[] bulky = new byte[8192];
+        new java.util.Random(42).nextBytes(bulky);
+        Files.write(src.resolve("big.bin"), bulky);
+
+        storage.persist("coder", "sess-big", src);
+
+        assertTrue(store.objects.isEmpty(), "超过上限时应跳过保存，不能把内存打爆");
+    }
+
+    @Test
+    void hydrate_shouldRejectTarEntryEscapingWorkspace(@TempDir Path tmp) throws Exception {
+        InMemoryObjectStore store = new InMemoryObjectStore();
+        SessionWorkspaceStorage storage = new SessionWorkspaceStorage(store, "workspaces/", BIG_ENOUGH);
+        // 构造被篡改的归档：一条 ../escaped.txt 试图写到工作区之外
+        store.objects.put(storage.objectKey("coder", "evil"), maliciousArchive());
+
+        Path ws = tmp.resolve("ws");
+        storage.hydrate("coder", "evil", ws);
+
+        assertFalse(Files.exists(tmp.resolve("escaped.txt")), "越界条目不该被写出到工作区之外");
+        assertTrue(Files.exists(ws.resolve("ok.txt")), "同归档内的合法条目应正常解出");
+    }
+
+    /** 含一条越界条目 + 一条正常条目的 tar.gz。 */
+    private static byte[] maliciousArchive() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(out);
+             TarArchiveOutputStream tar = new TarArchiveOutputStream(gzip)) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            writeEntry(tar, "../escaped.txt", "secret");
+            writeEntry(tar, "ok.txt", "fine");
+        }
+        return out.toByteArray();
+    }
+
+    private static void writeEntry(TarArchiveOutputStream tar, String name, String content) throws IOException {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(bytes.length);
+        tar.putArchiveEntry(entry);
+        tar.write(bytes);
+        tar.closeArchiveEntry();
+    }
+
+    /** 进程内对象存储替身：只用到 storeAt / read。 */
+    private static class InMemoryObjectStore implements AttachmentFileStorage {
+        private final Map<String, byte[]> objects = new ConcurrentHashMap<>();
+
+        @Override
+        public String store(byte[] data, String id, String ext) {
+            String key = id + (ext == null || ext.isEmpty() ? "" : "." + ext);
+            objects.put(key, data);
+            return key;
+        }
+
+        @Override
+        public void storeAt(String storagePath, byte[] data) {
+            objects.put(storagePath, data);
+        }
+
+        @Override
+        public byte[] read(String storagePath) throws IOException {
+            byte[] data = objects.get(storagePath);
+            if (data == null) {
+                throw new IOException("object not found: " + storagePath);
+            }
+            return data;
+        }
+
+        @Override
+        public void delete(String storagePath) {
+            objects.remove(storagePath);
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentFileStorage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentFileStorage.java
@@ -25,6 +25,19 @@ public interface AttachmentFileStorage {
     String store(byte[] data, String id, String ext) throws IOException;
 
     /**
+     * 按<b>调用方指定的 key</b> 覆盖写入。
+     *
+     * <p>与 {@link #store} 的区别：那个由本 SPI 生成 {@code {yyyyMM}/{uuid}.{ext}} 形式的 key，
+     * 适合"每次上传都是一个新对象"的附件语义；本方法适合"一个业务实体固定对应一个对象、每次覆盖"的
+     * 场景（如 VibeCoding 会话工作区归档），key 由调用方按业务维度拼出且需要稳定可寻址。</p>
+     *
+     * @param storagePath 对象 key（调用方保证稳定与合法）
+     * @param data        文件字节
+     * @throws IOException 存储失败
+     */
+    void storeAt(String storagePath, byte[] data) throws IOException;
+
+    /**
      * 按相对 key 读回原始文件字节（供附件预览 / 下载链路）。
      *
      * @param storagePath {@link #store} 返回并落 DB 的相对 key（形如 {@code 202607/{id}.{ext}}）

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/MinioAttachmentFileStorage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/MinioAttachmentFileStorage.java
@@ -73,6 +73,22 @@ public class MinioAttachmentFileStorage implements AttachmentFileStorage {
     }
 
     @Override
+    public void storeAt(String storagePath, byte[] data) throws IOException {
+        try {
+            ensureBucket();
+            client.putObject(PutObjectArgs.builder()
+                .bucket(bucket)
+                .object(storagePath)
+                .contentType(OBJECT_CONTENT_TYPE)
+                .stream(new ByteArrayInputStream(data), data.length, -1)
+                .build());
+        } catch (Exception e) {
+            throw new IOException("failed to put object to minio, bucket=" + bucket + ", key=" + storagePath, e);
+        }
+        log.info("object stored to minio, bucket={}, key={}, size={}", bucket, storagePath, data.length);
+    }
+
+    @Override
     public byte[] read(String storagePath) throws IOException {
         // 读路径不做 ensureBucket：读不到对象（桶/对象不存在）本身即"不存在"，getObject 抛异常包成 IOException。
         try (GetObjectResponse resp = client.getObject(GetObjectArgs.builder()

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/RuntimeWorkDir.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/RuntimeWorkDir.java
@@ -14,9 +14,12 @@ import java.nio.file.Paths;
  *   <li>XXL-JOB 执行器日志：调度中心 SDK 要求一个本地日志目录。</li>
  * </ul>
  *
- * <p>这些目录里的内容<b>都是可随时重建的派生物</b>（技能包每次启动全量重建、沙箱产出物随会话销毁、
- * 执行器日志本就是日志），没有权威数据，因此放系统临时目录而不是项目目录——项目目录里出现
- * {@code ./data/} 会让人误以为那是需要备份的数据。</p>
+ * <p>放系统临时目录而不是项目目录：项目目录里出现 {@code ./data/} 会让人误以为那是需要备份的数据。</p>
+ *
+ * <p><b>注意：这里的内容不全是可丢弃的。</b>技能物化目录（每次启动从 MySQL 全量重建）与执行器日志确实
+ * 可随时重建；但 <b>VibeCoding 会话工作区里是用户生成的代码</b>，磁盘上只有一份。那部分的权威副本由
+ * {@code SessionWorkspaceStorage} 存进 MinIO（整树 tar.gz，含 {@code .git}），本目录只是它的工作副本。
+ * 今后往这里放新目录时，先判断内容是不是真的可重建——不可重建的必须自带权威存储。</p>
  * @author owlzhangfq@gmail.com
  */
 public final class RuntimeWorkDir {

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/attachment/InMemoryTestFileStorage.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/attachment/InMemoryTestFileStorage.java
@@ -29,6 +29,11 @@ public class InMemoryTestFileStorage implements AttachmentFileStorage {
     }
 
     @Override
+    public void storeAt(String storagePath, byte[] data) {
+        objects.put(storagePath, data);
+    }
+
+    @Override
     public byte[] read(String storagePath) throws IOException {
         byte[] data = objects.get(storagePath);
         if (data == null) {


### PR DESCRIPTION
## 变更说明 / What

修复 #92 引入的一个缺陷：**VibeCoding 会话产出物会被系统清理掉**。

#92 把 VibeCoding workspace 从 `./data/admin-workspace` 挪到了系统临时目录，理由写的是"这里全是可随时重建的派生物"。这句话对技能物化目录（每次启动从 MySQL 全量重建）和 XXL-JOB 执行器日志成立，**但对 VibeCoding 产出物不成立**——那是用户在会话里生成的代码，磁盘上只有一份，没有任何 DB 副本（产物面板是直接 `Files.walkFileTree` 读磁盘的）。等于给用户的代码加了个定时器：

| 环境 | 后果 |
|---|---|
| macOS | `/var/folders/.../T/` 由系统定期清理 |
| Linux | `systemd-tmpfiles` 默认 10 天清理 `/tmp`，不少发行版重启即清 |
| Docker | 临时目录在容器内，容器重建即消失 |

### 修复：整棵会话目录树打成 tar.gz 存进 MinIO

一个会话一个对象（`{prefix}{agentCode}/{sessionId}.tar.gz`），磁盘退化为工作副本 —— 与本项目 Harness `MEMORY.md`、技能包一致的"对象存储权威 + 磁盘可重建"模式。

- **`SessionWorkspaceStorage`**：`hydrate`（对象存储 → 本地，仅本地为空时）/ `persist`（本地 → 对象存储）
- **`AttachmentFileStorage` 新增 `storeAt(key, data)`**：现有 `store` 自己生成 `{yyyyMM}/{uuid}` 形式的 key，不适合"一个会话固定一个对象、每次覆盖"的语义

### 挂载点

| 时机 | 位置 | 说明 |
|---|---|---|
| 恢复 | `AdminAgentInstanceFactory#resolveSessionWorkspace` | 所有会话级功能（stream / files / file-content / rollback）解析路径的**公共入口**，一处覆盖全链路 |
| 保存 | 对话轮次 `doFinally` | 放 `doFinally` 而非 `onComplete`——用户中途取消时本轮已写出的文件同样要保住 |
| 保存 | 手工保存文件 | `saveFileContent` |
| 保存 | 一键回滚 | 不保存的话权威副本仍是回滚前状态，下次恢复会把已撤销的改动又拉回来 |

## 类型 / Type
- [ ] feat 新功能
- [x] fix 修复
- [ ] docs 文档
- [x] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（新增功能附了单元测试）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定
- [x] 必要时更新了 README / 配置项说明（`admin.vibecoding.workspace.*` 已在 application.yml 注释说明）

## Reviewer 需要知道的

### 为什么整树打包，而不是逐文件同步

**`.git` 必须一起同步**，这是正确性要求不是优化：`GitWorkspaceService#ensureRepo` 见不到 `.git` 就用**当前内容**建新基线。只同步业务文件的话，恢复之后：

- "本轮变更" diff 变空（用户看不到自己改了什么）
- 一键回滚回滚到"已修改"状态（等于回滚失效）

两个功能都是**静默失效**，不报错。而 `.git` 动辄上百个小对象，逐个传既慢又难保证一致性；打成单归档天然原子，tar 还能保住可执行位（脚本与 git 钩子需要）。

### 安全

解包时逐条目校验路径必须仍落在工作区内（**tar slip**）—— 归档虽由本服务自己产生，但对象存储里的数据可能被篡改，`../` 条目会写到工作区之外。有专门用例覆盖。

### 容量

归档在内存里构建，超过 `max-archive-mb`（默认 100）跳过保存并记 error（产出物仍在本地，但不再有权威副本，需要运维介入）。

### ⚠️ 已知限制

恢复以"**本地目录为空**"为触发条件。多副本部署时，A 副本持有本地旧副本、B 副本更新了对象存储，A 不会重新拉取。admin 当前是单实例部署，如需多副本请配会话粘滞或引入版本号比对。已在 `SessionWorkspaceStorage` 类注释里写明，没有藏着。

### 顺带修正

`RuntimeWorkDir` 的类注释原文断言"这些目录里的内容都是可随时重建的派生物"——这句话是错的，本次的问题正是它造成的。已改成明确区分：技能物化目录/执行器日志可重建，VibeCoding 工作区不可重建、必须自带权威存储，并提示今后往这里加新目录时先判断。

## 测试

新增 `SessionWorkspaceStorageTest` 6 例：

| 用例 | 验证点 |
|---|---|
| 整树往返 | 多级目录 + 文件内容一致 |
| `.git` 保留 | 含深层长路径（`.git/objects/ab/cdef...`，同时验证不被 tar 头部 100 字节限制截断） |
| 本地非空不覆盖 | 远端旧副本不能顶掉本进程刚写出的产出物 |
| 对象缺失不报错 | 新会话没有权威副本是常态 |
| 超限跳过 | 不把内存打爆 |
| tar slip 拦截 | 越界条目不写出，同归档内合法条目正常解出 |

全量：admin **747 → 753**，starter 1201 / app 80 / channel 65 / gateway 1，**BUILD SUCCESS**。

已**从远端全新 clone 重跑验证**（#92 有过"文件被 .gitignore 静默吞掉导致远端编译不过"的教训，现在验证一律以干净克隆为准）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
