### PR TITLE
docs: 对齐文档与代码——补齐 B6 运营闭环，修正过期描述

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,9 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1319** + admin-server **747** + app 80 + customer-channel 65 + gateway 1
-  （B6 那次实测：starter 1319 / 5 skip、admin 747 / 1 skip，MinIO 当时未起；
+- 测试基线：starter **1323** + admin-server **753** + app 80 + customer-channel 65 + gateway 1（合计 **2222**）
+  （2026-08-14 实测：starter 1323 / 5 skip、admin 753 / 1 skip，BUILD SUCCESS；
+  排除了 `RedisSessionPersistenceTest`（本机 Redis 无密码）。上一版 B6 实测为 starter 1319 / admin 747，MinIO 当时未起；
   MinIO 起着时那 3 个门控用例会跑起来，总数不变、skip 相应减少）
   （2026-08-13 B6 运营闭环批次：评测链路打通 + badcase 回流 + 语义缓存 + 模型分级路由 +
   提示词版本归因 + CSAT + 知识盲区 + 死信队列，starter +118，admin 侧只加薄壳与跨库门面故不变。
@@ -176,5 +177,5 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 
 ## 本机环境
 
-本机专属信息（容器、凭据、IDE 坑）见 `Codex.local.md`（gitignored，不进仓库）。
+本机专属信息（容器、凭据、IDE 坑）见 `CLAUDE.local.md`（gitignored，不进仓库）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1319** + admin-server **747** + app 80 + customer-channel 65 + gateway 1
-  （B6 那次实测：starter 1319 / 5 skip、admin 747 / 1 skip，MinIO 当时未起；
+- 测试基线：starter **1323** + admin-server **753** + app 80 + customer-channel 65 + gateway 1（合计 **2222**）
+  （2026-08-14 实测：starter 1323 / 5 skip、admin 753 / 1 skip，BUILD SUCCESS；
+  排除了 `RedisSessionPersistenceTest`（本机 Redis 无密码）。上一版 B6 实测为 starter 1319 / admin 747，MinIO 当时未起；
   MinIO 起着时那 3 个门控用例会跑起来，总数不变、skip 相应减少）
   （2026-08-13 B6 运营闭环批次：评测链路打通 + badcase 回流 + 语义缓存 + 模型分级路由 +
   提示词版本归因 + CSAT + 知识盲区 + 死信队列，starter +118，admin 侧只加薄壳与跨库门面故不变。

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ stateDiagram-v2
 | 配置面 | Nacos 提示词/运行时配置热更新（后台 8082 改 → 客服 8080 免重启生效）、配置版本化快照 + 一键回滚 + 按租户灰度发布、MCP / Higress / Studio 接入 | §6.15~6.17、§6.30 |
 | 多租户 SaaS | 租户行级隔离（拦截器全局改写 + fail-closed）、租户管理与双视角权限、水平扩展（Redis 窗口计数 / 会话锁 + K8s 清单）、租户 token 配额 + T+1 计费账单 | §6.27~6.29 |
 | 数据飞轮 | 会话质检、坐席辅助、消息级点赞点踩、意图自动化评测（CI 可跑） | §6.11 末、§6.20 |
+| 运营闭环 | 评测中心（触发/报告/与上一版对比归因）、badcase 回流（负反馈→采纳为知识条目或评测用例）、语义缓存（白名单意图，命中即省整条模型链）、提示词版本（内容指纹归因）、CSAT 满意度（邀请与回收分开记）、知识盲区 TopN、死信队列（指数退避重投，耗尽转 ABANDONED 不删） | §6.31 |
 | 后台管理系统 | RBAC 权限、模型/MCP/Skill/智能体配置、工作区聊天 + VibeCoding、渠道、定时任务(XXL-JOB)、工单工作台、内容风控、数据字典、开发者工具箱（HTTP/证书/cron/JWT/diff/格式互转/SQL 客户端等）、调用统计（token + 缓存命中率）、AI 编码助手 | §6.21 |
 
 ## 五、快速开始
@@ -238,8 +239,8 @@ curl -X POST http://localhost:8080/api/customer/chat \
 ```
 
 - 启动后打开 **http://localhost:8080/swagger-ui.html** 在线调试全部接口。
-- 跑测试（无需 API Key，任何环境全绿）：`mvn test` ——当前基线 **2065 个**（starter 1180 + admin-server 741 +
-  app 78 + customer-channel 65 + gateway 1），外部依赖（Redis/MySQL/Nacos/百炼/OCR/MinIO）不可达的用例自动跳过。
+- 跑测试（无需 API Key，任何环境全绿）：`mvn test` ——当前基线 **2222 个**（starter 1323 + admin-server 753 +
+  app 80 + customer-channel 65 + gateway 1），外部依赖（Redis/MySQL/Nacos/百炼/OCR/MinIO）不可达的用例自动跳过。
 - 环境要求、前端启动、构建坑位速查见 [新人必读](docs/新人必读.md)。
 
 ## 六、Roadmap
@@ -252,6 +253,7 @@ timeline
     已完成 · 生产化 : HITL 审批闭环 + 人机切换工单 : 用户工单系统（JWT + WS 双通道 + 7 态状态机） : 后台管理系统 + Nacos 配置热更新 : 真实业务后端 jdbc + 附件解析 OCR : Nacos 注册发现 + SCG 网关 + XXL-JOB
     已完成 · 平台化 : 内容风控（敏感词 + 限流）+ 数据字典 + 开发者工具箱 : 十项通用能力薄壳化下沉 starter : OTel 链路追踪 + 一键 Grafana / Tempo 监控栈 : 登录态 Redis 持久化 + streamEvents 流式重构
     已完成 · SaaS 化 : 多租户行级隔离 + 租户管理双视角 : 水平扩展（Redis 计数 / 会话锁 + K8s 清单） : 租户配额 + T+1 计费账单 : 配置版本化 + 按租户灰度 : starter 按域拆分治理
+    已完成 · 运营闭环 : 评测中心 + badcase 回流 : 语义缓存 + 模型分级路由 : 提示词版本归因 + CSAT : 知识盲区 + 死信队列
     规划中 · 扩展点 : 租户安全合规（审计归档 / 退租数据导出） : A2A Agent Card 注册发现 : RocketMQ 异步消息 : Training 数据飞轮（RM Gallery / Trinity-RFT） : 后台 AI 编码助手 P1~P3 演进
 ```
 
