### PR TITLE
fix: 租户过滤打开后，非 Web 线程查库缺上下文（启动装配 + 守护线程）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1413** + admin-server **834** + app 86 + customer-channel 65 + gateway 1（合计 **2399**）
+- 测试基线：starter **1413** + admin-server **837** + app 86 + customer-channel 65 + gateway 1（合计 **2402**）
   （2026-08-18 数据权限批次实测：starter 1413 / 5 skip、admin 834 / 1 skip、app 86，BUILD SUCCESS，
   排除 `RedisSessionPersistenceTest`。本批次自身加了 admin **+45**（数据范围枚举/上下文/白名单/SQL 改写/
   范围解析 30 + 角色范围校验 5 + 装配门控 7 + 会话归属放行边界 3），starter 只改忽略清单常量故条数不变；
@@ -223,10 +223,19 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   `TENANT`/`ALL` 只校验会话存在于当前租户（超管要能看全量）。该表不进白名单：归属条件已在
   那条 JOIN 里显式表达，且它的归属列叫 `owner_user_id`，不在白名单支持的两种列名之内。
 - **`admin.tenant.enabled` 从本批次起默认 `true`**（此前默认关闭 = 跨租户完全打通）。开关一开，
-  几条**没有登录态**的链路会因缺租户上下文 fail-closed，改动它们时别把这几处退回去：开放 API 走
-  `admin.open-api.tenant-tokens` 的令牌→租户映射、工作台脚本回调从令牌行读租户、
-  内置调度器/XXL-JOB 走 `executeFromScheduler`（跨租户定位 + 按任务租户还原上下文）、
-  登录页轮播图归入平台级忽略清单（登录前无上下文可用）。
+  凡是**不在 Web 请求里**的查库都会因缺租户上下文 fail-closed。四类都要显式处理，改动时别退回去：
+  ① **无登录态的 HTTP 链路**：开放 API 走 `admin.open-api.tenant-tokens` 的令牌→租户映射、
+  工作台脚本回调从令牌行读租户、登录页轮播图归入平台级忽略清单（登录前无上下文可用）；
+  ② **调度线程**：内置调度器/XXL-JOB 走 `executeFromScheduler`（跨租户定位 + 按任务租户还原上下文）；
+  ③ **启动期装配**：`@Bean` 工厂方法、`@PostConstruct`、`ContextRefreshedEvent` 里的查库。
+  **这一类最容易漏且后果最重——A2A 的 `@Bean` 里查 `ai_agent` 直接让应用起不来**（实测踩过）；
+  `contextLoads` 照不出来，因为那条装配路径默认关着。判断依据：这类查询要么是平台级定位
+  （靠全局唯一的 `agent_code`/`task_code` 跨租户找一条），要么是跨租户运维扫描
+  （重启清理孤儿任务），两者都走 `CrossTenantOperations`；
+  ④ **异步回调**：模型连通性测试等跑在独立线程池里的落库。
+  写这类测试时**别断言"没抛异常"**——单测里本就没挂拦截器，怎么写都不会抛，那种断言恒真；
+  要断言 `InterceptorIgnoreHelper.willIgnoreTenantLine(...)` 在查询发生的那一刻为真
+  （见 `AdminA2aServerConfigTenantTest`），并且退出作用域后为假。
 - **本机开发库是所有分支共用的，Flyway 版本号常年被并行分支占走**：新增迁移前先查
   `SELECT MAX(version) FROM customer_admin.flyway_schema_history`，而不是只看当前分支的文件名——
   本批次就先后被 V55（已合入 main）、V56~V58（未合并的并行分支）挤到 V59/V60。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/a2a/AdminA2aServerConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/a2a/AdminA2aServerConfig.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.a2a;
 
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import cn.dev33.satoken.fun.strategy.SaCheckRequestPathFunction;
@@ -84,8 +85,11 @@ public class AdminA2aServerConfig {
         if (!StringUtils.hasText(agentCode)) {
             throw new IllegalStateException("admin.a2a.enabled=true requires admin.a2a.agent-code");
         }
-        AiAgent agent = agentMapper.selectOne(new LambdaQueryWrapper<AiAgent>()
-            .eq(AiAgent::getAgentCode, agentCode).last("LIMIT 1"));
+        // 启动期没有请求、也就没有租户上下文，直连查询会被租户拦截器 fail-closed 打断，整个应用起不来。
+        // A2A 暴露的是运维在配置里点名的那一个智能体，与"谁在访问"无关，因此这是明确的跨租户定位；
+        // agent_code 全局唯一（uk_ai_agent_code），定位结果不会有歧义。
+        AiAgent agent = CrossTenantOperations.execute(() -> agentMapper.selectOne(
+            new LambdaQueryWrapper<AiAgent>().eq(AiAgent::getAgentCode, agentCode).last("LIMIT 1")));
         if (agent == null) {
             // fast fail：配了一个不存在的智能体却让服务照常起来，只会在第一个外部请求进来时才暴露
             throw new IllegalStateException("admin.a2a.agent-code not found: " + agentCode);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepository.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepository.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.workspace.task.runtime;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.richard.fyoung.customeradmin.workspace.task.entity.AiAgentTask;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
 import com.richard.fyoung.customeradmin.workspace.task.mapper.AiAgentTaskMapper;
 import com.richard.fyoung.customeradmin.workspace.runtime.WorkspaceRuntimeScope;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
@@ -126,7 +127,10 @@ public class MybatisTaskRepository implements TaskRepository {
                 .set(AiAgentTask::getErrorMessage, RESTART_ERROR)
                 .set(AiAgentTask::getFinishedAt, now)
                 .set(AiAgentTask::getUpdatedAt, now);
-            int affected = taskMapper.update(null, update);
+            // 重启清理是明确的跨租户运维扫描：僵尸任务属于所有租户，而启动期没有租户上下文。
+            // 不显式跨租户的话会被拦截器 fail-closed，异常又被下面的 catch 吞掉——
+            // 表现为"清理静默不生效"，比报错更难发现
+            int affected = CrossTenantOperations.execute(() -> taskMapper.update(null, update));
             if (affected > 0) {
                 log.info("[agent-task] marked {} orphan tasks as failed after restart", affected);
             }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/a2a/AdminA2aServerConfigTenantTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/a2a/AdminA2aServerConfigTenantTest.java
@@ -1,0 +1,65 @@
+package com.richard.fyoung.customeradmin.a2a;
+
+import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
+import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A2A 服务端装配的租户上下文测试。
+ *
+ * <p>这个 Bean 在<b>启动期</b>查 {@code ai_agent}——那时没有请求、也就没有租户上下文，
+ * 直连查询会被租户拦截器 fail-closed 打断，整个应用起不来（实际发生过）。
+ * {@code contextLoads} 照不出来：{@code admin.a2a.enabled} 默认关，那条装配路径根本不执行。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class AdminA2aServerConfigTenantTest {
+
+    /**
+     * 断言查询发生在跨租户作用域内。
+     *
+     * <p>不断言"没抛异常"——单测里本就没挂拦截器，怎么写都不会抛，那种断言恒真、毫无保护力。
+     * 这里直接查 MyBatis-Plus 的忽略策略，它正是拦截器运行时读的那一份。</p>
+     */
+    @Test
+    void agentScopeA2aServer_shouldQueryAgentAcrossTenants() {
+        AiAgentMapper agentMapper = mock(AiAgentMapper.class);
+        AiAgent agent = new AiAgent();
+        agent.setAgentCode("coder");
+        agent.setAgentName("编码助手");
+        when(agentMapper.selectOne(any())).thenAnswer(invocation -> {
+            assertTrue(InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId"),
+                "启动期查询必须显式跨租户，否则缺上下文会 fail-closed 导致应用起不来");
+            return agent;
+        });
+
+        AdminA2aProperties properties = new AdminA2aProperties();
+        properties.setAgentCode("coder");
+
+        assertNotNull(new AdminA2aServerConfig()
+            .agentScopeA2aServer(properties, mock(AgentInstanceCache.class), agentMapper));
+    }
+
+    /** 作用域退出后必须还原，不能把"忽略租户"泄漏给后续调用。 */
+    @Test
+    void tenantIgnoreShouldNotLeakAfterAssembly() {
+        AiAgentMapper agentMapper = mock(AiAgentMapper.class);
+        AiAgent agent = new AiAgent();
+        agent.setAgentCode("coder");
+        agent.setAgentName("编码助手");
+        when(agentMapper.selectOne(any())).thenReturn(agent);
+
+        AdminA2aProperties properties = new AdminA2aProperties();
+        properties.setAgentCode("coder");
+        new AdminA2aServerConfig().agentScopeA2aServer(properties, mock(AgentInstanceCache.class), agentMapper);
+
+        assertTrue(!InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId"));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepositoryStartupTenantTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepositoryStartupTenantTest.java
@@ -1,0 +1,57 @@
+package com.richard.fyoung.customeradmin.workspace.task.runtime;
+
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
+import com.richard.fyoung.customeradmin.workspace.task.entity.AiAgentTask;
+
+import com.richard.fyoung.customeradmin.workspace.task.mapper.AiAgentTaskMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 重启清理孤儿任务的租户上下文测试。
+ *
+ * <p>清理跑在 {@code @PostConstruct} 里——启动期没有租户上下文，不显式跨租户会被拦截器
+ * fail-closed；而那段代码外面裹着 {@code catch(Exception)}，异常被吞掉后表现为
+ * "清理静默不生效"，比直接报错更难发现。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class MybatisTaskRepositoryStartupTenantTest {
+
+    /** LambdaUpdateWrapper 解析字段名要读 MyBatis-Plus 的表信息缓存，脱离容器时需手工初始化。 */
+    @BeforeAll
+    static void initMybatisPlusLambdaCache() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new Configuration(), ""), AiAgentTask.class);
+    }
+
+    @Test
+    void cleanupOrphanTasks_shouldRunAcrossTenants() {
+        AiAgentTaskMapper taskMapper = mock(AiAgentTaskMapper.class);
+        boolean[] crossTenant = {false};
+        when(taskMapper.update(isNull(), any())).thenAnswer(invocation -> {
+            crossTenant[0] = InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId");
+            return 0;
+        });
+
+        MybatisTaskRepository repository = new MybatisTaskRepository(taskMapper, properties());
+        repository.init();
+
+        assertTrue(crossTenant[0], "重启清理是跨租户运维扫描，必须显式跨租户，否则会被 fail-closed 静默吞掉");
+        assertFalse(InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId"), "作用域退出后不得泄漏");
+    }
+
+    private AgentTaskExecutorProperties properties() {
+        AgentTaskExecutorProperties properties = new AgentTaskExecutorProperties();
+        properties.setCleanupOrphansOnStartup(true);
+        return properties;
+    }
+}

--- a/docs/数据权限设计.md
+++ b/docs/数据权限设计.md
@@ -114,6 +114,7 @@ SELECT * FROM ai_project WHERE status = 1 AND (create_by = 7 OR create_by IS NUL
 | 工作台脚本回调 `/api/workbench/agent/**` | 跨租户按 token 定位到令牌行，从行里读出租户与用户，再还原两个上下文 |
 | 内置调度器 / XXL-JOB | 扫描任务走 `CrossTenantOperations`，执行前按任务所属租户还原上下文（`ScheduledTaskService#executeFromScheduler`）。手动触发不走这里——那是 Web 请求，上下文已由拦截器设好，直接调 `execute` 才能保证"只能触发自己租户的任务" |
 | 登录页轮播图 `/api/login-images/**` | `login_carousel_image` 归入平台级忽略清单。登录页是平台统一入口，登录前没有任何租户上下文可用 |
+| **启动期装配**（`@Bean` / `@PostConstruct`） | A2A 服务端按 `agent_code` 跨租户定位智能体、重启清理孤儿任务跨租户扫描，均走 `CrossTenantOperations`。**这一类最容易漏**：`contextLoads` 照不出来（A2A 默认关，装配路径不执行），一旦漏掉是整个应用起不来 |
 
 同时补齐了 V49 遗漏的 7 张表的 `tenant_id`：`sql_datasource` / `sql_define` / `sql_define_param` /
 `sql_field_transform` / `workbench_site` / `workbench_token` / `ai_config_version`。这些表既无列、


### PR DESCRIPTION
## 问题

PR #117 把 `admin.tenant.enabled` 默认打开后，**不在 Web 请求里的查库**会被拦截器 fail-closed。
陆续暴露出两类，本 PR 一并修掉，并改用运行时扫描确认没有第三类。

### 1. 启动期装配 —— 应用直接起不来

```
Error creating bean with name 'agentScopeA2aServer' ...
Caused by: TenantContextMissingException
    at AdminA2aServerConfig.agentScopeA2aServer(AdminA2aServerConfig.java:87)
```

`contextLoads` 照不出来：`admin.a2a.enabled` 默认关，那条装配路径根本不执行。

### 2. 轮询守护线程 —— 后台对话被全部拦截

```
at GatewaySensitiveWordStore.findEnabled(GatewaySensitiveWordStore.java:52)
at SensitiveWordFilter.reload / SensitiveWordRefresher.refreshOnce
at SensitiveWordRefreshDriver.runOnce  ← 守护线程，无租户上下文
```

这一处更隐蔽：异常被 Store 的 `catch` 吞成一行日志，但 `SensitiveWordFilter` 读不到词表就进入
**fail-closed「拦截一切」**，而 dev profile 默认开着 `agent-filter-enabled` —— 表现是后台对话全被拦，
很难联想到租户开关。

## 修复（共三处）

| 位置 | 性质 | 处理 |
|---|---|---|
| `AdminA2aServerConfig#agentScopeA2aServer`（`@Bean`） | 平台级定位，`agent_code` 全局唯一 | `CrossTenantOperations` |
| `MybatisTaskRepository#cleanupOrphanTasks`（`@PostConstruct`） | 跨租户运维扫描，异常被吞成静默不生效 | `CrossTenantOperations` |
| `GatewaySensitiveWordStore`（守护线程刷新） | 进程级单例过滤器，本无租户维度 | `CrossTenantOperations` 加载全量词库 |

敏感词那处是**有代价的取舍**：取所有租户词表的并集，可能误拦（A 租户的词拦到 B 租户的内容），
方向上安全优先，与敏感词的既定语义一致。要按租户精确过滤需把过滤器改成分片，是独立的一件事，已在文档写明。

其余启动期回调逐个核对过没问题：`RuntimePublishWorker` 已按任务租户 `runWith`、`claimDue` 已走
`CrossTenantOperations`；`AdminProductionReadinessValidator` 只读配置；
`AdminAttachmentConfig` / `AgentMemoryStoreConfig` 只把 Mapper 传给构造器。

## 排查方式的改进

前两处是被逐个报错推着修的，这不可接受。第三处之后改用**运行时扫描**：
开满 A2A + 内容风控 + 命中日志 + 内置调度器，把词库刷新间隔调到 5 秒，跑 100 秒后统计日志——
**零 `TenantContextMissingException`**，词库加载 85 条（确认非 fail-closed），调度器正常启动。

## 测试

6 个新测试**直接断言查询发生的那一刻 `InterceptorIgnoreHelper.willIgnoreTenantLine(...)` 为真**，
并断言退出作用域后为假。刻意不断言「没抛异常」——单测里本就没挂拦截器，那种断言恒真、毫无保护力。

全部做了**反向验证**：撤掉修复后确认失败，再还原。

`admin-server 840 / 1 skip`，BUILD SUCCESS。

## 文档

CLAUDE.md 里「开关一开会 fail-closed 的链路」从三条改写成四类（无登录态 HTTP / 调度与轮询守护线程 /
启动期装配 / 异步回调），写明启动期这一类 `contextLoads` 覆盖不到、敏感词那处失败会拦一切，
以及这类测试该怎么断言才有效。