### PR TITLE
feat(config): 非生产环境默认启用 AI 编码能力

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminProductionReadinessValidator.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminProductionReadinessValidator.java
@@ -20,6 +20,11 @@ public class AdminProductionReadinessValidator implements InitializingBean {
     private static final String DEV_AES_KEY = "0123456789abcdef0123456789abcdef";
     private static final String DEV_AGENT_SECRET = "dev-agent-secret-change-me-0001";
     private static final String DEV_MINIO_CREDENTIAL = "minioadmin";
+    private static final List<String> FORBIDDEN_PRODUCTION_AI_CODING_FEATURES = List.of(
+        "admin.sandbox.features.command-execution-enabled",
+        "admin.sandbox.features.diagnosis-enabled",
+        "admin.sandbox.features.refactor-enabled",
+        "admin.sandbox.features.management-enabled");
 
     private final Environment environment;
 
@@ -58,6 +63,8 @@ public class AdminProductionReadinessValidator implements InitializingBean {
             require(violations, "admin.sandbox.docker.network",
                 "none".equalsIgnoreCase(value("admin.sandbox.docker.network")));
         }
+        FORBIDDEN_PRODUCTION_AI_CODING_FEATURES.forEach(key ->
+            require(violations, key, !environment.getProperty(key, Boolean.class, false)));
 
         requireRemote(violations, "customer-work.attachment.storage.minio.endpoint");
         requireNonDefaultSecret(violations, "customer-work.attachment.storage.minio.access-key",

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminSandboxProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminSandboxProperties.java
@@ -142,7 +142,8 @@ public class AdminSandboxProperties {
     /**
      * AI 编码助手 P1/P2 能力开关与会话沙箱回收参数。
      *
-     * <p>命令执行、诊断、重构、沙箱管理均是新增攻击面，Java 默认值必须保持关闭；只有显式配置后才开放。
+     * <p>命令执行、诊断、重构、沙箱管理均是新增攻击面，Java fallback 保持关闭；非生产环境由
+     * {@code application.yml} 默认开放，生产环境由 prod profile 与启动门禁强制关闭。
      * {@code idleTimeoutMinutes} 只针对本模块管理的交互式命令沙箱，空闲超过阈值后在下一次查询/执行时回收。</p>
      */
     @Data

--- a/customer-admin-server/src/main/resources/application-prod.yml
+++ b/customer-admin-server/src/main/resources/application-prod.yml
@@ -25,6 +25,16 @@ springdoc:
   swagger-ui:
     enabled: ${SPRINGDOC_ENABLED:false}
 
+# AI 编码命令、诊断、重构与沙箱管理属于高风险开发能力，生产环境禁止开放。
+# 即使环境变量试图覆盖这些值，AdminProductionReadinessValidator 也会拒绝启动。
+admin:
+  sandbox:
+    features:
+      command-execution-enabled: false
+      diagnosis-enabled: false
+      refactor-enabled: false
+      management-enabled: false
+
 logging:
   level:
     root: INFO

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -199,11 +199,12 @@ admin:
       confirm-timeout-seconds: ${ADMIN_SANDBOX_HITL_CONFIRM_TIMEOUT_SECONDS:300}
       batch-modify-threshold: ${ADMIN_SANDBOX_HITL_BATCH_MODIFY_THRESHOLD:3}
     features:
-      # P1/P2 增量能力全部默认关闭，生产环境按功能逐项灰度开启。
-      command-execution-enabled: ${ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED:false}
-      diagnosis-enabled: ${ADMIN_SANDBOX_DIAGNOSIS_ENABLED:false}
-      refactor-enabled: ${ADMIN_SANDBOX_REFACTOR_ENABLED:false}
-      management-enabled: ${ADMIN_SANDBOX_MANAGEMENT_ENABLED:false}
+      # P1/P2 能力在非生产环境默认开放，可通过环境变量逐项关闭；prod profile 强制关闭，
+      # ProductionReadinessValidator 会拒绝任何试图在生产开启这些能力的配置。
+      command-execution-enabled: ${ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED:true}
+      diagnosis-enabled: ${ADMIN_SANDBOX_DIAGNOSIS_ENABLED:true}
+      refactor-enabled: ${ADMIN_SANDBOX_REFACTOR_ENABLED:true}
+      management-enabled: ${ADMIN_SANDBOX_MANAGEMENT_ENABLED:true}
       idle-timeout-minutes: ${ADMIN_SANDBOX_IDLE_TIMEOUT_MINUTES:30}
   skill:
     # Skill 保存/上传时把 SKILL.md 正文发布到勾选的存储目标（minio/nacos/sftp）；运行时消费仍从数据库读。

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/AdminProdProfileConfigTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/AdminProdProfileConfigTest.java
@@ -14,6 +14,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class AdminProdProfileConfigTest {
 
     @Test
+    void shouldEnableAiCodingFeaturesByDefaultOutsideProduction() throws Exception {
+        List<PropertySource<?>> sources = new YamlPropertySourceLoader().load(
+            "application", new ClassPathResource("application.yml"));
+
+        assertEquals("${ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED:true}", property(sources,
+            "admin.sandbox.features.command-execution-enabled"));
+        assertEquals("${ADMIN_SANDBOX_DIAGNOSIS_ENABLED:true}", property(sources,
+            "admin.sandbox.features.diagnosis-enabled"));
+        assertEquals("${ADMIN_SANDBOX_REFACTOR_ENABLED:true}", property(sources,
+            "admin.sandbox.features.refactor-enabled"));
+        assertEquals("${ADMIN_SANDBOX_MANAGEMENT_ENABLED:true}", property(sources,
+            "admin.sandbox.features.management-enabled"));
+    }
+
+    @Test
     void shouldDisableSwaggerAndLimitActuatorByDefault() throws Exception {
         List<PropertySource<?>> sources = new YamlPropertySourceLoader().load(
             "application-prod", new ClassPathResource("application-prod.yml"));
@@ -25,6 +40,14 @@ class AdminProdProfileConfigTest {
             "springdoc.api-docs.enabled"));
         assertEquals("${SPRINGDOC_ENABLED:false}", property(sources,
             "springdoc.swagger-ui.enabled"));
+        assertEquals(Boolean.FALSE, property(sources,
+            "admin.sandbox.features.command-execution-enabled"));
+        assertEquals(Boolean.FALSE, property(sources,
+            "admin.sandbox.features.diagnosis-enabled"));
+        assertEquals(Boolean.FALSE, property(sources,
+            "admin.sandbox.features.refactor-enabled"));
+        assertEquals(Boolean.FALSE, property(sources,
+            "admin.sandbox.features.management-enabled"));
     }
 
     private Object property(List<PropertySource<?>> sources, String key) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/AdminProductionReadinessValidatorTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/AdminProductionReadinessValidatorTest.java
@@ -3,6 +3,8 @@ package com.richard.fyoung.customeradmin.config;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -46,6 +48,24 @@ class AdminProductionReadinessValidatorTest {
             () -> new AdminProductionReadinessValidator(environment).afterPropertiesSet());
 
         assertTrue(error.getMessage().contains("admin.sandbox.docker.network"));
+    }
+
+    @Test
+    void aiCodingFeatures_shouldBeForbiddenInProduction() {
+        List<String> featureKeys = List.of(
+            "admin.sandbox.features.command-execution-enabled",
+            "admin.sandbox.features.diagnosis-enabled",
+            "admin.sandbox.features.refactor-enabled",
+            "admin.sandbox.features.management-enabled");
+
+        for (String featureKey : featureKeys) {
+            MockEnvironment environment = validEnvironment().withProperty(featureKey, "true");
+
+            IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> new AdminProductionReadinessValidator(environment).afterPropertiesSet());
+
+            assertTrue(error.getMessage().contains(featureKey));
+        }
     }
 
     @Test

--- a/docs/AI编码助手需求文档.md
+++ b/docs/AI编码助手需求文档.md
@@ -693,13 +693,16 @@ admin:
     hitl:                                          # 仅 permission-mode=hitl 时生效（P1-1）
       confirm-timeout-seconds: ${ADMIN_SANDBOX_HITL_CONFIRM_TIMEOUT_SECONDS:300}  # 确认超时，超时按拒绝
       batch-modify-threshold: ${ADMIN_SANDBOX_HITL_BATCH_MODIFY_THRESHOLD:3}      # 单轮批量修改超此值需确认
-    features:                                      # P1/P2 增量能力默认全部关闭，按项灰度
-      command-execution-enabled: ${ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED:false}
-      diagnosis-enabled: ${ADMIN_SANDBOX_DIAGNOSIS_ENABLED:false}
-      refactor-enabled: ${ADMIN_SANDBOX_REFACTOR_ENABLED:false}
-      management-enabled: ${ADMIN_SANDBOX_MANAGEMENT_ENABLED:false}
+    features:                                      # 非生产环境默认开放；prod 强制全部关闭
+      command-execution-enabled: ${ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED:true}
+      diagnosis-enabled: ${ADMIN_SANDBOX_DIAGNOSIS_ENABLED:true}
+      refactor-enabled: ${ADMIN_SANDBOX_REFACTOR_ENABLED:true}
+      management-enabled: ${ADMIN_SANDBOX_MANAGEMENT_ENABLED:true}
       idle-timeout-minutes: ${ADMIN_SANDBOX_IDLE_TIMEOUT_MINUTES:30}
 ```
+
+> 以上四项属于开发期高风险能力。生产环境禁止启用：`application-prod.yml` 固定关闭，且
+> `AdminProductionReadinessValidator` 会在任一最终生效值为 `true` 时拒绝启动。
 
 > **Plan Mode HITL（P1-1）**：`permission-mode=hitl` 时，vibecoding 会话中 Agent 计划执行高风险操作
 > （删除文件 / 执行非只读或破坏性命令 `rm`·`mvn clean` 等 / 修改 pom.xml 等依赖文件 / 单轮批量修改超阈值）

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -209,11 +209,15 @@
 | `ADMIN_SANDBOX_HITL_CONFIRM_TIMEOUT_SECONDS` | `300` | HITL 确认等待超时(秒),超时按拒绝处理、流正常结束 |
 | `ADMIN_SANDBOX_HITL_BATCH_MODIFY_THRESHOLD` | `3` | 单轮批量修改文件数阈值,超过即需人工确认 |
 | `ADMIN_SANDBOX_GUARD_ENABLED` | `true` | 破坏性命令护栏总开关(最后防线,与 HITL 叠加,不建议关) |
-| `ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED` | `false` | 交互式命令执行面板；用户输入仍强制经过同一危险命令护栏 |
-| `ADMIN_SANDBOX_DIAGNOSIS_ENABLED` | `false` | Bug/日志诊断入口；修复复用 VibeCoding 文件变更、测试与回滚链路 |
-| `ADMIN_SANDBOX_REFACTOR_ENABLED` | `false` | 自动化重构入口；每个任务先强制计划确认，批准后才允许修改 |
-| `ADMIN_SANDBOX_MANAGEMENT_ENABLED` | `false` | 会话交互式沙箱列表、资源查看和手工清理 |
+| `ADMIN_SANDBOX_COMMAND_EXECUTION_ENABLED` | `true`（prod 强制 `false`） | 交互式命令执行面板；用户输入仍强制经过同一危险命令护栏 |
+| `ADMIN_SANDBOX_DIAGNOSIS_ENABLED` | `true`（prod 强制 `false`） | Bug/日志诊断入口；修复复用 VibeCoding 文件变更、测试与回滚链路 |
+| `ADMIN_SANDBOX_REFACTOR_ENABLED` | `true`（prod 强制 `false`） | 自动化重构入口；每个任务先强制计划确认，批准后才允许修改 |
+| `ADMIN_SANDBOX_MANAGEMENT_ENABLED` | `true`（prod 强制 `false`） | 会话交互式沙箱列表、资源查看和手工清理 |
 | `ADMIN_SANDBOX_IDLE_TIMEOUT_MINUTES` | `30` | 交互式会话沙箱空闲回收阈值；下一次执行/查询时机会式清理 |
+
+> **生产禁用 AI 编码开发面**：`prod` profile 将上述四项固定为 `false`，启动门禁同时校验最终生效值。
+> 任何通过环境变量将其中一项改为 `true` 的生产实例都会启动失败；生产需要代码诊断或变更时，应在隔离的
+> 非生产环境完成并通过正常发布流程上线。
 
 > **Docker 模式产物同步(P1-3,bind mount 挂 agent 工作区根)**:docker 模式下后端把宿主机 agent 工作区根
 > `./data/admin-workspace/{agentCode}` 以 `docker run -v` 挂进容器 `/workspace`,会话产物(`sessions/{sessionId}/`)、


### PR DESCRIPTION
## 变更说明

- 非生产环境默认启用交互式命令执行、Bug/日志诊断、自动化重构和沙箱管理
- `prod` profile 明确关闭上述四项高风险开发能力
- 生产启动门禁校验最终生效配置，任一能力为 `true` 时拒绝启动
- 同步部署手册和 AI 编码助手需求文档

## 验证

- 定向配置与启动门禁测试：8 条通过
- 全量 Maven：2361 条测试，0 失败，0 错误，6 条环境门控跳过
- `git diff --check` 通过

## 生产约束

生产环境禁止开放上述四项能力。代码诊断和变更应在隔离的非生产环境完成，并通过正常发布流程上线。
