### PR TITLE
chore: 清理 fact-log 已失效的文件轮转配置

### DIFF
--- a/customer-work-app-server/src/main/resources/application.yml
+++ b/customer-work-app-server/src/main/resources/application.yml
@@ -10,8 +10,6 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      # Flyway 由 starter 显式绑定 customerWorkDataSource；禁止 Boot 把该数据源当成默认库重复迁移。
-      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
   # 响应式编解码器缓冲上限：控制单次请求聚合到内存的最大字节数（默认 256KB）。
   # 附件上传要把整份文件读进内存交给解析器，故放宽到 12MB（略大于附件 10MB 上限，留边界余量）。
   codec:
@@ -239,12 +237,10 @@ customer-work:
     # 审批存储模式：memory（进程内，默认）| jdbc（数据库持久化，重启不丢）
     store-mode: memory
   fact-log:
-    # 三层记忆第三层：只追加事实日志（可审计、跨会话）
+    # 三层记忆第三层：只追加事实日志（可审计、跨会话），落库 cw_fact_log
     enabled: true
-    # 单文件最大大小（MB），超过则轮转到 .1 / .2 归档；<=0 禁用轮转
-    max-file-mb: 10
-    # 最多保留的归档文件数（超出最旧的自动删除）；<=0 不限制
-    max-archived-files: 5
+    # 单次读取的条数上限：事实日志只增不减，不封顶会把整表拉进内存；超限时保留最近 N 条
+    read-limit: 10000
   security:
     # 接入层安全：API Key 鉴权（默认关闭，生产开启并配置 api-keys）
     auth:
@@ -383,7 +379,7 @@ customer-work:
       url-prefix: /api/avatars/
   # ===================== B6 运营闭环 =====================
   # 下面八项的存储默认都是 memory（进程内、重启即丢），而后台是**跨库读客服端库**的——
-  # 不切 jdbc，后台的运营闭环页面永远是空的。建表与增量变更由客服库 Flyway 统一负责。
+  # 不切 jdbc，后台的运营闭环页面永远是空的。建表由 SchemaInitializer 统一负责。
 
   # 评测：跑标准集 → 出报告 → 与上一版对比。意图评测纯离线（不调模型、零 token 成本）
   eval:

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -76,7 +76,7 @@
 | **会话/状态持久化（AgentStateStore）** | `SessionConfig` | 开 | `session.mode=memory/json/redis/mysql`（取代 1.x Session） |
 | 状态运维门面 | `SessionStateManager`(AgentStateStore) | 开 | 注入使用 |
 | 长期记忆（多租户） | `LongTermMemoryProvider` | 开 | `memory.provider=memory/bailian/mem0/reme` |
-| 三层记忆 + 事实日志（**文件轮转**） | `InMemoryLongTermMemory` + `FactLog` | 开 | `fact-log.enabled`、`fact-log.max-file-mb` |
+| 三层记忆 + 事实日志（**落库 `cw_fact_log`**） | `InMemoryLongTermMemory` + `MybatisFactLog` | 开 | `fact-log.enabled`、`fact-log.read-limit` |
 | **上下文压缩（Compaction）** | `ContextMemoryFactory`→`CompactionConfig` | 关 | `context.compression-enabled=true`（取代 1.x AutoContext） |
 | RAG 知识检索 | `KnowledgeProvider` | 开 | `rag.provider=memory/simple/bailian/dify` |
 | 工具集成 + Tool Group | `ToolRegistrar` / `buildToolkit` | 开 | — |
@@ -340,12 +340,12 @@ customer-work.memory:
 
 ### 6.6 三层记忆体系 + 事实日志
 
-L1 短期 `Memory` + L2 长期 `LongTermMemory` + L3 只追加 `FactLog`（MySQL，可审计）。
+L1 短期 `Memory` + L2 长期 `LongTermMemory` + L3 只追加 `FactLog`（落库 `cw_fact_log`，可审计）。
 ```yaml
-customer-work.fact-log: { enabled: true, directory: ./data/facts, max-file-mb: 10, max-archived-files: 5 }
+customer-work.fact-log: { enabled: true, read-limit: 10000 }
 ```
