### PR TITLE
feat: 后台登录用户也纳入速率配额（ADMIN_USER 主体）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,13 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1388** + admin-server **754** + app 86 + customer-channel 65 + gateway 1（合计 **2294**）
-  （2026-08-18 B7 主体配额批次实测：starter 1388 / 5 skip、admin 754 / 1 skip、app 86，BUILD SUCCESS，
-  排除 `RedisSessionPersistenceTest`。**本批次自身只加了 starter +46**
-  （主体配额 39 + 滑动求和 4 + 用户等级 3），其余差额来自 2026-08-14 之后合入 main 的批次；
-  admin 侧只加薄壳与跨库门面故未加用例。
+- 测试基线：starter **1396** + admin-server **765** + app 86 + customer-channel 65 + gateway 1（合计 **2313**）
+  （2026-08-18 B7 主体配额批次实测：starter 1396 / 5 skip、admin 765 / 1 skip、app 86，BUILD SUCCESS，
+  排除 `RedisSessionPersistenceTest`。本批次自身加了 starter **+54**（C 端 46 + 后台侧 8）
+  与 admin **+11**（拦截器 5 + 等级绑定 6）。
+  **admin 的 `CustomerAdminServerApplicationTests` 在被并行分支迁移污染过的本机库上必挂**
+  （Flyway 报 "Detected applied migration not resolved locally"）——那不是代码问题，
+  用一个临时库跑（`ADMIN_MYSQL_URL` 指向新库，Flyway 会从空库跑全量迁移）即可验证。
   **改客服端库 schema 时记得同步改 `CustomerWorkSchemaMigrationIntegrationTest` 的表数断言**——
   它硬编码了"空库迁移后应有 N 张表"，加表必挂，这是预期内的断言更新而不是 bug。
   上一版基线 2026-08-14：starter 1323 / admin 753 / app 80，合计 2222；
@@ -197,6 +199,30 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   都要查一次用户表，限流本身会成为最重的一段。后台页面必须把这件事写给运营看。
   新增的 `subject-quota.store-mode` 已登记进 `PersistenceJdbcCondition`（漏登记会出现
   "Store 想用 jdbc 但持久化环境没激活"的错配）。