@@ -290,7 +292,8 @@ timeline
   升级遇 API 不匹配请对照该版本源码微调。
 - API Key 支持配置项与环境变量两种来源，**生产请用环境变量注入**，勿把密钥留在仓库。
 - 业务链路全异步（`Mono`/`Flux`，无 `.block()`）；所有外部后端均为配置开关，默认实现保证离线开箱即用与单测全绿。
-- 包名：`com.richard.fyoung.customerwork`。
+- 包名按模块划分，根均为 `com.richard.fyoung`：starter `…customerwork`、app-server `…customerworkapp`、
+  channel `…customerchannel`、admin-server `…customeradmin`、gateway `…customerworkgateway`。
 
 ## 关注作者
 

--- a/docs/AI编码助手需求文档.md
+++ b/docs/AI编码助手需求文档.md
@@ -453,7 +453,7 @@ Agent 根据异常堆栈、应用日志自动定位问题并生成修复补丁�
 > **完整形态前置依赖**：starter 侧真实向量检索（接真向量数据库、增量/租户隔离的语义检索）。
 >
 > **降级实现**：用 **DashScope 真实 Embedding**（`text-embedding-v3`，走既有 `ai_model_config` 模型配置体系拿
-> Key）+ MySQL 向量存储（新表 `ai_code_knowledge_index` / `ai_code_knowledge_chunk`，Flyway V23）+ **应用层
+> Key）+ MySQL 向量存储（新表 `ai_code_knowledge_index` / `ai_code_knowledge_chunk`，Flyway V26）+ **应用层
 > 余弦相似度** 实现语义检索与检索增强问答。落 `KnowledgeService`：对指定源码目录按 **类/方法级** 切块（`CodeChunker`）
 > → Embedding → 入库；`/knowledge/search`（语义 top-k）+ `/knowledge/ask`（RAG 问答，带出处）。索引构建 **显式触发、
 > 进度可查**（索引行 status + chunk_count）；源码路径受 `admin.knowledge.allowed-roots` 白名单约束；Embedding Key

--- a/docs/MIGRATION-2.0.md
+++ b/docs/MIGRATION-2.0.md
@@ -1,7 +1,8 @@
-# AgentScope Java 1.x → 2.0 迁移说明（ga2.0 分支）
+# AgentScope Java 1.x → 2.0 迁移说明
 
 > 当前依赖：`io.agentscope:agentscope-harness:2.0.0`（GA 正式版，经 `agentscope-bom` 统一管理）
-> 基线分支：`main`（`io.agentscope:agentscope:1.0.12`）→ 迁移分支：`rc2.0`（2.0.0-RC4，已冻结为历史存档）→ 现行分支：`ga2.0`（2.0.0 GA）
+> 迁移路径：`main`（升级前 `io.agentscope:agentscope:1.0.12`）→ `rc2.0`（2.0.0-RC4，已冻结为历史存档）
+> → `ga2.0`（2.0.0 GA 开发分支）→ **现行分支：`main`**（`ga2.0` 已并入，后续新工作直接基于 `main`）
 > JDK 17 / Maven 3.9+ / Spring Boot 3.2.5
 
 本文第 1~8 节记录的是 **1.0.12 → 2.0.0-RC4** 首轮迁移的全部改动、API 映射、新增能力，以及**不能迁移**的

--- a/docs/customer-channel操作文档.md
+++ b/docs/customer-channel操作文档.md
@@ -1,6 +1,6 @@
 # customer-channel 操作文档（AgentScope 2.0 配套前端 · 客服 Agent 控制台 + 对话入口）
 
-> 模块：`customer-channel` ｜ 依赖：`agentscope-admin` + `agentscope-chat-completions-web` + `agentscope-agui`（均 2.0.0 GA starter，`ga2.0` 分支）｜ Web 栈：Spring **MVC** ｜ JDK 17
+> 模块：`customer-channel` ｜ 依赖：`agentscope-admin` + `agentscope-chat-completions-web` + `agentscope-agui`（均 2.0.0 GA starter）｜ 分支：`main` ｜ Web 栈：Spring **MVC** ｜ JDK 17
 >
 > **模块定位**：多渠道接入演示模块（官方五套前端能力接入），非主链路必需。
 
