### PR TITLE
feat: 主体级速率配额（每用户/每IP/每Key 的滚动窗口 token 与次数限流）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,14 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1323** + admin-server **753** + app 80 + customer-channel 65 + gateway 1（合计 **2222**）
-  （2026-08-14 实测：starter 1323 / 5 skip、admin 753 / 1 skip，BUILD SUCCESS；
+- 测试基线：starter **1388** + admin-server **754** + app 86 + customer-channel 65 + gateway 1（合计 **2294**）
+  （2026-08-18 B7 主体配额批次实测：starter 1388 / 5 skip、admin 754 / 1 skip、app 86，BUILD SUCCESS，
+  排除 `RedisSessionPersistenceTest`。**本批次自身只加了 starter +46**
+  （主体配额 39 + 滑动求和 4 + 用户等级 3），其余差额来自 2026-08-14 之后合入 main 的批次；
+  admin 侧只加薄壳与跨库门面故未加用例。
+  **改客服端库 schema 时记得同步改 `CustomerWorkSchemaMigrationIntegrationTest` 的表数断言**——
+  它硬编码了"空库迁移后应有 N 张表"，加表必挂，这是预期内的断言更新而不是 bug。
+  上一版基线 2026-08-14：starter 1323 / admin 753 / app 80，合计 2222；
   排除了 `RedisSessionPersistenceTest`（本机 Redis 无密码）。上一版 B6 实测为 starter 1319 / admin 747，MinIO 当时未起；
   MinIO 起着时那 3 个门控用例会跑起来，总数不变、skip 相应减少）
   （2026-08-13 B6 运营闭环批次：评测链路打通 + badcase 回流 + 语义缓存 + 模型分级路由 +
@@ -163,6 +169,34 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   此前两个实现各自硬编码同一句话，改文案会让统计静默失效；
   ⑧ **死信重试耗尽转 ABANDONED 而不删**，退避必须指数（下游多半在重启，密集重试是自制雪崩）；
   没注册 handler 的类型跳过且**不累计次数**——累计会让它悄悄耗尽，掩盖"这类压根没人处理"。
+- **主体级速率配额（B7 起）**：按**调用者**限流（每登录用户 / 每匿名 IP / 每把 API Key），
+  滚动窗口内的 token 量与请求次数双上限，默认关闭（`customer-work.subject-quota.enabled`）。
+  与 B3 租户配额并存互不替代：那边是"这个客户这个月能花多少钱"（自然日/月对齐，要跟账单对得上），
+  这边是"这个调用者这半小时能用多少"（滚动窗口，防滥用）。九条约定：
+  ① **判定只读、放行后才记账**：`check` 不写计数，通过后 `recordRequest`、模型调用后由
+  `AgentCallTimingMiddleware`（token 唯一落点）补 `recordTokens`。因此被拒的请求不占额度，
+  持续打压不会把窗口越推越远；代价是并发下允许少量超额，这是刻意取舍；
+  ② **主体身份必须走 `QuotaSubjectContext`**（ThreadLocal + Reactor 自动传播，机制同 `TenantContext`）：
+  token 用量要到模型调用后才知道，那时已隔了几次线程切换，方法签名里没有"用户"参数。
+  写入方必须**同时**写 ThreadLocal 与 Reactor Context，只写一个会在某类链路上拿不到主体；
+  ③ **`SubjectQuotaWebFilter` 的 Order 必须排在两个鉴权过滤器之后**（`+30` > ApiKey `+10` > UserAuth `+20`），
+  抢在前面会把登录用户全按匿名 IP 限。它还会自己验一次 Bearer——`UserAuthWebFilter` 只覆盖
+  `/api/customer/user/**`，不自己验的话换条路径就能从"按人限"退化成"按 IP 限"；
+  ④ **WS 入口必须单独判**：H5 用户真正的发消息入口是 `/ws/user`，WebFilter 管不到，
+  只做 HTTP 侧等于对主战场不生效。判定与记账都要包在 `TenantContext.callWith(用户租户)` 里——
+  等级表按租户隔离，拿错租户会查到别人那一档；
+  ⑤ **token 是"量"不是"次"**：`WindowCounter#incrementSlidingSum` 用 30 桶近似滑动窗口
+  （逐条记时间戳在高 QPS 下会吃光内存/Redis），统计范围刻意**不短于**名义窗口（多留一桶），
+  误差方向必须 fail-closed；口径计算在 `SlidingSumBuckets`，两个实现共用（降级时要能对得上）；
+  ⑥ **API Key 只留 SHA-256 指纹**：主体标识会进 Redis 键、命中表与日志，明文落任何一处都是凭据泄露；
+  ⑦ **额度自查接口 `/api/customer/user/quota` 必须豁免判定**：不豁免则查一次扣一次，
+  且额度耗尽后连"还剩多少"都看不到——偏偏那正是最需要它的时刻；
+  ⑧ **超限落"命中记录"而不是实时余额**：余额在计数器里（跨进程读不到），而运营要回答的是
+  "谁在刷、哪档配紧了"。只在触顶那一刻写一条，正常流量零写入；
+  ⑨ **生效延迟 60 秒是设计的一部分**（等级快照指纹轮询 + 绑定本地缓存）：不缓存的话每个请求
+  都要查一次用户表，限流本身会成为最重的一段。后台页面必须把这件事写给运营看。
+  新增的 `subject-quota.store-mode` 已登记进 `PersistenceJdbcCondition`（漏登记会出现
+  "Store 想用 jdbc 但持久化环境没激活"的错配）。
 - 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
 - 持久层异常兜底必须 `catch(Exception)`（HikariPool/MyBatis 初始化异常是 RuntimeException）。
 - 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayFactory.java