+  **后台登录用户同样纳入（`admin.subject-quota.enabled`，默认关闭）**，六条补充约定：
+  ① **主体类型单列 `ADMIN_USER`**：`sys_user` 与 `cw_user` 是两套 ID 空间，同一个 ID 值指的是
+  不同的人，混用 `USER` 会让计数键碰撞（管理员与终端用户共用一份额度，且查不出原因）；
+  等级定义共用 `cw_subject_quota_level`（靠 `subject_type` 区分），绑定落 `sys_user.level_code`；
+  ② **判定用 MVC `HandlerInterceptor`**：admin 是 Servlet 不是 WebFlux，没有 `WebFilter`。
+  超限返回 429 + `Retry-After`，错误码单列 `QUOTA_EXCEEDED(40043)`——额度用尽既不是没权限也不是参数错，
+  混进既有码会让前端提示"联系管理员开权限"；
+  ③ **等级快照走惰性刷新**（`SubjectQuotaLevelProvider` 的三参构造）：admin 刻意不开
+  `@EnableScheduling`，客服端那套 `@Scheduled` 轮询在这边根本不会跑，不改成读路径刷新的话
+  后台改完等级永远不生效；
+  ④ **上下文传播只接主体、不搭车改租户**：admin 此前完全没有 Reactor 上下文传播（starter 自动装配被
+  exclude）。补租户会让多租户开启后 AI 链路的持久层操作开始真正带过滤，那是独立的行为变更，
+  该单独评估。自动传播是全局静态开关，故只在 `enabled=true` 时打开——代价是开配置要重启；
+  ⑤ **路径清单刻意比 C 端窄**（只覆盖 `chat/stream`、`vibecoding`、`agent-task` 三条真正调模型的入口）：
+  后台用户是内部员工，防的是"调用失控"而不是"有人刷接口"，把翻列表也算进去只会让人干不了活；
+  ⑥ **委派任务要在提交那一刻捕获主体**（`MybatisTaskRepository#putTask`）：它跑在自建线程池上，
+  Reactor 的自动传播覆盖不到，不用 `QuotaSubjectContext.callWith` 带进去的话，
+  那条链路烧的 token 就没有主人（额度里只有"提交次数"在动）；
+  ⑦ **admin 侧写 SQL 条件不要用 MyBatis-Plus 的 lambda wrapper**：lambda 解析依赖 `TableInfo` 缓存，
+  不启动容器的单测里拿不到，会直接抛 `MybatisPlusException`；跨库门面场景同样没有拦截器，
+  一律用字符串列名（`new QueryWrapper<>().eq("id", x)`）；
+  ⑧ **加 Flyway 迁移前先扫一遍各 worktree 的最大版本号**：并行开发时版本号极易撞车
+  （本批次的 V56 就撞上了另一个分支已 apply 到本机库的 V56，表现为 checksum mismatch 启动失败）。
+  本机库被别的分支迁移污染时，用一个临时库验证自己的迁移与上下文加载，别去动共享库的 history。
 - 业务工具后端走 `tool.backend.*` 接口 + `@ConditionalOnMissingBean` Mock，下游声明同类型 Bean 覆盖。
 - 持久层异常兜底必须 `catch(Exception)`（HikariPool/MyBatis 初始化异常是 RuntimeException）。
 - 给 `ToolRegistrar` 加构造参数前先 `grep -rn "new ToolRegistrar("`（多处调用点要同步）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -85,6 +85,10 @@ public enum ResultCode {
     TENANT_SUSPENDED(40041, "租户已被冻结或已退租，请联系运营方"),
     TENANT_VIEW_FORBIDDEN(40042, "只有平台运营方可以切换租户视角"),
 
+    // 主体级速率配额（B7）：额度用尽不是权限问题也不是参数问题，单独发码，
+    // 前端据此给"稍后再试"而不是"联系管理员开权限"
+    QUOTA_EXCEEDED(40043, "本时段的 AI 用量额度已用尽，请稍后再试"),
+
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/AdminQuotaWebConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/AdminQuotaWebConfig.java
@@ -1,0 +1,46 @@
+package com.richard.fyoung.customeradmin.subjectquota.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.subjectquota.runtime.AdminQuotaInterceptor;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 注册后台用量判定拦截器。
+ *
+ * <p>路径按 {@code admin.subject-quota.path-patterns} 配（默认只覆盖真正调模型的三条入口）：
+ * 后台的列表、详情、附件下载不消耗额度，把它们算进去只会让内部员工翻两页记录就被限。</p>
+ *
+ * <p>排在租户拦截器之前（{@code LOWEST_PRECEDENCE - 10}）：判定要拿登录态与租户，
+ * 但不依赖租户 ThreadLocal——拦截器内部自己按登录态包了一层租户上下文。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Configuration
+public class AdminQuotaWebConfig implements WebMvcConfigurer {
+
+    private final SubjectQuotaGuard guard;
+    private final ObjectMapper objectMapper;
+    private final AdminSubjectQuotaProperties properties;
+
+    public AdminQuotaWebConfig(SubjectQuotaGuard adminSubjectQuotaGuard,
+                               ObjectMapper objectMapper,
+                               AdminSubjectQuotaProperties properties) {
+        this.guard = adminSubjectQuotaGuard;
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        if (!properties.isEnabled() || properties.getPathPatterns() == null
+            || properties.getPathPatterns().isEmpty()) {
+            return;
+        }
+        registry.addInterceptor(new AdminQuotaInterceptor(guard, objectMapper))
+            .addPathPatterns(properties.getPathPatterns())
+            .order(Ordered.LOWEST_PRECEDENCE - 10);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/AdminSubjectQuotaConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/AdminSubjectQuotaConfig.java
@@ -1,0 +1,130 @@
+package com.richard.fyoung.customeradmin.subjectquota.config;
+
+import com.richard.fyoung.customeradmin.subjectquota.runtime.AdminUserLevelBinding;
+import com.richard.fyoung.customeradmin.subjectquota.runtime.LazyCrossDbHitStore;
+import com.richard.fyoung.customeradmin.subjectquota.runtime.LazyCrossDbLevelStore;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
+import com.richard.fyoung.customerwork.infra.counter.InMemoryWindowCounter;
+import com.richard.fyoung.customerwork.infra.counter.RedissonWindowCounter;
+import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContextThreadLocalAccessor;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectLevelResolver;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitStore;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevelProvider;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevelStore;
+import io.micrometer.context.ContextRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Hooks;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 后台用户配额装配。
+ *
+ * <p>本模块已 {@code spring.autoconfigure.exclude} 关闭 starter 自动装配，故 starter 的
+ * {@code SubjectQuotaConfig} 不会加载，这里手动 new（与 {@code AdminDistributedLockConfig}
+ * 等既有配置同一手法）。</p>
+ *
+ * <p><b>计数器优先用 Redisson</b>：后台多副本时进程内计数等于把额度放大 N 倍。与客服端共用同一个
+ * Redis 也不会串——主体类型不同（{@code ADMIN_USER} vs {@code USER}），计数键天然分开，
+ * 共享反而让多副本的额度真正合成一份。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(AdminSubjectQuotaProperties.class)
+public class AdminSubjectQuotaConfig {
+
+    private final AdminSubjectQuotaProperties properties;
+
+    public AdminSubjectQuotaConfig(AdminSubjectQuotaProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * 把主体上下文接进 Reactor 的自动传播。
+     *
+     * <p><b>为什么非做不可</b>：判定发生在 MVC 拦截器（Tomcat 线程），而 token 的真实用量要到
+     * 模型调用之后才知道，那时链路早已切到 Reactor 线程——不接传播，后台用户的额度就只有次数在动、
+     * token 永远是 0。admin 此前完全没有这套机制（starter 的自动装配被 exclude 了）。</p>
+     *
+     * <p><b>只接主体，不顺手把租户也接上</b>：租户上下文在 admin 的 Reactor 链上同样是丢的，
+     * 但补它会让多租户开启后，AI 链路里的持久层操作开始真正带上租户过滤——那是一次独立的行为变更，
+     * 该单独评估、单独验证，不该搭这次的车。</p>
+     *
+     * <p>Accessor 无条件注册（它本身没有开销），但全局的自动传播开关只在功能开启时才动——
+     * 有全局影响的东西不该在功能关闭时生效。代价是打开配置需要重启。</p>
+     */
+    @PostConstruct
+    public void setUpContextPropagation() {
+        ContextRegistry.getInstance().registerThreadLocalAccessor(new QuotaSubjectContextThreadLocalAccessor());
+        if (properties.isEnabled()) {
+            Hooks.enableAutomaticContextPropagation();
+            log.info("admin quota subject context propagation enabled");
+        }
+    }
+
+    @Bean
+    public SubjectQuotaLevelStore adminSubjectQuotaLevelStore(SubjectQuotaGatewayProvider gatewayProvider) {
+        return new LazyCrossDbLevelStore(gatewayProvider);
+    }
+
+    @Bean
+    public SubjectQuotaHitStore adminSubjectQuotaHitStore(SubjectQuotaGatewayProvider gatewayProvider) {
+        return new LazyCrossDbHitStore(gatewayProvider);
+    }
+
+    /**
+     * 等级快照：定时刷新关闭、惰性刷新打开。
+     *
+     * <p>构造时会 reload 一次，此时客服端库若不可达，{@link LazyCrossDbLevelStore} 会把异常
+     * 吞成"读取失败"，Provider 保留空快照继续启动——后台不该因为客服端库没起来就起不来。</p>
+     */
+    @Bean
+    public SubjectQuotaLevelProvider adminSubjectQuotaLevelProvider(SubjectQuotaLevelStore adminSubjectQuotaLevelStore) {
+        return new SubjectQuotaLevelProvider(adminSubjectQuotaLevelStore, false,
+            properties.isEnabled() ? properties.getLazyRefreshMs() : 0L);
+    }
+
+    @Bean
+    public SubjectLevelResolver adminSubjectLevelResolver(SubjectQuotaLevelProvider adminSubjectQuotaLevelProvider,
+                                                          SysUserMapper sysUserMapper) {
+        // 复用 starter 的解析器，只把"后台默认档"与缓存参数灌进它认识的配置对象；
+        // 客服端那几项（注册默认档、匿名档、API Key 档）在 admin 侧用不到，保持默认即可
+        SubjectQuotaProperties starterProperties = new SubjectQuotaProperties();
+        starterProperties.setDefaultAdminLevel(properties.getDefaultLevel());
+        starterProperties.setLevelCacheTtlMs(properties.getLevelCacheTtlMs());
+        return new SubjectLevelResolver(adminSubjectQuotaLevelProvider,
+            new AdminUserLevelBinding(sysUserMapper), starterProperties);
+    }
+
+    @Bean
+    public SubjectQuotaGuard adminSubjectQuotaGuard(SubjectLevelResolver adminSubjectLevelResolver,
+                                                    SubjectQuotaHitStore adminSubjectQuotaHitStore,
+                                                    ObjectProvider<RedissonClient> redissonProvider) {
+        WindowCounter counter = buildCounter(redissonProvider);
+        if (properties.isEnabled()) {
+            log.info("admin subject quota guard enabled, defaultLevel={}, counter={}",
+                properties.getDefaultLevel(), counter.getClass().getSimpleName());
+        }
+        return new SubjectQuotaGuard(adminSubjectLevelResolver, counter,
+            adminSubjectQuotaHitStore, properties.isEnabled());
+    }
+
+    private WindowCounter buildCounter(ObjectProvider<RedissonClient> redissonProvider) {
+        InMemoryWindowCounter inMemory = new InMemoryWindowCounter();
+        RedissonClient redisson = redissonProvider.getIfAvailable();
+        if (redisson == null) {
+            // Redis 不可用时退进程内：限流是旁路保护，不该因为它拖垮后台的可启动性
+            log.info("admin subject quota counter falls back to in-process (no RedissonClient)");
+            return inMemory;
+        }
+        return new RedissonWindowCounter(redisson, "cw:counter:", inMemory);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/AdminSubjectQuotaProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/AdminSubjectQuotaProperties.java
@@ -1,0 +1,48 @@
+package com.richard.fyoung.customeradmin.subjectquota.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+/**
+ * 后台登录用户的速率配额配置。
+ *
+ * <p>与客服端的 {@code customer-work.subject-quota.*} 分开配：两边的负载形态完全不同——
+ * 后台用户跑的是智能体调试、VibeCoding 这类单次很重、频次很低的任务，
+ * 拿 C 端的档位套上去只会把内部员工挡在门外。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@ConfigurationProperties(prefix = "admin.subject-quota")
+public class AdminSubjectQuotaProperties {
+
+    /** 是否开启后台用户配额判定。默认关闭，行为与引入前完全一致。 */
+    private boolean enabled = false;
+
+    /** 未单独分档的后台账号走这一档（等级定义在客服端库 {@code cw_subject_quota_level}）。 */
+    private String defaultLevel = "admin-default";
+
+    /**
+     * 等级快照的惰性刷新间隔（毫秒）。
+     *
+     * <p>admin 刻意不开 {@code @EnableScheduling}（开了会把容器里所有 {@code @Scheduled} 一并激活），
+     * 所以这边的快照只能靠读路径上的惰性刷新更新，不能用客服端那套定时轮询。</p>
+     */
+    private long lazyRefreshMs = 60000L;
+
+    /** 用户等级绑定的本地缓存有效期（毫秒）：不缓存的话每个 AI 请求都要查一次 sys_user。 */
+    private long levelCacheTtlMs = 60000L;
+
+    /**
+     * 参与判定的路径（Ant 模式）。
+     *
+     * <p>只覆盖真正调模型的入口——后台的列表、详情、附件下载不消耗额度。
+     * 这与客服端刻意不同：那边为了给登录用户的所有接口加防刷闸门而覆盖了整个用户面，
+     * 而后台用户是内部员工，防的是"调用失控"而不是"有人刷接口"。</p>
+     */
+    private List<String> pathPatterns = List.of(
+        "/api/workspace/*/chat/stream",
+        "/api/workspace/*/vibecoding/**",
+        "/api/aiconfig/agent-task/**");
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/controller/SubjectQuotaController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/controller/SubjectQuotaController.java
@@ -5,6 +5,8 @@ import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.subjectquota.dto.AdminQuotaUserVO;
+import com.richard.fyoung.customeradmin.subjectquota.dto.AdminUserLevelSaveRequest;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaHitVO;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelSaveRequest;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelVO;
@@ -82,6 +84,23 @@ public class SubjectQuotaController {
     @PostMapping("/users/level")
     public Result<Void> assignUserLevel(@Valid @RequestBody UserLevelSaveRequest request) {
         service.assignUserLevel(TenantSession.effectiveTenant(), request.getUserId(), request.getLevelCode());
+        return Result.success();
+    }
+
+    // ---------- 后台用户分档 ----------
+
+    @SaCheckPermission("subject-quota:view")
+    @GetMapping("/admin-users")
+    public Result<PageResult<AdminQuotaUserVO>> pageAdminUsers(PageQuery query) {
+        return Result.success(service.pageAdminUsers(query));
+    }
+
+    @SaCheckPermission("subject-quota:user-edit")
+    @OperationLog(operation = "分配后台用户配额等级", target = "sys_user")
+    @PostMapping("/admin-users/level")
+    public Result<Void> assignAdminUserLevel(@Valid @RequestBody AdminUserLevelSaveRequest request) {
+        service.assignAdminUserLevel(TenantSession.effectiveTenant(),
+            request.getUserId(), request.getLevelCode());
         return Result.success();
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/AdminQuotaUserVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/AdminQuotaUserVO.java
@@ -1,0 +1,25 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 后台用户分档视图（只暴露分配等级需要的字段）。
+ *
+ * <p>与 {@link SubjectQuotaUserVO}（客服端终端用户）刻意分成两个类型：{@code sys_user} 与
+ * {@code cw_user} 的主键类型、状态取值都不一样，硬塞进一个 VO 只会让前端处处判断"这是哪种用户"。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AdminQuotaUserVO {
+
+    private Long userId;
+    private String username;
+    private String nickname;
+    /** 当前绑定等级；空表示走配置里的 default-admin-level。 */
+    private String levelCode;
+    /** 0 禁用 / 1 启用。 */
+    private Integer status;
+    private LocalDateTime createTime;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/AdminUserLevelSaveRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/dto/AdminUserLevelSaveRequest.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customeradmin.subjectquota.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * 后台用户等级分配请求。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class AdminUserLevelSaveRequest {
+
+    @NotNull(message = "用户不能为空")
+    private Long userId;
+
+    /** 目标等级编码；传空表示回到配置里的默认档。 */
+    private String levelCode;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/AdminQuotaInterceptor.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/AdminQuotaInterceptor.java
@@ -1,0 +1,97 @@
+package com.richard.fyoung.customeradmin.subjectquota.runtime;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaDecision;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 后台登录用户的 AI 用量判定入口。
+ *
+ * <p>admin 是 Spring MVC，没有 {@code WebFilter}，因此这套判定用 {@link HandlerInterceptor} 实现，
+ * 而不是复用客服端那个 {@code SubjectQuotaWebFilter}。</p>
+ *
+ * <p><b>为什么要写 {@code QuotaSubjectContext}</b>：token 的真实用量要到模型调用之后才知道，
+ * 由 {@code AgentCallTimingMiddleware} 补记。MVC 这一段虽是同一个线程，但 AI 链路随后会切到
+ * Reactor 线程，故 {@code ChatService} 还要把它写进 Reactor Context——两处缺一，token 就记不到人头上。</p>
+ *
+ * <p><b>租户上下文</b>：等级表按租户隔离，而租户拦截器排在最后执行（本拦截器之后），
+ * 所以这里自己按登录态的租户包一层，不能依赖那个还没跑的拦截器。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class AdminQuotaInterceptor implements HandlerInterceptor {
+
+    private final SubjectQuotaGuard guard;
+    private final ObjectMapper objectMapper;
+
+    public AdminQuotaInterceptor(SubjectQuotaGuard guard, ObjectMapper objectMapper) {
+        this.guard = guard;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        if (!guard.isEnabled() || !StpUtil.isLogin()) {
+            // 未登录的请求由 Sa-Token 拦截器负责拒绝，这里不重复判身份，也无从算额度
+            return true;
+        }
+        QuotaSubject subject = QuotaSubject.adminUser(StpUtil.getLoginIdAsString());
+        String tenantId = tenantOf();
+        SubjectQuotaDecision decision = TenantContext.callWith(tenantId,
+            () -> guard.check(subject, request.getRequestURI()));
+
+        if (decision.shouldBlock()) {
+            writeQuotaExceeded(response, decision);
+            return false;
+        }
+        TenantContext.runWith(tenantId, () -> guard.recordRequest(subject));
+        QuotaSubjectContext.set(subject);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        // 线程是复用的，不清理会让下一个请求的 token 记到上一个人头上
+        QuotaSubjectContext.clear();
+    }
+
+    /** 登录态里的租户；取不到按默认租户算（未开多租户时就是这种情况）。 */
+    private static String tenantOf() {
+        String tenantId = TenantSession.effectiveTenant();
+        return tenantId == null || tenantId.isBlank() ? TenantContext.DEFAULT : tenantId;
+    }
+
+    /**
+     * 429 + 统一 Result 包装。
+     *
+     * <p>状态码用 429 而不是 200：前端的响应拦截器按状态码分流，用 200 包一个错误码
+     * 会让"额度用尽"混进正常响应里，只有认真读 body 的调用方才发现。</p>
+     */
+    private void writeQuotaExceeded(HttpServletResponse response, SubjectQuotaDecision decision)
+            throws Exception {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(decision.retryAfterSeconds()));
+        Result<Void> body = Result.failure(ResultCode.QUOTA_EXCEEDED, decision.message());
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/AdminUserLevelBinding.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/AdminUserLevelBinding.java
@@ -1,0 +1,59 @@
+package com.richard.fyoung.customeradmin.subjectquota.runtime;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectLevelBinding;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+/**
+ * 后台登录用户 → 配额等级的绑定查询（{@code sys_user.level_code}）。
+ *
+ * <p>与客服端那份 {@code UserAccountLevelBinding} 是同一个 SPI 的两个实现：一边查 {@code cw_user}，
+ * 一边查 {@code sys_user}。解析逻辑不需要知道这个区别——它只问"这个人是哪一档"。</p>
+ *
+ * <p>查询走 {@link CrossTenantOperations}：限流判定发生在拦截器里，那时租户上下文尚未写入
+ * （租户拦截器排在最后执行），带过滤会直接 fail-closed 抛错，把一次限流判定变成一个 500。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class AdminUserLevelBinding implements SubjectLevelBinding {
+
+    private final SysUserMapper userMapper;
+
+    public AdminUserLevelBinding(SysUserMapper userMapper) {
+        this.userMapper = userMapper;
+    }
+
+    @Override
+    public Optional<String> levelCodeOf(String adminUserId) {
+        if (adminUserId == null || adminUserId.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            // 只取等级这一列：为了一个档位把整行（含密码哈希）拉出来没有必要。
+            // 用字符串列名而不是 lambda：lambda 解析依赖 MyBatis-Plus 的 TableInfo 缓存，
+            // 在不启动容器的单测里拿不到，会直接抛 MybatisPlusException
+            SysUser user = CrossTenantOperations.execute(() -> userMapper.selectOne(
+                new QueryWrapper<SysUser>()
+                    .select("level_code")
+                    .eq("id", Long.valueOf(adminUserId.trim()))));
+            return Optional.ofNullable(user)
+                .map(SysUser::getLevelCode)
+                .filter(code -> !code.isBlank());
+        } catch (NumberFormatException e) {
+            // 登录 ID 恒为 sys_user.id（Long），解析不了说明调用方传错了主体，按未绑定处理
+            log.error("admin quota level binding got non-numeric user id, code={}, id={}",
+                "SQUOTA-ADMIN-BINDING-BAD-ID", adminUserId);
+            return Optional.empty();
+        } catch (Exception e) {
+            // 查不到绑定就走默认档：为一次等级查询失败把用户挡在门外，比放行的代价大得多
+            log.error("admin quota level binding query failed, code={}, id={}",
+                "SQUOTA-ADMIN-BINDING-FAIL", adminUserId, e);
+            return Optional.empty();
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/LazyCrossDbHitStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/LazyCrossDbHitStore.java
@@ -1,0 +1,59 @@
+package com.richard.fyoung.customeradmin.subjectquota.runtime;
+
+import com.richard.fyoung.customeradmin.subjectquota.config.SubjectQuotaGatewayProvider;
+import com.richard.fyoung.customerwork.safety.subjectquota.MybatisSubjectQuotaHitStore;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHit;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitRank;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaHitStore;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+/**
+ * 命中记录存储的惰性跨库包装（理由同 {@link LazyCrossDbLevelStore}）。
+ *
+ * <p>写入失败只记日志：命中记录是观测数据，为它让一个"本来就要被拒"的请求再抛一个错，
+ * 是把观测手段变成了故障源。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class LazyCrossDbHitStore implements SubjectQuotaHitStore {
+
+    private final SubjectQuotaGatewayProvider gatewayProvider;
+
+    public LazyCrossDbHitStore(SubjectQuotaGatewayProvider gatewayProvider) {
+        this.gatewayProvider = gatewayProvider;
+    }
+
+    @Override
+    public void record(SubjectQuotaHit hit) {
+        try {
+            new MybatisSubjectQuotaHitStore(gatewayProvider.get().hitMapper()).record(hit);
+        } catch (Exception e) {
+            log.error("admin subject quota hit record failed, code={}, subject={}:{}",
+                "SQUOTA-ADMIN-HIT-FAIL", hit.subjectType(), hit.subjectId(), e);
+        }
+    }
+
+    @Override
+    public List<SubjectQuotaHit> findRecent(String tenantId, long sinceMs, int limit) {
+        try {
+            return new MybatisSubjectQuotaHitStore(gatewayProvider.get().hitMapper())
+                .findRecent(tenantId, sinceMs, limit);
+        } catch (Exception e) {
+            log.error("admin subject quota hit query failed, code={}", "SQUOTA-ADMIN-HIT-QUERY-FAIL", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public List<SubjectQuotaHitRank> rank(String tenantId, long sinceMs, int limit) {
+        try {
+            return new MybatisSubjectQuotaHitStore(gatewayProvider.get().hitMapper())
+                .rank(tenantId, sinceMs, limit);
+        } catch (Exception e) {
+            log.error("admin subject quota hit rank failed, code={}", "SQUOTA-ADMIN-HIT-RANK-FAIL", e);
+            return List.of();
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/LazyCrossDbLevelStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/runtime/LazyCrossDbLevelStore.java
@@ -1,0 +1,65 @@
+package com.richard.fyoung.customeradmin.subjectquota.runtime;
+
+import com.richard.fyoung.customeradmin.subjectquota.config.SubjectQuotaGatewayProvider;
+import com.richard.fyoung.customerwork.safety.subjectquota.MybatisSubjectQuotaLevelStore;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevel;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevelStore;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 等级存储的惰性跨库包装：每次调用才去取门面，且把"库不可达"翻译成"读取失败"。
+ *
+ * <p><b>为什么不能直接把跨库 Store 交给 Provider</b>：Provider 在构造时就会 reload 一次，
+ * 而 admin 的铁律是<b>启动期绝不触碰客服端库</b>——后台不该因为客服端库没起来就启动不了。
+ * 这里把异常吞成 {@code Optional.empty()}，Provider 据此保留空快照并打 error 日志，
+ * 启动继续；等级会在后续的惰性刷新里补上。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class LazyCrossDbLevelStore implements SubjectQuotaLevelStore {
+
+    private final SubjectQuotaGatewayProvider gatewayProvider;
+
+    public LazyCrossDbLevelStore(SubjectQuotaGatewayProvider gatewayProvider) {
+        this.gatewayProvider = gatewayProvider;
+    }
+
+    private Optional<SubjectQuotaLevelStore> delegate() {
+        try {
+            return Optional.of(new MybatisSubjectQuotaLevelStore(gatewayProvider.get().levelMapper()));
+        } catch (Exception e) {
+            log.error("subject quota level store unavailable (cross-db), code={}",
+                "SQUOTA-ADMIN-LEVEL-DS-UNAVAILABLE", e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<List<SubjectQuotaLevel>> findAllEnabled() {
+        return delegate().flatMap(SubjectQuotaLevelStore::findAllEnabled);
+    }
+
+    @Override
+    public List<SubjectQuotaLevel> findByTenant(String tenantId) {
+        return delegate().map(store -> store.findByTenant(tenantId)).orElseGet(List::of);
+    }
+
+    @Override
+    public void save(SubjectQuotaLevel level) {
+        // 写路径不吞异常：后台点了保存却什么都没发生，比报一个错糟糕得多
+        new MybatisSubjectQuotaLevelStore(gatewayProvider.get().levelMapper()).save(level);
+    }
+
+    @Override
+    public void delete(String tenantId, String levelCode) {
+        new MybatisSubjectQuotaLevelStore(gatewayProvider.get().levelMapper()).delete(tenantId, levelCode);
+    }
+
+    @Override
+    public Optional<String> fingerprint() {
+        return delegate().flatMap(SubjectQuotaLevelStore::fingerprint);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/service/SubjectQuotaAdminService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/service/SubjectQuotaAdminService.java
@@ -7,11 +7,14 @@ import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.subjectquota.config.SubjectQuotaGatewayProvider;
+import com.richard.fyoung.customeradmin.subjectquota.dto.AdminQuotaUserVO;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaHitVO;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelSaveRequest;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaLevelVO;
 import com.richard.fyoung.customeradmin.subjectquota.dto.SubjectQuotaUserVO;
 import com.richard.fyoung.customeradmin.subjectquota.jdbc.SubjectQuotaGateway;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customerwork.data.user.entity.UserDO;
 import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
 import com.richard.fyoung.customerwork.safety.subjectquota.MybatisSubjectQuotaHitStore;
@@ -52,8 +55,13 @@ public class SubjectQuotaAdminService {
 
     private final SubjectQuotaGatewayProvider gatewayProvider;
 
-    public SubjectQuotaAdminService(SubjectQuotaGatewayProvider gatewayProvider) {
+    /** 后台用户表在 admin 主库，不走跨库门面——它跟等级定义不在一个库里。 */
+    private final SysUserMapper sysUserMapper;
+
+    public SubjectQuotaAdminService(SubjectQuotaGatewayProvider gatewayProvider,
+                                    SysUserMapper sysUserMapper) {
         this.gatewayProvider = gatewayProvider;
+        this.sysUserMapper = sysUserMapper;
     }
 
     // ---------- 等级 ----------
@@ -165,6 +173,67 @@ public class SubjectQuotaAdminService {
     private boolean hasLevel(String tenantId, String levelCode) {
         return levelStore().findByTenant(tenantId).stream()
             .anyMatch(level -> level.levelCode().equals(levelCode));
+    }
+
+    // ---------- 后台用户分档 ----------
+
+    /**
+     * 后台用户列表（带当前等级）。
+     *
+     * <p>走 admin 主数据源，租户过滤由 MyBatis-Plus 拦截器按当前视角自动完成，不必显式加条件——
+     * 这与上面的终端用户列表刻意不同：那边是跨库门面，那里没有拦截器。</p>
+     */
+    public PageResult<AdminQuotaUserVO> pageAdminUsers(PageQuery query) {
+        long size = Math.max(1, query.getPageSize());
+        long offset = Math.max(0, (query.getPageNum() - 1) * size);
+
+        long total = sysUserMapper.selectCount(adminUserWrapper(query.getKeyword()));
+        List<AdminQuotaUserVO> list = new ArrayList<>();
+        if (total > 0) {
+            List<SysUser> rows = sysUserMapper.selectList(adminUserWrapper(query.getKeyword())
+                .orderByDesc("create_time")
+                .last("LIMIT " + size + " OFFSET " + offset));
+            for (SysUser row : rows) {
+                list.add(toVO(row));
+            }
+        }
+        PageResult<AdminQuotaUserVO> result = new PageResult<>();
+        result.setPageNum(query.getPageNum());
+        result.setPageSize(size);
+        result.setTotal(total);
+        result.setList(list);
+        return result;
+    }
+
+    /** 分配后台用户等级；传空表示回到默认档。 */
+    public void assignAdminUserLevel(String tenantId, Long userId, String levelCode) {
+        String normalized = levelCode == null || levelCode.isBlank() ? null : levelCode.trim();
+        assertLevelExists(tenantId, normalized);
+        int updated = sysUserMapper.update(null, new UpdateWrapper<SysUser>()
+            .set("level_code", normalized)
+            .eq("id", userId));
+        log.info("admin user quota level assigned, user={}, level={}, updated={}",
+            userId, normalized, updated);
+    }
+
+    private static QueryWrapper<SysUser> adminUserWrapper(String keyword) {
+        QueryWrapper<SysUser> wrapper = new QueryWrapper<>();
+        if (keyword != null && !keyword.isBlank()) {
+            String like = keyword.trim();
+            wrapper.and(w -> w.like("username", like).or().like("nickname", like));
+        }
+        return wrapper;
+    }
+
+    private static AdminQuotaUserVO toVO(SysUser row) {
+        AdminQuotaUserVO vo = new AdminQuotaUserVO();
+        vo.setUserId(row.getId());
+        vo.setUsername(row.getUsername());
+        vo.setNickname(row.getNickname());
+        vo.setLevelCode(row.getLevelCode());
+        vo.setStatus(row.getStatus());
+        vo.setCreateTime(row.getCreateTime());
+        return vo;
     }
 
     // ---------- 命中记录 ----------

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/entity/SysUser.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/entity/SysUser.java
@@ -39,6 +39,15 @@ public class SysUser {
     private String nickname;
     /** 账号来源：LOCAL 本地账号 / LDAP 域账号（OA 单点登录，见 AuthService#ssoLogin）。 */
     private String loginType;
+
+    /**
+     * 配额等级编码（可为空 = 走配置里的 default-admin-level）。
+     *
+     * <p>等级定义本身在客服端库的 {@code cw_subject_quota_level}（与终端用户共用一张表、
+     * 靠 {@code subject_type} 区分），这里只存绑定——绑定跟着用户表走，
+     * 另建映射表会让每次限流判定多一次跨表查询，而 {@code sys_user} 本就要查。</p>
+     */
+    private String levelCode;
     /** 0禁用 / 1启用。 */
     private Integer status;
     private LocalDateTime lastLoginTime;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsStoreConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsStoreConfig.java
@@ -4,6 +4,8 @@ import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsG
 import com.richard.fyoung.customerwork.data.calllog.AgentCallRecordSink;
 import com.richard.fyoung.customerwork.data.calllog.AgentCallTimingMiddleware;
 import com.richard.fyoung.customerwork.data.calllog.StoreAgentCallRecordSink;
+import com.richard.fyoung.customerwork.safety.quota.TenantQuotaGuard;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
 import com.richard.fyoung.customerwork.data.calllog.ToolKindRegistry;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -61,11 +63,16 @@ public class AgentCallStatsStoreConfig {
             @Value("${customer-work.call-log.enabled:true}") boolean callLogEnabled,
             ToolKindRegistry agentCallToolKindRegistry,
             AgentCallRecordSink agentCallRecordSink,
-            ObjectProvider<MeterRegistry> meterRegistryProvider) {
+            ObjectProvider<MeterRegistry> meterRegistryProvider,
+            ObjectProvider<SubjectQuotaGuard> subjectQuotaGuardProvider) {
         CustomerWorkProperties properties = new CustomerWorkProperties();
         properties.getCallLog().setEnabled(callLogEnabled);
-        // meterRegistry 可选注入：容器里没有 Micrometer 时中间件降级为只落库、不出 token 指标
+        // meterRegistry 可选注入：容器里没有 Micrometer 时中间件降级为只落库、不出 token 指标。
+        // subjectQuotaGuard 同样可选：它是后台用量记账的落点——token 的唯一落点就在这个中间件里，
+        // 不接进来的话后台用户的额度只有次数在动、token 永远是 0。
+        // 租户配额（TenantQuotaGuard）在 admin 侧没有装配，故传 null：那是客服端链路的成本上限。
         return new AgentCallTimingMiddleware(properties, agentCallToolKindRegistry,
-            agentCallRecordSink, meterRegistryProvider);
+            agentCallRecordSink, meterRegistryProvider, (ObjectProvider<TenantQuotaGuard>) null,
+            subjectQuotaGuardProvider);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -13,6 +13,9 @@ import com.richard.fyoung.customeradmin.workspace.runtime.mode.ExecutionModeRegi
 import com.richard.fyoung.customeradmin.workspace.vibecoding.service.PlanConfirmationService;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.service.PlanConfirmationService.PlanChannel;
 import com.richard.fyoung.customerwork.data.calllog.AgentCallMeta;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContextThreadLocalAccessor;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
@@ -240,6 +243,10 @@ public class ChatService {
                                              Consumer<ChatUsage> usageTotalObserver) {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
         RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
+        // 在 Tomcat 线程上把限流主体取下来：下面整条链会切到 Reactor 线程，ThreadLocal 到不了那边，
+        // 而 token 记账（AgentCallTimingMiddleware）恰恰发生在那里。主体由 AdminQuotaInterceptor 写入，
+        // 功能关闭或非 AI 入口时为 null，此时不写 Context。
+        QuotaSubject quotaSubject = QuotaSubjectContext.get();
         // 绑定调用元数据供 AgentCallTimingMiddleware 采集（requestId/username/agentName/sessionType/question）；
         // 缺省（旧调用点/测试）不绑，中间件按 ctx.userId/MDC 降级，不影响主链路。
         if (callMeta != null) {
@@ -330,7 +337,10 @@ public class ChatService {
                     planConfirmationService.events(channel)),
                 planConfirmationService::closeChannel)
             .doFirst(() -> executionModeRegistry.put(agentCode, safeSession, executionMode))
-            .doFinally(signal -> executionModeRegistry.remove(agentCode, safeSession));
+            .doFinally(signal -> executionModeRegistry.remove(agentCode, safeSession))
+            // Reactor Context 不接受 null 值，故主体为空时原样返回
+            .contextWrite(context -> quotaSubject == null ? context
+                : context.put(QuotaSubjectContextThreadLocalAccessor.KEY, quotaSubject));
     }
 
     /** 收集单次模型调用的用量：按 {@code replyId} 存一份（同一 replyId 只会来一条 MODEL_CALL_END）。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepository.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepository.java
@@ -4,6 +4,8 @@ import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.richard.fyoung.customeradmin.workspace.task.entity.AiAgentTask;
 import com.richard.fyoung.customeradmin.workspace.task.mapper.AiAgentTaskMapper;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
@@ -141,7 +143,13 @@ public class MybatisTaskRepository implements TaskRepository {
 
         CompletableFuture<String> future;
         if (spec instanceof TaskRunSpec.LocalTaskRunSpec local) {
-            future = CompletableFuture.supplyAsync(() -> runLocal(sessionId, taskId, local.execution()), executor);
+            // 提交任务的这一刻还在 Tomcat 线程上，主体上下文尚在；任务体跑在自建线程池里，
+            // ThreadLocal 到不了那边（Reactor 的自动传播只覆盖 Reactor 的线程边界）。
+            // 不带过去的话，委派任务烧掉的 token 就没有主人——额度里只有"提交次数"在动。
+            QuotaSubject quotaSubject = QuotaSubjectContext.get();
+            future = CompletableFuture.supplyAsync(
+                () -> QuotaSubjectContext.callWith(quotaSubject,
+                    () -> runLocal(sessionId, taskId, local.execution())), executor);
         } else if (spec instanceof TaskRunSpec.AdoptedTaskRunSpec adopted) {
             // 同步调用超时后被提升为后台任务：future 已经在跑，只补挂状态回写，绝不能重复提交执行
             future = adopted.future();

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -87,6 +87,23 @@ admin:
     # 开放 API（/api/open/**）访问令牌，供 customer-channel 等外部模块通过请求头 X-Open-Api-Token 调用。
     # 无默认值：未配置时所有开放 API 一律 401（见 OpenApiAuthInterceptor），不留“空 token 放行”后门。
     token: ${ADMIN_OPEN_API_TOKEN:}
+  # 后台登录用户的 AI 用量额度：按 sys_user 登录 ID 计，与客服端的
+  # customer-work.subject-quota（按终端用户/IP/API Key 计）是同一套机制的两个部署侧。
+  # 等级定义共用客服端库的 cw_subject_quota_level（靠 subject_type=ADMIN_USER 区分），
+  # 绑定落 sys_user.level_code；后台在「内容风控 → 用户额度 → 后台用户」维护。
+  subject-quota:
+    enabled: true
+    # 未单独分档的后台账号走这一档（出厂种子：1 小时 / 200 万 token / 200 次）
+    default-level: admin-default
+    # 等级快照的惰性刷新间隔：admin 刻意不开 @EnableScheduling，客服端那套定时轮询在这边不会跑，
+    # 只能在读路径上判断"距上次重载是否超过间隔"
+    lazy-refresh-ms: 60000
+    # 只覆盖真正调模型的入口（Ant 模式）。刻意比客服端窄：后台用户是内部员工，
+    # 防的是"调用失控"而不是"有人刷接口"，把翻列表也算进去只会让人干不了活。
+    path-patterns:
+      - /api/workspace/*/chat/stream
+      - /api/workspace/*/vibecoding/**
+      - /api/aiconfig/agent-task/**
   agent-memory:
     # 智能体长期记忆权威存储：留空（默认）= 落库 ai_agent_memory 表；
     # 需要存磁盘时在此显式指定根目录，记忆改存 {disk-root}/{agentCode}/MEMORY.md（不再读写库表）

--- a/customer-admin-server/src/main/resources/db/migration/V59__admin_user_quota_level.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V59__admin_user_quota_level.sql
@@ -1,0 +1,11 @@
+-- 后台登录用户的配额等级绑定。
+--
+-- 等级定义本身在**客服端库**的 cw_subject_quota_level（与终端用户共用一张表、靠 subject_type 区分），
+-- 这里只加"这个后台账号属于哪一档"的绑定列——绑定必须跟着用户表走，
+-- 另建映射表会让每次限流判定多一次跨表查询，而 sys_user 本就要查。
+--
+-- 空值 = 走配置里的 default-admin-level（admin-default）。
+--
+-- 版本号取 V59 而不是紧挨着上一版：V56/V57/V58 已被并行开发的分支占用（本机库里 V56 甚至已经 apply），
+-- 撞号会让 Flyway 在 checksum 校验上直接拒绝启动。加迁移前先扫一遍各 worktree 的最大版本号。
+ALTER TABLE `sys_user` ADD COLUMN `level_code` VARCHAR(64) DEFAULT NULL COMMENT '配额等级编码（空=默认档），见客服端库 cw_subject_quota_level';

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/subjectquota/AdminQuotaInterceptorTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/subjectquota/AdminQuotaInterceptorTest.java
@@ -1,0 +1,149 @@
+package com.richard.fyoung.customeradmin.subjectquota;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.subjectquota.runtime.AdminQuotaInterceptor;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectType;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectExceedAction;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaDecision;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaGuard;
+import com.richard.fyoung.customerwork.safety.subjectquota.SubjectQuotaLevel;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 后台用量判定拦截器单测：关闭放行、未登录放行、额度内放行并写上下文、超限 429、请求后清理上下文。
+ * @author owlzhangfq@gmail.com
+ */
+class AdminQuotaInterceptorTest {
+
+    private static final String ADMIN_ID = "42";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @AfterEach
+    void tearDown() {
+        QuotaSubjectContext.clear();
+        TenantContext.clear();
+    }
+
+    private MockHttpServletRequest request() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/workspace/demo/chat/stream");
+        return request;
+    }
+
+    private static SubjectQuotaDecision exceeded() {
+        SubjectQuotaLevel level = new SubjectQuotaLevel(null, TenantContext.DEFAULT, "admin-default",
+            "后台用户", QuotaSubjectType.ADMIN_USER, 3600, 0L, 200, SubjectExceedAction.BLOCK, true, null);
+        return SubjectQuotaDecision.exceeded(SubjectQuotaDecision.LimitKind.REQUEST, level, 200L);
+    }
+
+    @Test
+    void preHandle_shouldPassThrough_whenDisabled() throws Exception {
+        SubjectQuotaGuard guard = mock(SubjectQuotaGuard.class);
+        when(guard.isEnabled()).thenReturn(false);
+        AdminQuotaInterceptor interceptor = new AdminQuotaInterceptor(guard, objectMapper);
+
+        assertTrue(interceptor.preHandle(request(), new MockHttpServletResponse(), new Object()));
+        // 关闭时连登录态都不该去碰，更不该写上下文
+        assertNull(QuotaSubjectContext.get());
+        verify(guard, never()).check(any(), any());
+    }
+
+    @Test
+    void preHandle_shouldPassThrough_whenNotLogin() throws Exception {
+        SubjectQuotaGuard guard = mock(SubjectQuotaGuard.class);
+        when(guard.isEnabled()).thenReturn(true);
+        AdminQuotaInterceptor interceptor = new AdminQuotaInterceptor(guard, objectMapper);
+
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::isLogin).thenReturn(false);
+            // 未登录由 Sa-Token 的鉴权拦截器负责拒绝，这里既不重复判身份，也无从算额度
+            assertTrue(interceptor.preHandle(request(), new MockHttpServletResponse(), new Object()));
+            verify(guard, never()).check(any(), any());
+        }
+    }
+
+    @Test
+    void preHandle_shouldRecordAndBindSubject_whenAllowed() throws Exception {
+        SubjectQuotaGuard guard = mock(SubjectQuotaGuard.class);
+        when(guard.isEnabled()).thenReturn(true);
+        when(guard.check(any(), any())).thenReturn(SubjectQuotaDecision.allow());
+        AdminQuotaInterceptor interceptor = new AdminQuotaInterceptor(guard, objectMapper);
+
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class);
+             MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            stpUtil.when(StpUtil::isLogin).thenReturn(true);
+            stpUtil.when(StpUtil::getLoginIdAsString).thenReturn(ADMIN_ID);
+            tenantSession.when(TenantSession::effectiveTenant).thenReturn("acme");
+
+            assertTrue(interceptor.preHandle(request(), new MockHttpServletResponse(), new Object()));
+
+            QuotaSubject bound = QuotaSubjectContext.get();
+            assertNotNull(bound, "放行后必须把主体写进上下文，否则 token 记不到人头上");
+            assertEquals(QuotaSubjectType.ADMIN_USER, bound.type());
+            assertEquals(ADMIN_ID, bound.id());
+            verify(guard).recordRequest(bound);
+        }
+    }
+
+    @Test
+    void preHandle_shouldReject_whenExceeded() throws Exception {
+        SubjectQuotaGuard guard = mock(SubjectQuotaGuard.class);
+        when(guard.isEnabled()).thenReturn(true);
+        when(guard.check(any(), any())).thenReturn(exceeded());
+        AdminQuotaInterceptor interceptor = new AdminQuotaInterceptor(guard, objectMapper);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class);
+             MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            stpUtil.when(StpUtil::isLogin).thenReturn(true);
+            stpUtil.when(StpUtil::getLoginIdAsString).thenReturn(ADMIN_ID);
+            tenantSession.when(TenantSession::effectiveTenant).thenReturn(null);
+
+            assertFalse(interceptor.preHandle(request(), response, new Object()));
+
+            assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), response.getStatus());
+            assertEquals("3600", response.getHeader(HttpHeaders.RETRY_AFTER),
+                "429 必须带 Retry-After，否则前端只能瞎猜什么时候能重试");
+            assertTrue(response.getContentAsString().contains("40043"),
+                "用专属错误码而不是权限/参数码：额度用尽既不是没权限也不是参数错");
+            // 被拒的请求不占额度：判定只读，记账发生在放行之后
+            verify(guard, never()).recordRequest(any());
+            assertNull(QuotaSubjectContext.get(), "被拒时不写上下文");
+        }
+    }
+
+    @Test
+    void afterCompletion_shouldClearContext() {
+        SubjectQuotaGuard guard = mock(SubjectQuotaGuard.class);
+        AdminQuotaInterceptor interceptor = new AdminQuotaInterceptor(guard, objectMapper);
+        QuotaSubjectContext.set(QuotaSubject.adminUser(ADMIN_ID));
+
+        interceptor.afterCompletion(request(), new MockHttpServletResponse(), new Object(), null);
+        // Tomcat 线程是复用的，不清理会把上一个请求的身份带给下一个人
+        assertNull(QuotaSubjectContext.get());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/subjectquota/AdminUserLevelBindingTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/subjectquota/AdminUserLevelBindingTest.java
@@ -1,0 +1,70 @@
+package com.richard.fyoung.customeradmin.subjectquota;
+
+import com.richard.fyoung.customeradmin.subjectquota.runtime.AdminUserLevelBinding;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 后台用户等级绑定单测：读到绑定、空绑定当未绑定、非数字 ID 与查询异常都按未绑定处理。
+ * @author owlzhangfq@gmail.com
+ */
+class AdminUserLevelBindingTest {
+
+    private final SysUserMapper mapper = mock(SysUserMapper.class);
+    private final AdminUserLevelBinding binding = new AdminUserLevelBinding(mapper);
+
+    private static SysUser userWithLevel(String levelCode) {
+        SysUser user = new SysUser();
+        user.setLevelCode(levelCode);
+        return user;
+    }
+
+    @Test
+    void levelCodeOf_shouldReturnBoundLevel() {
+        when(mapper.selectOne(any())).thenReturn(userWithLevel("admin-power"));
+        assertEquals(Optional.of("admin-power"), binding.levelCodeOf("42"));
+    }
+
+    @Test
+    void levelCodeOf_shouldTreatBlankAsUnbound() {
+        when(mapper.selectOne(any())).thenReturn(userWithLevel("  "));
+        assertTrue(binding.levelCodeOf("42").isEmpty(), "空白等级等于没绑定，应走默认档");
+    }
+
+    @Test
+    void levelCodeOf_shouldReturnEmpty_whenUserMissing() {
+        when(mapper.selectOne(any())).thenReturn(null);
+        assertTrue(binding.levelCodeOf("42").isEmpty());
+    }
+
+    @Test
+    void levelCodeOf_shouldNotQuery_forBlankId() {
+        assertTrue(binding.levelCodeOf("  ").isEmpty());
+        verify(mapper, never()).selectOne(any());
+    }
+
+    @Test
+    void levelCodeOf_shouldReturnEmpty_forNonNumericId() {
+        // 登录 ID 恒为 sys_user.id（Long），解析不了说明调用方传错了主体
+        assertTrue(binding.levelCodeOf("not-a-number").isEmpty());
+        verify(mapper, never()).selectOne(any());
+    }
+
+    @Test
+    void levelCodeOf_shouldReturnEmpty_whenQueryFails() {
+        when(mapper.selectOne(any())).thenThrow(new IllegalStateException("db down"));
+        // 为一次等级查询失败把用户挡在门外，比放行的代价大得多
+        assertTrue(binding.levelCodeOf("42").isEmpty(), "查询异常应按未绑定处理而不是抛出");
+    }
+}

--- a/customer-admin-web/src/api/request.ts
+++ b/customer-admin-web/src/api/request.ts
@@ -55,7 +55,11 @@ http.interceptors.response.use(((response: { data: Result<unknown> | Blob; confi
   ElMessage.error(body.message || '请求失败')
   return Promise.reject(body)
 }) as never, (error) => {
-  ElMessage.error(error.message || '网络异常')
+  // 非 2xx 的响应体同样是 Result 包装（如额度用尽返回 429 + code 40043），优先显示后端文案：
+  // 只读 error.message 的话用户看到的是 "Request failed with status code 429"，
+  // 而真正该看的"最近 60 分钟内已达 N 次上限"就被吞掉了
+  const body = error.response?.data as Result<unknown> | undefined
+  ElMessage.error(body?.message || error.message || '网络异常')
   return Promise.reject(error)
 })
 

--- a/customer-admin-web/src/api/subjectQuota.ts
+++ b/customer-admin-web/src/api/subjectQuota.ts
@@ -1,5 +1,7 @@
 import { request } from './request'
 import type {
+  AdminQuotaUserVO,
+  AdminUserLevelSaveRequest,
   PageQuery,
   PageResult,
   SubjectQuotaHitRank,
@@ -50,4 +52,16 @@ export function fetchSubjectQuotaHitRank(hours: number, limit: number) {
   return request<SubjectQuotaHitRank[]>({
     url: '/subject-quota/hits/rank', method: 'get', params: { hours, limit },
   })
+}
+
+// ---------- 后台用户分档 ----------
+
+export function pageAdminQuotaUsers(query: PageQuery) {
+  return request<PageResult<AdminQuotaUserVO>>({
+    url: '/subject-quota/admin-users', method: 'get', params: query,
+  })
+}
+
+export function assignAdminUserLevel(data: AdminUserLevelSaveRequest) {
+  return request<void>({ url: '/subject-quota/admin-users/level', method: 'post', data })
 }

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -1405,3 +1405,21 @@ export interface SubjectQuotaHitRank {
   hitCount: number
   lastHitAtMs: number
 }
+
+/** 后台用户分档视图（sys_user，与终端用户的主键类型/状态取值都不同，故单列一个类型）。 */
+export interface AdminQuotaUserVO {
+  userId: number
+  username: string
+  nickname?: string
+  /** 空表示走配置里的 default-admin-level */
+  levelCode?: string
+  /** 0 禁用 / 1 启用 */
+  status: number
+  createTime?: string
+}
+
+export interface AdminUserLevelSaveRequest {
+  userId: number
+  /** 传空表示回到默认档 */
+  levelCode?: string
+}

--- a/customer-admin-web/src/views/contentguard/SubjectQuotaManage.vue
+++ b/customer-admin-web/src/views/contentguard/SubjectQuotaManage.vue
@@ -2,16 +2,19 @@
 import { onMounted, reactive, ref } from 'vue'
 import type { FormInstance } from 'element-plus'
 import {
+  assignAdminUserLevel,
   assignUserLevel,
   deleteSubjectQuotaLevel,
   fetchSubjectQuotaHitRank,
   fetchSubjectQuotaHits,
   fetchSubjectQuotaLevels,
+  pageAdminQuotaUsers,
   pageSubjectQuotaUsers,
   saveSubjectQuotaLevel,
 } from '@/api/subjectQuota'
 import { useAuthStore } from '@/store/auth'
 import type {
+  AdminQuotaUserVO,
   PageQuery,
   SubjectQuotaHitRank,
   SubjectQuotaHitVO,
@@ -117,6 +120,34 @@ async function changeUserLevel(row: SubjectQuotaUserVO, levelCode: string | unde
   await loadUsers()
 }
 
+// ---------- 后台用户分档 ----------
+const adminUserLoading = ref(false)
+const adminUsers = ref<AdminQuotaUserVO[]>([])
+const adminUserTotal = ref(0)
+const adminUserQuery = reactive<PageQuery>({ pageNum: 1, pageSize: 10, keyword: '' })
+
+async function loadAdminUsers() {
+  adminUserLoading.value = true
+  try {
+    const page = await pageAdminQuotaUsers(adminUserQuery)
+    adminUsers.value = page.list
+    adminUserTotal.value = page.total
+  } finally {
+    adminUserLoading.value = false
+  }
+}
+
+function searchAdminUsers() {
+  adminUserQuery.pageNum = 1
+  return loadAdminUsers()
+}
+
+async function changeAdminUserLevel(row: AdminQuotaUserVO, levelCode: string | undefined) {
+  await assignAdminUserLevel({ userId: row.userId, levelCode: levelCode || undefined })
+  ElMessage.success('已调整，最长 60 秒后生效')
+  await loadAdminUsers()
+}
+
 // ---------- 超限命中 ----------
 const hitLoading = ref(false)
 const hitHours = ref(24)
@@ -139,7 +170,7 @@ async function loadHits() {
 
 // ---------- 公共 ----------
 const subjectTypeLabels: Record<string, string> = {
-  USER: '登录用户', IP: '匿名 IP', API_KEY: '接入方',
+  USER: '登录用户', ADMIN_USER: '后台用户', IP: '匿名 IP', API_KEY: '接入方',
 }
 
 const actionLabels: Record<string, string> = {
@@ -164,7 +195,7 @@ function formatTime(ms?: number): string {
 }
 
 onMounted(async () => {
-  await Promise.all([loadLevels(), loadUsers()])
+  await Promise.all([loadLevels(), loadUsers(), loadAdminUsers()])
 })
 </script>
 
@@ -173,7 +204,8 @@ onMounted(async () => {
     <el-alert type="warning" :closable="false" show-icon class="notice">
       按<b>调用者</b>限流：每个登录用户 / 每个匿名 IP / 每把 API Key 在最近一段时间内的 token 量与请求次数上限。
       与同级的<b>限流规则</b>（按路径限）、<b>配额与计费</b>（按租户限月度花费）三者并存，任一触顶都会被拦。
-      需客服端开启 <code>customer-work.subject-quota.enabled=true</code> 才真正生效——这里能配，不等于一定在跑。
+      客服端需开 <code>customer-work.subject-quota.enabled=true</code>、后台需开
+      <code>admin.subject-quota.enabled=true</code> 才真正生效——这里能配，不等于一定在跑。
       改动经指纹轮询与本地缓存下发，<b>最长 60 秒生效</b>。
     </el-alert>
 
@@ -292,6 +324,71 @@ onMounted(async () => {
         </el-card>
       </el-tab-pane>
 
+      <!-- 后台用户分档 -->
+      <el-tab-pane label="后台用户" name="admin-users">
+        <el-card>
+          <el-alert type="info" :closable="false" show-icon class="notice">
+            后台账号跑的是智能体调试、VibeCoding 这类单次很重、频次很低的任务，
+            所以默认档（<code>admin-default</code>）的窗口是 1 小时、额度比 C 端宽得多。
+            只统计真正调模型的入口，翻列表、看详情不占额度。
+          </el-alert>
+          <div class="toolbar">
+            <el-input
+              v-model="adminUserQuery.keyword"
+              placeholder="按用户名或昵称搜索"
+              style="width: 220px"
+              clearable
+              @keyup.enter="searchAdminUsers"
+            />
+            <el-button type="primary" @click="searchAdminUsers">搜索</el-button>
+          </div>
+
+          <el-table v-loading="adminUserLoading" :data="adminUsers" style="width: 100%">
+            <el-table-column prop="username" label="用户名" min-width="140" show-overflow-tooltip />
+            <el-table-column prop="nickname" label="昵称" min-width="120" show-overflow-tooltip />
+            <el-table-column prop="userId" label="用户 ID" width="100" />
+            <el-table-column label="状态" width="90">
+              <template #default="{ row }">
+                <el-tag :type="row.status === 1 ? 'success' : 'info'">
+                  {{ row.status === 1 ? '启用' : '禁用' }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="createTime" label="创建时间" width="180" />
+            <el-table-column label="额度等级" width="200" fixed="right">
+              <template #default="{ row }">
+                <el-select
+                  :model-value="row.levelCode ?? ''"
+                  placeholder="默认档"
+                  clearable
+                  style="width: 100%"
+                  :disabled="!auth.hasPermission('subject-quota:user-edit')"
+                  @change="(value: string) => changeAdminUserLevel(row, value)"
+                >
+                  <el-option
+                    v-for="level in levels.filter((l) => l.subjectType === 'ADMIN_USER')"
+                    :key="level.levelCode"
+                    :label="`${level.levelName}（${level.levelCode}）`"
+                    :value="level.levelCode"
+                  />
+                </el-select>
+              </template>
+            </el-table-column>
+          </el-table>
+
+          <el-pagination
+            v-model:current-page="adminUserQuery.pageNum"
+            v-model:page-size="adminUserQuery.pageSize"
+            :total="adminUserTotal"
+            :page-sizes="[10, 20, 50]"
+            layout="total, sizes, prev, pager, next"
+            class="pager"
+            @current-change="loadAdminUsers"
+            @size-change="searchAdminUsers"
+          />
+        </el-card>
+      </el-tab-pane>
+
       <!-- 超限记录 -->
       <el-tab-pane label="超限记录" name="hits">
         <el-card>
@@ -368,6 +465,7 @@ onMounted(async () => {
         <el-form-item label="适用主体">
           <el-select v-model="levelForm.subjectType" style="width: 100%">
             <el-option label="登录用户（按 userId 计）" value="USER" />
+            <el-option label="后台用户（按 sys_user 登录 ID 计）" value="ADMIN_USER" />
             <el-option label="匿名访客（按来源 IP 计）" value="IP" />
             <el-option label="接入方（按 API Key 指纹计）" value="API_KEY" />
           </el-select>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/properties/SubjectQuotaProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/properties/SubjectQuotaProperties.java
@@ -29,6 +29,14 @@ public class SubjectQuotaProperties {
     /** 注册用户的默认等级编码：新用户落这一档，后台可单独改人。 */
     private String defaultUserLevel = "free";
 
+    /**
+     * 后台管理系统登录用户的默认等级编码。
+     *
+     * <p>与终端用户分开配：后台用户是内部员工，跑的是调试、VibeCoding 这类重负载，
+     * 按 C 端的档位限会让他们干不了活；但完全不限又挡不住"某个脚本挂在后台狂刷"这种真实事故。</p>
+     */
+    private String defaultAdminLevel = "admin-default";
+
     /** 匿名调用方（无登录态，按 IP 计）的等级编码。 */
     private String anonymousLevel = "anonymous";
 
@@ -99,7 +107,8 @@ public class SubjectQuotaProperties {
      * 出厂默认三档。
      *
      * <p>数值取向：匿名最紧（谁都能打，且同一 NAT 后共享一份额度）、注册用户居中、
-     * 接入方最宽（一把 Key 背后是一个系统而非一个人）。</p>
+     * 后台用户放宽（内部员工，调试与 VibeCoding 单次就很重）、接入方最宽
+     * （一把 Key 背后是一个系统而非一个人）。</p>
      *
      * <p>次数看起来偏宽是因为口径含查询请求（见 {@link #paths}）：一次对话往往伴随
      * 若干次工单/消息查询，按"纯提问数"配会让用户在正常使用中就被拦。token 上限才是
@@ -108,6 +117,7 @@ public class SubjectQuotaProperties {
     private static Map<String, Level> defaultLevels() {
         Map<String, Level> levels = new LinkedHashMap<>();
         levels.put("free", level("USER", "免费用户", 1800, 50000L, 100));
+        levels.put("admin-default", level("ADMIN_USER", "后台用户", 3600, 2000000L, 200));
         levels.put("anonymous", level("IP", "匿名访客", 1800, 10000L, 20));
         levels.put("api-key", level("API_KEY", "接入方", 3600, 1000000L, 2000));
         return levels;

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubject.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubject.java
@@ -31,6 +31,11 @@ public record QuotaSubject(QuotaSubjectType type, String id) {
         return new QuotaSubject(QuotaSubjectType.USER, blankToUnknown(userId));
     }
 
+    /** 后台管理系统的登录用户（Sa-Token 登录 ID）。 */
+    public static QuotaSubject adminUser(String adminUserId) {
+        return new QuotaSubject(QuotaSubjectType.ADMIN_USER, blankToUnknown(adminUserId));
+    }
+
     public static QuotaSubject ip(String ip) {
         return new QuotaSubject(QuotaSubjectType.IP, blankToUnknown(ip));
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectType.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectType.java
@@ -3,19 +3,27 @@ package com.richard.fyoung.customerwork.safety.subjectquota;
 /**
  * 限流主体类型：决定"这一份额度是谁的"。
  *
- * <p>三类主体的身份来源完全不同，额度语义也不同，故必须分开而不是硬凑成一个"用户"概念：</p>
+ * <p>四类主体的身份来源完全不同，额度语义也不同，故必须分开而不是硬凑成一个"用户"概念：</p>
  * <ul>
- *   <li>{@link #USER}：已登录的自然人（JWT subject），额度按人分配，是本功能的主战场；</li>
+ *   <li>{@link #USER}：客服端已登录的终端用户（JWT subject，落 {@code cw_user}），是本功能的主战场；</li>
+ *   <li>{@link #ADMIN_USER}：后台管理系统的登录用户（Sa-Token 登录 ID，落 {@code sys_user}）；</li>
  *   <li>{@link #IP}：匿名调用方（无登录态），只能按来源 IP 归并——同一 NAT 后的多人会共享一份额度，
  *       这是匿名的固有代价，因此匿名档应当配得最紧；</li>
  *   <li>{@link #API_KEY}：服务端接入方，一把 Key 代表一个系统而非一个人，额度量级应当最大。</li>
  * </ul>
+ *
+ * <p><b>后台用户为什么不能复用 {@link #USER}</b>：{@code sys_user} 与 {@code cw_user} 是两套独立的
+ * ID 空间，同一个 ID 值在两边指的是不同的人。混在一个类型里，计数键就会碰撞——
+ * 一个后台管理员和一个终端用户莫名其妙共用一份额度，而且谁也查不出为什么。</p>
  * @author owlzhangfq@gmail.com
  */
 public enum QuotaSubjectType {
 
-    /** 已登录用户（按 userId 计）。 */
+    /** 客服端终端用户（按 cw_user 的 userId 计）。 */
     USER,
+
+    /** 后台管理系统登录用户（按 sys_user 的登录 ID 计）。 */
+    ADMIN_USER,
 
     /** 匿名调用方（按来源 IP 计）。 */
     IP,

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolver.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolver.java
@@ -63,7 +63,10 @@ public class SubjectLevelResolver {
     /** 主体对应的等级编码（用户查绑定，其余按类型取配置档）。 */
     private String levelCodeOf(QuotaSubject subject) {
         return switch (subject.type()) {
+            // 两类登录用户共用一套绑定查询：实现方按部署侧决定查哪张用户表
+            // （客服端查 cw_user、后台查 sys_user），解析逻辑本身不需要知道这个区别
             case USER -> boundLevelOf(subject.id()).orElse(properties.getDefaultUserLevel());
+            case ADMIN_USER -> boundLevelOf(subject.id()).orElse(properties.getDefaultAdminLevel());
             case IP -> properties.getAnonymousLevel();
             case API_KEY -> properties.getApiKeyLevel();
         };

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelProvider.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelProvider.java
@@ -25,13 +25,34 @@ public class SubjectQuotaLevelProvider {
     private final SubjectQuotaLevelStore store;
     private final boolean refreshEnabled;
 
+    /**
+     * 惰性刷新间隔（毫秒），0 = 关闭。
+     *
+     * <p>给<b>没有定时调度</b>的宿主用：admin-server 刻意不开 {@code @EnableScheduling}
+     * （开了会把容器里所有 {@code @Scheduled} 一并激活），那边的快照靠 {@link #scheduledRefresh}
+     * 永远不会更新。惰性刷新把"该不该重载"的判断挪到读路径上，不需要任何调度设施。</p>
+     */
+    private final long lazyRefreshIntervalMs;
+
+    private volatile long lastRefreshAtMs;
+
     /** 当前快照：key = tenantId + '\n' + levelCode。 */
     private volatile Map<String, SubjectQuotaLevel> snapshot = Map.of();
     private volatile String lastFingerprint;
 
     public SubjectQuotaLevelProvider(SubjectQuotaLevelStore store, boolean refreshEnabled) {
+        this(store, refreshEnabled, 0L);
+    }
+
+    /**
+     * @param lazyRefreshIntervalMs 惰性刷新间隔（毫秒），0 = 只靠定时刷新。
+     *                              两种刷新方式不该同时开——那只是把同一件事做两遍。
+     */
+    public SubjectQuotaLevelProvider(SubjectQuotaLevelStore store, boolean refreshEnabled,
+                                     long lazyRefreshIntervalMs) {
         this.store = store;
         this.refreshEnabled = refreshEnabled;
+        this.lazyRefreshIntervalMs = lazyRefreshIntervalMs;
         reload();
     }
 
@@ -73,6 +94,7 @@ public class SubjectQuotaLevelProvider {
         }
         this.snapshot = Map.copyOf(next);
         this.lastFingerprint = store.fingerprint().orElse(null);
+        this.lastRefreshAtMs = System.currentTimeMillis();
         return true;
     }
 
@@ -81,7 +103,26 @@ public class SubjectQuotaLevelProvider {
         if (tenantId == null || levelCode == null) {
             return null;
         }
+        refreshLazilyIfDue();
         return snapshot.get(key(tenantId, levelCode));
+    }
+
+    /**
+     * 读路径上的惰性刷新：距上次重载超过间隔就重载一次。
+     *
+     * <p>不加锁：并发下最多是几个线程同时重载同一份数据，代价只是多几次查询；
+     * 而为此上锁会让每个请求都经过一次同步块——限流判定本就在热路径上。</p>
+     */
+    private void refreshLazilyIfDue() {
+        if (lazyRefreshIntervalMs <= 0) {
+            return;
+        }
+        if (System.currentTimeMillis() - lastRefreshAtMs < lazyRefreshIntervalMs) {
+            return;
+        }
+        // 先推进时间戳再重载：重载失败时也不会让每个请求都去重试一次已知不可用的库
+        lastRefreshAtMs = System.currentTimeMillis();
+        reload();
     }
 
     /** 当前快照大小（观测 / 单测）。 */

--- a/customer-work-starter/src/main/resources/db/customerwork/migration/V5__admin_user_quota_level.sql
+++ b/customer-work-starter/src/main/resources/db/customerwork/migration/V5__admin_user_quota_level.sql
@@ -1,0 +1,18 @@
+-- 后台管理系统登录用户的配额档位。
+--
+-- 单独一档而不是复用 free：后台用户是内部员工，跑的是智能体调试、VibeCoding 这类重负载，
+-- 按 C 端档位限会让他们干不了活；但完全不限又挡不住"某个脚本挂在后台狂刷"这种真实事故。
+-- 窗口取 1 小时（后台操作本就是低频长任务，30 分钟窗口对一次长调试来说太短）。
+--
+-- 独立成 V5 而不是并进 V4：V4 已在环境上执行过，改动它会让 Flyway 的 checksum 校验失败。
+INSERT INTO `cw_subject_quota_level`
+    (`tenant_id`, `level_code`, `level_name`, `subject_type`, `window_seconds`,
+     `token_limit`, `request_limit`, `exceed_action`, `enabled`, `remark`,
+     `created_at_ms`, `updated_at_ms`)
+VALUES
+    ('default', 'admin-default', '后台用户', 'ADMIN_USER', 3600, 2000000, 200, 'BLOCK', 1,
+     '后台登录用户默认档，与 SubjectQuotaProperties 内置档一致',
+     UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'admin-power', '后台高配', 'ADMIN_USER', 3600, 10000000, 1000, 'BLOCK', 1,
+     '给需要跑大批量调试的账号单独提档',
+     UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrationIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrationIntegrationTest.java
@@ -54,7 +54,8 @@ class CustomerWorkSchemaMigrationIntegrationTest {
         try (HikariDataSource dataSource = dataSource(database, "flyway-empty-test")) {
             migrate(dataSource, database);
             assertEquals(44, countBusinessTables(dataSource));
-            assertEquals(4, countHistoryRows(dataSource));
+            // V5 只插 ADMIN_USER 档种子、不建表，故迁移记录 +1 而表数不变
+            assertEquals(5, countHistoryRows(dataSource));
             assertTrue(columnExists(dataSource, "cw_dead_letter", "lease_owner"));
             assertEquals(0, countHistoryVersion(dataSource, "0"), "空库不应写 baseline 记录");
         }
@@ -75,7 +76,7 @@ class CustomerWorkSchemaMigrationIntegrationTest {
             // V4 给存量 cw_user 加的配额等级列：这张表是 V1 就建好的，加列只能靠迁移补
             assertTrue(columnExists(dataSource, "cw_user", "level_code"));
             assertEquals(44, countBusinessTables(dataSource));
-            assertEquals(5, countHistoryRows(dataSource));
+            assertEquals(6, countHistoryRows(dataSource));
             assertEquals(1, countHistoryVersion(dataSource, "0"), "非空存量库必须先登记 baseline 0");
         }
     }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/QuotaSubjectTest.java
@@ -39,4 +39,12 @@ class QuotaSubjectTest {
             "解析不出身份也要有一份额度可算，否则等于放行");
         assertTrue(QuotaSubject.ip(null).counterKey().endsWith(QuotaSubject.UNKNOWN_ID));
     }
+
+    @Test
+    void adminUser_shouldNotShareQuotaWithEndUser() {
+        // sys_user 与 cw_user 是两套 ID 空间，同一个 ID 值指的是不同的人；
+        // 共用一个类型就会让一个后台管理员和一个终端用户莫名其妙共享额度
+        assertNotEquals(QuotaSubject.adminUser("1").counterKey(), QuotaSubject.user("1").counterKey());
+        assertEquals(QuotaSubjectType.ADMIN_USER, QuotaSubject.adminUser("1").type());
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolverTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectLevelResolverTest.java
@@ -145,4 +145,33 @@ class SubjectLevelResolverTest {
         SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.user("U-1"));
         assertEquals(66L, level.tokenLimit(), "没有租户上下文时按默认租户算，而不是直接不限");
     }
+
+    @Test
+    void resolve_shouldUseAdminDefaultLevel_forAdminSubject() {
+        TenantContext.set(TENANT);
+        store.save(new SubjectQuotaLevel(null, TENANT, "admin-default", "后台用户",
+            QuotaSubjectType.ADMIN_USER, 3600, 2000000L, 200, SubjectExceedAction.BLOCK, true, null));
+        // 后台用户不看客服端那份绑定（binding 由部署侧决定查哪张用户表），未绑定时走 admin 默认档
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.adminUser("7"));
+        assertEquals("admin-default", level.levelCode());
+        assertEquals(3600, level.effectiveWindowSeconds(), "后台窗口是 1 小时，与 C 端的 30 分钟不同");
+    }
+
+    @Test
+    void resolve_shouldPreferBoundLevel_forAdminSubject() {
+        TenantContext.set(TENANT);
+        store.save(new SubjectQuotaLevel(null, TENANT, "admin-power", "后台高配",
+            QuotaSubjectType.ADMIN_USER, 3600, 9L, 9, SubjectExceedAction.BLOCK, true, null));
+        SubjectQuotaLevel level = resolver(userId -> Optional.of("admin-power")).resolve(QuotaSubject.adminUser("7"));
+        assertEquals("admin-power", level.levelCode(), "单独提档的后台账号优先走绑定");
+    }
+
+    @Test
+    void resolve_shouldFallBackToBuiltinAdminLevel() {
+        TenantContext.set(TENANT);
+        SubjectQuotaLevel level = resolver(userId -> Optional.empty()).resolve(QuotaSubject.adminUser("7"));
+        assertNotNull(level, "库里没配也要有内置的后台档，否则开关一开却什么都不限");
+        assertEquals("admin-default", level.levelCode());
+        assertEquals(2000000L, level.tokenLimit(), "内置档数值须与出厂种子一致");
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelProviderTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaLevelProviderTest.java
@@ -1,0 +1,104 @@
+package com.richard.fyoung.customerwork.safety.subjectquota;
+
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 等级快照单测：读路径无锁、读失败保留旧快照、惰性刷新（给没有定时调度的宿主用）。
+ * @author owlzhangfq@gmail.com
+ */
+class SubjectQuotaLevelProviderTest {
+
+    private static final String TENANT = TenantContext.DEFAULT;
+
+    /** 可控制"读成功/读失败"与"被读了几次"的探针 Store。 */
+    private static final class ProbeStore implements SubjectQuotaLevelStore {
+        private final AtomicInteger loads = new AtomicInteger();
+        private volatile boolean available = true;
+        private volatile List<SubjectQuotaLevel> levels = List.of();
+
+        @Override
+        public Optional<List<SubjectQuotaLevel>> findAllEnabled() {
+            loads.incrementAndGet();
+            return available ? Optional.of(levels) : Optional.empty();
+        }
+
+        @Override
+        public List<SubjectQuotaLevel> findByTenant(String tenantId) {
+            return levels;
+        }
+
+        @Override
+        public void save(SubjectQuotaLevel level) {
+            levels = List.of(level);
+        }
+
+        @Override
+        public void delete(String tenantId, String levelCode) {
+            levels = List.of();
+        }
+    }
+
+    private static SubjectQuotaLevel level(String code, long tokenLimit) {
+        return new SubjectQuotaLevel(null, TENANT, code, code, QuotaSubjectType.USER,
+            1800, tokenLimit, 0, SubjectExceedAction.BLOCK, true, null);
+    }
+
+    @Test
+    void find_shouldReturnSnapshotEntry() {
+        ProbeStore store = new ProbeStore();
+        store.save(level("free", 100));
+        SubjectQuotaLevelProvider provider = new SubjectQuotaLevelProvider(store, false);
+
+        assertNotNull(provider.find(TENANT, "free"));
+        assertNull(provider.find(TENANT, "nope"), "没有的档返回 null，由调用方回落内置档");
+        assertEquals(1, provider.size());
+    }
+
+    @Test
+    void reload_shouldKeepSnapshot_whenStoreUnavailable() {
+        ProbeStore store = new ProbeStore();
+        store.save(level("free", 100));
+        SubjectQuotaLevelProvider provider = new SubjectQuotaLevelProvider(store, false);
+
+        store.available = false;
+        assertEquals(false, provider.reload(), "读失败应返回 false");
+        // 读不到等级就把所有人限死是自伤，故保留上一份快照而不是清空
+        assertNotNull(provider.find(TENANT, "free"), "读取失败必须保留旧快照");
+    }
+
+    @Test
+    void find_shouldNotReload_whenLazyRefreshDisabled() {
+        ProbeStore store = new ProbeStore();
+        SubjectQuotaLevelProvider provider = new SubjectQuotaLevelProvider(store, false);
+        int afterConstruct = store.loads.get();
+
+        provider.find(TENANT, "free");
+        provider.find(TENANT, "free");
+        assertEquals(afterConstruct, store.loads.get(), "关闭惰性刷新时读路径不得产生查询");
+    }
+
+    @Test
+    void find_shouldReloadLazily_whenIntervalElapsed() throws Exception {
+        ProbeStore store = new ProbeStore();
+        // 间隔 1ms：admin 侧真实配置是 60 秒，这里只验证"到点会重载"这件事
+        SubjectQuotaLevelProvider provider = new SubjectQuotaLevelProvider(store, false, 1L);
+        int afterConstruct = store.loads.get();
+
+        store.save(level("vip", 999));
+        Thread.sleep(5L);
+        SubjectQuotaLevel found = provider.find(TENANT, "vip");
+
+        assertNotNull(found, "惰性刷新后应能读到新增的档");
+        // admin 刻意不开 @EnableScheduling，快照只能靠读路径更新；不重载的话后台改完档永远不生效
+        assertEquals(true, store.loads.get() > afterConstruct, "到点后读路径应触发一次重载");
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -1794,6 +1794,61 @@ token 的真实用量要到模型调用之后才知道，那时已隔了好几�
 **已知边界**：内存计数模式下多副本各算各的，等于把额度放大 N 倍；生产多副本请把
 `customer-work.distributed.counter-mode` 切 `redis`（见 §6.28），与限流/熔断共用同一个计数器实现。
 
+#### 6.32.1 后台登录用户的额度（`admin.subject-quota`，默认关闭）
+
+后台账号同样会烧 token——智能体调试、VibeCoding、委派任务都在调模型，而且单次比 C 端重得多。
+这一节把同一套配额机制接到 admin-server 上。
+
+```yaml
+admin:
+  subject-quota:
+    enabled: true
+    default-level: admin-default   # 未单独分档的后台账号走这一档
+    lazy-refresh-ms: 60000
+    path-patterns:                 # Ant 模式，只覆盖真正调模型的入口
+      - /api/workspace/*/chat/stream
+      - /api/workspace/*/vibecoding/**
+      - /api/aiconfig/agent-task/**
+```
+
+**主体类型单列 `ADMIN_USER`**：`sys_user` 与 `cw_user` 是两套独立的 ID 空间，同一个 ID 值在两边
+指的是不同的人。混用 `USER` 会让计数键碰撞——一个后台管理员和一个终端用户莫名其妙共用一份额度，
+而且谁也查不出为什么。
+
+**等级定义与终端用户共用一张表**（客服端库 `cw_subject_quota_level`，靠 `subject_type` 区分），
+绑定则落 `sys_user.level_code`。出厂两档：`admin-default`（1 小时 / 200 万 token / 200 次）与
+`admin-power`（给需要跑大批量调试的账号提档）。窗口取 1 小时而不是 C 端的 30 分钟——后台操作
+本就是低频长任务，30 分钟窗口对一次长调试来说太短。
+
+**判定用 MVC 拦截器而不是 WebFilter**：admin 是 Spring MVC，没有 `WebFilter`。超限返回 **429 +
+`Retry-After`**，响应体是统一 `Result` 包装、错误码 `40043`（`QUOTA_EXCEEDED`）——额度用尽既不是
+没权限也不是参数错，混进既有错误码会让前端提示"联系管理员开权限"。
+
+**路径清单刻意比 C 端窄**：只覆盖真正调模型的三条入口，翻列表、看详情、下载附件不占额度。
+C 端为了给登录用户的全部接口加防刷闸门而覆盖了整个用户面，而后台用户是内部员工，
+这里防的是"调用失控"而不是"有人刷接口"。
+
+**等级快照走惰性刷新**：admin 刻意不开 `@EnableScheduling`（开了会把容器里所有 `@Scheduled` 一并激活），
+所以客服端那套定时轮询在这边根本不会跑。改成在读路径上判断"距上次重载是否超过间隔"，
+不需要任何调度设施。
+
+**三条入口的 token 都记得上**：对话与 VibeCoding 都走 `ChatService.chatStream`（那里把主体写进
+Reactor Context）；委派任务跑在自建线程池上，Reactor 的自动传播覆盖不到，故在**提交任务的那一刻**
+捕获主体、用 `QuotaSubjectContext.callWith` 带进任务体。不带的话，委派任务烧掉的 token 就没有主人——
+额度里只有"提交次数"在动。
+
+**上下文传播只接主体、不搭车改租户**：判定在 MVC 拦截器（Tomcat 线程），而 token 用量要到模型调用
+之后才知道，那时链路早已切到 Reactor 线程。admin 此前完全没有这套机制（starter 的自动装配被 exclude 了），
+本次注册了主体的 `ThreadLocalAccessor` 并在功能开启时打开自动传播。**租户上下文在 admin 的 Reactor 链上
+同样是丢的，但没有一并补**——补它会让多租户开启后 AI 链路里的持久层操作开始真正带上租户过滤，
+那是一次独立的行为变更，该单独评估验证。
+
+**计数器优先用 Redisson**（admin 已有 `RedissonClient`）：后台多副本时进程内计数等于把额度放大 N 倍。
+与客服端共用同一个 Redis 也不会串——主体类型不同，计数键天然分开，共享反而让多副本的额度真正合成一份。
+
+**开关生效需要重启**：自动传播是全局静态开关，有全局影响的东西不该在功能关闭时生效，
+所以只在 `enabled=true` 时打开。
+
 ## 七、配置项总表
 
 全部位于 `application.yml` 的 `customer-work.*`（支持环境变量覆盖）：
@@ -1817,6 +1872,7 @@ token 的真实用量要到模型调用之后才知道，那时已隔了好几�
 | `distributed` | counter-mode(memory), counter-key-prefix(cw:counter:), session-lock-mode(memory), session-lock-wait-seconds(10), session-lock-lease-seconds(120)（见 §6.28，Redis 连接复用 `distributed-lock.redis.*`） |
 | `quota` | enabled(false), store-mode(memory)（见 §6.29；admin 侧归集对应 `admin.billing.aggregation.*`） |
 | `subject-quota` | enabled(false), store-mode(memory), refresh-interval-ms(60000), default-user-level(free), anonymous-level(anonymous), api-key-level(api-key), level-cache-ttl-ms(60000), level-cache-max-size(10000), paths([/api/customer/chat, /intent, /consult, /agui, /api/customer/user/]), builtin-levels{free,anonymous,api-key}（见 §6.32；按调用者限流，与 §6.29 的按租户限费并存） |
+| `admin.subject-quota`（非 `customer-work.*` 前缀，属 admin 自身配置）| enabled(false), default-level(admin-default), lazy-refresh-ms(60000), level-cache-ttl-ms(60000), path-patterns([/api/workspace/*/chat/stream, /api/workspace/*/vibecoding/**, /api/aiconfig/agent-task/**])（见 §6.32.1；后台登录用户的 AI 用量额度） |
 | `eval`（B6）| store-mode(memory), baseline-enabled(false), baseline-cron(0 0 3 * * ?), judge-timeout-seconds(60)，见 §6.31 |
 | `badcase`（B6）| store-mode(memory), auto-collect(true)，见 §6.31 |
 | `prompt-version`（B6）| store-mode(memory)：记「运行时实际生效」的那份，版本号取内容指纹，见 §6.31 |

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -971,4 +971,7 @@ VALUES
     ('default', 'vip',       'VIP用户',  'USER',    1800,  200000,  300, 'BLOCK', 1, '付费用户',       UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
     ('default', 'svip',      'SVIP用户', 'USER',    1800, 1000000, 1000, 'BLOCK', 1, '高级付费用户',   UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
     ('default', 'anonymous', '匿名访客', 'IP',      1800,   10000,   20, 'BLOCK', 1, '未登录，按来源IP计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
-    ('default', 'api-key',   '接入方',   'API_KEY', 3600, 1000000, 2000, 'BLOCK', 1, '服务端接入，按Key指纹计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000);
+    ('default', 'api-key',   '接入方',   'API_KEY', 3600, 1000000, 2000, 'BLOCK', 1, '服务端接入，按Key指纹计', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    -- 后台管理系统登录用户（sys_user）：内部员工跑调试/VibeCoding，负载重、频次低，故窗口 1 小时、额度放宽
+    ('default', 'admin-default', '后台用户', 'ADMIN_USER', 3600,  2000000,  200, 'BLOCK', 1, '后台登录用户默认档', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+    ('default', 'admin-power',   '后台高配', 'ADMIN_USER', 3600, 10000000, 1000, 'BLOCK', 1, '给需要跑大批量调试的账号单独提档', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000);

--- a/mysql/02-customer-admin/59-V59__admin_user_quota_level.sql
+++ b/mysql/02-customer-admin/59-V59__admin_user_quota_level.sql
@@ -1,0 +1,11 @@
+-- 后台登录用户的配额等级绑定。
+--
+-- 等级定义本身在**客服端库**的 cw_subject_quota_level（与终端用户共用一张表、靠 subject_type 区分），
+-- 这里只加"这个后台账号属于哪一档"的绑定列——绑定必须跟着用户表走，
+-- 另建映射表会让每次限流判定多一次跨表查询，而 sys_user 本就要查。
+--
+-- 空值 = 走配置里的 default-admin-level（admin-default）。
+--
+-- 版本号取 V59 而不是紧挨着上一版：V56/V57/V58 已被并行开发的分支占用（本机库里 V56 甚至已经 apply），
+-- 撞号会让 Flyway 在 checksum 校验上直接拒绝启动。加迁移前先扫一遍各 worktree 的最大版本号。
+ALTER TABLE `sys_user` ADD COLUMN `level_code` VARCHAR(64) DEFAULT NULL COMMENT '配额等级编码（空=默认档），见客服端库 cw_subject_quota_level';


### PR DESCRIPTION
> 基于 #113（`feature/subject-rate-quota`），只看本 PR 的增量。合并顺序：先 #113，再本 PR。

## 做了什么

admin-server 的登录账号同样会烧 token——智能体调试、VibeCoding、委派任务都在调模型，且单次比 C 端重得多。本 PR 把 #113 那套配额机制接到后台侧。

- **主体类型单列 `ADMIN_USER`**：`sys_user` 与 `cw_user` 是两套独立 ID 空间，同一个 ID 值在两边指的是不同的人。混用 `USER` 会让计数键碰撞——一个后台管理员和一个终端用户莫名其妙共用一份额度，而且谁也查不出为什么。
- **等级定义与终端用户共用一张表**（`cw_subject_quota_level`，靠 `subject_type` 区分），绑定落 `sys_user.level_code`。出厂两档：`admin-default`（1 小时 / 200 万 token / 200 次）、`admin-power`。
- **后台页面加「后台用户」Tab**（内容风控 → 用户额度），可搜索、可改档。

## 与客服端刻意不同的五处

| | 客服端 | 后台 | 为什么 |
|---|---|---|---|
| 判定入口 | `WebFilter` | `HandlerInterceptor` | admin 是 Servlet 不是 WebFlux |
| 覆盖路径 | 整个 `/api/customer/user/` 面 | 只有 3 条调模型的入口 | 后台用户是内部员工，防的是"调用失控"不是"有人刷接口"；把翻列表算进去只会让人干不了活 |
| 窗口 | 30 分钟 | 1 小时 | 后台是低频长任务，30 分钟对一次长调试太短 |
| 等级刷新 | `@Scheduled` 定时轮询 | 读路径惰性刷新 | admin 刻意不开 `@EnableScheduling`，定时轮询在这边根本不会跑 |
| 超限响应 | 429 + 裸 JSON | 429 + 统一 `Result`（`QUOTA_EXCEEDED(40043)`） | 额度用尽既不是没权限也不是参数错，混进既有码会让前端提示"联系管理员开权限" |

## 三条 AI 入口的 token 都记得上

对话与 VibeCoding 都走 `ChatService.chatStream`（那里把主体写进 Reactor Context）；**委派任务跑在自建线程池上**，Reactor 的自动传播覆盖不到，故在提交任务的那一刻捕获主体、用 `QuotaSubjectContext.callWith` 带进任务体。不带的话，委派任务烧掉的 token 就没有主人——额度里只有"提交次数"在动。

## 上下文传播只接主体、不搭车改租户

admin 此前**完全没有** Reactor 上下文传播（starter 的自动装配被 exclude 了）。本 PR 注册了主体的 `ThreadLocalAccessor` 并在功能开启时打开自动传播。

租户上下文在 admin 的 Reactor 链上同样是丢的，但**没有一并补**——补它会让多租户开启后 AI 链路里的持久层操作开始真正带上租户过滤，那是一次独立的行为变更，该单独评估、单独验证。

## 顺带修掉的前端缺陷

admin-web 的响应拦截器失败回调只读 `error.message`，非 2xx 的响应体（同样是 `Result` 包装）被整个吞掉。修之前用户看到的是 `Request failed with status code 429`，而真正该看的"最近 60 分钟内已达 N 次上限"没了。

## 迁移版本号取 V59

`V56`/`V57`/`V58` 已被并行开发的分支占用（本机 admin 库里 V56 甚至已经 apply 了），撞号会让 Flyway 在 checksum 校验上直接拒绝启动——本 PR 开发过程中真踩了一次。**加迁移前先扫一遍各 worktree 的最大版本号**，这条已写进 CLAUDE.md。

## 验证

**端到端实测**（临时库 + 18082 端口，不碰本机既有库与用户进程）：

| 验证项 | 结果 |
|---|---|
| 装配 | `admin subject quota guard enabled, counter=RedissonWindowCounter`、上下文传播已启用 |
| 干净库迁移 | 54 个迁移全过（含 V59），上下文加载通过 |
| 限流 | `admin-verify` 档 3 次/小时 → 前 3 次放行，第 4 次 429 |
| 响应体 | `{"code":40043,"message":"提问太频繁了：最近 60 分钟内已达 3 次上限，请稍后再试。"}` |
| 命中落库 | `cw_subject_quota_hit` 记录主体 `ADMIN_USER:1`、等级 `admin-verify`、`used=3/limit=3`、触发路径 |
| 未登录 | 由 Sa-Token 拦截（`code=10001`），判定拦截器不误判 |

**全量回归 BUILD SUCCESS**：starter 1396 / admin 765 / app 86 / channel 65 / gateway 1 = **2313**，6 skip。本批次新增 starter +8、admin +11。

> 注：admin 的 `CustomerAdminServerApplicationTests` 在被并行分支迁移污染过的本机库上必挂（Flyway 报 `Detected applied migration not resolved locally`），那不是代码问题——用临时库跑即可，已写进 CLAUDE.md。

## 已知边界

委派任务的主体捕获依赖"提交时上下文还在"。若将来有从定时任务/MQ 触发的后台 AI 调用（没有 HTTP 请求上下文），那条链路的 token 同样不会记账——届时需要在触发点显式指定主体。