@@ -86,7 +86,7 @@ mvn -s settings-central-direct.xml -pl customer-channel -am -DskipTests install
 # 启动控制台（默认端口 8081）
 mvn -s settings-central-direct.xml -pl customer-channel spring-boot:run
 # 或打包后运行
-java -jar customer-channel/target/customer-channel-1.0.0.jar
+java -jar customer-channel/target/customer-channel-2.2.0.jar   # 版本号随父 POM
 ```
 
 ### 3.3 访问入口（已实测，端口 8081）

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -110,6 +110,9 @@
 | **水平扩展（限流/成本熔断/会话锁共享）** | `WindowCounter` + `SessionLock`（Redisson 实现） | 关 | `customer-work.distributed.counter-mode=redis` + `session-lock-mode=redis`，见 §6.28 |
 | **租户配额与计费（token 硬上限 + 账单）** | `TenantQuotaGuard`（starter）+ `BillingController`（admin） | 关 | `customer-work.quota.enabled=true`，见 §6.29 |
 | **配置版本化与按租户灰度** | `ConfigVersionService` + `ConfigRollbackService`（admin） | 随发布能力 | `admin.runtime-publish.nacos.enabled=true` 即生效，见 §6.30 |
+| **运营闭环：评测中心 / badcase 回流 / 提示词版本** | `IntentEvalRunner` + `QualityEvalRunner` + `BadcaseService` + `PromptVersionStore`（starter，admin 经跨库门面复用） | 评测手动触发（每日基线关）；badcase 开 | `customer-work.eval.*` / `customer-work.badcase.*` / `customer-work.prompt-version.*`，见 §6.31 |
+| **运营闭环：CSAT / 知识盲区 / 死信队列** | `CsatService` / `KnowledgeGapService` / `DeadLetterService`（starter） | 开 | `customer-work.csat.*` / `customer-work.knowledge-gap.*` / `customer-work.dead-letter.*`，见 §6.31 |
+| **语义缓存（命中即省整条模型链）** | `SemanticCacheService`（starter，依赖 `EmbeddingClient`） | 关（app-server 示例开启） | `customer-work.semantic-cache.enabled=true`，仅缓存白名单意图（默认仅 `consult`，阈值 0.95），见 §6.31 |
 | 运维就绪（健康/停机/巡检） | `SessionHealthIndicator` / `GracefulShutdownService` / `MaintenanceScheduler` | 开 | `/actuator/health` |
 | 模型多厂商 + 私有化兜底 / 重试 / **成本熔断** | `ModelConfig`（或 2.0 内置 `maxRetries`/`fallbackModel`）+ `ModelCostCircuitBreaker` | 开 | `model.provider`、`model.fallback.enabled`、`model.cost-control.enabled` |
 | MCP 接入 | `McpToolkitConfigurer` | 关 | `mcp.enabled=true` |
@@ -178,6 +181,8 @@
 | POST | `/api/customer/feedback` | 提交消息级反馈（点赞/点踩，同 messageId 重复提交覆盖） |
 | GET | `/api/customer/feedback/{messageId}` | 查询单条消息反馈 |
 | GET | `/api/customer/feedback?sessionId=` | 查询某会话全部反馈 |
+| POST | `/api/customer/eval/intent` `/eval/quality` | 触发意图 / 质量评测（供 CI 门禁调用），见 §6.31 |
+| GET | `/api/customer/eval/runs` `/runs/{runId}` `/runs/{runId}/comparison` | 评测运行记录 / 详情 / 与上一版对比 |
 | DELETE | `/api/customer/session/{id}` | 结束并清理会话 |
 | POST | `/api/customer/auth/register` `/auth/login` | 终端用户注册 / 登录（返回 JWT） |
 | GET | `/api/customer/auth/me` | 当前用户信息（`Authorization: Bearer <JWT>`） |
@@ -827,7 +832,7 @@ customer-work:
 
 ```bash
 export DASHSCOPE_API_KEY=sk-xxxx
-java -jar customer-channel/target/customer-channel-1.0.0.jar     # 端口 8081
+java -jar customer-channel/target/customer-channel-2.2.0.jar     # 端口 8081（版本号随父 POM）
 ```
 | 入口 | 能力 |
 |---|---|
@@ -884,7 +889,7 @@ Skill、智能体,并支持对智能体在线聊天与 VibeCoding。技术栈按
 ```bash
 # 后端：端口 8082；dev profile 自动跑 Flyway 迁移建出 customer_admin 库全部表 + 种子数据（admin/admin）
 export ADMIN_MYSQL_PASSWORD=root ADMIN_AES_SECRET_KEY=<32字节密钥>
-java -jar customer-admin-server/target/customer-admin-server-1.0.0.jar --spring.profiles.active=dev
+java -jar customer-admin-server/target/customer-admin-server-2.2.0.jar --spring.profiles.active=dev
 
 # 前端：端口 5174（vite.config.ts 固定），开发期把 /api 代理到后端 8082，见 customer-admin-web/vite.config.ts
 cd customer-admin-web && npm install && npm run dev