-> 文件轮转：超过 `max-file-mb` 自动归档为 `.1` / `.2`，超出 `max-archived-files` 的最旧文件自动删除；`<=0` 禁用轮转。
-测试：`FactLogTest`（追加/读取/租户隔离/禁用/文件轮转）。
+> B5 起只有落库一种形态（`cw_fact_log`），已无目录 / 轮转配置。`read-limit` 是单次读取的条数上限：事实日志只增不减，不封顶会把整表拉进内存，超限时保留最近 N 条。
+测试：`MybatisFactLogTest`（追加/读取/租户隔离/禁用/读取上限）、`FactLogConfigTest`（装配）。
 
 ### 6.7 智能上下文压缩（长对话上下文有界）
 


### PR DESCRIPTION
## 变更说明 / What

B5 存储落库批次删掉本地盘实现后，`FactLogProperties` 只剩 `enabled` / `readLimit`，Javadoc 明确写着"只有落库一种形态（`cw_fact_log`），故没有目录 / 轮转配置"。

但 `customer-work-app-server/src/main/resources/application.yml` 里仍留着 `max-file-mb: 10` 与 `max-archived-files: 5`，注释还在描述"超过则轮转到 .1 / .2 归档"。Spring Boot 对未知属性默认不报错，所以这两项是**设了不生效**的遗留配置，注释会让人误以为事实日志仍在落盘。

**application.yml**
- 删除 `max-file-mb` / `max-archived-files` 及其轮转注释；
- `enabled` 的注释补上"落库 cw_fact_log"点明真实形态；
- 显式给出 `read-limit: 10000`。

**docs/功能与配置全量参考.md**（同源陈旧描述，PR #95 / #96 只修到了附录默认值表）
- 能力总表：`FactLog（文件轮转）` → `MybatisFactLog（落库 cw_fact_log）`，配置项改 `read-limit`；
- §6.6 示例 yml 仍写着 `directory: ./data/facts`（与"项目内不落盘"直接冲突），改为 `{ enabled: true, read-limit: 10000 }`，轮转说明换成 read-limit 说明；
- 测试名 `FactLogTest` 已不存在，更正为 `MybatisFactLogTest` / `FactLogConfigTest`。

`CHANGELOG.md` 里的文件轮转记录是历史事实，未改。

### `read-limit` 为什么显式写出来

不是"必须"，而是删完只剩 `enabled` 会丢掉这段唯一有生产意义的可调项：

- 不写也生效（`FactLogProperties.readLimit = 10000` 是 Java 默认值）；
- 它**不属于** `PersistenceJdbcCondition.JDBC_BY_DEFAULT_KEYS` 那类"必须写进 yml 才被 Environment 看见"的键（那条约束只针对 `store-mode`），所以写它是为可发现性，不是为正确性；
- 但 `cw_fact_log` 只增不减，`MybatisFactLog` 靠这个值封顶，不封顶就是整表进内存，运维需要能看到并调它；
- 同段的 `human-approval` 也把 `timeout-seconds` / `store-mode` 这类默认值全列出来带注释，风格一致。

## 类型 / Type
- [ ] feat 新功能
- [ ] fix 修复
- [x] docs 文档
- [x] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿：`-pl customer-work-app-server` 实测 `Tests run: 86, Failures: 0, Errors: 0, Skipped: 0`（已 rebase 到最新 main，含 PR #96 后新增的 6 个用例），含校验 prod profile 的 `ProdProfileConfigTest`。本 PR 只删失效配置与修文档，无新增逻辑故未加测试
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 不涉及新增外部后端
- [x] 已更新配置项说明（`docs/功能与配置全量参考.md` 三处）

另：全仓 grep 确认 `max-file-mb` / `max-archived-files` 除 `CHANGELOG.md` 的历史记录外再无第二处引用。