@@ -1,0 +1,40 @@
+package com.richard.fyoung.customeradmin.subjectquota.config;
+
+import com.richard.fyoung.customeradmin.subjectquota.jdbc.SubjectQuotaGateway;
+import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
+import com.richard.fyoung.customerwork.infra.gateway.CrossDbGateway;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaHitMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaLevelMapper;
+
+import java.util.List;
+
+/**
+ * 把客服端库的跨库环境装配成主体配额门面。
+ *
+ * <p>{@link UserMapper} 没有自己的 XML（只用 BaseMapper 的 CRUD），故走接口注册；
+ * 另两个有 XML，靠 namespace 绑定自动注册，<b>不能</b>再登记进接口列表——同名语句会冲突。
+ * 这条规则在内容风控那边踩过，照抄即可。</p>
+ * @author owlzhangfq@gmail.com
+ */
+final class SubjectQuotaGatewayFactory {
+
+    /** starter jar 内的等级 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
+    private static final String STARTER_LEVEL_XML = "classpath*:customerwork/mapper/SubjectQuotaLevelMapper.xml";
+    /** starter jar 内的命中记录 Mapper XML。 */
+    private static final String STARTER_HIT_XML = "classpath*:customerwork/mapper/SubjectQuotaHitMapper.xml";
+
+    /** 无 XML、只用 BaseMapper CRUD 的 Mapper 接口。 */
+    static final List<Class<?>> MAPPER_CLASSES = List.of(UserMapper.class);
+
+    static final List<String> MAPPER_XML_LOCATIONS = List.of(STARTER_LEVEL_XML, STARTER_HIT_XML);
+
+    private SubjectQuotaGatewayFactory() {
+    }
+
+    static SubjectQuotaGateway build(CrossDbGateway gateway) {
+        return new SubjectQuotaGateway(
+            gateway.getMapper(SubjectQuotaLevelMapper.class),
+            gateway.getMapper(SubjectQuotaHitMapper.class),
+            gateway.getMapper(UserMapper.class));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayProvider.java
@@ -1,0 +1,67 @@
+package com.richard.fyoung.customeradmin.subjectquota.config;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.contentguard.config.ContentGuardProperties;
+import com.richard.fyoung.customeradmin.subjectquota.jdbc.SubjectQuotaGateway;
+import com.richard.fyoung.customerwork.infra.gateway.CrossDbConnectionSettings;
+import com.richard.fyoung.customerwork.infra.gateway.CrossDbGatewayProvider;
+import com.richard.fyoung.customerwork.infra.gateway.CrossDbGateways;
+import com.richard.fyoung.customerwork.infra.gateway.CrossDbUnavailableException;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * 客服端库主体配额门面的惰性提供者。
+ *
+ * <p>连接参数复用 {@link ContentGuardProperties}——这些表与内容风控三表、租户配额同在客服端库，
+ * 再配一套连接参数只会多一处要同步维护的配置。</p>
+ *
+ * <p>惰性建连，<b>绝不在 admin 启动期触碰客服端库</b>：后台不该因为客服端库没起来就启动不了。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class SubjectQuotaGatewayProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(SubjectQuotaGatewayProvider.class);
+
+    private static final String POOL_NAME = "subject-quota-pool";
+    private static final int MAX_POOL_SIZE = 3;
+
+    private final ContentGuardProperties properties;
+    private final CrossDbGatewayProvider<SubjectQuotaGateway> delegate;
+
+    public SubjectQuotaGatewayProvider(ContentGuardProperties properties) {
+        this.properties = properties;
+        this.delegate = CrossDbGateways.lazy(this::connectionSettings,
+            SubjectQuotaGatewayFactory.MAPPER_CLASSES,
+            SubjectQuotaGatewayFactory.MAPPER_XML_LOCATIONS,
+            SubjectQuotaGatewayFactory::build);
+    }
+
+    /** 取门面（惰性构建 + 探测 + 缓存）；库不可达抛明确业务异常。 */
+    public SubjectQuotaGateway get() {
+        try {
+            return delegate.get();
+        } catch (CrossDbUnavailableException e) {
+            log.error("subject quota datasource unavailable, code={}, url={}",
+                "SQUOTA-DS-UNAVAILABLE", properties.jdbcUrl(), e);
+            throw new BizException(ResultCode.CUSTOMER_WORK_UNAVAILABLE,
+                "客服端库不可达（主体配额等级存放于此）：" + e.rootMessage());
+        }
+    }
+
+    private CrossDbConnectionSettings connectionSettings() {
+        return CrossDbConnectionSettings.builder(POOL_NAME, properties.jdbcUrl())
+            .credentials(properties.getUsername(), properties.getPassword())
+            .maximumPoolSize(MAX_POOL_SIZE)
+            .build();
+    }
+
+    @PreDestroy
+    public void close() {
+        delegate.close();
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/controller/SubjectQuotaController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/controller/SubjectQuotaController.java
@@ -1,0 +1,105 @@
+package com.richard.fyoung.customeradmin.subjectquota.controller;
+
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import com.richard.fyoung.customeradmin.common.log.OperationLog;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaHitVO;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelSaveRequest;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelVO;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaUserVO;
+import com.richard.fyoung.customeradmin.subjectquota.dto.UserLevelSaveRequest;
+import com.richard.fyoung.customeradmin.subjectquota.service.SubjectQuotaAdminService;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitRank;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 主体级速率配额管理：等级维护、用户分档、超限命中查看。
+ *
+ * <p><b>租户取当前视角</b>（{@link TenantSession#effectiveTenant()}）而不是让前端传：
+ * 等级与用户名单都是租户内数据，让参数决定读哪个租户，等于把越权做成了一个查询参数。
+ * 运营方要看别的租户，走已有的"切换视角"，权限校验在那一步完成。</p>
+ *
+ * <p>与租户配额（{@code /api/billing/quota}）的分工见 {@code SubjectQuotaGuard} 类注释：
+ * 那边是计费上限，这边是防滥用闸门，两者同时生效。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/subject-quota")
+public class SubjectQuotaController {
+
+    private final SubjectQuotaAdminService service;
+
+    public SubjectQuotaController(SubjectQuotaAdminService service) {
+        this.service = service;
+    }
+
+    // ---------- 等级 ----------
+
+    @SaCheckPermission("subject-quota:view")
+    @GetMapping("/levels")
+    public Result<List<SubjectQuotaLevelVO>> listLevels() {
+        return Result.success(service.listLevels(TenantSession.effectiveTenant()));
+    }
+
+    @SaCheckPermission("subject-quota:level-edit")
+    @OperationLog(operation = "保存配额等级", target = "cw_subject_quota_level")
+    @PostMapping("/levels")
+    public Result<Void> saveLevel(@Valid @RequestBody SubjectQuotaLevelSaveRequest request) {
+        service.saveLevel(TenantSession.effectiveTenant(), request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("subject-quota:level-edit")
+    @OperationLog(operation = "删除配额等级", target = "cw_subject_quota_level")
+    @DeleteMapping("/levels")
+    public Result<Void> deleteLevel(@RequestParam String levelCode) {
+        service.deleteLevel(TenantSession.effectiveTenant(), levelCode);
+        return Result.success();
+    }
+
+    // ---------- 用户分档 ----------
+
+    @SaCheckPermission("subject-quota:view")
+    @GetMapping("/users")
+    public Result<PageResult<SubjectQuotaUserVO>> pageUsers(PageQuery query) {
+        return Result.success(service.pageUsers(TenantSession.effectiveTenant(), query));
+    }
+
+    @SaCheckPermission("subject-quota:user-edit")
+    @OperationLog(operation = "分配用户配额等级", target = "cw_user")
+    @PostMapping("/users/level")
+    public Result<Void> assignUserLevel(@Valid @RequestBody UserLevelSaveRequest request) {
+        service.assignUserLevel(TenantSession.effectiveTenant(), request.getUserId(), request.getLevelCode());
+        return Result.success();
+    }
+
+    // ---------- 命中记录 ----------
+
+    /** 超限命中明细。默认回看 24 小时——再长就该去查日志而不是翻页面。 */
+    @SaCheckPermission("subject-quota:view")
+    @GetMapping("/hits")
+    public Result<List<SubjectQuotaHitVO>> listHits(@RequestParam(defaultValue = "24") int hours,
+                                                    @RequestParam(defaultValue = "100") int limit) {
+        return Result.success(service.listHits(TenantSession.effectiveTenant(), hours, limit));
+    }
+
+    /** 超限命中排行（谁在刷）。 */
+    @SaCheckPermission("subject-quota:view")
+    @GetMapping("/hits/rank")
+    public Result<List<SubjectQuotaHitRank>> rankHits(@RequestParam(defaultValue = "24") int hours,
+                                                      @RequestParam(defaultValue = "20") int limit) {
+        return Result.success(service.rankHits(TenantSession.effectiveTenant(), hours, limit));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaHitVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaHitVO.java
@@ -1,0 +1,25 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import lombok.Data;
+
+/**
+ * 超限命中明细展示对象。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SubjectQuotaHitVO {
+
+    private String subjectType;
+    private String subjectId;
+    private String levelCode;
+    /** TOKEN / REQUEST。 */
+    private String limitKind;
+    private Long used;
+    private Long limitValue;
+    private Integer windowSeconds;
+    /** BLOCK 真拦了 / WARN 只记录。 */
+    private String action;
+    /** 触发位置（HTTP 路径或 ws:chat）。 */
+    private String resource;
+    private Long createdAtMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaLevelSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaLevelSaveRequest.java
@@ -1,0 +1,47 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * 配额等级新增/编辑请求（按当前视角租户 + levelCode 覆盖）。
+ *
+ * <p><b>刻意不含 tenantId</b>：租户取后端的当前视角，让请求体决定写哪个租户，
+ * 等于把越权做成了一个可填字段。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SubjectQuotaLevelSaveRequest {
+
+    @NotBlank(message = "等级编码不能为空")
+    private String levelCode;
+
+    @NotBlank(message = "等级名称不能为空")
+    private String levelName;
+
+    /** USER / IP / API_KEY。 */
+    private String subjectType;
+
+    /**
+     * 滚动窗口长度（秒）。
+     *
+     * <p>下限 60 秒：更短的窗口在分桶计数下精度已无意义（桶最细到 1 秒，30 桶即 30 秒），
+     * 且这种量级的限流该用接入层的路径规则做，不该走按人配额这条链路。</p>
+     */
+    @Min(value = 60, message = "窗口长度不能小于 60 秒")
+    private Integer windowSeconds;
+
+    @Min(value = 0, message = "token 上限不能为负")
+    private Long tokenLimit;
+
+    @Min(value = 0, message = "次数上限不能为负")
+    private Integer requestLimit;
+
+    /** BLOCK / WARN。 */
+    private String exceedAction;
+
+    private Boolean enabled;
+
+    private String remark;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaLevelVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaLevelVO.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import lombok.Data;
+
+/**
+ * 配额等级展示对象。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SubjectQuotaLevelVO {
+
+    private String tenantId;
+    private String levelCode;
+    private String levelName;
+    /** USER / IP / API_KEY。 */
+    private String subjectType;
+    /** 滚动窗口长度（秒）。 */
+    private Integer windowSeconds;
+    /** 窗口内 token 上限，0 = 不限。 */
+    private Long tokenLimit;
+    /** 窗口内请求次数上限，0 = 不限。 */
+    private Integer requestLimit;
+    /** BLOCK / WARN。 */
+    private String exceedAction;
+    private Boolean enabled;
+    private String remark;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaUserVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/SubjectQuotaUserVO.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import lombok.Data;
+
+/**
+ * 用户等级分配视图（只暴露分配等级需要的字段）。
+ *
+ * <p>刻意不带密码哈希、手机号等账户字段：这个页面的用途是"给谁配哪一档"，
+ * 顺手把账户全字段查出来渲染，只会让一个配额页面变成又一个用户资料泄露面。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SubjectQuotaUserVO {
+
+    private String userId;
+    private String username;
+    private String nickname;
+    /** 当前绑定等级；空表示走配置里的默认档。 */
+    private String levelCode;
+    private String status;
+    private Long createdAtMs;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/UserLevelSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/UserLevelSaveRequest.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * 用户等级分配请求。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class UserLevelSaveRequest {
+
+    @NotBlank(message = "用户不能为空")
+    private String userId;
+
+    /** 目标等级编码；传空表示回到配置里的默认档。 */
+    private String levelCode;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/jdbc/SubjectQuotaGateway.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/jdbc/SubjectQuotaGateway.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customeradmin.subjectquota.jdbc;
+
+import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaHitMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaLevelMapper;
+
+/**
+ * 客服端库上的主体配额数据门面。
+ *
+ * <p>三张表都在客服端库（运行时要读它们来拦请求），后台经跨库门面维护——
+ * 与内容风控三表、租户配额同一套路。用户表也在其中：等级绑定就落在 {@code cw_user.level_code} 上，
+ * 后台改档必须写到同一个地方，另存一份映射表只会多出一个要对账的真源。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public record SubjectQuotaGateway(SubjectQuotaLevelMapper levelMapper,
+                                  SubjectQuotaHitMapper hitMapper,
+                                  UserMapper userMapper) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/service/SubjectQuotaAdminService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/service/SubjectQuotaAdminService.java
@@ -1,0 +1,260 @@
+package com.richard.fyoung.customeradmin.subjectquota.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.common.page.PageResult;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.subjectquota.config.SubjectQuotaGatewayProvider;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaHitVO;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelSaveRequest;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelVO;
+import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaUserVO;
+import com.richard.fyoung.customeradmin.subjectquota.jdbc.SubjectQuotaGateway;
+import com.richard.fyoung.customerwork.data.user.entity.UserDO;
+import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.MybatisSubjectQuotaHitStore;
+import com.richard.fyoung.customerwork.safety.subjectquota.MybatisSubjectQuotaLevelStore;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectType;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectExceedAction;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHit;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitRank;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitStore;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevel;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevelStore;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 后台的主体配额维护：直接读写客服端库的三张表，客服端轮询等级快照即生效。
+ *
+ * <p>复用 starter 的 {@link MybatisSubjectQuotaLevelStore} / {@link MybatisSubjectQuotaHitStore}
+ * 而不是重写一套 CRUD——同一张表、同一套解析（超限处置的脏值兜底、窗口的默认值），
+ * 重写只会多出一份要同步维护的代码，且两边对同一行算出不同结果是最难查的 bug。</p>
+ *
+ * <p><b>生效延迟是设计的一部分</b>：等级定义由客服端按指纹轮询（默认 60 秒）换快照，
+ * 用户等级绑定由 {@code SubjectLevelResolver} 的本地缓存兜住（默认 60 秒）。
+ * 改完不是立刻生效，页面上必须把这件事写给运营看，否则会被当成故障反复重试。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Service
+public class SubjectQuotaAdminService {
+
+    /** 命中查询的默认回看时长与条数上限，避免一次拉穿整张表。 */
+    private static final int MAX_HIT_LIMIT = 500;
+    private static final long HOUR_MS = 3600_000L;
+
+    private final SubjectQuotaGatewayProvider gatewayProvider;
+
+    public SubjectQuotaAdminService(SubjectQuotaGatewayProvider gatewayProvider) {
+        this.gatewayProvider = gatewayProvider;
+    }
+
+    // ---------- 等级 ----------
+
+    public List<SubjectQuotaLevelVO> listLevels(String tenantId) {
+        return levelStore().findByTenant(tenantId).stream()
+            .map(SubjectQuotaAdminService::toVO)
+            .toList();
+    }
+
+    public void saveLevel(String tenantId, SubjectQuotaLevelSaveRequest request) {
+        SubjectQuotaLevel level = new SubjectQuotaLevel(
+            null,
+            tenantId,
+            request.getLevelCode(),
+            request.getLevelName(),
+            QuotaSubjectType.parse(request.getSubjectType()),
+            request.getWindowSeconds() == null
+                ? SubjectQuotaLevel.DEFAULT_WINDOW_SECONDS : request.getWindowSeconds(),
+            request.getTokenLimit() == null ? 0L : request.getTokenLimit(),
+            request.getRequestLimit() == null ? 0 : request.getRequestLimit(),
+            SubjectExceedAction.parse(request.getExceedAction()),
+            request.getEnabled() == null || request.getEnabled(),
+            request.getRemark());
+        levelStore().save(level);
+        log.info("subject quota level saved, tenant={}, level={}, window={}s, token={}, request={}, action={}",
+            tenantId, level.levelCode(), level.effectiveWindowSeconds(), level.tokenLimit(),
+            level.requestLimit(), level.exceedAction());
+    }
+
+    public void deleteLevel(String tenantId, String levelCode) {
+        levelStore().delete(tenantId, levelCode);
+        log.info("subject quota level deleted, tenant={}, level={}", tenantId, levelCode);
+    }
+
+    // ---------- 用户等级分配 ----------
+
+    /**
+     * 用户列表（带当前等级）。
+     *
+     * <p>手写 LIMIT 而非 {@code selectPage}：跨库门面用的是独立的 SqlSessionFactory，
+     * 那里没有装分页插件，{@code selectPage} 会静默返回全表（照 {@code SensitiveWordHitLogService} 的先例）。</p>
+     */
+    public PageResult<SubjectQuotaUserVO> pageUsers(String tenantId, PageQuery query) {
+        UserMapper mapper = gatewayProvider.get().userMapper();
+        long size = Math.max(1, query.getPageSize());
+        long offset = Math.max(0, (query.getPageNum() - 1) * size);
+
+        long total = mapper.selectCount(userWrapper(tenantId, query.getKeyword()));
+        List<SubjectQuotaUserVO> list = new ArrayList<>();
+        if (total > 0) {
+            List<UserDO> rows = mapper.selectList(userWrapper(tenantId, query.getKeyword())
+                .orderByDesc("created_at_ms")
+                .last("LIMIT " + size + " OFFSET " + offset));
+            for (UserDO row : rows) {
+                list.add(toVO(row));
+            }
+        }
+        PageResult<SubjectQuotaUserVO> result = new PageResult<>();
+        result.setPageNum(query.getPageNum());
+        result.setPageSize(size);
+        result.setTotal(total);
+        result.setList(list);
+        return result;
+    }
+
+    /**
+     * 分配用户等级。
+     *
+     * <p>显式 {@code SET level_code = ?} 而不是 {@code updateById}：后者只更新非空字段，
+     * 用它把等级置空（取消特批）会静默失败，表现为"后台看着已经取消、线上还按特批放行"。</p>
+     */
+    public void assignUserLevel(String tenantId, String userId, String levelCode) {
+        String normalized = levelCode == null || levelCode.isBlank() ? null : levelCode.trim();
+        assertLevelExists(tenantId, normalized);
+        // UpdateWrapper.set 对 null 会生成 SET level_code = ? 并绑定 null，这正是"取消特批"要的效果；
+        // 租户条件不能省：少了它就能改到别的租户的用户
+        int updated = gatewayProvider.get().userMapper().update(null,
+            new UpdateWrapper<UserDO>()
+                .set("level_code", normalized)
+                .eq("tenant_id", tenantId)
+                .eq("id", userId));
+        log.info("subject quota user level assigned, tenant={}, user={}, level={}, updated={}",
+            tenantId, userId, normalized, updated);
+    }
+
+    /**
+     * 校验目标等级确实存在（空值表示回默认档，不校验）。
+     *
+     * <p>不校验的话，配错一个字母的等级码会让这个人静默落回默认档——页面上显示着"已设为 vip"，
+     * 线上按 free 拦，且没有任何地方会报错。</p>
+     *
+     * <p>本租户与平台默认租户都算数：运行时的 {@code SubjectLevelResolver} 就是这么回落的
+     * （租户没配某档时用平台的同名档）。这里只认本租户，会把一个运行时完全合法的等级判成不存在。</p>
+     */
+    private void assertLevelExists(String tenantId, String levelCode) {
+        if (levelCode == null) {
+            return;
+        }
+        if (hasLevel(tenantId, levelCode)) {
+            return;
+        }
+        if (!TenantContext.DEFAULT.equals(tenantId) && hasLevel(TenantContext.DEFAULT, levelCode)) {
+            return;
+        }
+        throw new BizException(ResultCode.PARAM_INVALID, "等级不存在：" + levelCode);
+    }
+
+    private boolean hasLevel(String tenantId, String levelCode) {
+        return levelStore().findByTenant(tenantId).stream()
+            .anyMatch(level -> level.levelCode().equals(levelCode));
+    }
+
+    // ---------- 命中记录 ----------
+
+    /** 最近 N 小时的命中明细（时间倒序）。 */
+    public List<SubjectQuotaHitVO> listHits(String tenantId, int hours, int limit) {
+        return hitStore().findRecent(tenantId, sinceMs(hours), cappedLimit(limit)).stream()
+            .map(SubjectQuotaAdminService::toVO)
+            .toList();
+    }
+
+    /** 最近 N 小时的命中排行（"谁在刷"）。 */
+    public List<SubjectQuotaHitRank> rankHits(String tenantId, int hours, int limit) {
+        return hitStore().rank(tenantId, sinceMs(hours), cappedLimit(limit));
+    }
+
+    // ---------- 内部 ----------
+
+    /** 每次取新的 Store：门面本身是惰性缓存的，这里只是把它包成 Store 语义，无额外开销。 */
+    private SubjectQuotaLevelStore levelStore() {
+        return new MybatisSubjectQuotaLevelStore(gatewayProvider.get().levelMapper());
+    }
+
+    private SubjectQuotaHitStore hitStore() {
+        return new MybatisSubjectQuotaHitStore(gatewayProvider.get().hitMapper());
+    }
+
+    /**
+     * 用户查询条件。
+     *
+     * <p>租户列用字符串列名而不是 {@code UserDO} 字段：跨库门面没有租户拦截器，
+     * 而 DO 本身也不持有 {@code tenantId}（starter 侧靠拦截器自动补），只能显式写列名。
+     * 漏掉这个条件就是跨租户看到别人的用户名单。</p>
+     */
+    private static QueryWrapper<UserDO> userWrapper(String tenantId, String keyword) {
+        QueryWrapper<UserDO> wrapper = new QueryWrapper<UserDO>().eq("tenant_id", tenantId);
+        if (keyword != null && !keyword.isBlank()) {
+            String like = keyword.trim();
+            wrapper.and(w -> w.like("username", like).or().like("nickname", like));
+        }
+        return wrapper;
+    }
+
+    private static long sinceMs(int hours) {
+        int effective = hours <= 0 ? 24 : hours;
+        return System.currentTimeMillis() - effective * HOUR_MS;
+    }
+
+    private static int cappedLimit(int limit) {
+        return limit <= 0 ? 100 : Math.min(limit, MAX_HIT_LIMIT);
+    }
+
+    private static SubjectQuotaLevelVO toVO(SubjectQuotaLevel level) {
+        SubjectQuotaLevelVO vo = new SubjectQuotaLevelVO();
+        vo.setTenantId(level.tenantId());
+        vo.setLevelCode(level.levelCode());
+        vo.setLevelName(level.levelName());
+        vo.setSubjectType(level.subjectType().name());
+        vo.setWindowSeconds(level.effectiveWindowSeconds());
+        vo.setTokenLimit(level.tokenLimit());
+        vo.setRequestLimit(level.requestLimit());
+        vo.setExceedAction(level.exceedAction().name());
+        vo.setEnabled(level.enabled());
+        vo.setRemark(level.remark());
+        return vo;
+    }
+
+    private static SubjectQuotaUserVO toVO(UserDO row) {
+        SubjectQuotaUserVO vo = new SubjectQuotaUserVO();
+        vo.setUserId(row.getId());
+        vo.setUsername(row.getUsername());
+        vo.setNickname(row.getNickname());
+        vo.setLevelCode(row.getLevelCode());
+        vo.setStatus(row.getStatus());
+        vo.setCreatedAtMs(row.getCreatedAtMs());
+        return vo;
+    }
+
+    private static SubjectQuotaHitVO toVO(SubjectQuotaHit hit) {
+        SubjectQuotaHitVO vo = new SubjectQuotaHitVO();
+        vo.setSubjectType(hit.subjectType().name());
+        vo.setSubjectId(hit.subjectId());
+        vo.setLevelCode(hit.levelCode());
+        vo.setLimitKind(hit.limitKind() == null ? null : hit.limitKind().name());
+        vo.setUsed(hit.used());
+        vo.setLimitValue(hit.limitValue());
+        vo.setWindowSeconds(hit.windowSeconds());
+        vo.setAction(hit.action() == null ? null : hit.action().name());
+        vo.setResource(hit.resource());
+        vo.setCreatedAtMs(hit.createdAtMs());
+        return vo;
+    }
+}

--- a/customer-admin-server/src/main/resources/db/migration/V55__subject_rate_quota.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V55__subject_rate_quota.sql
@@ -1,0 +1,19 @@
+-- 主体级速率配额（用户额度）的菜单与权限点。
+--
+-- 本次没有建表：三处数据（cw_subject_quota_level / cw_subject_quota_hit / cw_user.level_code）都在
+-- 客服端库 agent_scope_customer_work，由 starter 的 Flyway V4 建，后台只是这份数据的维护端。
+-- 刻意不在 admin 库另存副本——限流配置双写出现不一致，表现是"后台显示已放宽、线上照样拦"。
+--
+-- 挂在"内容风控"下而不是"配额与计费"下：它与同级的"限流规则"是同一件事的两个维度
+-- （那边按路径限、这边按人限），而计费那边管的是"这个客户这个月能花多少钱"，周期和目的都不同。
+
+-- 二级菜单：用户额度（sort=4，接在命中看板之后）
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (244, 204, '用户额度', 'subject-quota:view', 1, '/contentguard/subject-quota', 'Stopwatch', 'library', 4);
+
+-- 三级：按钮/接口权限点（type=2）。
+-- 等级维护与用户分档分开发点：前者改的是"这一档多少额度"（影响一批人），
+-- 后者改的是"这个人属于哪一档"（影响一个人），两种误操作的爆炸半径差一个数量级。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (245, 244, '维护等级',   'subject-quota:level-edit', 2, 1),
+    (246, 244, '分配用户等级', 'subject-quota:user-edit',  2, 2);

--- a/customer-admin-web/src/api/subjectQuota.ts
+++ b/customer-admin-web/src/api/subjectQuota.ts
@@ -1,0 +1,53 @@
+import { request } from './request'
+import type {
+  PageQuery,
+  PageResult,
+  SubjectQuotaHitRank,
+  SubjectQuotaHitVO,
+  SubjectQuotaLevelSaveRequest,
+  SubjectQuotaLevelVO,
+  SubjectQuotaUserVO,
+  UserLevelSaveRequest,
+} from '@/types/api'
+
+// 租户一律取后端的当前视角，前端不传 tenantId——让参数决定读哪个租户等于把越权做成查询参数
+
+// ---------- 等级 ----------
+
+export function fetchSubjectQuotaLevels() {
+  return request<SubjectQuotaLevelVO[]>({ url: '/subject-quota/levels', method: 'get' })
+}
+
+export function saveSubjectQuotaLevel(data: SubjectQuotaLevelSaveRequest) {
+  return request<void>({ url: '/subject-quota/levels', method: 'post', data })
+}
+
+export function deleteSubjectQuotaLevel(levelCode: string) {
+  return request<void>({ url: '/subject-quota/levels', method: 'delete', params: { levelCode } })
+}
+
+// ---------- 用户分档 ----------
+
+export function pageSubjectQuotaUsers(query: PageQuery) {
+  return request<PageResult<SubjectQuotaUserVO>>({
+    url: '/subject-quota/users', method: 'get', params: query,
+  })
+}
+
+export function assignUserLevel(data: UserLevelSaveRequest) {
+  return request<void>({ url: '/subject-quota/users/level', method: 'post', data })
+}
+
+// ---------- 超限命中 ----------
+
+export function fetchSubjectQuotaHits(hours: number, limit: number) {
+  return request<SubjectQuotaHitVO[]>({
+    url: '/subject-quota/hits', method: 'get', params: { hours, limit },
+  })
+}
+
+export function fetchSubjectQuotaHitRank(hours: number, limit: number) {
+  return request<SubjectQuotaHitRank[]>({
+    url: '/subject-quota/hits/rank', method: 'get', params: { hours, limit },
+  })
+}

--- a/customer-admin-web/src/router/component-map.ts
+++ b/customer-admin-web/src/router/component-map.ts
@@ -37,6 +37,7 @@ export const staticRouteComponents: Record<string, () => Promise<Component>> = {
   '/contentguard/sensitive-word': () => import('@/views/contentguard/SensitiveWordManage.vue'),
   '/contentguard/rate-limit': () => import('@/views/contentguard/RateLimitRuleManage.vue'),
   '/contentguard/hit-log': () => import('@/views/contentguard/SensitiveHitLogBoard.vue'),
+  '/contentguard/subject-quota': () => import('@/views/contentguard/SubjectQuotaManage.vue'),
   '/aiconfig/channel-robot': () => import('@/views/aiconfig/ChannelRobotManage.vue'),
   '/ticket/user-ticket': () => import('@/views/ticket/UserTicketManage.vue'),
   '/ticket/user-order': () => import('@/views/ticket/UserOrderManage.vue'),

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -1332,3 +1332,76 @@ export interface AgentTaskPageQuery extends MpPageQuery {
   status?: string
   agentCode?: string
 }
+
+// ---------- 主体级速率配额（用户额度） ----------
+
+/** 一档额度定义。窗口是滚动的（最近 N 秒），与租户配额的自然日/月对齐不同。 */
+export interface SubjectQuotaLevelVO {
+  tenantId: string
+  levelCode: string
+  levelName: string
+  /** USER 登录用户 / IP 匿名 / API_KEY 接入方 */
+  subjectType: string
+  windowSeconds: number
+  /** 0 = 不限 */
+  tokenLimit: number
+  /** 0 = 不限 */
+  requestLimit: number
+  /** BLOCK 拦截 / WARN 仅记录 */
+  exceedAction: string
+  enabled: boolean
+  remark?: string
+}
+
+export interface SubjectQuotaLevelSaveRequest {
+  levelCode: string
+  levelName: string
+  subjectType: string
+  windowSeconds: number
+  tokenLimit: number
+  requestLimit: number
+  exceedAction: string
+  enabled: boolean
+  remark?: string
+}
+
+/** 用户分档视图（只含分配等级所需字段，不含账户敏感信息）。 */
+export interface SubjectQuotaUserVO {
+  userId: string
+  username: string
+  nickname?: string
+  /** 空表示走配置里的默认档 */
+  levelCode?: string
+  status: string
+  createdAtMs?: number
+}
+
+export interface UserLevelSaveRequest {
+  userId: string
+  /** 传空表示回到默认档 */
+  levelCode?: string
+}
+
+/** 超限命中明细。 */
+export interface SubjectQuotaHitVO {
+  subjectType: string
+  subjectId: string
+  levelCode?: string
+  /** TOKEN / REQUEST */
+  limitKind: string
+  used: number
+  limitValue: number
+  windowSeconds: number
+  action: string
+  resource?: string
+  createdAtMs: number
+}
+
+/** 超限命中排行（谁在刷）。 */
+export interface SubjectQuotaHitRank {
+  subjectType: string
+  subjectId: string
+  levelCode?: string
+  hitCount: number
+  lastHitAtMs: number
+}

--- a/customer-admin-web/src/views/contentguard/SubjectQuotaManage.vue
+++ b/customer-admin-web/src/views/contentguard/SubjectQuotaManage.vue
@@ -1,0 +1,440 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import type { FormInstance } from 'element-plus'
+import {
+  assignUserLevel,
+  deleteSubjectQuotaLevel,
+  fetchSubjectQuotaHitRank,
+  fetchSubjectQuotaHits,
+  fetchSubjectQuotaLevels,
+  pageSubjectQuotaUsers,
+  saveSubjectQuotaLevel,
+} from '@/api/subjectQuota'
+import { useAuthStore } from '@/store/auth'
+import type {
+  PageQuery,
+  SubjectQuotaHitRank,
+  SubjectQuotaHitVO,
+  SubjectQuotaLevelSaveRequest,
+  SubjectQuotaLevelVO,
+  SubjectQuotaUserVO,
+} from '@/types/api'
+
+const auth = useAuthStore()
+const activeTab = ref('levels')
+
+// ---------- 等级 ----------
+const levelLoading = ref(false)
+const levels = ref<SubjectQuotaLevelVO[]>([])
+const levelDialogVisible = ref(false)
+const levelDialogMode = ref<'create' | 'edit'>('create')
+const levelFormRef = ref<FormInstance>()
+const levelForm = reactive<SubjectQuotaLevelSaveRequest>(initLevelForm())
+
+function initLevelForm(): SubjectQuotaLevelSaveRequest {
+  return {
+    levelCode: '', levelName: '', subjectType: 'USER', windowSeconds: 1800,
+    tokenLimit: 50000, requestLimit: 100, exceedAction: 'BLOCK', enabled: true, remark: '',
+  }
+}
+
+const levelRules = {
+  levelCode: [{ required: true, message: '请填写等级编码', trigger: 'blur' }],
+  levelName: [{ required: true, message: '请填写等级名称', trigger: 'blur' }],
+  windowSeconds: [{ required: true, message: '请填写窗口长度', trigger: 'blur' }],
+}
+
+async function loadLevels() {
+  levelLoading.value = true
+  try {
+    levels.value = await fetchSubjectQuotaLevels()
+  } finally {
+    levelLoading.value = false
+  }
+}
+
+function openLevelCreate() {
+  levelDialogMode.value = 'create'
+  Object.assign(levelForm, initLevelForm())
+  levelDialogVisible.value = true
+}
+
+function openLevelEdit(row: SubjectQuotaLevelVO) {
+  levelDialogMode.value = 'edit'
+  Object.assign(levelForm, {
+    levelCode: row.levelCode, levelName: row.levelName, subjectType: row.subjectType,
+    windowSeconds: row.windowSeconds, tokenLimit: row.tokenLimit, requestLimit: row.requestLimit,
+    exceedAction: row.exceedAction, enabled: row.enabled, remark: row.remark ?? '',
+  })
+  levelDialogVisible.value = true
+}
+
+async function submitLevel() {
+  if (!levelFormRef.value) return
+  await levelFormRef.value.validate()
+  await saveSubjectQuotaLevel({ ...levelForm })
+  ElMessage.success('已保存，客服端最长 60 秒后生效')
+  levelDialogVisible.value = false
+  await loadLevels()
+}
+
+async function removeLevel(row: SubjectQuotaLevelVO) {
+  await ElMessageBox.confirm(
+    `确认删除等级「${row.levelName}」？删除后挂在该档的用户会落回配置里的默认档。`,
+    '提示', { type: 'warning' },
+  )
+  await deleteSubjectQuotaLevel(row.levelCode)
+  ElMessage.success('已删除')
+  await loadLevels()
+}
+
+// ---------- 用户分档 ----------
+const userLoading = ref(false)
+const users = ref<SubjectQuotaUserVO[]>([])
+const userTotal = ref(0)
+const userQuery = reactive<PageQuery>({ pageNum: 1, pageSize: 10, keyword: '' })
+
+async function loadUsers() {
+  userLoading.value = true
+  try {
+    const page = await pageSubjectQuotaUsers(userQuery)
+    users.value = page.list
+    userTotal.value = page.total
+  } finally {
+    userLoading.value = false
+  }
+}
+
+function searchUsers() {
+  userQuery.pageNum = 1
+  return loadUsers()
+}
+
+/** 改档立即提交：这个下拉本身就是操作，再加一个"保存"按钮只会让人以为没生效。 */
+async function changeUserLevel(row: SubjectQuotaUserVO, levelCode: string | undefined) {
+  await assignUserLevel({ userId: row.userId, levelCode: levelCode || undefined })
+  ElMessage.success('已调整，客服端最长 60 秒后生效')
+  await loadUsers()
+}
+
+// ---------- 超限命中 ----------
+const hitLoading = ref(false)
+const hitHours = ref(24)
+const hits = ref<SubjectQuotaHitVO[]>([])
+const hitRank = ref<SubjectQuotaHitRank[]>([])
+
+async function loadHits() {
+  hitLoading.value = true
+  try {
+    const [rank, detail] = await Promise.all([
+      fetchSubjectQuotaHitRank(hitHours.value, 20),
+      fetchSubjectQuotaHits(hitHours.value, 100),
+    ])
+    hitRank.value = rank
+    hits.value = detail
+  } finally {
+    hitLoading.value = false
+  }
+}
+
+// ---------- 公共 ----------
+const subjectTypeLabels: Record<string, string> = {
+  USER: '登录用户', IP: '匿名 IP', API_KEY: '接入方',
+}
+
+const actionLabels: Record<string, string> = {
+  BLOCK: '拦截', WARN: '仅记录',
+}
+
+const kindLabels: Record<string, string> = {
+  TOKEN: 'token 用量', REQUEST: '请求次数',
+}
+
+function formatWindow(seconds: number): string {
+  if (!seconds) return '-'
+  return seconds % 60 === 0 ? `${seconds / 60} 分钟` : `${seconds} 秒`
+}
+
+function formatLimit(value: number, unit: string): string {
+  return value > 0 ? `${value} ${unit}` : '不限'
+}
+
+function formatTime(ms?: number): string {
+  return ms ? new Date(ms).toLocaleString('zh-CN') : '-'
+}
+
+onMounted(async () => {
+  await Promise.all([loadLevels(), loadUsers()])
+})
+</script>
+
+<template>
+  <div class="page">
+    <el-alert type="warning" :closable="false" show-icon class="notice">
+      按<b>调用者</b>限流：每个登录用户 / 每个匿名 IP / 每把 API Key 在最近一段时间内的 token 量与请求次数上限。
+      与同级的<b>限流规则</b>（按路径限）、<b>配额与计费</b>（按租户限月度花费）三者并存，任一触顶都会被拦。
+      需客服端开启 <code>customer-work.subject-quota.enabled=true</code> 才真正生效——这里能配，不等于一定在跑。
+      改动经指纹轮询与本地缓存下发，<b>最长 60 秒生效</b>。
+    </el-alert>
+
+    <el-tabs v-model="activeTab">
+      <!-- 等级 -->
+      <el-tab-pane label="额度等级" name="levels">
+        <el-card>
+          <div class="toolbar">
+            <el-button v-permission="'subject-quota:level-edit'" type="primary" @click="openLevelCreate">
+              新增等级
+            </el-button>
+            <el-button @click="loadLevels">刷新</el-button>
+          </div>
+
+          <el-table v-loading="levelLoading" :data="levels" style="width: 100%">
+            <el-table-column prop="levelCode" label="等级编码" width="130" />
+            <el-table-column prop="levelName" label="等级名称" min-width="130" show-overflow-tooltip />
+            <el-table-column label="适用主体" width="110">
+              <template #default="{ row }">{{ subjectTypeLabels[row.subjectType] ?? row.subjectType }}</template>
+            </el-table-column>
+            <el-table-column label="滚动窗口" width="110">
+              <template #default="{ row }">{{ formatWindow(row.windowSeconds) }}</template>
+            </el-table-column>
+            <el-table-column label="token 上限" width="130">
+              <template #default="{ row }">{{ formatLimit(row.tokenLimit, 'token') }}</template>
+            </el-table-column>
+            <el-table-column label="次数上限" width="110">
+              <template #default="{ row }">{{ formatLimit(row.requestLimit, '次') }}</template>
+            </el-table-column>
+            <el-table-column label="超限处置" width="100">
+              <template #default="{ row }">
+                <el-tag :type="row.exceedAction === 'BLOCK' ? 'danger' : 'warning'">
+                  {{ actionLabels[row.exceedAction] ?? row.exceedAction }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="状态" width="90">
+              <template #default="{ row }">
+                <el-tag :type="row.enabled ? 'success' : 'info'">{{ row.enabled ? '启用' : '停用' }}</el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="remark" label="备注" min-width="140" show-overflow-tooltip />
+            <el-table-column label="操作" width="140" fixed="right">
+              <template #default="{ row }">
+                <el-button v-permission="'subject-quota:level-edit'" link type="primary" @click="openLevelEdit(row)">
+                  编辑
+                </el-button>
+                <el-button v-permission="'subject-quota:level-edit'" link type="danger" @click="removeLevel(row)">
+                  删除
+                </el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-card>
+      </el-tab-pane>
+
+      <!-- 用户分档 -->
+      <el-tab-pane label="用户分档" name="users">
+        <el-card>
+          <div class="toolbar">
+            <el-input
+              v-model="userQuery.keyword"
+              placeholder="按用户名或昵称搜索"
+              style="width: 220px"
+              clearable
+              @keyup.enter="searchUsers"
+            />
+            <el-button type="primary" @click="searchUsers">搜索</el-button>
+          </div>
+
+          <el-table v-loading="userLoading" :data="users" style="width: 100%">
+            <el-table-column prop="username" label="用户名" min-width="140" show-overflow-tooltip />
+            <el-table-column prop="nickname" label="昵称" min-width="120" show-overflow-tooltip />
+            <el-table-column prop="userId" label="用户 ID" min-width="200" show-overflow-tooltip />
+            <el-table-column label="状态" width="90">
+              <template #default="{ row }">
+                <el-tag :type="row.status === 'ACTIVE' ? 'success' : 'info'">
+                  {{ row.status === 'ACTIVE' ? '启用' : '停用' }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="注册时间" width="180">
+              <template #default="{ row }">{{ formatTime(row.createdAtMs) }}</template>
+            </el-table-column>
+            <el-table-column label="额度等级" width="200" fixed="right">
+              <template #default="{ row }">
+                <el-select
+                  :model-value="row.levelCode ?? ''"
+                  placeholder="默认档"
+                  clearable
+                  style="width: 100%"
+                  :disabled="!auth.hasPermission('subject-quota:user-edit')"
+                  @change="(value: string) => changeUserLevel(row, value)"
+                >
+                  <el-option
+                    v-for="level in levels.filter((l) => l.subjectType === 'USER')"
+                    :key="level.levelCode"
+                    :label="`${level.levelName}（${level.levelCode}）`"
+                    :value="level.levelCode"
+                  />
+                </el-select>
+              </template>
+            </el-table-column>
+          </el-table>
+
+          <el-pagination
+            v-model:current-page="userQuery.pageNum"
+            v-model:page-size="userQuery.pageSize"
+            :total="userTotal"
+            :page-sizes="[10, 20, 50]"
+            layout="total, sizes, prev, pager, next"
+            class="pager"
+            @current-change="loadUsers"
+            @size-change="searchUsers"
+          />
+        </el-card>
+      </el-tab-pane>
+
+      <!-- 超限记录 -->
+      <el-tab-pane label="超限记录" name="hits">
+        <el-card>
+          <div class="toolbar">
+            <el-select v-model="hitHours" style="width: 140px" @change="loadHits">
+              <el-option label="最近 1 小时" :value="1" />
+              <el-option label="最近 24 小时" :value="24" />
+              <el-option label="最近 7 天" :value="168" />
+            </el-select>
+            <el-button type="primary" @click="loadHits">查询</el-button>
+            <span class="hint">只在真的触顶时才记录，正常流量不产生任何数据。</span>
+          </div>
+
+          <el-divider content-position="left">谁在刷（命中次数排行）</el-divider>
+          <el-table v-loading="hitLoading" :data="hitRank" style="width: 100%">
+            <el-table-column label="主体类型" width="110">
+              <template #default="{ row }">{{ subjectTypeLabels[row.subjectType] ?? row.subjectType }}</template>
+            </el-table-column>
+            <el-table-column prop="subjectId" label="主体标识" min-width="220" show-overflow-tooltip />
+            <el-table-column prop="levelCode" label="等级" width="120" />
+            <el-table-column prop="hitCount" label="命中次数" width="110" sortable />
+            <el-table-column label="最近命中" width="180">
+              <template #default="{ row }">{{ formatTime(row.lastHitAtMs) }}</template>
+            </el-table-column>
+          </el-table>
+
+          <el-divider content-position="left">命中明细</el-divider>
+          <el-table v-loading="hitLoading" :data="hits" style="width: 100%">
+            <el-table-column label="时间" width="180">
+              <template #default="{ row }">{{ formatTime(row.createdAtMs) }}</template>
+            </el-table-column>
+            <el-table-column label="主体" min-width="220" show-overflow-tooltip>
+              <template #default="{ row }">
+                {{ subjectTypeLabels[row.subjectType] ?? row.subjectType }} · {{ row.subjectId }}
+              </template>
+            </el-table-column>
+            <el-table-column prop="levelCode" label="等级" width="110" />
+            <el-table-column label="触顶维度" width="120">
+              <template #default="{ row }">{{ kindLabels[row.limitKind] ?? row.limitKind }}</template>
+            </el-table-column>
+            <el-table-column label="用量 / 上限" width="150">
+              <template #default="{ row }">{{ row.used }} / {{ row.limitValue }}</template>
+            </el-table-column>
+            <el-table-column label="处置" width="100">
+              <template #default="{ row }">
+                <el-tag :type="row.action === 'BLOCK' ? 'danger' : 'warning'">
+                  {{ actionLabels[row.action] ?? row.action }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="resource" label="触发位置" min-width="200" show-overflow-tooltip />
+          </el-table>
+        </el-card>
+      </el-tab-pane>
+    </el-tabs>
+
+    <!-- 等级编辑弹窗 -->
+    <el-dialog
+      v-model="levelDialogVisible"
+      :title="levelDialogMode === 'create' ? '新增等级' : '编辑等级'"
+      width="560px"
+    >
+      <el-form ref="levelFormRef" :model="levelForm" :rules="levelRules" label-width="110px">
+        <el-form-item label="等级编码" prop="levelCode">
+          <el-input
+            v-model="levelForm.levelCode"
+            :disabled="levelDialogMode === 'edit'"
+            placeholder="如 free / vip"
+          />
+        </el-form-item>
+        <el-form-item label="等级名称" prop="levelName">
+          <el-input v-model="levelForm.levelName" placeholder="如 免费用户" />
+        </el-form-item>
+        <el-form-item label="适用主体">
+          <el-select v-model="levelForm.subjectType" style="width: 100%">
+            <el-option label="登录用户（按 userId 计）" value="USER" />
+            <el-option label="匿名访客（按来源 IP 计）" value="IP" />
+            <el-option label="接入方（按 API Key 指纹计）" value="API_KEY" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="滚动窗口" prop="windowSeconds">
+          <el-input-number v-model="levelForm.windowSeconds" :min="60" :step="300" style="width: 100%" />
+          <div class="form-hint">秒。1800 = 30 分钟，3600 = 1 小时。窗口是滚动的，不在整点归零。</div>
+        </el-form-item>
+        <el-form-item label="token 上限">
+          <el-input-number v-model="levelForm.tokenLimit" :min="0" :step="10000" style="width: 100%" />
+          <div class="form-hint">0 = 不限。只统计模型实际消耗，查询类请求不计入。</div>
+        </el-form-item>
+        <el-form-item label="次数上限">
+          <el-input-number v-model="levelForm.requestLimit" :min="0" :step="10" style="width: 100%" />
+          <div class="form-hint">0 = 不限。口径是 HTTP 请求数与 WS 对话数，含查询类请求。</div>
+        </el-form-item>
+        <el-form-item label="超限处置">
+          <el-radio-group v-model="levelForm.exceedAction">
+            <el-radio label="BLOCK">拦截</el-radio>
+            <el-radio label="WARN">仅记录</el-radio>
+          </el-radio-group>
+          <div class="form-hint">新等级上线可先用「仅记录」观察几天，确认阈值合理再收紧。</div>
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-switch v-model="levelForm.enabled" active-text="启用" inactive-text="停用" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="levelForm.remark" type="textarea" :rows="2" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="levelDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="submitLevel">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.page {
+  padding: 16px;
+}
+
+.notice {
+  margin-bottom: 12px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.hint {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.pager {
+  margin-top: 12px;
+  justify-content: flex-end;
+}
+
+.form-hint {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+</style>

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchService.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchService.java
@@ -8,6 +8,12 @@ import com.richard.fyoung.customerwork.data.ticket.TicketActorType;
 import com.richard.fyoung.customerwork.data.ticket.TicketCategory;
 import com.richard.fyoung.customerwork.data.ticket.TicketService;
 import com.richard.fyoung.customerwork.safety.security.UserPrincipal;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContextThreadLocalAccessor;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaDecision;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContextThreadLocalAccessor;
 import com.richard.fyoung.customerwork.infra.ws.WsFrame;
 import com.richard.fyoung.customerwork.infra.ws.WsSessionRegistry;
 import org.slf4j.Logger;
@@ -44,6 +50,9 @@ public class ChatDispatchService {
     private static final String NOTICE_WAITING_CONFIRM = "本次问题坐席已处理，请在工单中确认是否解决";
     private static final String ERR_SESSION_OWNERSHIP = "会话不属于当前用户";
 
+    /** 主体配额的触发位置标识：与 HTTP 侧的路径同位，用于在命中记录里区分是哪条链路被限。 */
+    private static final String QUOTA_RESOURCE_WS_CHAT = "ws:chat";
+
     private static final String KEY_MESSAGE_ID = "messageId";
     private static final String KEY_SESSION_ID = "sessionId";
     private static final String KEY_TICKET_ID = "ticketId";
@@ -58,16 +67,26 @@ public class ChatDispatchService {
     private final HandoffKeywordDetector keywordDetector;
     private final WsSessionRegistry registry;
 
+    /**
+     * 主体配额守卫：WS 是终端用户真正的发消息入口，HTTP 过滤器管不到这里。
+     *
+     * <p>不判的话，用户只要改走 WS 就完全绕开了限流——而 H5 前端本来就走 WS，
+     * 等于这个功能对主战场不生效。</p>
+     */
+    private final SubjectQuotaGuard subjectQuotaGuard;
+
     public ChatDispatchService(TicketService ticketService,
                                ChatLogService chatLogService,
                                CustomerServiceService customerServiceService,
                                HandoffKeywordDetector keywordDetector,
-                               WsSessionRegistry registry) {
+                               WsSessionRegistry registry,
+                               SubjectQuotaGuard subjectQuotaGuard) {
         this.ticketService = ticketService;
         this.chatLogService = chatLogService;
         this.customerServiceService = customerServiceService;
         this.keywordDetector = keywordDetector;
         this.registry = registry;
+        this.subjectQuotaGuard = subjectQuotaGuard;
     }
 
     /** 分发动作：由工单状态与关键词共同决定。 */
@@ -89,6 +108,17 @@ public class ChatDispatchService {
             registry.pushToUser(user.userId(), WsFrame.error("CHAT-SESSION-DENIED", ERR_SESSION_OWNERSHIP));
             return Mono.empty();
         }
+        QuotaSubject subject = QuotaSubject.user(user.userId());
+        // 判定与记账都要在用户归属租户下进行：等级表按租户隔离，拿错租户就会查到别人那一档
+        SubjectQuotaDecision quota = TenantContext.callWith(tenantOf(user),
+            () -> subjectQuotaGuard.check(subject, QUOTA_RESOURCE_WS_CHAT));
+        if (quota.shouldBlock()) {
+            // 用 system 帧而非 error 帧：这不是故障，是额度用完了，前端应当把它当成一条正常的系统提示展示
+            registry.pushToUser(user.userId(), WsFrame.system(quota.message(), sessionId, null));
+            return Mono.empty();
+        }
+        TenantContext.runWith(tenantOf(user), () -> subjectQuotaGuard.recordRequest(subject));
+
         return Mono.fromCallable(() -> prepare(user, sessionId, content))
             .subscribeOn(Schedulers.boundedElastic())
             .flatMap(decision -> act(user.userId(), sessionId, content, decision))
@@ -97,7 +127,18 @@ public class ChatDispatchService {
                     "CHAT-USER-DISPATCH-FAIL", e);
                 registry.pushToUser(user.userId(), WsFrame.error("CHAT-USER-DISPATCH-FAIL", "消息处理失败，请稍后再试"));
                 return Mono.empty();
-            });
+            })
+            // 主体与租户随流下传：token 记账发生在模型调用之后、好几次线程切换之外，
+            // 只有写进 Reactor Context 才能在那里还原出"这次是谁在用"
+            .contextWrite(ctx -> ctx
+                .put(QuotaSubjectContextThreadLocalAccessor.KEY, subject)
+                .put(TenantContextThreadLocalAccessor.KEY, tenantOf(user)));
+    }
+
+    /** 用户归属租户；令牌里没有（旧令牌）时按默认租户算，与 {@code UserJwtService} 的签发默认一致。 */
+    private static String tenantOf(UserPrincipal user) {
+        String tenantId = user.tenantId();
+        return tenantId == null || tenantId.isBlank() ? TenantContext.DEFAULT : tenantId;
     }
 
     /**

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserQuotaController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserQuotaController.java
@@ -1,0 +1,85 @@
+package com.richard.fyoung.customerworkapp.controller;
+
+import com.richard.fyoung.customerwork.safety.security.UserAuthWebFilter;
+import com.richard.fyoung.customerwork.safety.security.UserPrincipal;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaUsage;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 当前用户的额度查询（登录态必需，由 {@code UserAuthWebFilter} 保证）。
+ *
+ * <p><b>为什么要把额度暴露给用户自己</b>：被限流的那一刻才知道有额度，是最糟的知情方式。
+ * 前端可以据此提前提示"本时段还剩几次"，把一次硬邦邦的 429 变成一句可预期的提醒。</p>
+ *
+ * <p>只读当前用量，不返回"何时恢复"：滚动窗口下额度是连续释放的，任何一个恢复时刻都只对
+ * 某一笔用量成立，报出去只会变成客服要解释的新问题。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@RestController
+@RequestMapping("/api/customer/user/quota")
+@Tag(name = "用户额度", description = "当前登录用户的速率额度与已用量")
+public class UserQuotaController {
+
+    private static final String KEY_LEVEL_CODE = "levelCode";
+    private static final String KEY_WINDOW_SECONDS = "windowSeconds";
+    private static final String KEY_TOKEN_USED = "tokenUsed";
+    private static final String KEY_TOKEN_LIMIT = "tokenLimit";
+    private static final String KEY_TOKEN_REMAINING = "tokenRemaining";
+    private static final String KEY_REQUEST_USED = "requestUsed";
+    private static final String KEY_REQUEST_LIMIT = "requestLimit";
+    private static final String KEY_REQUEST_REMAINING = "requestRemaining";
+    private static final String KEY_LIMITED = "limited";
+
+    private final SubjectQuotaGuard subjectQuotaGuard;
+
+    public UserQuotaController(SubjectQuotaGuard subjectQuotaGuard) {
+        this.subjectQuotaGuard = subjectQuotaGuard;
+    }
+
+    @Operation(summary = "我的额度", description = "当前滚动窗口内的 token 与次数用量；-1 表示该维度不限")
+    @GetMapping
+    public Mono<Map<String, Object>> myQuota(ServerWebExchange exchange) {
+        UserPrincipal user = principal(exchange);
+        // 等级按租户隔离，判定必须在用户归属租户下进行
+        String tenantId = user.tenantId() == null || user.tenantId().isBlank()
+            ? TenantContext.DEFAULT : user.tenantId();
+        SubjectQuotaUsage usage = TenantContext.callWith(tenantId,
+            () -> subjectQuotaGuard.usage(QuotaSubject.user(user.userId())));
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put(KEY_LEVEL_CODE, usage.levelCode());
+        body.put(KEY_WINDOW_SECONDS, usage.windowSeconds());
+        body.put(KEY_TOKEN_USED, usage.tokenUsed());
+        body.put(KEY_TOKEN_LIMIT, usage.tokenLimit());
+        body.put(KEY_TOKEN_REMAINING, usage.tokenRemaining());
+        body.put(KEY_REQUEST_USED, usage.requestUsed());
+        body.put(KEY_REQUEST_LIMIT, usage.requestLimit());
+        body.put(KEY_REQUEST_REMAINING, usage.requestRemaining());
+        // 显式给一个"到底受不受限"的布尔，免得前端自己去猜 levelCode 为空是什么意思
+        body.put(KEY_LIMITED, usage.levelCode() != null);
+        return Mono.just(body);
+    }
+
+    /** 从 exchange 属性取当前用户主体（过滤器已保证存在，此处为单一防御点）。 */
+    private UserPrincipal principal(ServerWebExchange exchange) {
+        UserPrincipal user = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
+        }
+        return user;
+    }
+}

--- a/customer-work-app-server/src/main/resources/application.yml
+++ b/customer-work-app-server/src/main/resources/application.yml
@@ -258,6 +258,26 @@ customer-work:
       window-seconds: 60
       rule-enabled: true
       store-mode: jdbc
+  # 主体级速率配额：按调用者限（每登录用户 / 每匿名 IP / 每把 API Key），
+  # 滚动窗口内的 token 量与请求次数双上限。与上面按路径限的 rate-limit 正交，两者都判。
+  subject-quota:
+    enabled: true
+    # jdbc：等级读 cw_subject_quota_level（后台「内容风控 → 用户额度」可维护）。
+    # 配成 memory 则只认 SubjectQuotaProperties 里的内置档，后台改了不会生效。
+    store-mode: jdbc
+    # 新注册用户落这一档；匿名与接入方各走一档，见 cw_subject_quota_level 的出厂种子
+    default-user-level: free
+    anonymous-level: anonymous
+    api-key-level: api-key
+    # 参与判定的路径前缀。次数口径是「HTTP 请求数 + WS 对话数」，因为覆盖了整个
+    # /api/customer/user/ 面，翻历史消息也会占额度——只想限对话就把最后一行去掉。
+    # 真正卡成本的是 token 那一维，它只在模型调用后累加。
+    paths:
+      - /api/customer/chat
+      - /api/customer/intent
+      - /api/customer/consult
+      - /api/customer/agui
+      - /api/customer/user/
   multi-agent:
     # 多 Agent 编排：fanout（并行多专家聚合）| sequential（流水串行细化）
     enabled: true

--- a/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchServiceTest.java
+++ b/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchServiceTest.java
@@ -9,6 +9,8 @@ import com.richard.fyoung.customerwork.data.ticket.TicketActorType;
 import com.richard.fyoung.customerwork.data.ticket.TicketCategory;
 import com.richard.fyoung.customerwork.data.ticket.TicketService;
 import com.richard.fyoung.customerwork.safety.security.UserPrincipal;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaDecision;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
 import com.richard.fyoung.customerwork.infra.ws.WsFrame;
 import com.richard.fyoung.customerwork.infra.ws.WsSessionRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +47,7 @@ class ChatDispatchServiceTest {
     private CustomerServiceService customerServiceService;
     private HandoffKeywordDetector keywordDetector;
     private WsSessionRegistry registry;
+    private SubjectQuotaGuard subjectQuotaGuard;
     private ChatDispatchService dispatch;
 
     private final UserPrincipal user = new UserPrincipal(USER_ID, "alice", "Alice", TenantContext.DEFAULT);
@@ -56,8 +59,11 @@ class ChatDispatchServiceTest {
         customerServiceService = mock(CustomerServiceService.class);
         keywordDetector = mock(HandoffKeywordDetector.class);
         registry = mock(WsSessionRegistry.class);
+        // 默认放行：本类测的是分发路由，配额行为另有专门用例
+        subjectQuotaGuard = mock(SubjectQuotaGuard.class);
+        lenient().when(subjectQuotaGuard.check(any(), any())).thenReturn(SubjectQuotaDecision.allow());
         dispatch = new ChatDispatchService(ticketService, chatLogService, customerServiceService,
-            keywordDetector, registry);
+            keywordDetector, registry, subjectQuotaGuard);
         // 落库统一返回一条带 messageId 的消息（AI 流式收尾需要读 messageId）
         lenient().when(chatLogService.append(any(), any(), any(), any(), any()))
             .thenReturn(ChatMessage.of("MSG-9", SESSION_ID, "TK-1", TicketActorType.BOT, null, "txt"));

--- a/customer-work-app/src/api/quota.ts
+++ b/customer-work-app/src/api/quota.ts
@@ -1,0 +1,13 @@
+import { request } from '@/api/request'
+import type { UserQuota } from '@/types/api'
+
+/**
+ * 查我的额度：当前滚动窗口内的 token 与提问次数用量。
+ *
+ * <p>该路径在服务端豁免限流判定——否则查一次扣一次，且额度耗尽后连"还剩多少"都看不到。</p>
+ *
+ * silentError：额度是锦上添花的信息，查不到就不显示，不该弹一个用户看不懂的错误提示。
+ */
+export function fetchMyQuota(): Promise<UserQuota> {
+  return request({ url: '/customer/user/quota', method: 'get', silentError: true })
+}

--- a/customer-work-app/src/types/api.ts
+++ b/customer-work-app/src/types/api.ts
@@ -229,3 +229,28 @@ export interface WsErrorMessage {
   code: string
   message: string
 }
+
+/**
+ * 我的额度（主体级速率配额）。
+ *
+ * 窗口是滚动的（最近 windowSeconds 秒），不在整点归零；额度连续释放，
+ * 因此服务端刻意不返回"何时恢复"——任何一个恢复时刻都只对某一笔用量成立。
+ */
+export interface UserQuota {
+  /** 生效等级；未受限时为 null */
+  levelCode: string | null
+  /** 滚动窗口长度（秒），1800 = 30 分钟 */
+  windowSeconds: number
+  tokenUsed: number
+  /** 0 = 不限 */
+  tokenLimit: number
+  /** -1 = 不限 */
+  tokenRemaining: number
+  requestUsed: number
+  /** 0 = 不限 */
+  requestLimit: number
+  /** -1 = 不限 */
+  requestRemaining: number
+  /** 是否真的受限（levelCode 为空时为 false） */
+  limited: boolean
+}

--- a/customer-work-app/src/views/Chat.vue
+++ b/customer-work-app/src/views/Chat.vue
@@ -17,10 +17,11 @@ import {
 } from '@/api/ticket'
 import { fetchSessionFeedback, submitFeedback } from '@/api/feedback'
 import { uploadChatAttachment } from '@/api/chat'
+import { fetchMyQuota } from '@/api/quota'
 import { useAuthStore } from '@/store/auth'
 import { chatSocket } from '@/utils/ws'
 import { TICKET_STATUS_TAG_TYPE, TICKET_STATUS_TEXT, isTicketEnded } from '@/types/api'
-import type { ChatMessage, FeedbackType, Ticket, WsChatChunk, WsChatDone, WsChatMessage, WsErrorMessage, WsSystemMessage, WsTicketEvent } from '@/types/api'
+import type { ChatMessage, FeedbackType, Ticket, UserQuota, WsChatChunk, WsChatDone, WsChatMessage, WsErrorMessage, WsSystemMessage, WsTicketEvent } from '@/types/api'
 
 const HTTP_CONFLICT = 409
 /** Outbox 是至少一次投递；按工单事件主键去重，避免重试帧重复弹提示。 */
@@ -74,6 +75,48 @@ const acting = ref(false)
 // 消息级反馈（点赞/点踩）：messageId -> 已点类型，切会话时按 sessionId 重拉回显
 const feedbackByMessage = ref<Record<string, FeedbackType>>({})
 const feedbackSubmitting = ref(false)
+
+/**
+ * 我的额度：只在快用完时才提示。
+ *
+ * 常驻显示一个剩余次数对绝大多数正常用户是纯噪音，还会让人盯着数字聊天；
+ * 而完全不显示的话，用户只能在被拦的那一刻才知道有额度这回事——那是最糟的知情方式。
+ */
+const quota = ref<UserQuota | null>(null)
+
+/** 触发提示的剩余比例：低于两成才出现。 */
+const QUOTA_WARN_RATIO = 0.2
+
+const quotaHint = computed(() => {
+  const q = quota.value
+  if (!q || !q.limited) {
+    return ''
+  }
+  const minutes = Math.max(1, Math.round(q.windowSeconds / 60))
+  // 两个维度各算剩余比例，谁更紧张报谁——token 对用户是不可理解的概念，故换算成百分比说
+  const requestRatio = q.requestLimit > 0 ? q.requestRemaining / q.requestLimit : 1
+  const tokenRatio = q.tokenLimit > 0 ? q.tokenRemaining / q.tokenLimit : 1
+  if (requestRatio > QUOTA_WARN_RATIO && tokenRatio > QUOTA_WARN_RATIO) {
+    return ''
+  }
+  if (requestRatio <= tokenRatio) {
+    return q.requestRemaining <= 0
+      ? `${minutes} 分钟内的提问次数已用完，稍等片刻即可继续`
+      : `${minutes} 分钟内还可提问 ${q.requestRemaining} 次`
+  }
+  return q.tokenRemaining <= 0
+    ? `${minutes} 分钟内的用量额度已用完，稍等片刻即可继续`
+    : `${minutes} 分钟内的用量额度剩余 ${Math.round(tokenRatio * 100)}%`
+})
+
+/** 拉额度。失败静默：额度是锦上添花的信息，查不到就不显示。 */
+async function refreshQuota() {
+  try {
+    quota.value = await fetchMyQuota()
+  } catch {
+    quota.value = null
+  }
+}
 
 const scrollBox = ref<HTMLElement | null>(null)
 
@@ -313,6 +356,8 @@ function onWsChatDone(data: unknown) {
   streamingContent.value = ''
   streamingSessionId.value = null
   scrollToBottom()
+  // 回复定稿后才刷额度：token 记在模型调用之后，回复过程中查到的还是上一轮的数
+  refreshQuota()
 }
 
 function onWsTicketEvent(data: unknown) {
@@ -604,6 +649,8 @@ onMounted(async () => {
     inputContent.value = `我想咨询订单 ${orderId} 的情况`
   }
   connectWs()
+  // 进页面先看一眼：已经快用完的话，第一条消息发出去之前就该知道
+  refreshQuota()
 })
 
 onUnmounted(() => {
@@ -693,6 +740,10 @@ onUnmounted(() => {
           <van-loading v-if="a.status === 'uploading'" size="12" class="chip-loading" />
           📎 {{ a.name }}
         </van-tag>
+      </div>
+      <div v-if="quotaHint" class="quota-hint">
+        <van-icon name="info-o" class="quota-hint-icon" />
+        {{ quotaHint }}
       </div>
       <div class="input-bar">
         <van-field
@@ -886,6 +937,20 @@ onUnmounted(() => {
 .attach-icon {
   color: var(--cw-text-secondary);
   padding: 0 4px;
+}
+
+.quota-hint {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--van-orange, #ff976a);
+  background: #fff7e8;
+}
+
+.quota-hint-icon {
+  font-size: 13px;
 }
 
 .input-bar {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/calllog/AgentCallTimingMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/calllog/AgentCallTimingMiddleware.java
@@ -3,6 +3,9 @@ package com.richard.fyoung.customerwork.data.calllog;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.observability.MdcContextLifter;
 import com.richard.fyoung.customerwork.safety.quota.TenantQuotaGuard;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
@@ -76,11 +79,23 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
     /** 可为 null：配额未装配时不记账（配额默认关闭）。 */
     private final TenantQuotaGuard quotaGuard;
 
+    /** 可为 null：主体配额未装配时不记账。与租户配额并列而非二选一——两者是不同维度的上限。 */
+    private final SubjectQuotaGuard subjectQuotaGuard;
+
     public AgentCallTimingMiddleware(CustomerWorkProperties properties,
                                      ToolKindRegistry toolKindRegistry,
                                      AgentCallRecordSink sink,
                                      ObjectProvider<MeterRegistry> meterRegistryProvider) {
-        this(properties, toolKindRegistry, sink, meterRegistryProvider, null);
+        this(properties, toolKindRegistry, sink, meterRegistryProvider, null, null);
+    }
+
+    /** 兼容既有五参调用（只接租户配额）：主体配额缺省不记账。 */
+    public AgentCallTimingMiddleware(CustomerWorkProperties properties,
+                                     ToolKindRegistry toolKindRegistry,
+                                     AgentCallRecordSink sink,
+                                     ObjectProvider<MeterRegistry> meterRegistryProvider,
+                                     ObjectProvider<TenantQuotaGuard> quotaGuardProvider) {
+        this(properties, toolKindRegistry, sink, meterRegistryProvider, quotaGuardProvider, null);
     }
 
     /**
@@ -94,12 +109,15 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
                                      ToolKindRegistry toolKindRegistry,
                                      AgentCallRecordSink sink,
                                      ObjectProvider<MeterRegistry> meterRegistryProvider,
-                                     ObjectProvider<TenantQuotaGuard> quotaGuardProvider) {
+                                     ObjectProvider<TenantQuotaGuard> quotaGuardProvider,
+                                     ObjectProvider<SubjectQuotaGuard> subjectQuotaGuardProvider) {
         this.enabled = properties.getCallLog().isEnabled();
         this.toolKindRegistry = toolKindRegistry;
         this.sink = sink;
         this.meterRegistry = meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable();
         this.quotaGuard = quotaGuardProvider == null ? null : quotaGuardProvider.getIfAvailable();
+        this.subjectQuotaGuard = subjectQuotaGuardProvider == null
+            ? null : subjectQuotaGuardProvider.getIfAvailable();
     }
 
     @Override
@@ -276,6 +294,7 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
             recordTokens(inputTokens, outputTokens);
             // 配额记账搭同一趟车：token 的落点只此一处，记在别处迟早与落库口径漂移
             recordQuotaUsage(inputTokens, outputTokens);
+            recordSubjectQuotaUsage(inputTokens, outputTokens);
         } catch (Exception e) {
             log.error("agent call segment collect failed, code={}, kind={}, name={}",
                 "CALLLOG-SEGMENT-FAIL", kind, name, e);
@@ -300,6 +319,34 @@ public class AgentCallTimingMiddleware implements MiddlewareBase {
             quotaGuard.record(null, total);
         } catch (Exception e) {
             log.error("quota usage record failed, code={}", "QUOTA-RECORD-FAIL", e);
+        }
+    }
+
+    /**
+     * 把本段 token 计入当前主体（用户 / 匿名 IP / 接入方）的滚动窗口用量。
+     *
+     * <p>与租户记账共用同一个 token 数、分别记两笔：租户额度是这个客户的月度总量，
+     * 主体额度是这个调用者的半小时用量，任一维度都可能先触顶。</p>
+     *
+     * <p>主体来自 {@link QuotaSubjectContext}——接入层写入、Reactor 自动传播还原。取不到就不记：
+     * 那多半是内部任务或定时链路，本就没有"调用者"可言，硬记只会算到某个上一次请求残留的身份上。</p>
+     */
+    private void recordSubjectQuotaUsage(Long inputTokens, Long outputTokens) {
+        if (subjectQuotaGuard == null) {
+            return;
+        }
+        QuotaSubject subject = QuotaSubjectContext.get();
+        if (subject == null) {
+            return;
+        }
+        long total = (inputTokens == null ? 0L : inputTokens) + (outputTokens == null ? 0L : outputTokens);
+        if (total <= 0) {
+            return;
+        }
+        try {
+            subjectQuotaGuard.recordTokens(subject, total);
+        } catch (Exception e) {
+            log.error("subject quota usage record failed, code={}", "SQUOTA-RECORD-FAIL", e);
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/InMemoryUserAccountStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/InMemoryUserAccountStore.java
@@ -41,4 +41,12 @@ public class InMemoryUserAccountStore implements UserAccountStore {
             account.changeAvatar(avatarUrl);
         }
     }
+
+    @Override
+    public void updateLevel(String id, String levelCode) {
+        UserAccount account = byId.get(id);
+        if (account != null) {
+            account.changeLevel(levelCode);
+        }
+    }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/MybatisUserAccountStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/MybatisUserAccountStore.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.data.user;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.richard.fyoung.customerwork.data.user.entity.UserDO;
 import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
 import org.slf4j.Logger;
@@ -78,6 +79,23 @@ public class MybatisUserAccountStore implements UserAccountStore {
         }
     }
 
+    @Override
+    public void updateLevel(String id, String levelCode) {
+        if (id == null) {
+            return;
+        }
+        try {
+            // 必须走 UpdateWrapper 显式 set：updateById 只更新非空字段，用它把等级置空会静默失败，
+            // 表现为"后台取消了特批额度、线上却一直按特批放行"
+            mapper.update(null, new LambdaUpdateWrapper<UserDO>()
+                .set(UserDO::getLevelCode, levelCode)
+                .eq(UserDO::getId, id));
+        } catch (Exception e) {
+            log.error("user level update failed, code={}, id={}", "USER-STORE-UPDATE-LEVEL-FAIL", id, e);
+            throw new IllegalStateException("failed to update user level: " + id, e);
+        }
+    }
+
     private UserAccount toDomain(UserDO row) {
         return UserAccount.reconstruct(
             row.getId(),
@@ -87,7 +105,8 @@ public class MybatisUserAccountStore implements UserAccountStore {
             row.getPhone(),
             UserAccount.Status.valueOf(row.getStatus()),
             row.getCreatedAtMs(),
-            row.getAvatarUrl());
+            row.getAvatarUrl(),
+            row.getLevelCode());
     }
 
     private UserDO toDO(UserAccount account) {
@@ -100,6 +119,7 @@ public class MybatisUserAccountStore implements UserAccountStore {
         row.setStatus(account.getStatus().name());
         row.setCreatedAtMs(account.getCreatedAtMs());
         row.setAvatarUrl(account.getAvatarUrl());
+        row.setLevelCode(account.getLevelCode());
         return row;
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccount.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccount.java
@@ -32,8 +32,16 @@ public class UserAccount {
     /** 头像访问 URL（相对路径，可为空——注册时无头像，上传后回填）。 */
     private volatile String avatarUrl;
 
+    /**
+     * 配额等级编码（可为空——空表示走配置里的默认档）。
+     *
+     * <p>放在账户实体上而不是另建一张绑定表：等级是"这个账户能用多少"的属性，
+     * 与启停、头像同属账户自身状态，拆出去只会让每次限流判定多一次跨表查询。</p>
+     */
+    private volatile String levelCode;
+
     private UserAccount(String id, String username, String passwordHash, String nickname,
-                        String phone, Status status, long createdAtMs, String avatarUrl) {
+                        String phone, Status status, long createdAtMs, String avatarUrl, String levelCode) {
         this.id = id;
         this.username = username;
         this.passwordHash = passwordHash;
@@ -42,12 +50,19 @@ public class UserAccount {
         this.status = status;
         this.createdAtMs = createdAtMs;
         this.avatarUrl = avatarUrl;
+        this.levelCode = levelCode;
     }
 
-    /** 注册静态工厂：初始 ACTIVE，无头像。 */
+    /** 注册静态工厂：初始 ACTIVE，无头像，等级留空（= 走配置默认档）。 */
     public static UserAccount create(String id, String username, String passwordHash, String nickname, String phone) {
+        return create(id, username, passwordHash, nickname, phone, null);
+    }
+
+    /** 注册静态工厂（指定配额等级）：注册链路按配置的默认等级建号，见 {@link UserAccountService#register}。 */
+    public static UserAccount create(String id, String username, String passwordHash, String nickname,
+                                     String phone, String levelCode) {
         return new UserAccount(id, username, passwordHash, nickname, phone, Status.ACTIVE,
-            System.currentTimeMillis(), null);
+            System.currentTimeMillis(), null, levelCode);
     }
 
     /** 停用账户（禁止后续登录）。 */
@@ -65,9 +80,16 @@ public class UserAccount {
         this.avatarUrl = avatarUrl;
     }
 
+    /** 调整配额等级（后台改档）；传 null 视为回到默认档。 */
+    public void changeLevel(String levelCode) {
+        this.levelCode = levelCode;
+    }
+
     /** 供持久化层从数据源重建（跳过业务语义，仅回填字段）。包级可见。 */
     static UserAccount reconstruct(String id, String username, String passwordHash, String nickname,
-                                   String phone, Status status, long createdAtMs, String avatarUrl) {
-        return new UserAccount(id, username, passwordHash, nickname, phone, status, createdAtMs, avatarUrl);
+                                   String phone, Status status, long createdAtMs, String avatarUrl,
+                                   String levelCode) {
+        return new UserAccount(id, username, passwordHash, nickname, phone, status, createdAtMs,
+            avatarUrl, levelCode);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountConfig.java
@@ -2,6 +2,8 @@ package com.richard.fyoung.customerwork.data.user;
 
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectLevelBinding;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectLevelResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -38,7 +40,24 @@ public class UserAccountConfig {
 
     @Bean
     @ConditionalOnMissingBean(UserAccountService.class)
-    public UserAccountService userAccountService(UserAccountStore userAccountStore) {
-        return new UserAccountService(userAccountStore);
+    public UserAccountService userAccountService(UserAccountStore userAccountStore,
+                                                 CustomerWorkProperties properties,
+                                                 ObjectProvider<SubjectLevelResolver> resolverProvider) {
+        SubjectLevelResolver resolver = resolverProvider.getIfAvailable();
+        return new UserAccountService(userAccountStore,
+            properties.getSubjectQuota().getDefaultUserLevel(),
+            resolver == null ? null : resolver::evictBinding);
+    }
+
+    /**
+     * 用户 → 配额等级 的绑定查询实现。
+     *
+     * <p>无条件装配（不看配额开关）：Bean 存在本身没有开销，而按开关装配会让运行期
+     * 打开配额时缺一个 Bean——那种"配置生效了但功能没生效"的状态最难查。</p>
+     */
+    @Bean
+    @ConditionalOnMissingBean(SubjectLevelBinding.class)
+    public SubjectLevelBinding userAccountLevelBinding(UserAccountStore userAccountStore) {
+        return new UserAccountLevelBinding(userAccountStore);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountLevelBinding.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountLevelBinding.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customerwork.data.user;
+
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectLevelBinding;
+
+import java.util.Optional;
+
+/**
+ * 从账户表读取用户的配额等级绑定（{@link SubjectLevelBinding} 在本项目的唯一实现）。
+ *
+ * <p>薄薄一层适配：配额领域只想知道"这个用户是哪一档"，把整个账户实体递过去会让它认识
+ * 密码哈希、头像这些与限流无关的东西。查询频次由 {@code SubjectLevelResolver} 的本地缓存兜住，
+ * 本类不再自建一层缓存——两层缓存会让"改了等级多久生效"变成没人算得清的问题。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class UserAccountLevelBinding implements SubjectLevelBinding {
+
+    private final UserAccountStore store;
+
+    public UserAccountLevelBinding(UserAccountStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public Optional<String> levelCodeOf(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return Optional.empty();
+        }
+        return store.findById(userId)
+            .map(UserAccount::getLevelCode)
+            .filter(code -> !code.isBlank());
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountService.java
@@ -7,6 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * 用户账户服务：注册与登录校验。
@@ -25,9 +26,31 @@ public class UserAccountService {
     private final UserAccountStore store;
     private final PasswordEncoder passwordEncoder;
 
+    /** 新注册账户落的配额等级（来自 {@code customer-work.subject-quota.default-user-level}）；空表示不写等级。 */
+    private final String defaultLevelCode;
+
+    /**
+     * 等级变更监听（可为 null）：用来让配额侧的绑定缓存立即失效。
+     *
+     * <p>用 {@link Consumer} 而不是直接持有配额领域的对象，是为了不让账户领域反向依赖它——
+     * 账户只需要广播"这个人的等级变了"，谁关心、怎么处理不归它管。</p>
+     */
+    private final Consumer<String> levelChangeListener;
+
     public UserAccountService(UserAccountStore store) {
+        this(store, null, null);
+    }
+
+    public UserAccountService(UserAccountStore store, String defaultLevelCode) {
+        this(store, defaultLevelCode, null);
+    }
+
+    public UserAccountService(UserAccountStore store, String defaultLevelCode,
+                              Consumer<String> levelChangeListener) {
         this.store = store;
         this.passwordEncoder = new BCryptPasswordEncoder();
+        this.defaultLevelCode = defaultLevelCode;
+        this.levelChangeListener = levelChangeListener;
     }
 
     /**
@@ -41,9 +64,11 @@ public class UserAccountService {
         }
         String id = ID_PREFIX + UUID.randomUUID();
         String hash = passwordEncoder.encode(rawPassword);
-        UserAccount account = UserAccount.create(id, username, hash, nickname, phone);
+        // 注册即落默认等级：不落的话新用户在等级表里查无此人，只能靠"查不到就用默认档"兜着——
+        // 那条兜底路径必须一直留着，运营也永远看不到"这个人现在是哪一档"
+        UserAccount account = UserAccount.create(id, username, hash, nickname, phone, defaultLevelCode);
         store.save(account);
-        log.info("user registered: id={}, username={}", id, username);
+        log.info("user registered: id={}, username={}, level={}", id, username, defaultLevelCode);
         return account;
     }
 
@@ -75,6 +100,26 @@ public class UserAccountService {
      * @throws IllegalStateException 账户不存在
      * @return 已更新头像的账户
      */
+    /**
+     * 调整用户配额等级：查出账户 → 充血实体自改等级 → 持久化。
+     *
+     * @param levelCode 目标等级编码；传 null 表示回到默认档
+     * @throws IllegalStateException 账户不存在
+     * @return 已更新等级的账户
+     */
+    public UserAccount updateLevel(String userId, String levelCode) {
+        UserAccount account = store.findById(userId)
+            .orElseThrow(() -> new IllegalStateException("user not found: " + userId));
+        account.changeLevel(levelCode);
+        store.updateLevel(account.getId(), account.getLevelCode());
+        // 同进程改档立即生效：不通知的话这里也要等绑定缓存过期，而缓存本是为跨进程场景设的
+        if (levelChangeListener != null) {
+            levelChangeListener.accept(userId);
+        }
+        log.info("user quota level updated: id={}, level={}", userId, levelCode);
+        return account;
+    }
+
     public UserAccount updateAvatar(String userId, String avatarUrl) {
         UserAccount account = store.findById(userId)
             .orElseThrow(() -> new IllegalStateException("user not found: " + userId));

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountStore.java
@@ -23,4 +23,12 @@ public interface UserAccountStore {
 
     /** 更新账户头像 URL（按 ID 定向更新单列，不触碰其它字段）。 */
     void updateAvatar(String id, String avatarUrl);
+
+    /**
+     * 更新账户配额等级（按 ID 定向更新单列）。
+     *
+     * <p>传 null 表示回到默认档。实现须真的把列写成 NULL——MyBatis-Plus 默认只更新非空字段，
+     * 照抄 {@link #updateAvatar} 的写法会让"取消特批额度"这个操作静默失效。</p>
+     */
+    void updateLevel(String id, String levelCode);
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/entity/UserDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/entity/UserDO.java
@@ -28,4 +28,6 @@ public class UserDO {
     private Long createdAtMs;
     /** 头像访问 URL（相对路径，可为空）。 */
     private String avatarUrl;
+    /** 配额等级编码（可为空 = 走配置默认档），见 cw_subject_quota_level.level_code。 */
+    private String levelCode;
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkProperties.java
@@ -114,6 +114,9 @@ public class CustomerWorkProperties {
     /** 租户 token 配额（成本治理的硬上限）。 */
     private final QuotaProperties quota = new QuotaProperties();
 
+    /** 主体级速率配额（每用户 / 每 IP / 每 Key 的滚动窗口限流），与租户配额并存互不替代。 */
+    private final SubjectQuotaProperties subjectQuota = new SubjectQuotaProperties();
+
     /** 对话阶段状态机存储配置。 */
     private final DialogProperties dialog = new DialogProperties();
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcCondition.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcCondition.java
@@ -45,6 +45,8 @@ public class PersistenceJdbcCondition implements Condition {
         "customer-work.sensitive-word.hit-log.store-mode",
         // 限流规则层同理：只开规则层、其余域全是 memory 时，也必须能激活持久化环境
         "customer-work.security.rate-limit.store-mode",
+        // 主体级速率配额（等级表 + 命中记录）同理：它可能是宿主唯一想落库的东西
+        "customer-work.subject-quota.store-mode",
         "customer-work.tool-backend.mode"
     };
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/properties/SubjectQuotaProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/properties/SubjectQuotaProperties.java
@@ -1,0 +1,125 @@
+package com.richard.fyoung.customerwork.infra.config.properties;
+
+import lombok.Data;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 主体级速率配额配置（每个用户 / 每个匿名 IP / 每把 API Key 的滚动窗口限流）。
+ *
+ * <p>默认关闭——没开时行为与引入本功能之前完全一致。与租户配额（{@link QuotaProperties}）
+ * 是两件事：那个管"这个客户这个月能花多少钱"，这个管"单个调用者半小时内能用多少"，
+ * 一个是计费上限、一个是防滥用闸门，同时生效互不替代。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SubjectQuotaProperties {
+
+    /** 是否开启主体配额判定。关闭时一律放行，也不记账。 */
+    private boolean enabled = false;
+
+    /** 存储：{@code memory} 进程内 / {@code jdbc} 落 {@code cw_subject_quota_level}。 */
+    private String storeMode = "memory";
+
+    /** 等级快照轮询间隔（毫秒）。同时被 {@code @Scheduled} 的占位符引用，改这里即改刷新频率。 */
+    private long refreshIntervalMs = 60000L;
+
+    /** 注册用户的默认等级编码：新用户落这一档，后台可单独改人。 */
+    private String defaultUserLevel = "free";
+
+    /** 匿名调用方（无登录态，按 IP 计）的等级编码。 */
+    private String anonymousLevel = "anonymous";
+
+    /** 服务端接入方（API Key，按 Key 指纹计）的等级编码。 */
+    private String apiKeyLevel = "api-key";
+
+    /**
+     * 用户等级绑定的本地缓存有效期（毫秒）。
+     *
+     * <p>不缓存的话每个请求都要查一次用户表——限流本身成了系统里最重的一段。
+     * 代价是后台改等级后最多滞后这么久生效，默认 60 秒是可接受的折中。</p>
+     */
+    private long levelCacheTtlMs = 60000L;
+
+    /** 用户等级缓存的最大条目数：超出即清理过期项，避免用户量大时无界增长。 */
+    private int levelCacheMaxSize = 10000;
+
+    /**
+     * 参与判定的请求路径前缀。
+     *
+     * <p><b>次数口径是"HTTP 请求数"，不是"提问数"</b>：默认清单覆盖了整个
+     * {@code /api/customer/user/} 面，因此翻历史消息、查工单也会占额度。这是刻意的——
+     * 登录用户的所有接口都该有防刷闸门，而不是只防对话。代价是次数上限必须配得比
+     * "纯提问次数"宽，见 {@link #defaultLevels()} 的取值。</p>
+     *
+     * <p>只想限对话时，把 {@code /api/customer/user/} 从清单里去掉即可；
+     * 反过来，想给某条查询路径单独设更严的阈值，用既有的
+     * {@code customer-work.security.rate-limit} 规则层（按路径配），两者正交共存。</p>
+     */
+    private List<String> paths = List.of(
+        "/api/customer/chat",
+        "/api/customer/intent",
+        "/api/customer/consult",
+        "/api/customer/agui",
+        "/api/customer/user/");
+
+    /**
+     * 内置兜底档：等级表里查不到时用它，保证"没建表、没配库"也能开箱工作。
+     *
+     * <p>库里的同名等级<b>优先</b>——内置档只是地板，不是覆盖层。</p>
+     */
+    private Map<String, Level> builtinLevels = defaultLevels();
+
+    /** 一档内置额度。 */
+    @Data
+    public static class Level {
+
+        /** 适用主体类型：USER / IP / API_KEY。 */
+        private String subjectType = "USER";
+
+        /** 滚动窗口长度（秒），1800 = 30 分钟。 */
+        private int windowSeconds = 1800;
+
+        /** 窗口内 token 上限，0 = 不限。 */
+        private long tokenLimit;
+
+        /** 窗口内请求次数上限，0 = 不限。 */
+        private int requestLimit;
+
+        /** 超限处置：BLOCK 拦截 / WARN 仅记录。 */
+        private String exceedAction = "BLOCK";
+
+        /** 等级显示名。 */
+        private String levelName;
+    }
+
+    /**
+     * 出厂默认三档。
+     *
+     * <p>数值取向：匿名最紧（谁都能打，且同一 NAT 后共享一份额度）、注册用户居中、
+     * 接入方最宽（一把 Key 背后是一个系统而非一个人）。</p>
+     *
+     * <p>次数看起来偏宽是因为口径含查询请求（见 {@link #paths}）：一次对话往往伴随
+     * 若干次工单/消息查询，按"纯提问数"配会让用户在正常使用中就被拦。token 上限才是
+     * 真正卡成本的那一维——它只在模型调用后累加，不受查询请求影响。</p>
+     */
+    private static Map<String, Level> defaultLevels() {
+        Map<String, Level> levels = new LinkedHashMap<>();
+        levels.put("free", level("USER", "免费用户", 1800, 50000L, 100));
+        levels.put("anonymous", level("IP", "匿名访客", 1800, 10000L, 20));
+        levels.put("api-key", level("API_KEY", "接入方", 3600, 1000000L, 2000));
+        return levels;
+    }
+
+    private static Level level(String subjectType, String name, int windowSeconds, long tokenLimit, int requestLimit) {
+        Level level = new Level();
+        level.setSubjectType(subjectType);
+        level.setLevelName(name);
+        level.setWindowSeconds(windowSeconds);
+        level.setTokenLimit(tokenLimit);
+        level.setRequestLimit(requestLimit);
+        return level;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/InMemoryWindowCounter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/InMemoryWindowCounter.java
@@ -76,6 +76,53 @@ public class InMemoryWindowCounter implements WindowCounter {
         }
     }
 
+    @Override
+    public long incrementSlidingSum(String key, long delta, int windowSeconds) {
+        long bucketMs = SlidingSumBuckets.bucketMs(windowSeconds);
+        long currentBucket = SlidingSumBuckets.currentBucket(bucketMs);
+        SumWindow window = (SumWindow) windows.compute(key, (k, existing) ->
+            // 窗口长度变了就重开一份：旧桶是按另一种口径切的，混着算出来的数没有意义
+            existing instanceof SumWindow s && s.bucketMs == bucketMs ? s : new SumWindow(bucketMs));
+        window.buckets.computeIfAbsent(currentBucket, b -> new AtomicLong()).addAndGet(delta);
+
+        long oldest = SlidingSumBuckets.oldestBucket(currentBucket, windowSeconds, bucketMs);
+        window.buckets.keySet().removeIf(bucket -> bucket < oldest);
+        if (windows.size() > MAX_TRACKED_KEYS) {
+            evictEmptySumWindows();
+        }
+        return sum(window, oldest);
+    }
+
+    @Override
+    public long currentSlidingSum(String key, int windowSeconds) {
+        Object existing = windows.get(key);
+        if (!(existing instanceof SumWindow window)) {
+            return 0L;
+        }
+        long bucketMs = SlidingSumBuckets.bucketMs(windowSeconds);
+        if (window.bucketMs != bucketMs) {
+            // 口径不符（窗口长度已改）：按 0 计，下一次写入会用新口径重开
+            return 0L;
+        }
+        long currentBucket = SlidingSumBuckets.currentBucket(bucketMs);
+        // 只读路径不清理过期桶：读操作产生写副作用会让并发行为难以推理
+        return sum(window, SlidingSumBuckets.oldestBucket(currentBucket, windowSeconds, bucketMs));
+    }
+
+    private static long sum(SumWindow window, long oldest) {
+        long total = 0L;
+        for (Map.Entry<Long, AtomicLong> entry : window.buckets.entrySet()) {
+            if (entry.getKey() >= oldest) {
+                total += entry.getValue().get();
+            }
+        }
+        return total;
+    }
+
+    private void evictEmptySumWindows() {
+        windows.entrySet().removeIf(e -> e.getValue() instanceof SumWindow sw && sw.buckets.isEmpty());
+    }
+
     private FixedWindow fixedWindow(String key, int windowSeconds) {
         long windowMs = windowSeconds * 1000L;
         long currentWindow = System.currentTimeMillis() / windowMs;
@@ -112,6 +159,20 @@ public class InMemoryWindowCounter implements WindowCounter {
         FixedWindow(long window, long expireAtMs) {
             this.window = window;
             this.expireAtMs = expireAtMs;
+        }
+    }
+
+    /**
+     * 滑动求和窗：按桶索引累加的量，桶索引 = 时刻 / 桶时长。
+     *
+     * <p>自带 {@code bucketMs} 是为了识别"窗口长度被改了"——不同口径的桶索引不可比。</p>
+     */
+    private static final class SumWindow {
+        private final Map<Long, AtomicLong> buckets = new ConcurrentHashMap<>();
+        private final long bucketMs;
+
+        SumWindow(long bucketMs) {
+            this.bucketMs = bucketMs;
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/RedissonWindowCounter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/RedissonWindowCounter.java
@@ -45,6 +45,42 @@ public class RedissonWindowCounter implements WindowCounter {
             + "redis.call('PEXPIRE', KEYS[1], ARGV[5]) "
             + "return 1";
 
+    /**
+     * 滑动求和累加：累加当前桶 → 清理出窗的桶 → 返回窗口内各桶之和。
+     *
+     * <p><b>清理必须在同一次脚本里做</b>：Hash 的 TTL 每次写入都被刷新，活跃键永远不会整体过期，
+     * 不删旧 field 就是一条无限增长的 Hash。</p>
+     *
+     * <p><b>为什么按索引范围删而不是遍历 HKEYS</b>：桶索引是连续整数，客户端算得出该删哪些；
+     * 而 {@code HKEYS}/{@code HGETALL} 返回顺序不确定，Redis 4.x 会拒绝在它们之后执行写命令
+     * （{@code write commands not allowed after non deterministic commands}）。全用确定性命令，
+     * 这个脚本在任何版本上都成立。删的范围取一个完整窗口的桶数，够覆盖低频写入跨过的空档；
+     * 更久不写的键由 TTL 整体回收。</p>
+     */
+    private static final String SLIDING_SUM_INCR_SCRIPT =
+        "redis.call('HINCRBY', KEYS[1], ARGV[2], ARGV[3]) "
+            + "redis.call('PEXPIRE', KEYS[1], ARGV[4]) "
+            + "local oldest = tonumber(ARGV[1]) "
+            + "for bucket = oldest - 1, oldest - tonumber(ARGV[5]), -1 do "
+            + "  redis.call('HDEL', KEYS[1], tostring(bucket)) "
+            + "end "
+            + "local data = redis.call('HGETALL', KEYS[1]) "
+            + "local sum = 0 "
+            + "for i = 1, #data, 2 do "
+            + "  if tonumber(data[i]) >= oldest then sum = sum + tonumber(data[i + 1]) end "
+            + "end "
+            + "return sum";
+
+    /** 滑动求和只读：过滤出窗桶后求和，刻意不删任何 field（只读路径不产生写副作用）。 */
+    private static final String SLIDING_SUM_READ_SCRIPT =
+        "local oldest = tonumber(ARGV[1]) "
+            + "local data = redis.call('HGETALL', KEYS[1]) "
+            + "local sum = 0 "
+            + "for i = 1, #data, 2 do "
+            + "  if tonumber(data[i]) >= oldest then sum = sum + tonumber(data[i + 1]) end "
+            + "end "
+            + "return sum";
+
     private final RedissonClient redisson;
     private final String keyPrefix;
 
@@ -111,6 +147,46 @@ public class RedissonWindowCounter implements WindowCounter {
             logDegraded(e);
             return fallback.tryAcquireSliding(key, limit, windowSeconds);
         }
+    }
+
+    @Override
+    public long incrementSlidingSum(String key, long delta, int windowSeconds) {
+        long bucketMs = SlidingSumBuckets.bucketMs(windowSeconds);
+        long currentBucket = SlidingSumBuckets.currentBucket(bucketMs);
+        long oldest = SlidingSumBuckets.oldestBucket(currentBucket, windowSeconds, bucketMs);
+        try {
+            Long sum = eval(SLIDING_SUM_INCR_SCRIPT, RScript.ReturnType.INTEGER, List.of(sumKey(key, bucketMs)),
+                String.valueOf(oldest), String.valueOf(currentBucket), String.valueOf(delta),
+                String.valueOf(SlidingSumBuckets.retentionMs(windowSeconds)),
+                String.valueOf(SlidingSumBuckets.BUCKETS));
+            return sum == null ? delta : sum;
+        } catch (Exception e) {
+            logDegraded(e);
+            return fallback.incrementSlidingSum(key, delta, windowSeconds);
+        }
+    }
+
+    @Override
+    public long currentSlidingSum(String key, int windowSeconds) {
+        long bucketMs = SlidingSumBuckets.bucketMs(windowSeconds);
+        long oldest = SlidingSumBuckets.oldestBucket(
+            SlidingSumBuckets.currentBucket(bucketMs), windowSeconds, bucketMs);
+        try {
+            Long sum = eval(SLIDING_SUM_READ_SCRIPT, RScript.ReturnType.INTEGER, List.of(sumKey(key, bucketMs)),
+                String.valueOf(oldest));
+            return sum == null ? 0L : sum;
+        } catch (Exception e) {
+            logDegraded(e);
+            return fallback.currentSlidingSum(key, windowSeconds);
+        }
+    }
+
+    /**
+     * 滑动求和的键带桶时长：窗口长度改了就换一把键，避免新旧口径的桶索引混在同一个 Hash 里。
+     * 旧键无人再写，靠 TTL 自行回收。
+     */
+    private String sumKey(String key, long bucketMs) {
+        return keyPrefix + "sum:" + key + ":" + bucketMs;
     }
 
     /** 固定窗口的键带窗口序号：窗口滚动即换键，天然避免跨窗口累加，过期由 TTL 兜底回收。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/SlidingSumBuckets.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/SlidingSumBuckets.java
@@ -1,0 +1,51 @@
+package com.richard.fyoung.customerwork.infra.counter;
+
+/**
+ * 滑动求和的分桶口径（进程内实现与 Redis 实现共用）。
+ *
+ * <p>抽出来是因为两个实现必须算出<b>同一个桶索引</b>：Redis 不可达时会降级到进程内计数，
+ * 两边口径不一致会让降级前后的用量无法相互解释。</p>
+ *
+ * <p>包级可见：这是实现细节，不属于 {@link WindowCounter} 的 SPI 表面。</p>
+ * @author owlzhangfq@gmail.com
+ */
+final class SlidingSumBuckets {
+
+    /**
+     * 分桶数：窗口切成这么多份，按桶累加、按桶过期。
+     *
+     * <p>30 桶意味着最坏误差是一个桶的时长（30 分钟窗口即 1 分钟，约 3%），
+     * 换来的是"每个计数键只占常数级空间"——逐条记 token 时间戳在高 QPS 下会直接把内存/Redis 吃光。</p>
+     */
+    static final int BUCKETS = 30;
+
+    private SlidingSumBuckets() {
+    }
+
+    /** 桶时长：窗口均分成 {@link #BUCKETS} 份，最细到秒（再细只会增加桶数，不增加精度价值）。 */
+    static long bucketMs(int windowSeconds) {
+        return Math.max(1000L, windowSeconds * 1000L / BUCKETS);
+    }
+
+    /** 当前时刻所属的桶索引。 */
+    static long currentBucket(long bucketMs) {
+        return System.currentTimeMillis() / bucketMs;
+    }
+
+    /**
+     * 最老的有效桶索引（小于它的桶已出窗）。
+     *
+     * <p>覆盖窗口所需桶数向上取整后，在当前桶之外整整保留这么多个——统计范围因此落在
+     * {@code [window, window + bucket)}，偏差方向是"多算一点"，即限得偏严。配额的误差
+     * 必须朝 fail-closed 偏：少算会让超额的请求溜过去，多算只是让人早几十秒被拦。</p>
+     */
+    static long oldestBucket(long currentBucket, int windowSeconds, long bucketMs) {
+        long span = (windowSeconds * 1000L + bucketMs - 1) / bucketMs;
+        return currentBucket - span;
+    }
+
+    /** 计数键的存活时长（毫秒）：略大于一个窗口，让不再活跃的键自行回收。 */
+    static long retentionMs(int windowSeconds) {
+        return windowSeconds * 2000L;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/WindowCounter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/WindowCounter.java
@@ -42,4 +42,25 @@ public interface WindowCounter {
      * @return true=放行（已记录本次），false=超限（未记录）
      */
     boolean tryAcquireSliding(String key, int limit, int windowSeconds);
+
+    /**
+     * 滑动窗口累加"量"并返回窗口内累计量。
+     *
+     * <p>与 {@link #tryAcquireSliding} 的区别是"量"与"次"：那个方法一次只能取 1 个额度，
+     * 而 token 消耗是一次几百上千的变量。逐条记时间戳对 token 不可行（高 QPS 下内存/Redis 直接爆），
+     * 故实现采用<b>分桶近似</b>：窗口切成固定份数的小桶，只按桶累加、按桶过期。</p>
+     *
+     * <p>实现须保证统计范围<b>不短于</b> {@code windowSeconds}（多留一个桶即可）：宁可把
+     * 刚出窗的一小段仍算进来（限得偏严），也不能提前把窗内用量丢掉（限得偏松）——
+     * 配额的误差方向必须是 fail-closed。</p>
+     *
+     * @param key           计数键
+     * @param delta         本次增量（如实际消耗的 token 数）
+     * @param windowSeconds 滑动窗口长度（秒）
+     * @return 窗口内累计量（含本次）
+     */
+    long incrementSlidingSum(String key, long delta, int windowSeconds);
+
+    /** 只读滑动窗口累计量，不产生任何计数副作用（含清理）。 */
+    long currentSlidingSum(String key, int windowSeconds);
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/InMemorySubjectQuotaHitStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/InMemorySubjectQuotaHitStore.java
@@ -1,0 +1,71 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 进程内命中记录（默认实现）。
+ *
+ * <p>有界环形：只保留最近若干条，超出即丢最老的。命中记录是可丢的观测数据，
+ * 为它把内存吃满才是真的事故；要长期留存就把 {@code store-mode} 切成 jdbc。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemorySubjectQuotaHitStore implements SubjectQuotaHitStore {
+
+    /** 保留的最大记录数：够撑起一次排障回看，又不至于占多少内存。 */
+    private static final int MAX_RECORDS = 2000;
+
+    private final Deque<SubjectQuotaHit> records = new ArrayDeque<>();
+
+    @Override
+    public synchronized void record(SubjectQuotaHit hit) {
+        records.addLast(hit);
+        while (records.size() > MAX_RECORDS) {
+            records.removeFirst();
+        }
+    }
+
+    @Override
+    public synchronized List<SubjectQuotaHit> findRecent(String tenantId, long sinceMs, int limit) {
+        List<SubjectQuotaHit> matched = new ArrayList<>();
+        for (SubjectQuotaHit hit : records) {
+            if (hit.tenantId().equals(tenantId) && hit.createdAtMs() >= sinceMs) {
+                matched.add(hit);
+            }
+        }
+        matched.sort(Comparator.comparingLong(SubjectQuotaHit::createdAtMs).reversed());
+        return matched.size() > limit ? matched.subList(0, limit) : matched;
+    }
+
+    @Override
+    public synchronized List<SubjectQuotaHitRank> rank(String tenantId, long sinceMs, int limit) {
+        Map<String, SubjectQuotaHitRank> grouped = new LinkedHashMap<>();
+        for (SubjectQuotaHit hit : records) {
+            if (!hit.tenantId().equals(tenantId) || hit.createdAtMs() < sinceMs) {
+                continue;
+            }
+            SubjectQuotaHitRank row = grouped.computeIfAbsent(
+                hit.subjectType().name() + '\n' + hit.subjectId(), key -> newRank(hit));
+            row.setHitCount(row.getHitCount() + 1);
+            row.setLastHitAtMs(Math.max(row.getLastHitAtMs(), hit.createdAtMs()));
+        }
+        List<SubjectQuotaHitRank> ranked = new ArrayList<>(grouped.values());
+        ranked.sort(Comparator.comparingLong(SubjectQuotaHitRank::getHitCount).reversed());
+        return ranked.size() > limit ? ranked.subList(0, limit) : ranked;
+    }
+
+    private static SubjectQuotaHitRank newRank(SubjectQuotaHit hit) {
+        SubjectQuotaHitRank row = new SubjectQuotaHitRank();
+        row.setSubjectType(hit.subjectType().name());
+        row.setSubjectId(hit.subjectId());
+        row.setLevelCode(hit.levelCode());
+        row.setHitCount(0L);
+        row.setLastHitAtMs(0L);
+        return row;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/InMemorySubjectQuotaLevelStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/InMemorySubjectQuotaLevelStore.java
@@ -1,0 +1,45 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 进程内等级存储（默认实现）。
+ *
+ * <p>不预置任何等级：内置兜底档由 {@code SubjectQuotaProperties} 提供，两处都塞一份
+ * 只会让"到底哪份生效"变成一个需要翻代码才能回答的问题。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemorySubjectQuotaLevelStore implements SubjectQuotaLevelStore {
+
+    /** key = tenantId + '\n' + levelCode，用不可能出现在两者中的分隔符拼，避免拼接歧义。 */
+    private final Map<String, SubjectQuotaLevel> levels = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<List<SubjectQuotaLevel>> findAllEnabled() {
+        return Optional.of(levels.values().stream().filter(SubjectQuotaLevel::enabled).toList());
+    }
+
+    @Override
+    public List<SubjectQuotaLevel> findByTenant(String tenantId) {
+        return levels.values().stream()
+            .filter(level -> level.tenantId().equals(tenantId))
+            .toList();
+    }
+
+    @Override
+    public void save(SubjectQuotaLevel level) {
+        levels.put(key(level.tenantId(), level.levelCode()), level);
+    }
+
+    @Override
+    public void delete(String tenantId, String levelCode) {
+        levels.remove(key(tenantId, levelCode));
+    }
+
+    private static String key(String tenantId, String levelCode) {
+        return tenantId + '\n' + levelCode;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/MybatisSubjectQuotaHitStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/MybatisSubjectQuotaHitStore.java
@@ -1,0 +1,111 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.entity.SubjectQuotaHitDO;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaHitMapper;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * 命中记录的 MyBatis-Plus 实现。
+ *
+ * <p>写入失败只记日志不抛：这条记录是观测数据，为了它让一个"本来就要被拒"的请求
+ * 再抛一个 500，是把观测手段变成了故障源。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisSubjectQuotaHitStore implements SubjectQuotaHitStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MybatisSubjectQuotaHitStore.class);
+
+    private final SubjectQuotaHitMapper mapper;
+
+    public MybatisSubjectQuotaHitStore(SubjectQuotaHitMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void record(SubjectQuotaHit hit) {
+        try {
+            CrossTenantOperations.run(() -> mapper.insert(toDO(hit)));
+        } catch (Exception e) {
+            log.error("subject quota hit record failed, code={}, subject={}:{}",
+                "SQUOTA-HIT-RECORD-FAIL", hit.subjectType(), hit.subjectId(), e);
+        }
+    }
+
+    @Override
+    public List<SubjectQuotaHit> findRecent(String tenantId, long sinceMs, int limit) {
+        try {
+            List<SubjectQuotaHitDO> rows = CrossTenantOperations.execute(() -> mapper.selectList(
+                new LambdaQueryWrapper<SubjectQuotaHitDO>()
+                    .eq(SubjectQuotaHitDO::getTenantId, tenantId)
+                    .ge(SubjectQuotaHitDO::getCreatedAtMs, sinceMs)
+                    .orderByDesc(SubjectQuotaHitDO::getCreatedAtMs)
+                    .last("LIMIT " + Math.max(1, limit))));
+            return rows.stream().map(MybatisSubjectQuotaHitStore::toDomain).toList();
+        } catch (Exception e) {
+            log.error("subject quota hit query failed, code={}, tenant={}",
+                "SQUOTA-HIT-QUERY-FAIL", tenantId, e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public List<SubjectQuotaHitRank> rank(String tenantId, long sinceMs, int limit) {
+        try {
+            return CrossTenantOperations.execute(
+                () -> mapper.selectRank(tenantId, sinceMs, Math.max(1, limit)));
+        } catch (Exception e) {
+            log.error("subject quota hit rank failed, code={}, tenant={}",
+                "SQUOTA-HIT-RANK-FAIL", tenantId, e);
+            return List.of();
+        }
+    }
+
+    private static SubjectQuotaHitDO toDO(SubjectQuotaHit hit) {
+        SubjectQuotaHitDO row = new SubjectQuotaHitDO();
+        row.setTenantId(hit.tenantId());
+        row.setSubjectType(hit.subjectType().name());
+        row.setSubjectId(hit.subjectId());
+        row.setLevelCode(hit.levelCode());
+        row.setLimitKind(hit.limitKind() == null ? null : hit.limitKind().name());
+        row.setUsed(hit.used());
+        row.setLimitValue(hit.limitValue());
+        row.setWindowSeconds(hit.windowSeconds());
+        row.setAction(hit.action() == null ? null : hit.action().name());
+        row.setResource(hit.resource());
+        row.setCreatedAtMs(hit.createdAtMs());
+        return row;
+    }
+
+    private static SubjectQuotaHit toDomain(SubjectQuotaHitDO row) {
+        return new SubjectQuotaHit(
+            row.getId(),
+            row.getTenantId(),
+            QuotaSubjectType.parse(row.getSubjectType()),
+            row.getSubjectId(),
+            row.getLevelCode(),
+            parseKind(row.getLimitKind()),
+            row.getUsed() == null ? 0L : row.getUsed(),
+            row.getLimitValue() == null ? 0L : row.getLimitValue(),
+            row.getWindowSeconds() == null ? 0 : row.getWindowSeconds(),
+            SubjectExceedAction.parse(row.getAction()),
+            row.getResource(),
+            row.getCreatedAtMs() == null ? 0L : row.getCreatedAtMs());
+    }
+
+    /** 脏值按 REQUEST 兜底：次数是更常见的触顶维度，落错只影响这条记录的展示分类。 */
+    private static SubjectQuotaDecision.LimitKind parseKind(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return SubjectQuotaDecision.LimitKind.REQUEST;
+        }
+        try {
+            return SubjectQuotaDecision.LimitKind.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return SubjectQuotaDecision.LimitKind.REQUEST;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/MybatisSubjectQuotaLevelStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/MybatisSubjectQuotaLevelStore.java
@@ -1,0 +1,123 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.entity.SubjectQuotaLevelDO;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaLevelMapper;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 等级的 MyBatis-Plus 实现。
+ *
+ * <p>全部查询走 {@link CrossTenantOperations}：快照加载发生在<b>定时任务</b>里（没有租户上下文），
+ * 且一个进程要同时服务所有租户，本就该把各租户的等级一次全取回来按 (租户, 等级码) 索引。
+ * 后台跨租户维护同理——两类调用方共用一个 Store，让 Store 自己按显式 tenantId 取数，
+ * 比让调用方各自记得切上下文更不容易出错（同 {@code MybatisTenantQuotaStore}）。</p>
+ *
+ * <p>异常一律 {@code catch(Exception)}：HikariPool / MyBatis 初始化异常是 RuntimeException，
+ * 不是 SQLException 子类。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class MybatisSubjectQuotaLevelStore implements SubjectQuotaLevelStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MybatisSubjectQuotaLevelStore.class);
+
+    private final SubjectQuotaLevelMapper mapper;
+
+    public MybatisSubjectQuotaLevelStore(SubjectQuotaLevelMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<List<SubjectQuotaLevel>> findAllEnabled() {
+        try {
+            List<SubjectQuotaLevelDO> rows = CrossTenantOperations.execute(() -> mapper.selectList(
+                new LambdaQueryWrapper<SubjectQuotaLevelDO>().eq(SubjectQuotaLevelDO::getEnabled, 1)));
+            return Optional.of(rows.stream().map(MybatisSubjectQuotaLevelStore::toDomain).toList());
+        } catch (Exception e) {
+            // 读失败返回 empty：Provider 据此保留上次快照 / 回退内置档，绝不把"读不到"当成"限死一切"
+            log.error("subject quota level findAllEnabled failed, code={}", "SQUOTA-LEVEL-LOAD-FAIL", e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SubjectQuotaLevel> findByTenant(String tenantId) {
+        try {
+            List<SubjectQuotaLevelDO> rows = CrossTenantOperations.execute(() -> mapper.selectList(
+                new LambdaQueryWrapper<SubjectQuotaLevelDO>()
+                    .eq(SubjectQuotaLevelDO::getTenantId, tenantId)
+                    .orderByAsc(SubjectQuotaLevelDO::getLevelCode)));
+            return rows.stream().map(MybatisSubjectQuotaLevelStore::toDomain).toList();
+        } catch (Exception e) {
+            log.error("subject quota level findByTenant failed, code={}, tenant={}",
+                "SQUOTA-LEVEL-QUERY-FAIL", tenantId, e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public void save(SubjectQuotaLevel level) {
+        long now = System.currentTimeMillis();
+        CrossTenantOperations.run(() -> {
+            SubjectQuotaLevelDO existing = mapper.selectOne(new LambdaQueryWrapper<SubjectQuotaLevelDO>()
+                .eq(SubjectQuotaLevelDO::getTenantId, level.tenantId())
+                .eq(SubjectQuotaLevelDO::getLevelCode, level.levelCode()));
+
+            SubjectQuotaLevelDO row = existing == null ? new SubjectQuotaLevelDO() : existing;
+            row.setTenantId(level.tenantId());
+            row.setLevelCode(level.levelCode());
+            row.setLevelName(level.levelName());
+            row.setSubjectType(level.subjectType().name());
+            row.setWindowSeconds(level.effectiveWindowSeconds());
+            row.setTokenLimit(level.tokenLimit());
+            row.setRequestLimit(level.requestLimit());
+            row.setExceedAction(level.exceedAction().name());
+            row.setEnabled(level.enabled() ? 1 : 0);
+            row.setRemark(level.remark());
+            row.setUpdatedAtMs(now);
+            if (existing == null) {
+                row.setCreatedAtMs(now);
+                mapper.insert(row);
+            } else {
+                mapper.updateById(row);
+            }
+        });
+    }
+
+    @Override
+    public void delete(String tenantId, String levelCode) {
+        CrossTenantOperations.run(() -> mapper.delete(new LambdaQueryWrapper<SubjectQuotaLevelDO>()
+            .eq(SubjectQuotaLevelDO::getTenantId, tenantId)
+            .eq(SubjectQuotaLevelDO::getLevelCode, levelCode)));
+    }
+
+    @Override
+    public Optional<String> fingerprint() {
+        try {
+            return Optional.ofNullable(CrossTenantOperations.execute(mapper::selectFingerprint));
+        } catch (Exception e) {
+            log.error("subject quota level fingerprint failed, code={}", "SQUOTA-LEVEL-FINGERPRINT-FAIL", e);
+            return Optional.empty();
+        }
+    }
+
+    private static SubjectQuotaLevel toDomain(SubjectQuotaLevelDO row) {
+        return new SubjectQuotaLevel(
+            row.getId(),
+            row.getTenantId(),
+            row.getLevelCode(),
+            row.getLevelName(),
+            QuotaSubjectType.parse(row.getSubjectType()),
+            row.getWindowSeconds() == null ? SubjectQuotaLevel.DEFAULT_WINDOW_SECONDS : row.getWindowSeconds(),
+            row.getTokenLimit() == null ? 0L : row.getTokenLimit(),
+            row.getRequestLimit() == null ? 0 : row.getRequestLimit(),
+            SubjectExceedAction.parse(row.getExceedAction()),
+            row.getEnabled() == null || row.getEnabled() == 1,
+            row.getRemark());
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubject.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubject.java
@@ -1,0 +1,70 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * 限流主体（不可变值对象）：一次请求要算在谁的额度上。
+ *
+ * <p>由接入层解析（登录态 → 用户、API Key → 接入方、都没有 → IP），随请求贯穿到 token 记账点，
+ * 见 {@link QuotaSubjectContext}。</p>
+ *
+ * <p><b>API Key 一律只留指纹</b>：主体 ID 会进 Redis 计数键、进超限记录表、进日志，
+ * 明文 Key 落到任何一处都是凭据泄露。指纹取 SHA-256 前 16 位十六进制——够长到不会碰撞，
+ * 又短到能直接放进 Redis key。</p>
+ *
+ * @param type 主体类型
+ * @param id   主体标识（用户 ID / IP / API Key 指纹）
+ * @author owlzhangfq@gmail.com
+ */
+public record QuotaSubject(QuotaSubjectType type, String id) {
+
+    /** 主体标识缺失时的占位：解析不出身份也要有一份额度可算，否则等于放行。 */
+    public static final String UNKNOWN_ID = "unknown";
+
+    private static final String KEY_PREFIX = "squota:";
+    private static final int FINGERPRINT_HEX_LEN = 16;
+
+    public static QuotaSubject user(String userId) {
+        return new QuotaSubject(QuotaSubjectType.USER, blankToUnknown(userId));
+    }
+
+    public static QuotaSubject ip(String ip) {
+        return new QuotaSubject(QuotaSubjectType.IP, blankToUnknown(ip));
+    }
+
+    /** 从明文 API Key 构造：只保留指纹，明文不落入本对象。 */
+    public static QuotaSubject apiKey(String rawApiKey) {
+        return new QuotaSubject(QuotaSubjectType.API_KEY, fingerprint(rawApiKey));
+    }
+
+    /** 计数键前缀（token 与次数各自再加后缀，见 {@link SubjectQuotaGuard}）。 */
+    public String counterKey() {
+        return KEY_PREFIX + type.name() + ":" + id;
+    }
+
+    private static String blankToUnknown(String value) {
+        return value == null || value.isBlank() ? UNKNOWN_ID : value;
+    }
+
+    /**
+     * API Key 指纹。
+     *
+     * <p>取不到摘要算法时退回明文的哈希码：宁可主体粒度粗一点，也不能因为一个基础算法缺失
+     * 就让整条限流链路抛异常——那是把保护性能力变成故障源。</p>
+     */
+    private static String fingerprint(String rawApiKey) {
+        if (rawApiKey == null || rawApiKey.isBlank()) {
+            return UNKNOWN_ID;
+        }
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(rawApiKey.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest).substring(0, FINGERPRINT_HEX_LEN);
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString(rawApiKey.hashCode());
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectContext.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectContext.java
@@ -1,0 +1,65 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.util.function.Supplier;
+
+/**
+ * 当前请求的限流主体上下文（全链路唯一真源）。
+ *
+ * <p><b>为什么必须有这么一个上下文</b>：主体身份只在接入层拿得到（JWT / API Key / 远端 IP），
+ * 而 token 的真实用量只在模型调用之后才知道，两处相隔整条业务链路，中间的方法签名里
+ * 一个"用户"参数都没有。把身份挂在上下文上，是让"记账记到正确的人头上"这件事成立的前提——
+ * 否则只能退回按 sessionId 猜用户，猜错就是把 A 的用量算到 B 头上。</p>
+ *
+ * <p>机制与 {@link com.richard.fyoung.customerwork.safety.tenant.TenantContext} 完全一致：
+ * ThreadLocal 承载，跨线程边界由 {@link QuotaSubjectContextThreadLocalAccessor} + Reactor
+ * 自动传播还原。用同一套而不是另造一套，是因为它们要在同样的线程切换点上活下来。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public final class QuotaSubjectContext {
+
+    private static final ThreadLocal<QuotaSubject> CURRENT = new ThreadLocal<>();
+
+    private QuotaSubjectContext() {
+    }
+
+    /** 写入当前主体；传 null 视为清理，避免半初始化状态被后续记账读到。 */
+    public static void set(QuotaSubject subject) {
+        if (subject == null) {
+            CURRENT.remove();
+            return;
+        }
+        CURRENT.set(subject);
+    }
+
+    /** 读取当前主体，未设置返回 {@code null}（记账方按"无主体则不记"处理，不抛异常）。 */
+    public static QuotaSubject get() {
+        return CURRENT.get();
+    }
+
+    public static boolean isPresent() {
+        return CURRENT.get() != null;
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+
+    /** 在指定主体下执行一段逻辑，结束后恢复原值（供 WS 等非 HTTP 入口使用）。 */
+    public static <T> T callWith(QuotaSubject subject, Supplier<T> action) {
+        QuotaSubject previous = CURRENT.get();
+        set(subject);
+        try {
+            return action.get();
+        } finally {
+            set(previous);
+        }
+    }
+
+    /** {@link #callWith(QuotaSubject, Supplier)} 的无返回值版本。 */
+    public static void runWith(QuotaSubject subject, Runnable action) {
+        callWith(subject, () -> {
+            action.run();
+            return null;
+        });
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectContextThreadLocalAccessor.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectContextThreadLocalAccessor.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import io.micrometer.context.ThreadLocalAccessor;
+
+/**
+ * 把 {@link QuotaSubjectContext} 的 ThreadLocal 接入 Reactor 自动上下文传播。
+ *
+ * <p>与租户上下文同理：请求链会在 boundedElastic 上执行阻塞 IO 与模型调用，线程一换
+ * ThreadLocal 就没了，而 token 记账恰恰发生在换过线程之后。没有这个 Accessor，
+ * 用量就永远记不到发起请求的那个人头上。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class QuotaSubjectContextThreadLocalAccessor implements ThreadLocalAccessor<QuotaSubject> {
+
+    /** Reactor Context 中承载主体的键，写入方（WebFilter / WS 分发）与本 Accessor 必须用同一个。 */
+    public static final String KEY = "customer-work.quota-subject";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public QuotaSubject getValue() {
+        return QuotaSubjectContext.get();
+    }
+
+    @Override
+    public void setValue(QuotaSubject value) {
+        QuotaSubjectContext.set(value);
+    }
+
+    @Override
+    public void setValue() {
+        QuotaSubjectContext.clear();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectType.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectType.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+/**
+ * 限流主体类型：决定"这一份额度是谁的"。
+ *
+ * <p>三类主体的身份来源完全不同，额度语义也不同，故必须分开而不是硬凑成一个"用户"概念：</p>
+ * <ul>
+ *   <li>{@link #USER}：已登录的自然人（JWT subject），额度按人分配，是本功能的主战场；</li>
+ *   <li>{@link #IP}：匿名调用方（无登录态），只能按来源 IP 归并——同一 NAT 后的多人会共享一份额度，
+ *       这是匿名的固有代价，因此匿名档应当配得最紧；</li>
+ *   <li>{@link #API_KEY}：服务端接入方，一把 Key 代表一个系统而非一个人，额度量级应当最大。</li>
+ * </ul>
+ * @author owlzhangfq@gmail.com
+ */
+public enum QuotaSubjectType {
+
+    /** 已登录用户（按 userId 计）。 */
+    USER,
+
+    /** 匿名调用方（按来源 IP 计）。 */
+    IP,
+
+    /** 服务端接入方（按 API Key 指纹计）。 */
+    API_KEY;
+
+    /** 宽松解析：空/非法回落 {@link #USER}（等级表里最常见的一类，落错只影响这条等级配置的归类展示）。 */
+    public static QuotaSubjectType parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return USER;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return USER;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectExceedAction.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectExceedAction.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+/**
+ * 主体配额超限后的处置方式。
+ *
+ * <p><b>刻意不复用租户配额的 {@code QuotaExceedAction}</b>：那个枚举有 {@code DEGRADE}（改用更便宜的模型），
+ * 而主体配额判定发生在接入层——那里既不知道会用哪个模型，也没有换模型的手段。把一个必然不生效的选项
+ * 摆在后台下拉框里，只会让运营配了一个"看起来在省钱、实际什么都没做"的策略。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum SubjectExceedAction {
+
+    /** 拦截：直接拒绝本次请求。防滥用的默认答案。 */
+    BLOCK,
+
+    /** 仅告警：不拦，只记录一条超限命中。用于新等级上线前的观察期。 */
+    WARN;
+
+    /** 宽松解析：脏值按 {@link #BLOCK} 兜底（fail-closed，宁可误拦也不放任刷量）。 */
+    public static SubjectExceedAction parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return BLOCK;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return BLOCK;
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelBinding.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelBinding.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.util.Optional;
+
+/**
+ * 用户 → 等级 的绑定查询 SPI。
+ *
+ * <p>抽成 SPI 而不是让配额领域直接依赖账户领域：配额只需要回答"这个用户是哪一档"，
+ * 不该因此认识用户名、密码哈希、头像这些与它无关的东西。实现方是
+ * {@code data.user} 包（等级列就落在 {@code cw_user} 上），装配见 {@code UserAccountConfig}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@FunctionalInterface
+public interface SubjectLevelBinding {
+
+    /**
+     * 查用户绑定的等级编码。
+     *
+     * @return 未绑定或查不到时返回 empty，调用方回落配置里的默认档
+     */
+    Optional<String> levelCodeOf(String userId);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolver.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolver.java
@@ -1,0 +1,125 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 把一个主体解析成它适用的那一档额度。
+ *
+ * <p>三步：定等级编码 → 查库里的等级快照 → 查不到回落配置里的内置档。</p>
+ *
+ * <p><b>等级编码怎么来</b>：登录用户查绑定（{@link SubjectLevelBinding}，落在 {@code cw_user.level_code}），
+ * 没绑定就用默认档；匿名与接入方没有"个人档位"可言，各自走配置指定的一档。</p>
+ *
+ * <p><b>为什么内置档不是可有可无的兜底</b>：它让功能在"还没建等级表 / 还没配任何一档"时就能生效。
+ * 否则开关一开却什么都不限，运维只能从"为什么没限住"倒查到"原来还要先去建数据"。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class SubjectLevelResolver {
+
+    private final SubjectQuotaLevelProvider levelProvider;
+    private final SubjectLevelBinding levelBinding;
+    private final SubjectQuotaProperties properties;
+
+    /** 用户等级绑定的本地缓存：限流判定在每个请求的热路径上，不能每次都去查用户表。 */
+    private final Map<String, CachedLevel> bindingCache = new ConcurrentHashMap<>();
+
+    public SubjectLevelResolver(SubjectQuotaLevelProvider levelProvider,
+                                SubjectLevelBinding levelBinding,
+                                SubjectQuotaProperties properties) {
+        this.levelProvider = levelProvider;
+        this.levelBinding = levelBinding;
+        this.properties = properties;
+    }
+
+    /**
+     * 解析主体适用的等级。
+     *
+     * @return 适用等级；无任何可用配置时返回 {@code null}（= 该主体不受限）
+     */
+    public SubjectQuotaLevel resolve(QuotaSubject subject) {
+        if (subject == null) {
+            return null;
+        }
+        String tenantId = currentTenant();
+        String levelCode = levelCodeOf(subject);
+        if (levelCode == null || levelCode.isBlank()) {
+            return null;
+        }
+        SubjectQuotaLevel configured = levelProvider.find(tenantId, levelCode);
+        if (configured != null) {
+            return configured;
+        }
+        // 该租户没配这一档：回落平台默认租户的同名等级，再回落内置档。
+        // 中间这一跳让"平台统一配一次、各租户不必重复配"成立，同时保留租户覆盖的能力。
+        SubjectQuotaLevel platformLevel = levelProvider.find(TenantContext.DEFAULT, levelCode);
+        return platformLevel != null ? platformLevel : builtin(tenantId, levelCode);
+    }
+
+    /** 主体对应的等级编码（用户查绑定，其余按类型取配置档）。 */
+    private String levelCodeOf(QuotaSubject subject) {
+        return switch (subject.type()) {
+            case USER -> boundLevelOf(subject.id()).orElse(properties.getDefaultUserLevel());
+            case IP -> properties.getAnonymousLevel();
+            case API_KEY -> properties.getApiKeyLevel();
+        };
+    }
+
+    /** 带 TTL 的绑定查询；缓存未命中才真正查库。 */
+    private Optional<String> boundLevelOf(String userId) {
+        long now = System.currentTimeMillis();
+        CachedLevel cached = bindingCache.get(userId);
+        if (cached != null && cached.expireAtMs > now) {
+            return Optional.ofNullable(cached.levelCode);
+        }
+        // 缓存里"查过但没绑定"也要记（levelCode 为 null），否则未绑定的用户每次都会打一次库
+        String resolved = levelBinding == null ? null : levelBinding.levelCodeOf(userId).orElse(null);
+        if (bindingCache.size() > properties.getLevelCacheMaxSize()) {
+            bindingCache.entrySet().removeIf(entry -> entry.getValue().expireAtMs <= now);
+        }
+        bindingCache.put(userId, new CachedLevel(resolved, now + properties.getLevelCacheTtlMs()));
+        return Optional.ofNullable(resolved);
+    }
+
+    /** 后台改完等级绑定后主动失效，让新档位立刻生效而不必等 TTL。 */
+    public void evictBinding(String userId) {
+        if (userId != null) {
+            bindingCache.remove(userId);
+        }
+    }
+
+    /** 把配置里的内置档翻成领域对象；没有同名内置档则返回 null（= 不受限）。 */
+    private SubjectQuotaLevel builtin(String tenantId, String levelCode) {
+        Map<String, SubjectQuotaProperties.Level> builtins = properties.getBuiltinLevels();
+        if (builtins == null) {
+            return null;
+        }
+        SubjectQuotaProperties.Level level = builtins.get(levelCode);
+        if (level == null) {
+            return null;
+        }
+        return new SubjectQuotaLevel(null, tenantId, levelCode,
+            level.getLevelName() == null ? levelCode : level.getLevelName(),
+            QuotaSubjectType.parse(level.getSubjectType()),
+            level.getWindowSeconds(),
+            level.getTokenLimit(),
+            level.getRequestLimit(),
+            SubjectExceedAction.parse(level.getExceedAction()),
+            true,
+            "builtin");
+    }
+
+    /** 当前租户；无上下文（如内部任务、未开多租户）时按默认租户算。 */
+    private static String currentTenant() {
+        String tenantId = TenantContext.get();
+        return tenantId == null || tenantId.isBlank() ? TenantContext.DEFAULT : tenantId;
+    }
+
+    /** 缓存项：{@code levelCode} 允许为 null，表示"查过，确实没绑定"。 */
+    private record CachedLevel(String levelCode, long expireAtMs) {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaConfig.java
@@ -1,0 +1,125 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
+import com.richard.fyoung.customerwork.infra.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
+import com.richard.fyoung.customerwork.safety.security.UserJwtService;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaHitMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaLevelMapper;
+import io.micrometer.context.ContextRegistry;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 主体级速率配额装配：Store 按 {@code store-mode} 选实现，Guard 按 {@code enabled} 决定是否真的拦。
+ *
+ * <p>无论开关是否打开都注册 {@link QuotaSubjectContextThreadLocalAccessor}：Accessor 只是让
+ * ThreadLocal 能跨线程还原，本身没有开销；而"开关打开后才注册"会让运行期动态开启（配置中心下发）
+ * 变成一个必须重启才生效的操作。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class SubjectQuotaConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(SubjectQuotaConfig.class);
+
+    private static final String MODE_JDBC = "jdbc";
+
+    @PostConstruct
+    public void registerContextAccessor() {
+        ContextRegistry.getInstance().registerThreadLocalAccessor(new QuotaSubjectContextThreadLocalAccessor());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SubjectQuotaLevelStore subjectQuotaLevelStore(CustomerWorkProperties properties,
+                                                         ObjectProvider<SubjectQuotaLevelMapper> mapperProvider) {
+        SubjectQuotaProperties cfg = properties.getSubjectQuota();
+        if (!MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode())) {
+            return new InMemorySubjectQuotaLevelStore();
+        }
+        SubjectQuotaLevelMapper mapper = mapperProvider.getIfAvailable();
+        if (mapper == null) {
+            // 配了 jdbc 却没有 Mapper（持久层未装配）：让位给内存实现而不是启动失败——
+            // 限流是旁路保护，不该拖垮主链路的可启动性；配置没生效这件事由 error 日志暴露
+            log.error("subject-quota store-mode=jdbc but SubjectQuotaLevelMapper unavailable, "
+                + "fallback to in-memory, code={}", "SQUOTA-LEVEL-MAPPER-MISSING");
+            return new InMemorySubjectQuotaLevelStore();
+        }
+        log.info("subject quota level store ready (jdbc)");
+        return new MybatisSubjectQuotaLevelStore(mapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SubjectQuotaHitStore subjectQuotaHitStore(CustomerWorkProperties properties,
+                                                     ObjectProvider<SubjectQuotaHitMapper> mapperProvider) {
+        SubjectQuotaProperties cfg = properties.getSubjectQuota();
+        if (!MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode())) {
+            return new InMemorySubjectQuotaHitStore();
+        }
+        SubjectQuotaHitMapper mapper = mapperProvider.getIfAvailable();
+        if (mapper == null) {
+            log.error("subject-quota store-mode=jdbc but SubjectQuotaHitMapper unavailable, "
+                + "fallback to in-memory, code={}", "SQUOTA-HIT-MAPPER-MISSING");
+            return new InMemorySubjectQuotaHitStore();
+        }
+        return new MybatisSubjectQuotaHitStore(mapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SubjectQuotaLevelProvider subjectQuotaLevelProvider(CustomerWorkProperties properties,
+                                                               SubjectQuotaLevelStore store) {
+        SubjectQuotaProperties cfg = properties.getSubjectQuota();
+        // 只有 jdbc 模式才需要轮询：内存 Store 的变更是同进程的，写入即生效，轮询纯属空转
+        boolean refreshEnabled = cfg.isEnabled() && MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode());
+        return new SubjectQuotaLevelProvider(store, refreshEnabled);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SubjectLevelResolver subjectLevelResolver(CustomerWorkProperties properties,
+                                                     SubjectQuotaLevelProvider levelProvider,
+                                                     ObjectProvider<SubjectLevelBinding> bindingProvider) {
+        return new SubjectLevelResolver(levelProvider,
+            bindingProvider.getIfAvailable(), properties.getSubjectQuota());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SubjectQuotaGuard subjectQuotaGuard(CustomerWorkProperties properties,
+                                               SubjectLevelResolver levelResolver,
+                                               SubjectQuotaHitStore hitStore,
+                                               ObjectProvider<WindowCounter> counterProvider) {
+        SubjectQuotaProperties cfg = properties.getSubjectQuota();
+        WindowCounter counter = counterProvider.getIfAvailable();
+        if (cfg.isEnabled()) {
+            log.info("subject quota guard enabled, storeMode={}, defaultUserLevel={}, anonymousLevel={}",
+                cfg.getStoreMode(), cfg.getDefaultUserLevel(), cfg.getAnonymousLevel());
+        }
+        return new SubjectQuotaGuard(levelResolver,
+            counter == null ? new InMemoryWindowCounter() : counter, hitStore, cfg.isEnabled());
+    }
+
+    /**
+     * HTTP 侧判定入口。
+     *
+     * <p>用 {@code @Bean} 而非给过滤器加 {@code @Component}：{@code @WebFluxTest} 切片会按类型
+     * 自动纳入所有 {@code WebFilter} Bean，切片里却没有 {@link UserJwtService}，那样每个控制器
+     * 切片测试都会因为一个与它无关的过滤器加载失败（{@code UserAuthWebFilter} 同样的理由）。</p>
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public SubjectQuotaWebFilter subjectQuotaWebFilter(CustomerWorkProperties properties,
+                                                       SubjectQuotaGuard guard,
+                                                       ObjectProvider<UserJwtService> jwtServiceProvider) {
+        return new SubjectQuotaWebFilter(properties, guard, jwtServiceProvider.getIfAvailable());
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaDecision.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaDecision.java
@@ -1,0 +1,71 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+/**
+ * 主体配额判定结果。
+ *
+ * @param allowed       是否在额度内
+ * @param kind          触顶的维度（放行时为 null）
+ * @param action        超限处置（放行时为 null）
+ * @param levelCode     判定所依据的等级（放行时可能为 null，表示没有适用等级）
+ * @param used          判定时的已用量
+ * @param limit         判定时的上限
+ * @param windowSeconds 判定所用的滚动窗口长度
+ * @author owlzhangfq@gmail.com
+ */
+public record SubjectQuotaDecision(boolean allowed,
+                                   LimitKind kind,
+                                   SubjectExceedAction action,
+                                   String levelCode,
+                                   long used,
+                                   long limit,
+                                   int windowSeconds) {
+
+    /** 触顶的维度。 */
+    public enum LimitKind {
+        /** token 用量触顶。 */
+        TOKEN,
+        /** 请求次数触顶。 */
+        REQUEST
+    }
+
+    private static final int SECONDS_PER_MINUTE = 60;
+
+    public static SubjectQuotaDecision allow() {
+        return new SubjectQuotaDecision(true, null, null, null, 0L, 0L, 0);
+    }
+
+    public static SubjectQuotaDecision exceeded(LimitKind kind, SubjectQuotaLevel level, long used) {
+        long limit = kind == LimitKind.TOKEN ? level.tokenLimit() : level.requestLimit();
+        return new SubjectQuotaDecision(false, kind, level.exceedAction(), level.levelCode(),
+            used, limit, level.effectiveWindowSeconds());
+    }
+
+    /**
+     * 是否应当拦下本次请求。
+     *
+     * <p>{@code WARN} 等级只记录不拦，故超限不等于拦截——这个区分是"新等级先观察一周再收紧"
+     * 这种上线方式能成立的前提。</p>
+     */
+    public boolean shouldBlock() {
+        return !allowed && action == SubjectExceedAction.BLOCK;
+    }
+
+    /**
+     * 建议的重试等待秒数。
+     *
+     * <p>给的是窗口长度这个<b>上界</b>而非精确值：滚动窗口下额度是逐步释放的，真实恢复时刻取决于
+     * 最早那笔用量何时出窗。与其算一个似是而非的精确值，不如给一个"最迟这么久一定能用"的保证。</p>
+     */
+    public int retryAfterSeconds() {
+        return windowSeconds;
+    }
+
+    /** 用户可见的超限文案（中文，直接下发给终端用户）。 */
+    public String message() {
+        int minutes = Math.max(1, windowSeconds / SECONDS_PER_MINUTE);
+        if (kind == LimitKind.REQUEST) {
+            return "提问太频繁了：最近 " + minutes + " 分钟内已达 " + limit + " 次上限，请稍后再试。";
+        }
+        return "最近 " + minutes + " 分钟的用量额度已用完，请稍后再试或联系管理员提升额度。";
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaGuard.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaGuard.java
@@ -1,0 +1,161 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * 主体级速率配额的判定与记账：每个用户 / 每个匿名 IP / 每把 API Key 在滚动窗口内的 token 量与请求次数。
+ *
+ * <p><b>与租户配额的分工</b>：{@code TenantQuotaGuard} 管"这个客户这个月能花多少钱"（自然日/月对齐，
+ * 要跟账单对得上）；本类管"单个调用者这半小时能用多少"（滚动窗口，防的是滥用而非超支）。
+ * 两者同时生效，任一触顶都拦——一个客户的总额度没花完，不代表其中某个用户可以一个人把它刷光。</p>
+ *
+ * <p><b>先判后记，判定只读</b>：{@link #check} 不写任何计数，放行之后由调用方
+ * {@link #recordRequest} 计一次、模型调用结束后 {@link #recordTokens} 补真实用量。
+ * 因此高并发下允许短暂的少量超额（N 个请求同时读到未超限）——限流不是记账，
+ * 为了掐死这几个请求而让每次判定都走一次原子写，代价与收益不成比例。</p>
+ *
+ * <p><b>被拒的请求不占额度</b>：正因为记账发生在放行之后，持续打压不会把窗口越推越远，
+ * 用户等到窗口滚过去就能恢复。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class SubjectQuotaGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(SubjectQuotaGuard.class);
+
+    /** 次数计数键后缀。与 token 分开计，因为它们是两个独立的上限。 */
+    private static final String SUFFIX_REQUEST = ":req";
+    private static final String SUFFIX_TOKEN = ":tok";
+
+    private final SubjectLevelResolver levelResolver;
+    private final WindowCounter counter;
+    private final SubjectQuotaHitStore hitStore;
+    private final boolean enabled;
+
+    public SubjectQuotaGuard(SubjectLevelResolver levelResolver,
+                             WindowCounter counter,
+                             SubjectQuotaHitStore hitStore,
+                             boolean enabled) {
+        this.levelResolver = levelResolver;
+        this.counter = counter;
+        this.hitStore = hitStore;
+        this.enabled = enabled;
+    }
+
+    /**
+     * 请求准入判定，超限时异步落一条命中记录。
+     *
+     * <p>先判次数后判 token：次数是更硬的防刷指标，且两者都超时报次数更容易让用户理解
+     * （"你问得太频繁"比"你的额度用完了"更接近他刚才做的事）。</p>
+     *
+     * @param subject  限流主体；为 null 视为无身份，直接放行（判定不了的场景不该由限流来兜）
+     * @param resource 触发位置（HTTP 路径或 {@code ws:chat}），只用于命中记录与排障
+     */
+    public SubjectQuotaDecision check(QuotaSubject subject, String resource) {
+        if (!enabled || subject == null) {
+            return SubjectQuotaDecision.allow();
+        }
+        SubjectQuotaLevel level = levelResolver.resolve(subject);
+        if (level == null || !level.effective()) {
+            return SubjectQuotaDecision.allow();
+        }
+        int window = level.effectiveWindowSeconds();
+
+        if (level.hasRequestLimit()) {
+            long used = counter.currentSlidingSum(subject.counterKey() + SUFFIX_REQUEST, window);
+            if (used >= level.requestLimit()) {
+                return reject(SubjectQuotaDecision.exceeded(
+                    SubjectQuotaDecision.LimitKind.REQUEST, level, used), subject, resource);
+            }
+        }
+        if (level.hasTokenLimit()) {
+            long used = counter.currentSlidingSum(subject.counterKey() + SUFFIX_TOKEN, window);
+            if (used >= level.tokenLimit()) {
+                return reject(SubjectQuotaDecision.exceeded(
+                    SubjectQuotaDecision.LimitKind.TOKEN, level, used), subject, resource);
+            }
+        }
+        return SubjectQuotaDecision.allow();
+    }
+
+    /** 记一次请求（判定放行之后调用）。 */
+    public void recordRequest(QuotaSubject subject) {
+        if (!enabled || subject == null) {
+            return;
+        }
+        SubjectQuotaLevel level = levelResolver.resolve(subject);
+        if (level == null || !level.hasRequestLimit()) {
+            return;
+        }
+        counter.incrementSlidingSum(subject.counterKey() + SUFFIX_REQUEST, 1L,
+            level.effectiveWindowSeconds());
+    }
+
+    /**
+     * 记录本次真实 token 消耗（模型调用之后）。
+     *
+     * <p>取的是实际值而非预估：预估本就不准，用它记账会让额度在"估多了"的方向上白白蒸发。</p>
+     */
+    public void recordTokens(QuotaSubject subject, long tokens) {
+        if (!enabled || subject == null || tokens <= 0) {
+            return;
+        }
+        SubjectQuotaLevel level = levelResolver.resolve(subject);
+        if (level == null || !level.hasTokenLimit()) {
+            return;
+        }
+        counter.incrementSlidingSum(subject.counterKey() + SUFFIX_TOKEN, tokens,
+            level.effectiveWindowSeconds());
+    }
+
+    /** 当前用量快照（给终端用户看"还剩多少"、给后台排障）。 */
+    public SubjectQuotaUsage usage(QuotaSubject subject) {
+        if (!enabled || subject == null) {
+            return SubjectQuotaUsage.unlimited();
+        }
+        SubjectQuotaLevel level = levelResolver.resolve(subject);
+        if (level == null || !level.effective()) {
+            return SubjectQuotaUsage.unlimited();
+        }
+        int window = level.effectiveWindowSeconds();
+        return new SubjectQuotaUsage(
+            level.levelCode(),
+            window,
+            counter.currentSlidingSum(subject.counterKey() + SUFFIX_TOKEN, window),
+            level.tokenLimit(),
+            counter.currentSlidingSum(subject.counterKey() + SUFFIX_REQUEST, window),
+            level.requestLimit());
+    }
+
+    /** 功能是否开启（调用方据此跳过整段逻辑，省掉无谓的上下文写入）。 */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * 落一条命中记录并返回原判定。
+     *
+     * <p>落库是阻塞 IO，判定却在响应式链路上，故切到弹性线程池异步执行——
+     * 让一次统计写入去占事件循环线程，是拿主链路吞吐换观测数据。</p>
+     */
+    private SubjectQuotaDecision reject(SubjectQuotaDecision decision, QuotaSubject subject, String resource) {
+        log.error("subject quota exceeded, code={}, subject={}:{}, level={}, kind={}, used={}, limit={}, action={}",
+            "SQUOTA-EXCEEDED", subject.type(), subject.id(), decision.levelCode(),
+            decision.kind(), decision.used(), decision.limit(), decision.action());
+        if (hitStore == null) {
+            return decision;
+        }
+        String tenantId = TenantContext.get();
+        SubjectQuotaHit hit = SubjectQuotaHit.of(
+            tenantId == null || tenantId.isBlank() ? TenantContext.DEFAULT : tenantId,
+            subject, decision, resource);
+        Mono.fromRunnable(() -> hitStore.record(hit))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe();
+        return decision;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaHit.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaHit.java
@@ -1,0 +1,44 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+/**
+ * 一条超限命中记录（谁、在哪、因为什么被限）。
+ *
+ * <p><b>为什么落库的是"命中"而不是"实时余额"</b>：余额在计数器里（进程内或 Redis），后台是另一个进程，
+ * 想看余额要么被迫依赖 Redis 模式、要么读到一个只属于某个副本的数。而运营真正要回答的问题是
+ * "谁在刷、哪一档配紧了"——那是命中记录的形状，写入量也只有超限那一刻这一次。</p>
+ *
+ * @param id            主键（JDBC 实现回填）
+ * @param tenantId      归属租户
+ * @param subjectType   主体类型
+ * @param subjectId     主体标识（API Key 已是指纹，不含明文）
+ * @param levelCode     判定所依据的等级
+ * @param limitKind     触顶维度
+ * @param used          触顶时的已用量
+ * @param limitValue    触顶时的上限
+ * @param windowSeconds 滚动窗口长度
+ * @param action        当时的处置（BLOCK 真拦了 / WARN 只记录）
+ * @param resource      触发位置（HTTP 路径或 {@code ws:chat}），排障时用来定位是哪条链路
+ * @param createdAtMs   命中时刻
+ * @author owlzhangfq@gmail.com
+ */
+public record SubjectQuotaHit(Long id,
+                              String tenantId,
+                              QuotaSubjectType subjectType,
+                              String subjectId,
+                              String levelCode,
+                              SubjectQuotaDecision.LimitKind limitKind,
+                              long used,
+                              long limitValue,
+                              int windowSeconds,
+                              SubjectExceedAction action,
+                              String resource,
+                              long createdAtMs) {
+
+    /** 由判定结果构造命中记录（时刻取当下）。 */
+    public static SubjectQuotaHit of(String tenantId, QuotaSubject subject,
+                                     SubjectQuotaDecision decision, String resource) {
+        return new SubjectQuotaHit(null, tenantId, subject.type(), subject.id(),
+            decision.levelCode(), decision.kind(), decision.used(), decision.limit(),
+            decision.windowSeconds(), decision.action(), resource, System.currentTimeMillis());
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaHitRank.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaHitRank.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import lombok.Data;
+
+/**
+ * 超限命中排行（后台"谁在刷"看板的一行）。
+ *
+ * <p>是 MyBatis 的聚合查询结果承载体，故用可变 POJO 而非 record——
+ * 聚合列名到字段的映射走 setter，与其它 XML 查询保持一致。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SubjectQuotaHitRank {
+
+    /** 主体类型（字符串形态，直接来自聚合结果）。 */
+    private String subjectType;
+    private String subjectId;
+    private String levelCode;
+    /** 统计区间内的命中次数。 */
+    private Long hitCount;
+    /** 最近一次命中时刻。 */
+    private Long lastHitAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaHitStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaHitStore.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.util.List;
+
+/**
+ * 超限命中记录存储 SPI。
+ *
+ * <p>写入只发生在超限那一刻，正常流量不产生任何写——这是它敢于同步落库的前提。
+ * 即便如此，调用方仍应异步提交（见 {@code SubjectQuotaGuard}），因为限流判定在响应式链路上，
+ * 阻塞 IO 不能占用事件循环线程。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface SubjectQuotaHitStore {
+
+    /** 记录一次命中。实现须自行吞掉异常：记不下这条统计，不该让本就被拒的请求再抛一个错。 */
+    void record(SubjectQuotaHit hit);
+
+    /** 按租户查最近的命中明细（时间倒序）。 */
+    List<SubjectQuotaHit> findRecent(String tenantId, long sinceMs, int limit);
+
+    /** 按租户查指定区间内的命中排行（命中次数倒序），供"谁在刷"看板。 */
+    List<SubjectQuotaHitRank> rank(String tenantId, long sinceMs, int limit);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevel.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevel.java
@@ -1,0 +1,60 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+/**
+ * 配额等级（不可变值对象）：一档额度的完整定义。
+ *
+ * <p>语义：属于本等级的主体，在最近 {@code windowSeconds} 秒内最多消耗 {@code tokenLimit} 个 token、
+ * 发起 {@code requestLimit} 次请求，任一维度触顶即按 {@code exceedAction} 处置。两个上限
+ * <b>各自独立</b>——token 拦的是"一次问得太重"，次数拦的是"问得太频繁"，一个拦不住另一个。</p>
+ *
+ * <p>窗口是<b>滚动</b>的（最近 N 秒），不是自然对齐的。与租户配额（自然日/月，要跟账单对齐）
+ * 刻意不同：防滥用不需要跟账单对齐，而整点归零会让刷量方掐着点把额度用两遍。</p>
+ *
+ * @param id            主键（JDBC 实现回填）
+ * @param tenantId      归属租户
+ * @param levelCode     等级编码（如 {@code free}/{@code vip}），租户内唯一
+ * @param levelName     等级名称（运营可读）
+ * @param subjectType   适用的主体类型
+ * @param windowSeconds 滚动窗口长度（秒），如 1800 = 30 分钟
+ * @param tokenLimit    窗口内 token 上限，0 = 不限
+ * @param requestLimit  窗口内请求次数上限，0 = 不限
+ * @param exceedAction  超限处置
+ * @param enabled       是否启用；停用等于该等级的主体不受限
+ * @param remark        备注
+ * @author owlzhangfq@gmail.com
+ */
+public record SubjectQuotaLevel(Long id,
+                                String tenantId,
+                                String levelCode,
+                                String levelName,
+                                QuotaSubjectType subjectType,
+                                int windowSeconds,
+                                long tokenLimit,
+                                int requestLimit,
+                                SubjectExceedAction exceedAction,
+                                boolean enabled,
+                                String remark) {
+
+    /** 窗口长度缺失时的兜底（30 分钟）：等级配了却没配窗口时，按最常用的档走而不是当成"不限"。 */
+    public static final int DEFAULT_WINDOW_SECONDS = 1800;
+
+    /** 是否设置了 token 上限（0 表示不限，不参与判定）。 */
+    public boolean hasTokenLimit() {
+        return tokenLimit > 0;
+    }
+
+    /** 是否设置了次数上限（0 表示不限，不参与判定）。 */
+    public boolean hasRequestLimit() {
+        return requestLimit > 0;
+    }
+
+    /** 实际生效的窗口长度：非正值一律按默认档，避免"0 秒窗口"把计数器变成永远超限。 */
+    public int effectiveWindowSeconds() {
+        return windowSeconds > 0 ? windowSeconds : DEFAULT_WINDOW_SECONDS;
+    }
+
+    /** 是否真的会拦住任何东西：停用或两个上限都为 0 时，这一档等于不存在。 */
+    public boolean effective() {
+        return enabled && (hasTokenLimit() || hasRequestLimit());
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelProvider.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelProvider.java
@@ -1,0 +1,95 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 等级快照持有者 + 定时刷新器：热路径无锁读，后台改等级后自动生效。
+ *
+ * <p>语义与 {@code RateLimitRuleProvider} 一致：快照整体替换（volatile 引用原子切换），
+ * 指纹没变就不拉全表；读失败保留上次快照。等级数量是"租户数 × 几档"这个量级，
+ * 全量缓存在内存里完全放得下，因此不需要按需查库——限流判定在每个请求的热路径上，
+ * 一次库查询就是一次不可接受的延迟。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class SubjectQuotaLevelProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(SubjectQuotaLevelProvider.class);
+
+    private final SubjectQuotaLevelStore store;
+    private final boolean refreshEnabled;
+
+    /** 当前快照：key = tenantId + '\n' + levelCode。 */
+    private volatile Map<String, SubjectQuotaLevel> snapshot = Map.of();
+    private volatile String lastFingerprint;
+
+    public SubjectQuotaLevelProvider(SubjectQuotaLevelStore store, boolean refreshEnabled) {
+        this.store = store;
+        this.refreshEnabled = refreshEnabled;
+        reload();
+    }
+
+    /** 定时轮询入口；间隔由 {@code customer-work.subject-quota.refresh-interval-ms} 决定（默认 60s）。 */
+    @Scheduled(fixedDelayString = "${customer-work.subject-quota.refresh-interval-ms:60000}")
+    public void scheduledRefresh() {
+        if (!refreshEnabled) {
+            return;
+        }
+        Optional<String> current = store.fingerprint();
+        if (current.isEmpty()) {
+            log.error("subject quota level fingerprint probe failed, keep current snapshot, code={}",
+                "SQUOTA-REFRESH-PROBE-FAIL");
+            return;
+        }
+        if (current.get().equals(lastFingerprint)) {
+            return;
+        }
+        if (reload()) {
+            log.info("subject quota levels changed, snapshot refreshed, levels={}", snapshot.size());
+        }
+    }
+
+    /**
+     * 重新加载并整体换快照（后台"立即生效"也复用本方法）。
+     *
+     * @return 是否加载成功；失败时保留原快照，下一轮继续重试
+     */
+    public boolean reload() {
+        Optional<List<SubjectQuotaLevel>> loaded = store.findAllEnabled();
+        if (loaded.isEmpty()) {
+            log.error("subject quota level reload failed, keep snapshot (levels={}), code={}",
+                snapshot.size(), "SQUOTA-RELOAD-FAIL");
+            return false;
+        }
+        Map<String, SubjectQuotaLevel> next = new HashMap<>();
+        for (SubjectQuotaLevel level : loaded.get()) {
+            next.put(key(level.tenantId(), level.levelCode()), level);
+        }
+        this.snapshot = Map.copyOf(next);
+        this.lastFingerprint = store.fingerprint().orElse(null);
+        return true;
+    }
+
+    /** 取某租户的某一档；快照里没有返回 null，由调用方回落内置档。 */
+    public SubjectQuotaLevel find(String tenantId, String levelCode) {
+        if (tenantId == null || levelCode == null) {
+            return null;
+        }
+        return snapshot.get(key(tenantId, levelCode));
+    }
+
+    /** 当前快照大小（观测 / 单测）。 */
+    public int size() {
+        return snapshot.size();
+    }
+
+    private static String key(String tenantId, String levelCode) {
+        return tenantId + '\n' + levelCode;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelStore.java
@@ -1,0 +1,48 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 配额等级存储 SPI（照既有 Store SPI 模式：接口 + InMemory 默认 + MyBatis-Plus 实现）。
+ *
+ * <p><b>读失败是 fail-open</b>：{@link #findAllEnabled()} 返回 empty 时
+ * {@link SubjectQuotaLevelProvider} 保留上次快照，从未加载成功则回退配置文件里的内置档。
+ * 与限流规则同向、与敏感词反向：读不到等级就把所有人限死是自伤，而漏放只是这段时间没限住。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface SubjectQuotaLevelStore {
+
+    /**
+     * 全部启用的等级（跨租户，供快照加载）。
+     *
+     * <p>{@code Optional.of(list)} 表示读取成功（空 list 是合法的"没配等级"），
+     * {@code Optional.empty()} 表示读取失败（库不可达等）。</p>
+     */
+    Optional<List<SubjectQuotaLevel>> findAllEnabled();
+
+    /** 指定租户的全部等级（含停用），供后台展示。 */
+    List<SubjectQuotaLevel> findByTenant(String tenantId);
+
+    /** 保存或更新（按 tenantId + levelCode 唯一）。 */
+    void save(SubjectQuotaLevel level);
+
+    /** 删除某租户的某个等级。 */
+    void delete(String tenantId, String levelCode);
+
+    /** 等级版本指纹：供 Provider 判断是否需要换快照；{@code empty} 表示读取失败。 */
+    default Optional<String> fingerprint() {
+        return findAllEnabled().map(levels -> {
+            List<String> items = new ArrayList<>(levels.size());
+            for (SubjectQuotaLevel level : levels) {
+                items.add(level.tenantId() + '|' + level.levelCode() + '|' + level.subjectType()
+                    + '|' + level.windowSeconds() + '|' + level.tokenLimit()
+                    + '|' + level.requestLimit() + '|' + level.exceedAction());
+            }
+            Collections.sort(items);
+            return levels.size() + ":" + Integer.toHexString(String.join(";", items).hashCode());
+        });
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaUsage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaUsage.java
@@ -1,0 +1,38 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+/**
+ * 主体的当前用量快照（给终端用户看"我还剩多少"、给排障看"他到底用了多少"）。
+ *
+ * <p>不含"何时恢复"：滚动窗口下额度是连续释放的，任何一个恢复时刻都只对某一笔用量成立，
+ * 报出去只会变成客服要解释的新问题。</p>
+ *
+ * @param levelCode     生效等级；无适用等级时为 null，此时各项上限均为 0（= 不限）
+ * @param windowSeconds 滚动窗口长度
+ * @param tokenUsed     窗口内已用 token
+ * @param tokenLimit    token 上限，0 = 不限
+ * @param requestUsed   窗口内已发起请求数
+ * @param requestLimit  次数上限，0 = 不限
+ * @author owlzhangfq@gmail.com
+ */
+public record SubjectQuotaUsage(String levelCode,
+                                int windowSeconds,
+                                long tokenUsed,
+                                long tokenLimit,
+                                long requestUsed,
+                                long requestLimit) {
+
+    /** 无适用等级（功能关闭或该主体不受限）时的空快照。 */
+    public static SubjectQuotaUsage unlimited() {
+        return new SubjectQuotaUsage(null, 0, 0L, 0L, 0L, 0L);
+    }
+
+    /** 剩余 token（不限时返回 -1，调用方据此区分"还剩 0"与"本来就不限"）。 */
+    public long tokenRemaining() {
+        return tokenLimit <= 0 ? -1L : Math.max(0L, tokenLimit - tokenUsed);
+    }
+
+    /** 剩余次数（不限时返回 -1）。 */
+    public long requestRemaining() {
+        return requestLimit <= 0 ? -1L : Math.max(0L, requestLimit - requestUsed);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaWebFilter.java
@@ -1,0 +1,173 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
+import com.richard.fyoung.customerwork.safety.security.UserAuthWebFilter;
+import com.richard.fyoung.customerwork.safety.security.UserJwtService;
+import com.richard.fyoung.customerwork.safety.security.UserPrincipal;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * 主体级速率配额过滤器：HTTP 侧的判定入口（登录用户 / 匿名 IP / API Key 接入方三类主体）。
+ *
+ * <p><b>Order 必须排在两个鉴权过滤器之后</b>（{@code +30} > ApiKey 的 {@code +10} 与 UserAuth 的 {@code +20}）：
+ * 主体身份由它们解析，抢在前面执行只会拿到一个还没鉴权的请求，把登录用户全按匿名 IP 限。</p>
+ *
+ * <p><b>为什么还要自己验一次令牌</b>：{@code UserAuthWebFilter} 只覆盖 {@code /api/customer/user/**}，
+ * 而 {@code /api/customer/chat} 是允许匿名的裸对话入口——带着登录态打这条路径的请求，
+ * 在那里不会被解析出用户。若不自己验，同一个人换条路径就能从"按人限"退化成"按 IP 限"，
+ * 而 IP 那一档还是共享的，等于给了一条绕过的门缝。已解析过的（属性里有主体）直接复用，不重复验签。</p>
+ *
+ * <p>放行时把主体写入 {@link QuotaSubjectContext} 与 Reactor Context，供链路末端的 token 记账取用；
+ * 超限返回 429 并带 {@code Retry-After}。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE + 30)
+public class SubjectQuotaWebFilter implements WebFilter {
+
+    /** 免于判定的路径：健康检查与监控端点被限会让探活先挂，那是自伤。 */
+    private static final String PATH_ACTUATOR = "/actuator";
+    private static final String PATH_HEALTH = "/api/customer/health";
+
+    /**
+     * 额度自查接口同样豁免。
+     *
+     * <p>它落在默认覆盖的 {@code /api/customer/user/} 之下，不豁免的话会有两个荒谬后果：
+     * 查一次"我还剩多少"就扣掉一次额度；以及额度耗尽后连"还剩多少"都查不到——
+     * 偏偏那正是用户最需要看到它的时刻。</p>
+     */
+    private static final String PATH_MY_QUOTA = "/api/customer/user/quota";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final CustomerWorkProperties properties;
+    private final SubjectQuotaGuard guard;
+
+    /** 可为 null：宿主没装配用户登录态时，登录用户一律退化为按 IP 判定。 */
+    private final UserJwtService jwtService;
+
+    public SubjectQuotaWebFilter(CustomerWorkProperties properties,
+                                 SubjectQuotaGuard guard,
+                                 UserJwtService jwtService) {
+        this.properties = properties;
+        this.guard = guard;
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        if (!guard.isEnabled()) {
+            return chain.filter(exchange);
+        }
+        String path = exchange.getRequest().getPath().value();
+        if (isExempt(path) || !matches(path)) {
+            return chain.filter(exchange);
+        }
+        QuotaSubject subject = resolveSubject(exchange);
+        SubjectQuotaDecision decision = guard.check(subject, path);
+        if (decision.shouldBlock()) {
+            return tooManyRequests(exchange, decision);
+        }
+        guard.recordRequest(subject);
+        return chainWithSubject(exchange, chain, subject);
+    }
+
+    /**
+     * 解析本次请求的限流主体。
+     *
+     * <p>优先级：已鉴权的用户 &gt; 自行验签得到的用户 &gt; API Key &gt; 来源 IP。
+     * 顺序即"身份可信度从高到低"，每退一级，额度的共享面就大一圈。</p>
+     */
+    private QuotaSubject resolveSubject(ServerWebExchange exchange) {
+        UserPrincipal principal = principalOf(exchange);
+        if (principal != null) {
+            return QuotaSubject.user(principal.userId());
+        }
+        String apiKey = exchange.getRequest().getHeaders()
+            .getFirst(properties.getSecurity().getAuth().getHeaderName());
+        if (apiKey != null && !apiKey.isBlank()) {
+            return QuotaSubject.apiKey(apiKey);
+        }
+        return QuotaSubject.ip(remoteAddress(exchange));
+    }
+
+    /** 取已鉴权主体；没有则尝试自行验签（覆盖允许匿名的对话入口）。 */
+    private UserPrincipal principalOf(ServerWebExchange exchange) {
+        Object attribute = exchange.getAttributes().get(UserAuthWebFilter.PRINCIPAL_ATTR);
+        if (attribute instanceof UserPrincipal principal) {
+            return principal;
+        }
+        if (jwtService == null) {
+            return null;
+        }
+        String header = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        // 验签失败不报错：这里只是想认出"他是谁"，令牌无效自有鉴权过滤器去拒，本类只管退回按 IP 限
+        return jwtService.verify(header.substring(BEARER_PREFIX.length())).orElse(null);
+    }
+
+    private static String remoteAddress(ServerWebExchange exchange) {
+        return exchange.getRequest().getRemoteAddress() == null
+            ? QuotaSubject.UNKNOWN_ID
+            : exchange.getRequest().getRemoteAddress().getAddress().getHostAddress();
+    }
+
+    /**
+     * 把主体写进下游上下文。
+     *
+     * <p>ThreadLocal 与 Reactor Context 都写，理由同租户上下文：前者供未发生线程切换时的同步代码读取，
+     * 后者在切到 boundedElastic（阻塞 IO、模型调用都在那里）时由自动传播还原。
+     * 只写一个，token 记账就会在某一类链路上拿不到主体。</p>
+     */
+    private Mono<Void> chainWithSubject(ServerWebExchange exchange, WebFilterChain chain, QuotaSubject subject) {
+        QuotaSubjectContext.set(subject);
+        return chain.filter(exchange)
+            .contextWrite(ctx -> ctx.put(QuotaSubjectContextThreadLocalAccessor.KEY, subject))
+            .doFinally(signal -> QuotaSubjectContext.clear());
+    }
+
+    private boolean matches(String path) {
+        SubjectQuotaProperties cfg = properties.getSubjectQuota();
+        List<String> paths = cfg.getPaths();
+        if (paths == null || paths.isEmpty()) {
+            return false;
+        }
+        for (String prefix : paths) {
+            if (prefix != null && !prefix.isBlank() && path.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isExempt(String path) {
+        return path.startsWith(PATH_ACTUATOR) || path.equals(PATH_HEALTH) || path.startsWith(PATH_MY_QUOTA);
+    }
+
+    /** 429 + Retry-After；响应体形如 {@code {"status":429,"error":"Too Many Requests","message":...}}。 */
+    private Mono<Void> tooManyRequests(ServerWebExchange exchange, SubjectQuotaDecision decision) {
+        exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+        exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        exchange.getResponse().getHeaders().set(HttpHeaders.RETRY_AFTER,
+            String.valueOf(decision.retryAfterSeconds()));
+        String body = "{\"status\":429,\"error\":\"Too Many Requests\",\"kind\":\"" + decision.kind()
+            + "\",\"retryAfterSeconds\":" + decision.retryAfterSeconds()
+            + ",\"message\":\"" + decision.message() + "\"}";
+        DataBuffer buffer = exchange.getResponse().bufferFactory()
+            .wrap(body.getBytes(StandardCharsets.UTF_8));
+        return exchange.getResponse().writeWith(Mono.just(buffer));
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/entity/SubjectQuotaHitDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/entity/SubjectQuotaHitDO.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customerwork.safety.subjectquota.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 超限命中记录持久化对象（贫血 DO，对应 {@code cw_subject_quota_hit}）。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_subject_quota_hit")
+public class SubjectQuotaHitDO {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String tenantId;
+    private String subjectType;
+    private String subjectId;
+    private String levelCode;
+    private String limitKind;
+    private Long used;
+    private Long limitValue;
+    private Integer windowSeconds;
+    private String action;
+    private String resource;
+    private Long createdAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/entity/SubjectQuotaLevelDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/entity/SubjectQuotaLevelDO.java
@@ -1,0 +1,34 @@
+package com.richard.fyoung.customerwork.safety.subjectquota.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 配额等级持久化对象（贫血 DO，对应 {@code cw_subject_quota_level}）。
+ *
+ * <p>显式持有 {@code tenantId} 的理由同 {@code TenantQuotaDO}：运营方跨租户维护等级时，
+ * 要读出"这一档属于谁"，靠拦截器自动补值读不出来。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@TableName("cw_subject_quota_level")
+public class SubjectQuotaLevelDO {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private String tenantId;
+    private String levelCode;
+    private String levelName;
+    private String subjectType;
+    private Integer windowSeconds;
+    private Long tokenLimit;
+    private Integer requestLimit;
+    private String exceedAction;
+    private Integer enabled;
+    private String remark;
+    private Long createdAtMs;
+    private Long updatedAtMs;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/mapper/SubjectQuotaHitMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/mapper/SubjectQuotaHitMapper.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customerwork.safety.subjectquota.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitRank;
+import com.richard.fyoung.customerwork.safety.subjectquota.entity.SubjectQuotaHitDO;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 超限命中 Mapper：写入与明细查询走 {@link BaseMapper}，排行是聚合、进 XML。
+ * @author owlzhangfq@gmail.com
+ */
+public interface SubjectQuotaHitMapper extends BaseMapper<SubjectQuotaHitDO> {
+
+    /** 命中排行：按主体分组计数，命中次数倒序。 */
+    List<SubjectQuotaHitRank> selectRank(@Param("tenantId") String tenantId,
+                                         @Param("sinceMs") long sinceMs,
+                                         @Param("limit") int limit);
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/mapper/SubjectQuotaLevelMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/mapper/SubjectQuotaLevelMapper.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customerwork.safety.subjectquota.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.entity.SubjectQuotaLevelDO;
+
+/**
+ * 配额等级 Mapper：CRUD 走 {@link BaseMapper}，
+ * {@link #selectFingerprint} 表达"等级表变没变"的单行聚合探测。
+ * @author owlzhangfq@gmail.com
+ */
+public interface SubjectQuotaLevelMapper extends BaseMapper<SubjectQuotaLevelDO> {
+
+    /** 等级表版本指纹（供快照刷新判断是否需要重新加载）。 */
+    String selectFingerprint();
+}

--- a/customer-work-starter/src/main/resources/customerwork/mapper/SubjectQuotaHitMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/SubjectQuotaHitMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaHitMapper">
+
+    <!--
+      命中排行："谁在刷"看板的数据源。按 (主体类型, 主体标识) 分组，
+      等级取 MAX 而非分组维度：同一主体在统计区间内可能被改过等级，
+      把它拆成两行只会让运营以为是两个不同的人。
+    -->
+    <select id="selectRank" resultType="com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitRank">
+        SELECT subject_type    AS subjectType,
+               subject_id      AS subjectId,
+               MAX(level_code) AS levelCode,
+               COUNT(*)        AS hitCount,
+               MAX(created_at_ms) AS lastHitAtMs
+        FROM cw_subject_quota_hit
+        WHERE tenant_id = #{tenantId}
+          AND created_at_ms &gt;= #{sinceMs}
+        GROUP BY subject_type, subject_id
+        ORDER BY hitCount DESC, lastHitAtMs DESC
+        LIMIT #{limit}
+    </select>
+</mapper>

--- a/customer-work-starter/src/main/resources/customerwork/mapper/SubjectQuotaLevelMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/SubjectQuotaLevelMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.richard.fyoung.customerwork.safety.subjectquota.mapper.SubjectQuotaLevelMapper">
+
+    <!--
+      等级表版本指纹：行数 : 最大更新时间 : 关键额度求和。
+      三者合一是因为单看任何一个都会漏：只看行数漏改额度，只看最大更新时间漏"删一条又加一条"，
+      只看求和漏"一档 +100、另一档 -100"。含停用行——停用本身就是一次需要生效的变更。
+    -->
+    <select id="selectFingerprint" resultType="java.lang.String">
+        SELECT CONCAT(COUNT(*), ':', COALESCE(MAX(updated_at_ms), 0), ':',
+                      COALESCE(SUM(token_limit + request_limit + window_seconds), 0))
+        FROM cw_subject_quota_level
+    </select>
+</mapper>

--- a/customer-work-starter/src/main/resources/db/customerwork/migration/V4__subject_rate_quota.sql
+++ b/customer-work-starter/src/main/resources/db/customerwork/migration/V4__subject_rate_quota.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- 主体级速率配额：每个用户 / 每个匿名 IP / 每把 API Key 在滚动窗口内的 token 量与请求次数上限。
+--
+-- 与 cw_tenant_quota 是两件事，刻意分表而不是加个维度列：
+--   · 租户配额  —— 自然日/月对齐，要跟账单对得上，管的是"这个客户这个月能花多少钱"；
+--   · 主体配额  —— 最近 N 秒滚动，跟账单无关，管的是"这个调用者这半小时能用多少"。
+-- 周期语义、判定时机、超限处置都不同，合表只会让两套逻辑互相牵制。
+-- ============================================================================
+
+-- 等级定义：一档额度的完整描述，租户内 level_code 唯一
+CREATE TABLE IF NOT EXISTS `cw_subject_quota_level` (
+    `tenant_id`      VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `level_code`     VARCHAR(64) NOT NULL COMMENT '等级编码，如 free/vip/anonymous',
+    `level_name`     VARCHAR(128) NOT NULL COMMENT '等级名称（运营可读）',
+    `subject_type`   VARCHAR(32) NOT NULL DEFAULT 'USER' COMMENT '适用主体: USER 登录用户 / IP 匿名 / API_KEY 接入方',
+    `window_seconds` INT NOT NULL DEFAULT 1800 COMMENT '滚动窗口长度（秒），1800=30分钟',
+    `token_limit`    BIGINT NOT NULL DEFAULT 0 COMMENT '窗口内 token 上限，0=不限',
+    `request_limit`  INT NOT NULL DEFAULT 0 COMMENT '窗口内请求次数上限，0=不限',
+    `exceed_action`  VARCHAR(16) NOT NULL DEFAULT 'BLOCK' COMMENT '超限处置: BLOCK 拦截 / WARN 仅记录',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `remark`         VARCHAR(255) COMMENT '备注',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_squota_level` (`tenant_id`, `level_code`),
+    INDEX `idx_squota_level_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='主体配额等级（每租户每档一条）';
+
+-- 超限命中记录：只在真的触顶那一刻写一条，正常流量不产生任何写入。
+-- 落的是"命中"而不是"实时余额"：余额在计数器里（进程内或 Redis），后台是另一个进程，
+-- 读它要么被迫依赖 Redis 模式、要么读到只属于某个副本的数；而运营真正要回答的是"谁在刷、哪档配紧了"。
+CREATE TABLE IF NOT EXISTS `cw_subject_quota_hit` (
+    `tenant_id`      VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `subject_type`   VARCHAR(32) NOT NULL COMMENT '主体类型: USER/IP/API_KEY',
+    `subject_id`     VARCHAR(128) NOT NULL COMMENT '主体标识（API Key 已做 SHA-256 指纹，不含明文）',
+    `level_code`     VARCHAR(64) COMMENT '判定所依据的等级',
+    `limit_kind`     VARCHAR(16) NOT NULL COMMENT '触顶维度: TOKEN/REQUEST',
+    `used`           BIGINT NOT NULL DEFAULT 0 COMMENT '触顶时已用量',
+    `limit_value`    BIGINT NOT NULL DEFAULT 0 COMMENT '触顶时的上限',
+    `window_seconds` INT NOT NULL DEFAULT 0 COMMENT '滚动窗口长度（秒）',
+    `action`         VARCHAR(16) NOT NULL DEFAULT 'BLOCK' COMMENT '当时处置: BLOCK 真拦了 / WARN 只记录',
+    `resource`       VARCHAR(255) COMMENT '触发位置（HTTP 路径或 ws:chat）',
+    `created_at_ms`  BIGINT NOT NULL COMMENT '命中时刻（毫秒）',
+    INDEX `idx_squota_hit_tenant_time` (`tenant_id`, `created_at_ms`),
+    INDEX `idx_squota_hit_subject` (`tenant_id`, `subject_type`, `subject_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='主体配额超限命中记录';
+
+-- 用户等级绑定落在账户表上，不另建映射表：等级是"这个账户能用多少"的自身属性，
+-- 与启停、头像同类；拆出去只会让每次限流判定多一次跨表查询。空值 = 走配置里的默认档。
+ALTER TABLE `cw_user` ADD COLUMN `level_code` VARCHAR(64) DEFAULT NULL COMMENT '配额等级编码（空=默认档）';
+
+-- 出厂五档种子（仅默认租户）。功能默认关闭，故种子不改变任何现有行为，
+-- 但让后台一打开就有东西可改——空表加一份看不见的"内置档"，运营只会问"到底哪个在生效"。
+-- free/anonymous/api-key 三档的数值与 SubjectQuotaProperties 的内置档保持一致，两处不能漂移。
+-- 次数上限看着宽是因为口径含查询请求（默认覆盖整个 /api/customer/user/ 面），
+-- 真正卡成本的是 token 那一维——它只在模型调用后累加。
+INSERT INTO `cw_subject_quota_level`
+    (`tenant_id`, `level_code`, `level_name`, `subject_type`, `window_seconds`,
+     `token_limit`, `request_limit`, `exceed_action`, `enabled`, `remark`,
+     `created_at_ms`, `updated_at_ms`)
+VALUES
+    ('default', 'free',      '免费用户', 'USER',    1800,   50000,  100, 'BLOCK', 1, '注册用户默认档', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'vip',       'VIP用户',  'USER',    1800,  200000,  300, 'BLOCK', 1, '付费用户',       UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'svip',      'SVIP用户', 'USER',    1800, 1000000, 1000, 'BLOCK', 1, '高级付费用户',   UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'anonymous', '匿名访客', 'IP',      1800,   10000,   20, 'BLOCK', 1, '未登录，按来源IP计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'api-key',   '接入方',   'API_KEY', 3600, 1000000, 2000, 'BLOCK', 1, '服务端接入，按Key指纹计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/user/UserAccountServiceTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/user/UserAccountServiceTest.java
@@ -102,4 +102,37 @@ class UserAccountServiceTest {
         init();
         assertThrows(IllegalStateException.class, () -> service.updateAvatar("U-ghost", "/api/avatars/x.png"));
     }
+
+    @Test
+    void register_shouldApplyDefaultLevel() {
+        UserAccountService withLevel = new UserAccountService(new InMemoryUserAccountStore(), "free");
+        UserAccount account = withLevel.register("levon", "pwd12345", "利文", null);
+        assertEquals("free", account.getLevelCode(), "注册即落默认档，运营才能在后台看到这个人现在是哪一档");
+    }
+
+    @Test
+    void updateLevel_shouldChangeAndPersist() {
+        InMemoryUserAccountStore store = new InMemoryUserAccountStore();
+        UserAccountService svc = new UserAccountService(store, "free");
+        UserAccount created = svc.register("mia", "pwd12345", "米娅", null);
+
+        svc.updateLevel(created.getId(), "vip");
+        assertEquals("vip", store.findById(created.getId()).orElseThrow().getLevelCode());
+
+        svc.updateLevel(created.getId(), null);
+        assertNull(store.findById(created.getId()).orElseThrow().getLevelCode(),
+            "传 null 表示取消特批、回到默认档，必须真的写空");
+    }
+
+    @Test
+    void updateLevel_shouldNotifyListener() {
+        InMemoryUserAccountStore store = new InMemoryUserAccountStore();
+        java.util.List<String> notified = new java.util.ArrayList<>();
+        UserAccountService svc = new UserAccountService(store, "free", notified::add);
+        UserAccount created = svc.register("nate", "pwd12345", "内特", null);
+
+        svc.updateLevel(created.getId(), "vip");
+        // 不广播的话，同进程改完档也要等绑定缓存过期——而那层缓存本是为跨进程场景设的
+        assertEquals(java.util.List.of(created.getId()), notified, "改档必须广播给配额侧失效缓存");
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrationIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrationIntegrationTest.java
@@ -53,8 +53,8 @@ class CustomerWorkSchemaMigrationIntegrationTest {
     private void verifyEmptyDatabaseMigration(String database) throws Exception {
         try (HikariDataSource dataSource = dataSource(database, "flyway-empty-test")) {
             migrate(dataSource, database);
-            assertEquals(42, countBusinessTables(dataSource));
-            assertEquals(3, countHistoryRows(dataSource));
+            assertEquals(44, countBusinessTables(dataSource));
+            assertEquals(4, countHistoryRows(dataSource));
             assertTrue(columnExists(dataSource, "cw_dead_letter", "lease_owner"));
             assertEquals(0, countHistoryVersion(dataSource, "0"), "空库不应写 baseline 记录");
         }
@@ -72,8 +72,10 @@ class CustomerWorkSchemaMigrationIntegrationTest {
 
             assertTrue(columnExists(dataSource, "cw_user", "avatar_url"));
             assertTrue(columnExists(dataSource, "cw_chat_attachment", "message_id"));
-            assertEquals(42, countBusinessTables(dataSource));
-            assertEquals(4, countHistoryRows(dataSource));
+            // V4 给存量 cw_user 加的配额等级列：这张表是 V1 就建好的，加列只能靠迁移补
+            assertTrue(columnExists(dataSource, "cw_user", "level_code"));
+            assertEquals(44, countBusinessTables(dataSource));
+            assertEquals(5, countHistoryRows(dataSource));
             assertEquals(1, countHistoryVersion(dataSource, "0"), "非空存量库必须先登记 baseline 0");
         }
     }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/counter/InMemoryWindowCounterTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/counter/InMemoryWindowCounterTest.java
@@ -69,4 +69,30 @@ class InMemoryWindowCounterTest {
         Thread.sleep(1100);
         assertTrue(counter.tryAcquireSliding("s", 1, 1), "窗口滑过后应恢复放行");
     }
+
+    @Test
+    void slidingSum_shouldAccumulateAmounts() {
+        assertEquals(300L, counter.incrementSlidingSum("tok", 300L, 1800));
+        assertEquals(500L, counter.incrementSlidingSum("tok", 200L, 1800), "同窗口内累加的是量不是次数");
+        assertEquals(500L, counter.currentSlidingSum("tok", 1800), "只读不产生副作用");
+    }
+
+    @Test
+    void slidingSum_shouldSeparateKeys() {
+        counter.incrementSlidingSum("a", 100L, 1800);
+        assertEquals(0L, counter.currentSlidingSum("b", 1800), "不同计数键互不干扰");
+    }
+
+    @Test
+    void slidingSum_shouldResetWhenWindowLengthChanges() {
+        counter.incrementSlidingSum("tok", 100L, 1800);
+        // 窗口长度变了，旧桶是按另一种口径切的，混着算出来的数没有意义
+        assertEquals(0L, counter.currentSlidingSum("tok", 3600), "口径变更后按 0 计");
+        assertEquals(50L, counter.incrementSlidingSum("tok", 50L, 3600), "下一次写入用新口径重开");
+    }
+
+    @Test
+    void slidingSum_shouldReturnZero_forUnknownKey() {
+        assertEquals(0L, counter.currentSlidingSum("never-written", 1800));
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectTest.java
@@ -1,0 +1,42 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 主体值对象单测：API Key 只留指纹、计数键按类型隔离、空值兜底。
+ * @author owlzhangfq@gmail.com
+ */
+class QuotaSubjectTest {
+
+    @Test
+    void apiKey_shouldNotKeepPlainText() {
+        QuotaSubject subject = QuotaSubject.apiKey("sk-super-secret-key");
+        assertFalse(subject.id().contains("secret"), "明文 Key 会进 Redis 键、命中表与日志，绝不能保留");
+        assertEquals(16, subject.id().length(), "指纹取 SHA-256 前 16 位十六进制");
+    }
+
+    @Test
+    void apiKey_shouldBeStable_forSameKey() {
+        assertEquals(QuotaSubject.apiKey("sk-a").id(), QuotaSubject.apiKey("sk-a").id(),
+            "同一把 Key 必须落到同一份额度上");
+        assertNotEquals(QuotaSubject.apiKey("sk-a").id(), QuotaSubject.apiKey("sk-b").id());
+    }
+
+    @Test
+    void counterKey_shouldSeparateTypes() {
+        // 同名标识但类型不同（如用户 ID 恰好等于某个 IP 字面量）不得共享额度
+        assertNotEquals(QuotaSubject.user("1.2.3.4").counterKey(), QuotaSubject.ip("1.2.3.4").counterKey());
+    }
+
+    @Test
+    void blankIdentifier_shouldFallBackToUnknown() {
+        assertEquals(QuotaSubject.UNKNOWN_ID, QuotaSubject.user("  ").id(),
+            "解析不出身份也要有一份额度可算，否则等于放行");
+        assertTrue(QuotaSubject.ip(null).counterKey().endsWith(QuotaSubject.UNKNOWN_ID));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolverTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolverTest.java
@@ -1,0 +1,148 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 等级解析单测：绑定优先、按主体类型取配置档、租户覆盖平台档、回落内置档、绑定缓存与失效。
+ * @author owlzhangfq@gmail.com
+ */
+class SubjectLevelResolverTest {
+
+    private static final String TENANT = "acme";
+
+    private final InMemorySubjectQuotaLevelStore store = new InMemorySubjectQuotaLevelStore();
+    private final SubjectQuotaProperties properties = new SubjectQuotaProperties();
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    private SubjectLevelResolver resolver(SubjectLevelBinding binding) {
+        return new SubjectLevelResolver(new SubjectQuotaLevelProvider(store, false), binding, properties);
+    }
+
+    private void saveLevel(String tenantId, String levelCode, long tokenLimit) {
+        store.save(new SubjectQuotaLevel(null, tenantId, levelCode, levelCode, QuotaSubjectType.USER,
+            1800, tokenLimit, 0, SubjectExceedAction.BLOCK, true, null));
+    }
+
+    @Test
+    void resolve_shouldPreferBoundLevel_forUser() {
+        TenantContext.set(TENANT);
+        saveLevel(TENANT, "vip", 999);
+        SubjectQuotaLevel level = resolver(userId -> Optional.of("vip")).resolve(QuotaSubject.user("U-1"));
+        assertEquals("vip", level.levelCode(), "用户绑定的等级优先于默认档");
+    }
+
+    @Test
+    void resolve_shouldFallBackToDefaultUserLevel_whenNotBound() {
+        TenantContext.set(TENANT);
+        saveLevel(TENANT, "free", 111);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1"));
+        assertEquals("free", level.levelCode(), "未绑定的用户走配置里的默认档");
+    }
+
+    @Test
+    void resolve_shouldUseAnonymousLevel_forIpSubject() {
+        TenantContext.set(TENANT);
+        SubjectQuotaLevel level = resolver(userId -> Optional.of("vip")).resolve(QuotaSubject.ip("1.2.3.4"));
+        assertEquals("anonymous", level.levelCode(), "匿名主体不看用户绑定，走匿名档");
+    }
+
+    @Test
+    void resolve_shouldUseApiKeyLevel_forApiKeySubject() {
+        TenantContext.set(TENANT);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.apiKey("sk-abc"));
+        assertEquals("api-key", level.levelCode());
+    }
+
+    @Test
+    void resolve_shouldPreferTenantLevel_overPlatformLevel() {
+        TenantContext.set(TENANT);
+        saveLevel(TenantContext.DEFAULT, "free", 100);
+        saveLevel(TENANT, "free", 500);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1"));
+        assertEquals(500L, level.tokenLimit(), "租户自己配的那一档优先于平台默认租户的同名档");
+    }
+
+    @Test
+    void resolve_shouldFallBackToPlatformLevel_whenTenantHasNone() {
+        TenantContext.set(TENANT);
+        saveLevel(TenantContext.DEFAULT, "free", 100);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1"));
+        assertEquals(100L, level.tokenLimit(), "租户没配时回落平台默认租户，免去每个租户重复配一遍");
+    }
+
+    @Test
+    void resolve_shouldFallBackToBuiltinLevel_whenStoreEmpty() {
+        TenantContext.set(TENANT);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1"));
+        assertNotNull(level, "库里没有任何等级时必须回落内置档，否则开关一开却什么都不限");
+        assertEquals("free", level.levelCode());
+        assertEquals(50000L, level.tokenLimit(), "内置档数值须与出厂种子一致");
+    }
+
+    @Test
+    void resolve_shouldReturnNull_whenNoBuiltinMatches() {
+        TenantContext.set(TENANT);
+        properties.setBuiltinLevels(new HashMap<>());
+        assertNull(resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1")),
+            "既没配也没内置档时返回 null（= 该主体不受限）");
+    }
+
+    @Test
+    void resolve_shouldCacheBinding_untilEvicted() {
+        TenantContext.set(TENANT);
+        saveLevel(TENANT, "vip", 1);
+        AtomicInteger lookups = new AtomicInteger();
+        SubjectLevelResolver resolver = resolver(userId -> {
+            lookups.incrementAndGet();
+            return Optional.of("vip");
+        });
+
+        resolver.resolve(QuotaSubject.user("U-1"));
+        resolver.resolve(QuotaSubject.user("U-1"));
+        assertEquals(1, lookups.get(), "绑定查询必须走缓存——它在每个请求的热路径上");
+
+        resolver.evictBinding("U-1");
+        resolver.resolve(QuotaSubject.user("U-1"));
+        assertEquals(2, lookups.get(), "主动失效后应重新查一次");
+    }
+
+    @Test
+    void resolve_shouldCacheAbsentBinding() {
+        TenantContext.set(TENANT);
+        AtomicInteger lookups = new AtomicInteger();
+        SubjectLevelResolver resolver = resolver(userId -> {
+            lookups.incrementAndGet();
+            return Optional.empty();
+        });
+
+        resolver.resolve(QuotaSubject.user("U-1"));
+        resolver.resolve(QuotaSubject.user("U-1"));
+        // "查过但没绑定"也要缓存，否则未绑定的用户每个请求都打一次库——那是绝大多数用户
+        assertEquals(1, lookups.get(), "未绑定的结果同样要缓存");
+    }
+
+    @Test
+    void resolve_shouldUseDefaultTenant_whenContextMissing() {
+        saveLevel(TenantContext.DEFAULT, "free", 66);
+        Map<String, SubjectQuotaProperties.Level> none = new HashMap<>();
+        properties.setBuiltinLevels(none);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1"));
+        assertEquals(66L, level.tokenLimit(), "没有租户上下文时按默认租户算，而不是直接不限");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaAssemblyTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaAssemblyTest.java
@@ -1,0 +1,67 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 装配门控测试：确认这一批 Bean 真的进了容器，而不是只在单测里被 new 出来过。
+ *
+ * <p><b>为什么必须有这个测试</b>：语义缓存踩过一模一样的坑——Service 层 21 条用例全绿，
+ * 功能却整体静默失效，因为它依赖的 Bean 从来没被装配过（{@code ObjectProvider.getIfAvailable()} 恒为 null）。
+ * 只测逻辑照不出"Bean 根本不存在"。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class SubjectQuotaAssemblyTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(PropertiesHolder.class, SubjectQuotaConfig.class));
+
+    @Test
+    void shouldAssembleAllBeans_withDefaults() {
+        runner.run(context -> {
+            assertEquals(1, context.getBeanNamesForType(SubjectQuotaLevelStore.class).length);
+            assertEquals(1, context.getBeanNamesForType(SubjectQuotaHitStore.class).length);
+            assertEquals(1, context.getBeanNamesForType(SubjectQuotaLevelProvider.class).length);
+            assertEquals(1, context.getBeanNamesForType(SubjectLevelResolver.class).length);
+            assertEquals(1, context.getBeanNamesForType(SubjectQuotaGuard.class).length);
+            assertEquals(1, context.getBeanNamesForType(SubjectQuotaWebFilter.class).length,
+                "HTTP 判定入口缺了，功能对三类 HTTP 主体就整体不生效");
+        });
+    }
+
+    @Test
+    void guard_shouldBeDisabled_byDefault() {
+        runner.run(context -> assertFalse(context.getBean(SubjectQuotaGuard.class).isEnabled(),
+            "默认关闭：没开时行为必须与引入本功能之前完全一致"));
+    }
+
+    @Test
+    void guard_shouldBeEnabled_whenConfigured() {
+        runner.withPropertyValues("customer-work.subject-quota.enabled=true")
+            .run(context -> assertTrue(context.getBean(SubjectQuotaGuard.class).isEnabled()));
+    }
+
+    @Test
+    void store_shouldFallBackToMemory_whenJdbcMapperMissing() {
+        // 配了 jdbc 却没有 Mapper（持久层没装配）：让位给内存实现而不是启动失败——
+        // 限流是旁路保护，不该拖垮主链路的可启动性
+        runner.withPropertyValues("customer-work.subject-quota.store-mode=jdbc")
+            .run(context -> {
+                assertFalse(context.getStartupFailure() != null, "缺 Mapper 不得导致启动失败");
+                assertTrue(context.getBean(SubjectQuotaLevelStore.class) instanceof InMemorySubjectQuotaLevelStore);
+            });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(CustomerWorkProperties.class)
+    static class PropertiesHolder {
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaGuardTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaGuardTest.java
@@ -1,0 +1,211 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
+import com.richard.fyoung.customerwork.infra.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 主体配额判定单测：关闭放行、无等级放行、两个维度各自触顶、WARN 不拦、被拒不占额度、用量快照。
+ * @author owlzhangfq@gmail.com
+ */
+class SubjectQuotaGuardTest {
+
+    private static final String TENANT = "acme";
+
+    private final InMemorySubjectQuotaLevelStore levelStore = new InMemorySubjectQuotaLevelStore();
+    private final InMemorySubjectQuotaHitStore hitStore = new InMemorySubjectQuotaHitStore();
+    private final InMemoryWindowCounter counter = new InMemoryWindowCounter();
+    private final SubjectQuotaProperties properties = new SubjectQuotaProperties();
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+        QuotaSubjectContext.clear();
+    }
+
+    private SubjectQuotaGuard guard(boolean enabled) {
+        // 内置档清空：本类要测的是库里配的等级，留着出厂档会让"没配等级"这个用例失去意义
+        properties.setBuiltinLevels(null);
+        SubjectQuotaLevelProvider provider = new SubjectQuotaLevelProvider(levelStore, false);
+        SubjectLevelResolver resolver = new SubjectLevelResolver(provider, userId -> Optional.of("gold"), properties);
+        return new SubjectQuotaGuard(resolver, counter, hitStore, enabled);
+    }
+
+    private void saveLevel(long tokenLimit, int requestLimit, SubjectExceedAction action) {
+        levelStore.save(new SubjectQuotaLevel(null, TENANT, "gold", "金卡", QuotaSubjectType.USER,
+            1800, tokenLimit, requestLimit, action, true, null));
+    }
+
+    @Test
+    void check_shouldAllow_whenDisabled() {
+        TenantContext.set(TENANT);
+        saveLevel(10, 1, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(false);
+        g.recordRequest(QuotaSubject.user("U-1"));
+        g.recordTokens(QuotaSubject.user("U-1"), 999);
+
+        assertTrue(g.check(QuotaSubject.user("U-1"), "/api/customer/chat").allowed(),
+            "功能关闭时一律放行，且不记账");
+    }
+
+    @Test
+    void check_shouldAllow_whenNoLevelConfigured() {
+        TenantContext.set(TENANT);
+        assertTrue(guard(true).check(QuotaSubject.user("U-1"), "/x").allowed(), "查不到等级等于不受限");
+    }
+
+    @Test
+    void check_shouldAllow_whenSubjectMissing() {
+        TenantContext.set(TENANT);
+        saveLevel(10, 1, SubjectExceedAction.BLOCK);
+        assertTrue(guard(true).check(null, "/x").allowed(), "无主体（内部任务）应放行而不是报错");
+    }
+
+    @Test
+    void check_shouldBlock_whenRequestLimitReached() {
+        TenantContext.set(TENANT);
+        saveLevel(0, 2, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+
+        g.recordRequest(subject);
+        assertTrue(g.check(subject, "/x").allowed(), "第 2 次请求仍在额度内");
+        g.recordRequest(subject);
+
+        SubjectQuotaDecision decision = g.check(subject, "/x");
+        assertFalse(decision.allowed(), "达到次数上限应拒绝");
+        assertTrue(decision.shouldBlock());
+        assertEquals(SubjectQuotaDecision.LimitKind.REQUEST, decision.kind());
+        assertEquals(1800, decision.retryAfterSeconds(), "重试建议给的是窗口长度这个上界");
+    }
+
+    @Test
+    void check_shouldBlock_whenTokenLimitReached() {
+        TenantContext.set(TENANT);
+        saveLevel(100, 0, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+
+        g.recordTokens(subject, 99);
+        assertTrue(g.check(subject, "/x").allowed(), "未达上限放行");
+        g.recordTokens(subject, 1);
+
+        SubjectQuotaDecision decision = g.check(subject, "/x");
+        assertFalse(decision.allowed());
+        assertEquals(SubjectQuotaDecision.LimitKind.TOKEN, decision.kind());
+        assertEquals(100L, decision.used());
+    }
+
+    @Test
+    void check_shouldReportRequestKind_whenBothLimitsReached() {
+        TenantContext.set(TENANT);
+        saveLevel(10, 1, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+        g.recordRequest(subject);
+        g.recordTokens(subject, 50);
+
+        // 两个维度都超时报次数：那更贴近用户刚才做的事（"你问得太频繁"比"额度用完了"好理解）
+        assertEquals(SubjectQuotaDecision.LimitKind.REQUEST, g.check(subject, "/x").kind());
+    }
+
+    @Test
+    void check_shouldNotBlock_whenActionIsWarn() {
+        TenantContext.set(TENANT);
+        saveLevel(0, 1, SubjectExceedAction.WARN);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+        g.recordRequest(subject);
+
+        SubjectQuotaDecision decision = g.check(subject, "/x");
+        assertFalse(decision.allowed(), "WARN 档同样判定为超限");
+        assertFalse(decision.shouldBlock(), "但不拦——观察期就是靠这个区分成立的");
+    }
+
+    @Test
+    void check_shouldNotConsumeQuota_whenRejected() {
+        TenantContext.set(TENANT);
+        saveLevel(0, 1, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+        g.recordRequest(subject);
+
+        g.check(subject, "/x");
+        g.check(subject, "/x");
+
+        // 判定只读、记账在放行之后，所以被拒的请求不会把窗口越推越远
+        assertEquals(1L, g.usage(subject).requestUsed(), "被拒绝的请求不得计入用量");
+    }
+
+    @Test
+    void usage_shouldReportRemaining() {
+        TenantContext.set(TENANT);
+        saveLevel(1000, 10, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+        g.recordRequest(subject);
+        g.recordTokens(subject, 200);
+
+        SubjectQuotaUsage usage = g.usage(subject);
+        assertEquals("gold", usage.levelCode());
+        assertEquals(200L, usage.tokenUsed());
+        assertEquals(800L, usage.tokenRemaining());
+        assertEquals(9L, usage.requestRemaining());
+    }
+
+    @Test
+    void usage_shouldReportUnlimited_whenNoLevel() {
+        TenantContext.set(TENANT);
+        SubjectQuotaUsage usage = guard(true).usage(QuotaSubject.user("U-1"));
+        assertNull(usage.levelCode());
+        assertEquals(-1L, usage.tokenRemaining(), "不限时返回 -1，与'还剩 0'区分开");
+    }
+
+    @Test
+    void check_shouldNotShareQuota_acrossSubjects() {
+        TenantContext.set(TENANT);
+        saveLevel(0, 1, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        g.recordRequest(QuotaSubject.user("U-1"));
+
+        assertTrue(g.check(QuotaSubject.user("U-2"), "/x").allowed(), "额度按主体独立，不得互相挤占");
+    }
+
+    /** 轮询等待异步落库；超时即返回当前值，让断言给出真实差异而不是一句超时。 */
+    private int awaitHitCount(int expected) {
+        long deadline = System.currentTimeMillis() + 2000L;
+        int size = hitStore.findRecent(TENANT, 0L, 10).size();
+        while (size < expected && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(20L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            size = hitStore.findRecent(TENANT, 0L, 10).size();
+        }
+        return size;
+    }
+
+    @Test
+    void check_shouldRecordHit_whenExceeded() {
+        TenantContext.set(TENANT);
+        saveLevel(0, 1, SubjectExceedAction.BLOCK);
+        SubjectQuotaGuard g = guard(true);
+        QuotaSubject subject = QuotaSubject.user("U-1");
+        g.recordRequest(subject);
+        g.check(subject, "/api/customer/chat");
+
+        // 命中落库是异步提交的（判定在响应式链路上，阻塞 IO 不能占事件循环线程），故这里要等一等
+        assertEquals(1, awaitHitCount(1), "超限应留下一条命中记录");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaWebFilterTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaWebFilterTest.java
@@ -1,0 +1,145 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.infra.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * HTTP 判定入口单测：路径匹配、主体解析优先级、超限 429、豁免路径、上下文写入。
+ * @author owlzhangfq@gmail.com
+ */
+class SubjectQuotaWebFilterTest {
+
+    private static final String CHAT_PATH = "/api/customer/chat";
+
+    private final CustomerWorkProperties properties = new CustomerWorkProperties();
+    private final InMemorySubjectQuotaLevelStore levelStore = new InMemorySubjectQuotaLevelStore();
+    private final InMemoryWindowCounter counter = new InMemoryWindowCounter();
+
+    /** 记录链路末端看到的主体，用来验证上下文确实写进去了。 */
+    private final AtomicReference<QuotaSubject> seen = new AtomicReference<>();
+
+    private final WebFilterChain chain = exchange -> Mono.fromRunnable(
+        () -> seen.set(QuotaSubjectContext.get()));
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+        QuotaSubjectContext.clear();
+    }
+
+    private SubjectQuotaGuard guard(boolean enabled) {
+        properties.getSubjectQuota().setEnabled(enabled);
+        SubjectLevelResolver resolver = new SubjectLevelResolver(
+            new SubjectQuotaLevelProvider(levelStore, false), userId -> Optional.empty(),
+            properties.getSubjectQuota());
+        return new SubjectQuotaGuard(resolver, counter, new InMemorySubjectQuotaHitStore(), enabled);
+    }
+
+    private SubjectQuotaWebFilter filter(SubjectQuotaGuard guard) {
+        return new SubjectQuotaWebFilter(properties, guard, null);
+    }
+
+    private MockServerWebExchange get(String path) {
+        return MockServerWebExchange.from(MockServerHttpRequest.get(path)
+            .remoteAddress(new java.net.InetSocketAddress("10.0.0.7", 12345)));
+    }
+
+    @Test
+    void filter_shouldPassThrough_whenDisabled() {
+        SubjectQuotaWebFilter f = filter(guard(false));
+        StepVerifier.create(f.filter(get(CHAT_PATH), chain)).verifyComplete();
+        assertNull(seen.get(), "功能关闭时连上下文都不该写——省掉一次无谓的 ThreadLocal 写入");
+    }
+
+    @Test
+    void filter_shouldPassThrough_whenPathNotCovered() {
+        SubjectQuotaWebFilter f = filter(guard(true));
+        StepVerifier.create(f.filter(get("/api/other/thing"), chain)).verifyComplete();
+        assertNull(seen.get(), "清单外的路径不判定");
+    }
+
+    @Test
+    void filter_shouldExemptQuotaSelfCheck() {
+        // 不豁免的话：查一次"我还剩多少"就扣一次额度，且额度耗尽后连查都查不了
+        SubjectQuotaWebFilter f = filter(guard(true));
+        StepVerifier.create(f.filter(get("/api/customer/user/quota"), chain)).verifyComplete();
+        assertNull(seen.get());
+    }
+
+    @Test
+    void filter_shouldResolveIpSubject_whenNoCredential() {
+        SubjectQuotaWebFilter f = filter(guard(true));
+        StepVerifier.create(f.filter(get(CHAT_PATH), chain)).verifyComplete();
+
+        assertNotNull(seen.get());
+        assertEquals(QuotaSubjectType.IP, seen.get().type(), "无凭据时按来源 IP 算");
+        assertEquals("10.0.0.7", seen.get().id());
+    }
+
+    @Test
+    void filter_shouldResolveApiKeySubject_whenHeaderPresent() {
+        String header = properties.getSecurity().getAuth().getHeaderName();
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get(CHAT_PATH).header(header, "sk-abc")
+                .remoteAddress(new java.net.InetSocketAddress("10.0.0.7", 12345)));
+
+        StepVerifier.create(filter(guard(true)).filter(exchange, chain)).verifyComplete();
+        assertEquals(QuotaSubjectType.API_KEY, seen.get().type(), "带 Key 时按接入方算，不退化到 IP");
+    }
+
+    @Test
+    void filter_shouldPreferAuthenticatedPrincipal() {
+        MockServerWebExchange exchange = get(CHAT_PATH);
+        exchange.getAttributes().put(
+            com.richard.fyoung.customerwork.safety.security.UserAuthWebFilter.PRINCIPAL_ATTR,
+            new com.richard.fyoung.customerwork.safety.security.UserPrincipal(
+                "U-9", "alice", "Alice", TenantContext.DEFAULT));
+
+        StepVerifier.create(filter(guard(true)).filter(exchange, chain)).verifyComplete();
+        assertEquals(QuotaSubjectType.USER, seen.get().type(), "已鉴权的用户优先于 IP");
+        assertEquals("U-9", seen.get().id());
+    }
+
+    @Test
+    void filter_shouldReturn429_whenExceeded() {
+        levelStore.save(new SubjectQuotaLevel(null, TenantContext.DEFAULT, "anonymous", "匿名",
+            QuotaSubjectType.IP, 1800, 0, 1, SubjectExceedAction.BLOCK, true, null));
+        SubjectQuotaGuard g = guard(true);
+        SubjectQuotaWebFilter f = filter(g);
+
+        StepVerifier.create(f.filter(get(CHAT_PATH), chain)).verifyComplete();
+
+        MockServerWebExchange second = get(CHAT_PATH);
+        StepVerifier.create(f.filter(second, chain)).verifyComplete();
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, second.getResponse().getStatusCode());
+        assertEquals(List.of("1800"), second.getResponse().getHeaders().get(HttpHeaders.RETRY_AFTER),
+            "429 必须带 Retry-After，否则客户端只能瞎猜什么时候能重试");
+    }
+
+    @Test
+    void filter_shouldClearContext_afterRequest() {
+        SubjectQuotaWebFilter f = filter(guard(true));
+        StepVerifier.create(f.filter(get(CHAT_PATH), chain)).verifyComplete();
+        assertTrue(QuotaSubjectContext.get() == null,
+            "请求结束必须清理 ThreadLocal，否则线程复用会把上一个请求的身份带给下一个人");
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -119,6 +119,7 @@
 | Higress AI 网关 | `HigressToolkitConfigurer` | 关 | `higress.enabled=true` |
 | Nacos 配置中心（提示词热更新） | `NacosPromptService` | 关 | `nacos.enabled=true` |
 | 接入层安全（鉴权/**滑动窗口限流**） | `ApiKeyAuthWebFilter` / `RateLimitWebFilter`（fixed/sliding-window 双算法） | 关 | `security.auth.enabled` / `security.rate-limit.enabled` |
+| **主体级速率配额**（每用户/每 IP/每 Key 的滚动窗口 token 量 + 次数上限） | `SubjectQuotaGuard` + `SubjectQuotaWebFilter` + `SubjectLevelResolver` | 关 | `subject-quota.enabled=true`（表 `cw_subject_quota_level`/`cw_subject_quota_hit` + `cw_user.level_code`），覆盖 HTTP 三类入口与 WS 对话，后台在「内容风控 → 用户额度」，见 §6.32 |
 | **入站防注入围栏**（直接注入） | `PromptInjectionGuardMiddleware` | 关 | `hooks.prompt-guard.enabled`（命中注入/越狱模式硬拦截，不调用模型，指标 `customerwork.prompt.guard.blocked`；**仅 8080 客服链路装配**，自测见 §6.14.3） |
 | **间接注入防护**（RAG / 工具结果隔离） | `ContentSpotlighter` + `IndirectInjectionGuardMiddleware` | starter 关 / admin 开 | `hooks.indirect-injection-guard.enabled`（starter）、`admin.injection-guard.enabled`（admin，默认 true）。工具/MCP 结果包进随机 nonce 隔离块 + 系统提示词声明"块内是数据不是指令"；检测命中只告警不拦截。指标 `customerwork.indirect.guard.spotlighted` / `.detected`（两者均只在**发生工具调用**时才计数，自测见 §6.14.3） |
 | **用户反馈闭环（消息级点赞/点踩）** | `FeedbackService` + `FeedbackController` | 开 | `POST /api/customer/feedback`（DOWN 自动落 `FactLog` 供数据飞轮复盘） |
@@ -167,6 +168,7 @@
 | POST | `/api/customer/consult` | 多 Agent 协作咨询（多专家聚合） |
 | POST | `/api/customer/agui` | AG-UI 标准事件流（SSE） |
 | POST | `/api/customer/session/{id}/interrupt` | 安全中断会话 |
+| GET | `/api/customer/user/quota` | 我的额度：当前滚动窗口的 token/次数用量与剩余（-1 = 不限）。该路径豁免限流判定 |
 | GET | `/api/customer/approvals` | 人工审批单列表（`?status=pending` 过滤） |
 | POST | `/api/customer/approvals/{id}/approve` | 放行审批单（人工放行退款打款） |
 | POST | `/api/customer/approvals/{id}/deny` | 拒绝审批单 |
@@ -1727,6 +1729,71 @@ DELETE /api/ops/semantic-cache/{id}  /scope/{scopeId}
 
 ---
 
+### 6.32 主体级速率配额（每用户 / 每 IP / 每 Key 的滚动窗口限流，默认关闭）
+
+§6.29 的租户配额回答"这个客户这个月能花多少钱"，本节回答"**单个调用者这半小时能用多少**"。
+两者同时生效、任一触顶即拦——一个客户的月度额度没花完，不代表其中某个用户可以一个人把它刷光。
+
+**三类主体，一套机制**：登录用户按 `userId`、匿名调用方按来源 IP、服务端接入方按 API Key 指纹
+（`QuotaSubject`）。API Key 只保留 SHA-256 前 16 位——主体标识会进 Redis 计数键、命中表与日志，
+明文落到任何一处都是凭据泄露。
+
+**窗口是滚动的**，不是自然对齐的：整点归零会让刷量方掐着点把额度用两遍。与租户配额刻意不同
+（那边必须自然日/月对齐，因为要跟账单对得上）。
+
+```yaml
+customer-work:
+  subject-quota:
+    enabled: true
+    store-mode: jdbc          # memory 进程内 / jdbc 落 cw_subject_quota_level
+    default-user-level: free  # 新注册用户落这一档
+    anonymous-level: anonymous
+    api-key-level: api-key
+    paths:                    # 参与判定的路径前缀
+      - /api/customer/chat
+      - /api/customer/user/
+```
+
+**两个上限各自独立**：`token_limit` 拦"一次问得太重"，`request_limit` 拦"问得太频繁"，
+一个拦不住另一个。**次数口径是 HTTP 请求数与 WS 对话数，含查询类请求**（默认覆盖整个
+`/api/customer/user/` 面），所以次数要配得比"纯提问数"宽；真正卡成本的是 token 那一维——
+它只在模型调用后累加。只想限对话就把 `/api/customer/user/` 从 `paths` 里去掉。
+
+**四条入口都判**：HTTP 三类由 `SubjectQuotaWebFilter` 收口（Order 排在两个鉴权过滤器之后，
+否则拿到的是还没鉴权的请求，会把登录用户全按匿名 IP 限）；WS `/ws/user` 由 `ChatDispatchService`
+判定——H5 用户真正的发消息入口在那里，只做 HTTP 侧等于对主战场不生效。
+
+**身份怎么传到记账点**：`QuotaSubjectContext`（ThreadLocal + Reactor 自动传播，机制同 `TenantContext`）。
+token 的真实用量要到模型调用之后才知道，那时已隔了好几次线程切换，方法签名里一个"用户"参数都没有。
+
+**先判后记，被拒不占额度**：判定只读计数，放行之后才 `recordRequest`，模型调用结束由
+`AgentCallTimingMiddleware`（token 的唯一落点）补 `recordTokens`。因此持续打压不会把窗口越推越远。
+代价是高并发下允许少量超额——为掐死这几个请求让每次判定都走一次原子写，代价与收益不成比例。
+
+**token 用分桶近似滑动窗口**（`WindowCounter#incrementSlidingSum`，30 桶）：逐条记 token 时间戳
+在高 QPS 下会直接把内存/Redis 吃光。统计范围刻意<b>不短于</b>名义窗口（多留一个桶），
+误差方向是"限得偏严"——配额的偏差必须 fail-closed。
+
+**超限响应**：HTTP 返回 429 + `Retry-After`（给的是窗口长度这个**上界**，滚动窗口下额度连续释放，
+精确恢复时刻只对某一笔用量成立）；WS 推一条 `system` 帧而非 `error` 帧——额度用完不是故障。
+`/api/customer/user/quota` 供用户自查剩余额度，该路径**豁免判定**：否则查一次扣一次，
+且额度耗尽后连"还剩多少"都看不到。
+
+**等级与分档**：等级表 `cw_subject_quota_level` 按租户隔离，出厂五档种子
+（free / vip / svip / anonymous / api-key）；租户没配某一档时回落平台默认租户的同名档，再回落
+配置里的内置档——内置档让功能在"还没建等级表"时就能生效。用户等级绑定落 `cw_user.level_code`
+（空 = 默认档）。后台在**内容风控 → 用户额度**维护，与同级的"限流规则"（按路径限）是同一件事的两个维度。
+
+**生效延迟是设计的一部分**：等级定义按指纹轮询换快照、用户绑定走本地缓存，**改完最长 60 秒生效**。
+不缓存的话每个请求都要查一次用户表——限流本身会成为系统里最重的一段。
+
+**超限命中落库而非实时余额**（`cw_subject_quota_hit`，只在触顶那一刻写一条）：余额在计数器里，
+后台是另一个进程，读它要么被迫依赖 Redis 模式、要么读到只属于某个副本的数；而运营真正要回答的是
+"谁在刷、哪一档配紧了"——那是命中记录的形状。
+
+**已知边界**：内存计数模式下多副本各算各的，等于把额度放大 N 倍；生产多副本请把
+`customer-work.distributed.counter-mode` 切 `redis`（见 §6.28），与限流/熔断共用同一个计数器实现。
+
 ## 七、配置项总表
 
 全部位于 `application.yml` 的 `customer-work.*`（支持环境变量覆盖）：
@@ -1749,6 +1816,7 @@ DELETE /api/ops/semantic-cache/{id}  /scope/{scopeId}
 | `tenant` | enabled(false), column-name(tenant_id), ignored-tables[], auto-context-propagation(true)（见 §6.27；admin 侧对应 `admin.tenant.*`） |
 | `distributed` | counter-mode(memory), counter-key-prefix(cw:counter:), session-lock-mode(memory), session-lock-wait-seconds(10), session-lock-lease-seconds(120)（见 §6.28，Redis 连接复用 `distributed-lock.redis.*`） |
 | `quota` | enabled(false), store-mode(memory)（见 §6.29；admin 侧归集对应 `admin.billing.aggregation.*`） |
+| `subject-quota` | enabled(false), store-mode(memory), refresh-interval-ms(60000), default-user-level(free), anonymous-level(anonymous), api-key-level(api-key), level-cache-ttl-ms(60000), level-cache-max-size(10000), paths([/api/customer/chat, /intent, /consult, /agui, /api/customer/user/]), builtin-levels{free,anonymous,api-key}（见 §6.32；按调用者限流，与 §6.29 的按租户限费并存） |
 | `eval`（B6）| store-mode(memory), baseline-enabled(false), baseline-cron(0 0 3 * * ?), judge-timeout-seconds(60)，见 §6.31 |
 | `badcase`（B6）| store-mode(memory), auto-collect(true)，见 §6.31 |
 | `prompt-version`（B6）| store-mode(memory)：记「运行时实际生效」的那份，版本号取内容指纹，见 §6.31 |

--- a/docs/多租户架构设计.md
+++ b/docs/多租户架构设计.md
@@ -44,7 +44,7 @@ starter 的 `CustomerWorkPersistenceConfig`（独立 `customerWorkSqlSessionFact
 
 | 类别 | 表 | 处理 |
 |---|---|---|
-| 客服端业务数据 | `cw_*` 全部 41 张 | 加 `tenant_id`，自动过滤 |
+| 客服端业务数据 | `cw_*` 全部 43 张（B7 新增 `cw_subject_quota_level` / `cw_subject_quota_hit`） | 加 `tenant_id`，自动过滤 |
 | admin 配置与业务数据 | `ai_*` 除下方例外的全部、`sys_user`、`sys_role`、`sys_operation_log`、关联表 | 加 `tenant_id`，自动过滤 |
 | 平台级（忽略过滤） | `sys_permission`、`sys_menu_change_log`、`ai_system_tool`、`sys_tenant`、`flyway_schema_history` | 不加列，进忽略清单 |
 | 框架自建（忽略过滤） | `ai_chat_session_state` | 见 §4.1 |
@@ -63,6 +63,7 @@ starter 的 `CustomerWorkPersistenceConfig`（独立 `customerWorkSqlSessionFact
 | `cw_knowledge` | `(title)` | `(tenant_id, title)` |
 | `cw_sensitive_word` | `(word)` | `(tenant_id, word)` |
 | `cw_rate_limit_rule` | `(rule_name)` | `(tenant_id, rule_name)` |
+| `cw_subject_quota_level`（B7 新建） | — | `(tenant_id, level_code)`，建表即带 |
 | `cw_dict_type` | `(dict_type)` | `(tenant_id, dict_type)` |
 | `cw_dict_item` | `(dict_type, item_key)` | `(tenant_id, dict_type, item_key)` |
 

--- a/docs/生产接口使用手册.md
+++ b/docs/生产接口使用手册.md
@@ -34,7 +34,16 @@ Key 比对为常量时间比较(防时序侧信道),错误或缺失返回 **401*
 
 ### 1.2 限流:超限返回 429
 
-`security.rate-limit` 按客户端维度限流(**优先按 API Key,无 Key 按远端 IP**),默认 120 次/分钟(`RATE_LIMIT_RPM`),超限返回 **429 Too Many Requests**。注意这是单实例进程内计数,多实例部署时全局限流应在网关层做(见部署手册第七节)。
+**两层限流，各限各的，任一触顶都返回 429**：
+
+- **按路径限**（`security.rate-limit`）：按客户端维度(**优先按 API Key,无 Key 按远端 IP**),默认 120 次/分钟(`RATE_LIMIT_RPM`)。
+- **按调用者限**（`subject-quota`，默认关闭）：每个登录用户 / 每个匿名 IP / 每把 API Key 在滚动窗口内的
+  **token 量**与**请求次数**双上限。响应带 `Retry-After`（给的是窗口长度这个上界——滚动窗口下额度连续释放，
+  精确恢复时刻只对某一笔用量成立），响应体含 `kind`（`TOKEN`/`REQUEST`）说明是哪一维触顶。
+  登录用户可用 `GET /api/customer/user/quota` 自查剩余额度（该路径豁免限流，否则额度耗尽时连查都查不了）。
+
+两者都是单实例进程内计数;多实例部署请把 `customer-work.distributed.counter-mode` 切 `redis`,
+或把全局限流放在网关层(见部署手册第七节)。
 
 ### 1.3 请求追踪:`X-Request-Id`
 
@@ -79,6 +88,7 @@ Swagger UI 免鉴权开放:`GET /swagger-ui/index.html`(OpenAPI 描述在 `/v3/a
 | POST | `/api/customer/feedback` | 提交消息级反馈(点赞/点踩) | §3.8 |
 | GET | `/api/customer/feedback/{messageId}` | 查询单条消息反馈 | §3.8 |
 | GET | `/api/customer/feedback` | 查询某会话全部反馈(`?sessionId=`) | §3.8 |
+| GET | `/api/customer/user/quota` | 我的额度:滚动窗口内 token/次数用量与剩余(需登录态) | §1.2 |
 | GET | `/api/customer/health` | 健康检查(免鉴权) | — |
 | POST | `/api/customer/forms/refund` | 退款多轮信息收集 | §4.2 |
 | GET | `/api/customer/approvals` | 审批单列表 | §5.1 |

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -180,6 +180,7 @@ CREATE TABLE IF NOT EXISTS `cw_user` (
     `status`         VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/DISABLED',
     `created_at_ms`  BIGINT NOT NULL COMMENT '创建时间戳（毫秒）',
     `avatar_url`     VARCHAR(255) COMMENT '头像访问URL（相对路径，可为空）',
+    `level_code`     VARCHAR(64) DEFAULT NULL COMMENT '配额等级编码（空=默认档），见 cw_subject_quota_level',
     UNIQUE KEY `uk_user_username` (`tenant_id`, `username`),
     INDEX `idx_user_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -918,3 +919,56 @@ CREATE TABLE IF NOT EXISTS `cw_outbox_message` (
     INDEX `idx_outbox_lease` (`tenant_id`, `status`, `lease_until_ms`),
     INDEX `idx_outbox_aggregate` (`tenant_id`, `aggregate_id`, `created_at_ms`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT='同库事务 Outbox';
+
+-- 主体配额等级表（cw_subject_quota_level）：每个用户/匿名IP/API Key 在滚动窗口内的额度定义。
+-- 与 cw_tenant_quota 刻意分表：那张是自然日/月对齐、要跟账单对得上的计费上限，
+-- 这张是最近 N 秒滚动、与账单无关的防滥用闸门。周期语义与判定时机都不同，合表只会互相牵制。
+CREATE TABLE IF NOT EXISTS `cw_subject_quota_level` (
+    `tenant_id`      VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `level_code`     VARCHAR(64) NOT NULL COMMENT '等级编码，如 free/vip/anonymous',
+    `level_name`     VARCHAR(128) NOT NULL COMMENT '等级名称（运营可读）',
+    `subject_type`   VARCHAR(32) NOT NULL DEFAULT 'USER' COMMENT '适用主体: USER 登录用户 / IP 匿名 / API_KEY 接入方',
+    `window_seconds` INT NOT NULL DEFAULT 1800 COMMENT '滚动窗口长度（秒），1800=30分钟',
+    `token_limit`    BIGINT NOT NULL DEFAULT 0 COMMENT '窗口内 token 上限，0=不限',
+    `request_limit`  INT NOT NULL DEFAULT 0 COMMENT '窗口内请求次数上限，0=不限',
+    `exceed_action`  VARCHAR(16) NOT NULL DEFAULT 'BLOCK' COMMENT '超限处置: BLOCK 拦截 / WARN 仅记录',
+    `enabled`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用: 1启用/0停用',
+    `remark`         VARCHAR(255) COMMENT '备注',
+    `created_at_ms`  BIGINT COMMENT '创建时间戳（毫秒）',
+    `updated_at_ms`  BIGINT COMMENT '更新时间戳（毫秒）',
+    UNIQUE KEY `uk_squota_level` (`tenant_id`, `level_code`),
+    INDEX `idx_squota_level_tenant` (`tenant_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT='主体配额等级（每租户每档一条）';
+
+-- 主体配额超限命中记录（cw_subject_quota_hit）：只在真的触顶那一刻写一条，正常流量零写入。
+-- 后台"谁在刷"看板的数据源；实时余额刻意不落库（那在计数器里，跨进程读不到也没必要读）。
+CREATE TABLE IF NOT EXISTS `cw_subject_quota_hit` (
+    `tenant_id`      VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+    `id`             BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '自增主键',
+    `subject_type`   VARCHAR(32) NOT NULL COMMENT '主体类型: USER/IP/API_KEY',
+    `subject_id`     VARCHAR(128) NOT NULL COMMENT '主体标识（API Key 已做 SHA-256 指纹，不含明文）',
+    `level_code`     VARCHAR(64) COMMENT '判定所依据的等级',
+    `limit_kind`     VARCHAR(16) NOT NULL COMMENT '触顶维度: TOKEN/REQUEST',
+    `used`           BIGINT NOT NULL DEFAULT 0 COMMENT '触顶时已用量',
+    `limit_value`    BIGINT NOT NULL DEFAULT 0 COMMENT '触顶时的上限',
+    `window_seconds` INT NOT NULL DEFAULT 0 COMMENT '滚动窗口长度（秒）',
+    `action`         VARCHAR(16) NOT NULL DEFAULT 'BLOCK' COMMENT '当时处置: BLOCK 真拦了 / WARN 只记录',
+    `resource`       VARCHAR(255) COMMENT '触发位置（HTTP 路径或 ws:chat）',
+    `created_at_ms`  BIGINT NOT NULL COMMENT '命中时刻（毫秒）',
+    INDEX `idx_squota_hit_tenant_time` (`tenant_id`, `created_at_ms`),
+    INDEX `idx_squota_hit_subject` (`tenant_id`, `subject_type`, `subject_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT='主体配额超限命中记录';
+
+-- 出厂五档种子（仅默认租户）。功能默认关闭，种子不改变任何现有行为。
+-- free/anonymous/api-key 三档必须与 SubjectQuotaProperties 的内置档数值一致，两处不能漂移。
+INSERT INTO `cw_subject_quota_level`
+    (`tenant_id`, `level_code`, `level_name`, `subject_type`, `window_seconds`,
+     `token_limit`, `request_limit`, `exceed_action`, `enabled`, `remark`,
+     `created_at_ms`, `updated_at_ms`)
+VALUES
+    ('default', 'free',      '免费用户', 'USER',    1800,   50000,  100, 'BLOCK', 1, '注册用户默认档', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'vip',       'VIP用户',  'USER',    1800,  200000,  300, 'BLOCK', 1, '付费用户',       UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'svip',      'SVIP用户', 'USER',    1800, 1000000, 1000, 'BLOCK', 1, '高级付费用户',   UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'anonymous', '匿名访客', 'IP',      1800,   10000,   20, 'BLOCK', 1, '未登录，按来源IP计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'api-key',   '接入方',   'API_KEY', 3600, 1000000, 2000, 'BLOCK', 1, '服务端接入，按Key指纹计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000);

--- a/mysql/02-customer-admin/55-V55__subject_rate_quota.sql
+++ b/mysql/02-customer-admin/55-V55__subject_rate_quota.sql
@@ -1,0 +1,19 @@
+-- 主体级速率配额（用户额度）的菜单与权限点。
+--
+-- 本次没有建表：三处数据（cw_subject_quota_level / cw_subject_quota_hit / cw_user.level_code）都在
+-- 客服端库 agent_scope_customer_work，由 starter 的 Flyway V4 建，后台只是这份数据的维护端。
+-- 刻意不在 admin 库另存副本——限流配置双写出现不一致，表现是"后台显示已放宽、线上照样拦"。
+--
+-- 挂在"内容风控"下而不是"配额与计费"下：它与同级的"限流规则"是同一件事的两个维度
+-- （那边按路径限、这边按人限），而计费那边管的是"这个客户这个月能花多少钱"，周期和目的都不同。
+
+-- 二级菜单：用户额度（sort=4，接在命中看板之后）
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`) VALUES
+    (244, 204, '用户额度', 'subject-quota:view', 1, '/contentguard/subject-quota', 'Stopwatch', 'library', 4);
+
+-- 三级：按钮/接口权限点（type=2）。
+-- 等级维护与用户分档分开发点：前者改的是"这一档多少额度"（影响一批人），
+-- 后者改的是"这个人属于哪一档"（影响一个人），两种误操作的爆炸半径差一个数量级。
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (245, 244, '维护等级',   'subject-quota:level-edit', 2, 1),
+    (246, 244, '分配用户等级', 'subject-quota:user-edit',  2, 2);


### PR DESCRIPTION
## 做了什么

按**调用者**限流：登录用户按 `userId`、匿名按来源 IP、服务端接入方按 API Key 指纹，在**滚动窗口**内同时限制 **token 消耗量**与**请求次数**，任一触顶即按等级配置处置（拦截 / 仅记录）。

与既有两套限流并存、互不替代：

| | 限什么 | 周期 | 目的 |
|---|---|---|---|
| 租户配额（B3） | 这个客户这个月花多少钱 | 自然日/月对齐（要跟账单对得上） | 计费上限 |
| 限流规则 | 这条路径每分钟多少请求 | 固定/滑动窗口 | 保护下游容量 |
| **主体配额（本 PR）** | **这个调用者这半小时用多少** | **滚动窗口** | **防滥用** |

默认关闭（`customer-work.subject-quota.enabled`），未开启时行为与引入前完全一致。

## 覆盖的四条入口

- HTTP `/api/customer/chat`、`/intent`、`/consult`、`/agui`、`/api/customer/user/**` — `SubjectQuotaWebFilter`
- WebSocket `/ws/user` — `ChatDispatchService`（**H5 用户真实的发消息入口在这里**，只做 HTTP 侧等于对主战场不生效）

## 关键设计取舍

**判定只读、放行后才记账。** `check` 不写计数，通过后 `recordRequest`、模型调用结束由 `AgentCallTimingMiddleware`（token 的唯一落点）补 `recordTokens`。因此被拒的请求不占额度，持续打压不会把窗口越推越远。代价是高并发下允许少量超额——为掐死这几个请求让每次判定都走一次原子写，代价与收益不成比例。

**主体身份经 `QuotaSubjectContext` 贯通**（ThreadLocal + Reactor 自动传播，机制同 `TenantContext`）。token 的真实用量要到模型调用之后才知道，那时已隔了好几次线程切换，方法签名里一个"用户"参数都没有。

**token 是"量"不是"次"。** `WindowCounter` 新增分桶近似滑动求和（30 桶）——逐条记 token 时间戳在高 QPS 下会直接把内存/Redis 吃光。统计范围刻意**不短于**名义窗口（多留一个桶），误差方向是"限得偏严"：配额的偏差必须 fail-closed。

**`SubjectQuotaWebFilter` 的 Order 排在两个鉴权过滤器之后**，否则拿到的是还没鉴权的请求，会把登录用户全按匿名 IP 限。它还会自己验一次 Bearer——`UserAuthWebFilter` 只覆盖 `/api/customer/user/**`，不自己验的话换条路径就能从"按人限"退化成"按 IP 限"，而 IP 那一档还是共享的。

**API Key 只保留 SHA-256 前 16 位指纹。** 主体标识会进 Redis 计数键、命中表与日志，明文落到任何一处都是凭据泄露。

**后台展示超限命中而非实时余额。** 余额在计数器里（进程内或 Redis），admin 是另一个进程，读它要么被迫依赖 Redis 模式、要么读到只属于某个副本的数；而运营真正要回答的是"谁在刷、哪一档配紧了"——那是命中记录的形状，且只在触顶那一刻写一条，正常流量零写入。用户自己的剩余额度走客服端的 `GET /api/customer/user/quota`（进程内，读得准），该路径**豁免判定**：否则查一次扣一次，且额度耗尽后连"还剩多少"都看不到。

**改配置最长 60 秒生效**（等级快照按指纹轮询 + 用户绑定本地缓存）。不缓存的话每个请求都要查一次用户表，限流本身会成为链路上最重的一段。页面上写明了这件事；同进程调 `UserAccountService.updateLevel` 会主动失效缓存，立即生效。

## 次数口径需要注意

**次数数的是 HTTP 请求数与 WS 对话数，含查询类请求**——默认覆盖整个 `/api/customer/user/` 面，所以翻历史消息、查工单也会占额度。因此默认档配成 free 100 次 / 30min，不是"提问 100 次"。真正卡成本的是 token 那一维（只在模型调用后累加）。只想限对话就把 `/api/customer/user/` 从 `paths` 里去掉。

## 数据变更

- 客服端库 **V4**：建 `cw_subject_quota_level`（含出厂五档种子）/ `cw_subject_quota_hit`，给 `cw_user` 加 `level_code`；`mysql/01-*/customer-work-schema.sql` 已同步
- admin 库 **V55**：「内容风控 → 用户额度」菜单 + 三个权限点（244/245/246）；`mysql/02-customer-admin/` 镜像已同步

## 顺带修正

`ChatDispatchService` 原本没有把 `UserPrincipal.tenantId` 写进上下文。等级表按租户隔离，不补的话多租户下会查到别的租户那一档。多租户默认关闭，所以这不是既有 bug 的暴露，但本功能依赖它。

## 验证

- 全量回归 **BUILD SUCCESS**：starter 1388 / admin 754 / app 86 / channel 65 / gateway 1 = **2294**，6 skip（排除 `RedisSessionPersistenceTest`，本机 Redis 无密码）
- 本批次新增 starter **+46**：判定/记账 12、等级解析 11、HTTP 入口 8、主体值对象 4、**装配门控 4**（防"Bean 根本不存在"那类静默失效）、滑动求和 4、用户等级 3
- `CustomerWorkSchemaMigrationIntegrationTest` 的表数断言 42→44、并新增 `cw_user.level_code` 加列断言
- 前端 `vue-tsc --noEmit` 与 `vite build` 均通过

## 已知边界

内存计数模式下多副本各算各的，等于把额度放大 N 倍。生产多副本请把 `customer-work.distributed.counter-mode` 切 `redis`，与限流/熔断共用同一个计数器实现。


---

## 追加：H5 额度展示 + 示例应用默认开启

**H5 用户端**：额度快用完时在输入框上方提示（"30 分钟内还可提问 N 次"）。只在剩余低于两成时出现——常驻显示一个数字对正常用户是纯噪音，而完全不显示的话，用户只能在被拦的那一刻才知道有额度这回事。两个维度取更紧张的那一维报；token 对用户是不可理解的概念，故换算成百分比说。进页面拉一次、每次 AI 回复定稿后刷新（token 记在模型调用之后，回复过程中查到的是上一轮的数）。

**app-server 示例配置开启** `subject-quota`（`enabled=true` + `store-mode=jdbc`），与 `tiered-routing` 同例：starter 默认关、示例应用开。

## 端到端实测（本机 MySQL + 8080）

| 验证项 | 结果 |
|---|---|
| 匿名 IP 档 20 次/30min | 第 21 次请求返回 429，带 `Retry-After: 1800` 与 JSON body（`kind=REQUEST`） |
| 主体隔离 | 同一 IP 匿名额度耗尽后，带登录态的请求照常放行（走 free 档，`requestUsed=5/100`） |
| 注册落档 | `cw_user.level_code = free` |
| 额度自查豁免 | `/api/customer/user/quota` 连打 8 次全 200，且 `requestUsed` 保持不变 |
| 命中落库 | `cw_subject_quota_hit` 正确记录主体/等级/维度/用量/处置/触发路径 |

顺带发现一个既有交互（非本 PR 引入）：本机 `cw_rate_limit_rule` 里有一条 `/api/customer/chat` 限 2 次/秒的规则，它的 Order 更靠前，会先于主体配额拦截。两层限流并存、任一触顶即拦，符合设计；只是排查时要注意 **429 无 body 的是路径规则拦的，带 `Retry-After` + JSON 的才是主体配额**。