@@ -915,6 +920,8 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/devtools/cert/{parse,match,keystore,keystore/private-key}` | 开发者工具箱 · 证书解析（X.509 证书链 / CSR / 私钥匹配校验 / PFX·JKS 密钥库 / 密钥库私钥导出，权限点复用 `devtools:view`） |
 | `/api/devtools/{cron/explain,jwt/decode,diff/text,format/convert}` | 开发者工具箱 · 纯计算工具（cron 解析与执行时间推算 / JWT 解码与 HS* 验签 / 行级文本比对 / JSON·YAML·XML 互转，权限点复用 `devtools:view`） |
 | `/api/dict/{types,items}` | 字典管理（类型 + 字典项两级 CRUD，权限点 `dict:*`），见「数据字典」小节 |
+| `/api/eval/**` · `/api/badcase/**` · `/api/ops/**` | 运营闭环七页：评测中心 / badcase 回流 / 语义缓存 / 提示词版本 / 满意度看板 / 知识盲区 / 死信队列（一级菜单 `/ops`），见 §6.31 |
+| `/api/tenant/**` · `/api/billing/**` · `/api/config-version/**` | 租户管理 / 配额与计费 / 配置版本，见 §6.27、§6.29、§6.30 |
 | `GET /api/dict/options/{dictType}` | 字典下拉选项（仅启用项，只要求登录不校验权限点，前端 `useDict` 消费） |
 | `/swagger-ui/index.html` | 接口文档 |
 
@@ -1598,6 +1605,106 @@ admin:
 
 ---
 
+### 6.31 运营闭环（B6：评测 / badcase / 语义缓存 / CSAT / 盲区 / 死信 / 提示词版本）
+
+把"造好但没接线"的能力接上入口：`capability/eval` 下的 Runner 早就写好了，但全仓除了自己的单测没有任何调用方——
+等于体温计造好了放在抽屉里，改提示词、换模型时只能靠人肉体感判断好坏。
+
+**评测跑在客服端、后台只做触发与展示**：评的必须是线上真实那一套（同一 orchestrator / 提示词 / 模型链），
+admin 侧实现一遍等价逻辑等于评了个副本。因此七条链路的数据表全部落**客服端库**（`cw_*`，由 starter 的
+`SchemaInitializer` 建表），admin 经跨库门面**直接复用 starter 的 Store 与领域对象**，不重写解析与判定——
+两边对同一行数据算出不同结果是最难查的 bug。
+
+后台入口统一在一级菜单 **运营闭环**（`/ops`）下，7 个页面：
+
+| 能力 | 配置前缀 | 表 | 后台页面 / 权限点 |
+|---|---|---|---|
+| 评测中心 | `customer-work.eval` | `cw_eval_run` / `cw_eval_case` | `/ops/eval`，`eval:view` / `eval:run` |
+| badcase 回流 | `customer-work.badcase` | `cw_badcase` | `/ops/badcase`，`badcase:view` / `badcase:adopt` |
+| 语义缓存 | `customer-work.semantic-cache` | `cw_semantic_cache` | `/ops/semantic-cache`，`semantic-cache:view` |
+| 提示词版本 | `customer-work.prompt-version` | `cw_prompt_version` | `/ops/prompt-version`，`prompt-version:view` |
+| 满意度看板 | `customer-work.csat` | `cw_csat_survey` | `/ops/csat`，`csat:view` |
+| 知识盲区 | `customer-work.knowledge-gap` | `cw_knowledge_gap` | `/ops/knowledge-gap`，`knowledge-gap:view` |
+| 死信队列 | `customer-work.dead-letter` | `cw_dead_letter` | `/ops/dead-letter`，`dead-letter:view` |
+
+**评测有三个触发入口**：app-server 侧 `/api/customer/eval/**`（带 `X-API-Key`，供 CI 门禁调用）、
+`EvalBaselineScheduler` 定时基线、后台"立即评测"按钮。app-server 侧接口：
+
+```
+POST   /api/customer/eval/intent            跑意图评测（纯离线，不调模型、零 token 成本）
+POST   /api/customer/eval/quality           跑质量评测（走 JudgeModel）
+GET    /api/customer/eval/runs  /{runId}  /{runId}/comparison
+```
+
+**后台接口**（admin 侧 8082）：
+
+```
+POST   /api/eval/run                        触发评测
+GET    /api/eval/runs  /runs/{runId}        运行记录 / 详情
+GET    /api/eval/runs/{runId}/comparison    与上一版对比（归因）
+GET    /api/badcase/page  /{id}             待筛队列 / 详情
+POST   /api/badcase/{id}/adopt-eval-case    采纳为评测用例
+POST   /api/badcase/{id}/adopt-knowledge    采纳为知识库条目
+POST   /api/badcase/{id}/ignore             忽略
+GET    /api/ops/csat/summary  /list         满意度汇总 / 明细
+GET    /api/ops/knowledge-gap/top           盲区 TopN
+POST   /api/ops/knowledge-gap/fill          标记已补
+GET    /api/ops/dead-letter/list  /stats    死信列表 / 统计
+POST   /api/ops/dead-letter/{id}/reopen     手工重投
+GET    /api/ops/prompt-version/list  /{fingerprint}
+GET    /api/ops/semantic-cache/list
+DELETE /api/ops/semantic-cache/{id}  /scope/{scopeId}
+```
+
+**关键设计约定**（改这几处前先读）：
+
+- **取"上一次"一律按写入顺序（自增 `seq`）而非时间戳**：评测是纯内存计算，连跑两次会落在同一毫秒，
+  按 `created_at_ms` 取基线会让第二次找不到上一版，CI 里必踩。
+- **语义缓存框架默认关闭，开启后也只缓存通用问答**：无差别缓存会把 A 用户的订单信息返回给 B。三道闸门收口在
+  `SemanticCacheService#cacheable` 一处——意图白名单（默认仅 `consult`）+ 个人标识过滤（问题或答案含
+  6 位以上连续数字即跳过）+ 双层隔离。往 `cacheable-intents` 加意图前，先回答
+  "两个不同用户问同一句话，答案是否必然相同"。相似度阈值 0.95 偏保守：
+  "怎么退货"与"怎么换货"能到 0.9 上下，定低了会把换货答成退货——宁可少命中，不可答错。
+- **提示词版本用内容指纹而非外部版本号**：Nacos 下发的是内容、没有随行版本号。指纹让
+  `EvalComparison#promptChanged` 成为归因支点——指标掉了先看这一位，没变就别再对着提示词逐字看。
+  记的是「运行时实际生效」的那份，与配置中心记的「发布了什么」会不一致。
+- **CSAT 必须邀请与回收分开记**：只记评分算不出回收率，而回收率低时那个漂亮的分数只代表愿意评价的一小撮人。
+  满意按 4 分及以上算（行业口径），不是平均分。与消息级点赞/点踩衡量的是不同的东西。
+- **知识未命中文案是接口契约**（`KnowledgeBackend.NO_HIT_REPLY` + `isMiss`）：盲区埋点据此判定，
+  改文案会让统计静默失效。太短的问题（"嗯""在吗"）不计入，否则会淹没真正的盲区。
+- **死信重试耗尽转 ABANDONED 而不删**：静默丢弃正是要解决的问题，留档才能让运营捞出来手工补。
+  退避必须指数（实际间隔 `base * 2^attempts`，下游多半在重启，密集重试是自制雪崩）；
+  没注册 handler 的类型跳过且**不累计次数**——累计会让它悄悄耗尽，掩盖"这类压根没人处理"。
+
+**主要默认值**（注意区分两列：starter 的框架默认保证离线开箱即用，`customer-work-app-server`
+的 `application.yml` 作为示例应用把七条链路都开到了落库形态）：
+
+| 配置项 | 框架默认 | app-server 示例 | 说明 |
+|---|---|---|---|
+| `eval.baseline-enabled` | `false` | `false` | 每日基线评测。开发环境每天跑只会稀释真正有对比价值的那几次 |
+| `eval.baseline-cron` | `0 0 3 * * ?` | 同 | 定时基线 cron |
+| `eval.judge-timeout-seconds` | `60` | 同 | Judge 单次打分超时，比常规对话宽松 |
+| `badcase.auto-collect` | `true` | `true` | 关掉不影响事实流水（那是审计），只是不再进人工筛选队列 |
+| `csat.invite-on-session-end` | `true` | `true` | 会话结束自动发邀请（幂等） |
+| `knowledge-gap.enabled` | `true` | `true` | — |
+| `knowledge-gap.min-question-length` | `4` | 同 | 低于此长度不计入盲区 |
+| `dead-letter.enabled` | `true` | `true` | — |
+| `dead-letter.max-attempts` | `5` | 同 | 耗尽转 `ABANDONED` |
+| `dead-letter.base-backoff-ms` | `30000` | 同 | 指数退避基数（实际间隔 `base * 2^attempts`） |
+| **`semantic-cache.enabled`** | **`false`** | **`true`** | 框架默认关闭（见下方安全约定）；示例应用显式开启 |
+| `semantic-cache.cacheable-intents` | `[consult]` | 同 | 仅政策咨询类 |
+| `semantic-cache.similarity-threshold` | `0.95` | 同 | 余弦相似度阈值 |
+| `semantic-cache.ttl-seconds` | `604800` | 同 | 政策会变，缓存不该永久有效 |
+| `semantic-cache.max-size` | `2000` | 同 | MySQL 8.0 无原生向量索引、应用层逐条算，无上限会让查缓存比调模型还慢 |
+| 七条链路的 `store-mode` | `memory` | `jdbc` | 框架默认内存实现（离线可跑、单测全绿）；示例应用统一落库 |
+
+语义缓存依赖 `EmbeddingClient`——
+**新增可选依赖的 Bean 时必须配一个装配门控测试**：语义缓存一度因 starter 从未装配过 `EmbeddingClient`
+而整体静默失效（`ObjectProvider.getIfAvailable()` 恒为 null），而 Service 层单测全程注入 mock，
+21 条用例照样全绿——只测逻辑照不出"Bean 根本不存在"。
+
+---
+
 ## 七、配置项总表
 
 全部位于 `application.yml` 的 `customer-work.*`（支持环境变量覆盖）：
@@ -1616,11 +1723,17 @@ admin:
 | `mcp` | enabled(false), servers[] |
 | `observability` | trace-enabled(false), trace-file, tracing-enabled(false), studio.*, otel.{enabled(false),endpoint(http://localhost:4317),service-name(customer-work),sampler-ratio(1.0)}（见 §6.13c；admin 侧对应 `admin.observability.otel.*`，非本表 `customer-work.*` 范围，随 admin 自身配置文档见 §6.21） |
 | `human-approval` | enabled(true), guarded-tools([submitRefund]), timeout-seconds(0), timeout-action(escalate), store-mode(memory) |
-| `fact-log` | enabled(true), directory(./data/facts), max-file-mb(10), max-archived-files(5) |
+| `fact-log` | enabled(true), read-limit(10000)（B5 起只有落库一种形态 `cw_fact_log`，故已无 directory / 轮转配置） |
 | `tenant` | enabled(false), column-name(tenant_id), ignored-tables[], auto-context-propagation(true)（见 §6.27；admin 侧对应 `admin.tenant.*`） |
 | `distributed` | counter-mode(memory), counter-key-prefix(cw:counter:), session-lock-mode(memory), session-lock-wait-seconds(10), session-lock-lease-seconds(120)（见 §6.28，Redis 连接复用 `distributed-lock.redis.*`） |
 | `quota` | enabled(false), store-mode(memory)（见 §6.29；admin 侧归集对应 `admin.billing.aggregation.*`） |
-| `security` | auth.{enabled(false),header-name(X-API-Key),api-keys[]}, rate-limit.{enabled(false),requests-per-minute(120),algorithm(fixed-window),window-seconds(60),rule-enabled(false),store-mode(memory),refresh-enabled(true),refresh-interval-ms(60000)} |
+| `eval`（B6）| store-mode(memory), baseline-enabled(false), baseline-cron(0 0 3 * * ?), judge-timeout-seconds(60)，见 §6.31 |
+| `badcase`（B6）| store-mode(memory), auto-collect(true)，见 §6.31 |
+| `prompt-version`（B6）| store-mode(memory)：记「运行时实际生效」的那份，版本号取内容指纹，见 §6.31 |
+| `csat`（B6）| store-mode(memory), invite-on-session-end(true)，见 §6.31 |
+| `knowledge-gap`（B6）| enabled(true), store-mode(memory), min-question-length(4)，见 §6.31 |
+| `dead-letter`（B6）| enabled(true), store-mode(memory), max-attempts(5), base-backoff-ms(30000), batch-size(50), scan-interval-ms(60000)，见 §6.31 |
+| `semantic-cache`（B6）| **enabled(false)**, store-mode(memory), cacheable-intents([consult]), similarity-threshold(0.95), ttl-seconds(604800), max-size(2000), max-candidates(200), min-question-length(4), max-question-length(200), embedding-{base-url,dimensions(1024),batch-size(10)}，见 §6.31 |
 | `security` | auth.{enabled(false),header-name(X-API-Key),api-keys[],tenant-keys{}}, rate-limit.{enabled(false),requests-per-minute(120),algorithm(fixed-window),window-seconds(60),rule-enabled(false),store-mode(memory),refresh-enabled(true),refresh-interval-ms(60000)} |
 | `sensitive-word` | enabled(false), direction(BOTH), store-mode(memory), default-action(BLOCK), mask-char(*), inbound-safe-reply, outbound-safe-reply, refresh-enabled(true), refresh-interval-ms(60000), hit-log.{enabled(false),store-mode(memory),queue-capacity(2048),snippet-max-length(64)} |
 | `multi-agent` | enabled(true), mode(fanout), max-iters(6) |

--- a/docs/多租户架构设计.md
+++ b/docs/多租户架构设计.md
@@ -44,7 +44,7 @@ starter 的 `CustomerWorkPersistenceConfig`（独立 `customerWorkSqlSessionFact
 
 | 类别 | 表 | 处理 |
 |---|---|---|
-| 客服端业务数据 | `cw_*` 全部 27 张 | 加 `tenant_id`，自动过滤 |
+| 客服端业务数据 | `cw_*` 全部 41 张 | 加 `tenant_id`，自动过滤 |
 | admin 配置与业务数据 | `ai_*` 除下方例外的全部、`sys_user`、`sys_role`、`sys_operation_log`、关联表 | 加 `tenant_id`，自动过滤 |
 | 平台级（忽略过滤） | `sys_permission`、`sys_menu_change_log`、`ai_system_tool`、`sys_tenant`、`flyway_schema_history` | 不加列，进忽略清单 |
 | 框架自建（忽略过滤） | `ai_chat_session_state` | 见 §4.1 |

--- a/docs/新人必读.md
+++ b/docs/新人必读.md
@@ -13,7 +13,7 @@
 > **每个能力 = 一个配置开关 + 一个可替换实现。** 默认用内置实现（离线即可跑、测试全绿），
 > 改一行配置或写一个 Bean，就能换成 Redis/MySQL/百炼/Nacos 等真实后端，**业务代码不用动**。
 
-工程是 **6 个模块**（4 个 Maven + 2 个前端），各自独立可跑：
+工程是 **7 个模块**（5 个 Maven + 2 个前端），各自独立可跑：
 
 | 模块 | 端口 | 类型 | 说明 |
 |---|---|---|---|
@@ -21,6 +21,7 @@
 | `customer-work-app-server` | **8080** | Maven | 可运行客服应用（HTTP + WebSocket 接口 + 用户工单系统） |
 | `customer-channel` | **8081** | Maven | 多渠道接入演示模块（官方五套前端能力接入：admin/chat-completions/AG-UI/Studio/Channel），非主链路必需 |
 | `customer-admin-server` | **8082** | Maven | 后台管理系统后端（MyBatis-Plus + Sa-Token，独立库 `customer_admin`，含坐席工单工作台） |
+| `customer-work-gateway` | **8888** | Maven | 统一入口网关（可选）：Spring Cloud Gateway + Nacos 服务发现，把 8080 / 8082 聚合到同一入口 |
 | `customer-admin-web` | **5174** | 前端（Vue3+TS+Vite） | 后台管理前端（含坐席工单工作台页面），**非 Maven 模块** |
 | `customer-work-app` | **5175** | 前端（Vue3+Vite+Vant4） | 终端用户端 H5（登录/聊天/我的工单），**非 Maven 模块** |
 

--- a/docs/生产接口使用手册.md
+++ b/docs/生产接口使用手册.md
@@ -1,6 +1,7 @@
 # 生产接口使用手册
 
-> 适用版本:`ga2.0` 分支(AgentScope Java 2.0.0 GA),主应用 `customer-work-app-server`(默认端口 8080)。
+> 适用版本:`main` 分支(AgentScope Java 2.0.0 GA),主应用 `customer-work-app-server`(默认端口 8080)。
+> (`ga2.0` 为已并入 `main` 的历史开发分支,仅作存档保留。)
 > 本手册面向**接入方与运维**:每个接口的请求/响应格式、鉴权方式、背后的业务逻辑与状态机,均从代码逐一核对。
 > 部署准备见 [部署手册.md](部署手册.md);管理控制台(customer-channel)的接口见 [customer-channel操作文档.md](customer-channel操作文档.md);架构原理见 [详细技术文档.md](详细技术文档.md)。
 
@@ -39,7 +40,10 @@ Key 比对为常量时间比较(防时序侧信道),错误或缺失返回 **401*
 
 每个响应都会带 `X-Request-Id` 响应头(调用方传入则透传,否则服务端生成)。**排查问题时请拿着这个值找运维查日志**——该请求在反应式链路上流经的每条日志都通过 MDC 自动带上 `requestId`(以及已知会话时的 `sessionId`),运维用它一次检索即可捞出全链路日志。出错时(4xx/5xx)错误响应体里也会带 `requestId` 字段,用户报障时直接截图即可提供定位凭据(见 §10)。
 
-若上游(API 网关/调用方)已跑分布式追踪并传入 W3C `traceparent` 请求头,本服务会解析其 **trace-id** 并一并写入日志 MDC(键 `traceId`)、回写 `X-Trace-Id` 响应头——本服务日志因此与上游 Jaeger/Tempo 链路共享同一 traceId,可交叉关联(`observability.trace-correlation-enabled`,默认开)。注:进程内真正采集 span 并导出到 OTLP 需引入 OpenTelemetry SDK(当前构建未含),属基础设施扩展点。
+若上游(API 网关/调用方)已跑分布式追踪并传入 W3C `traceparent` 请求头,本服务会解析其 **trace-id** 并一并写入日志 MDC(键 `traceId`)、回写 `X-Trace-Id` 响应头——本服务日志因此与上游 Jaeger/Tempo 链路共享同一 traceId,可交叉关联(`observability.trace-correlation-enabled`,默认开)。注:进程内真正采集 span 并导出到 OTLP **已落地**——开启 `customer-work.observability.otel.enabled`(starter)/
+`admin.observability.otel.enabled`(admin)后装配 OpenTelemetry SDK 与 OTLP exporter,按 agent/model/tool
+(starter 另加 HTTP 入口)三段出 span;关闭时整组 Bean 不装配,启动零开销。配套一键监控栈见
+[docker/observability/README.md](../docker/observability/README.md)。
 
 ### 1.4 sessionId 约定(重要)
 

--- a/docs/详细技术文档.md
+++ b/docs/详细技术文档.md
@@ -1,7 +1,8 @@
 # 《详细技术文档 · AgentScope 2.0 版》
 
-> 适用项目：**customer-work · 基于 AgentScope Java 2.0.0 GA 的生产级智能客服系统**（`ga2.0` 分支）
-> 包名：`com.richard.fyoung.customerwork` ｜ 协议：Apache-2.0 ｜ 文档与代码保持一致（全仓共 873 个测试全绿：starter 497 + app 56 + customer-channel 8 + 独立的 `customer-admin-server` 后台管理系统 312）
+> 适用项目：**customer-work · 基于 AgentScope Java 2.0.0 GA 的生产级智能客服系统**（`main` 分支）
+> 包名：`com.richard.fyoung.*`（starter `…customerwork`、app-server `…customerworkapp`、channel `…customerchannel`、admin-server `…customeradmin`、gateway `…customerworkgateway`）｜ 协议：Apache-2.0
+> ｜ 文档与代码保持一致（全仓共 2222 个测试全绿：starter 1323 + app 80 + customer-channel 65 + gateway 1 + 独立的 `customer-admin-server` 后台管理系统 753）
 > 依赖坐标：`io.agentscope:agentscope-harness:2.0.0`（经 `agentscope-bom` 管理）｜ JDK 17
 > `rc2.0`（2.0.0-RC4）分支已冻结为历史存档；RC4→GA 的具体改动见 [MIGRATION-2.0.md](MIGRATION-2.0.md) 「RC4 → GA」一节。
 
@@ -951,7 +952,7 @@ sequenceDiagram
 
 ```mermaid
 flowchart TB
-    subgraph 离线单测["离线单测 (mvn test 默认全绿, ga2.0)"]
+    subgraph 离线单测["离线单测 (mvn test 默认全绿)"]
         U1["Mockito 隔离模型/框架"]
         U2["StepVerifier 校验响应式链路"]
         U3["WebTestClient 驱动 Web 层"]

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -1,6 +1,7 @@
 # 生产部署手册
 
-> 适用版本:`ga2.0` 分支(AgentScope Java 2.0.0 GA / Spring Boot 3.2 / JDK 17)。`rc2.0`(2.0.0-RC4)分支已冻结为历史存档。
+> 适用版本:`main` 分支(AgentScope Java 2.0.0 GA / Spring Boot 3.2.5 / JDK 17)。
+> (`ga2.0` 为已并入 `main` 的历史开发分支,`rc2.0`(2.0.0-RC4)分支已冻结为历史存档。)
 > 本手册是**操作向**文档:按顺序执行即可完成生产部署。每一项都对应仓库里真实存在的配置键或已知实现边界,无杜撰项。
 > 风险评估的**结论依据**(为什么这样配)见 [生产就绪评估.md](生产就绪评估.md);框架迁移背景见 [MIGRATION-2.0.md](MIGRATION-2.0.md)。
 
@@ -382,7 +383,7 @@ Prometheus 指标 TSDB 保留 30 天(`--storage.tsdb.retention.time=30d`);Tempo 
        -Dcustomer-work.observability.otel.endpoint=http://<监控栈地址>:4317 \
        -Dcustomer-work.observability.otel.service-name=customer-work \
        -Dcustomer-work.observability.otel.sampler-ratio=1.0 \
-       -jar customer-work-app-server.jar --spring.profiles.active=prod
+       -jar customer-work.jar --spring.profiles.active=prod
   ```
 
   8082(admin-server)对应用 env 覆盖即可(`@ConfigurationProperties` 松散绑定已直接映射到环境变量,


### PR DESCRIPTION
以代码为准逐份核对全部文档，改掉与实现不符之处。核对基线：48 张 admin 表 + 41 张 `cw_*` 表、361 个接口端点、140 条权限记录、实测 **2222 个测试全绿**（`BUILD SUCCESS`）。

## 一、最大缺口：整个运营闭环功能域没有文档

B6 批次（#94，2026-08-13）七项功能代码已全部上线——**21 个接口、8 张表、7 个后台页面**——但三份主文档里 `badcase`、`知识盲区`、`死信队列` 的命中数为 **0**。

新增 [功能与配置全量参考 §6.31](docs/功能与配置全量参考.md)，覆盖评测中心 / badcase 回流 / 语义缓存 / 提示词版本 / CSAT / 知识盲区 / 死信队列的接口、表、权限点、设计约定与默认值；同步更新功能总表、配置项总表、HTTP 接口速查、README 能力地图与 Roadmap。

其中配置默认值刻意按 **「框架默认 vs app-server 示例」两列**记录：

| | starter 框架默认 | app-server 示例 |
|---|---|---|
| `semantic-cache.enabled` | **`false`** | `true` |
| 七条链路 `store-mode` | `memory` | `jdbc` |

这个区别此前无处可查，而它有安全含义——语义缓存框架默认关闭，是因为无差别缓存会把 A 用户的订单信息返给 B。

## 二、修正与代码不符的事实性描述

| 项 | 原 | 现 |
|---|---|---|
| 测试基线（四处互相矛盾） | README 2065 / 详细技术文档 **873** / CLAUDE.md 2212 | 实测 **2222**（starter 1323 + admin 753 + app 80 + channel 65 + gateway 1） |
| OTel 链路追踪 | 接口手册「当前构建未含」 | 已落地（`OtelTracingConfig` 等 3 个实现类 + 配套测试） |
| `fact-log` 配置 | `directory(./data/facts)` + 轮转两项 | B5 起只剩 `enabled` / `read-limit` |
| `cw_*` 表数 | 27 张 | 41 张 |
| jar 版本（3 处） | `-1.0.0.jar` | `-2.2.0.jar` |
| 新人必读模块数 | 6 个（漏 `customer-work-gateway`） | 7 个 |
| Flyway 版本 | AI 编码助手文档 V23 | V26（V22/V23 从未使用过） |
| 包名 | 统一写成 `…customerwork` | 五个模块各不相同 |
| 当前分支（4 处） | `ga2.0` | `main`（`ga2.0` 已并入；**历史陈述保持不动**） |
| AGENTS.md | 指向不存在的 `Codex.local.md` | `CLAUDE.local.md` |

另删除全量参考中重复的 `security` 配置行（旧行缺 `tenant-keys`）。

## 三、刻意未改的部分

- **《生产就绪评估》的 383 / 127**：那是「RC4→GA 回归闸门」的历史记录，不是当前状态声明，改了反而错。MIGRATION-2.0 与 CLAUDE.md 中的分支沿革同理。
- **`security.auth.*` 省略 `customer-work.` 前缀**（13 处）：照抄确实不生效，但全文档一致、明显是既定惯例而非笔误，是否统一加前缀留待决定。

## 四、附带发现的代码侧问题（本 PR 未改）

1. `application.yml` 的 `fact-log` 下 `max-file-mb` / `max-archived-files` 已失效（`FactLogProperties` 无此二字段），设了不生效且注释仍在描述已删除的轮转行为；
2. `tiered-routing` 注释写「默认关闭」，实际 `enabled: true`；
3. `customer-work-spring-boot-starter/` 是模块改名后的遗留空壳（只剩 `target/`），父 POM 已不含该模块。

## 验证

- 全库 markdown 内部链接 **零失效**
- 表格列数、锚点格式校验通过
- 测试基线为本机实测（`mvn clean test`，排除本机 Redis 无密码导致的 `RedisSessionPersistenceTest`）
