### PR TITLE
fix: 敏感词词库刷新守护线程缺租户上下文导致过滤器拦截一切

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1413** + admin-server **837** + app 86 + customer-channel 65 + gateway 1（合计 **2402**）
+- 测试基线：starter **1413** + admin-server **840** + app 86 + customer-channel 65 + gateway 1（合计 **2405**）
   （2026-08-18 数据权限批次实测：starter 1413 / 5 skip、admin 834 / 1 skip、app 86，BUILD SUCCESS，
   排除 `RedisSessionPersistenceTest`。本批次自身加了 admin **+45**（数据范围枚举/上下文/白名单/SQL 改写/
   范围解析 30 + 角色范围校验 5 + 装配门控 7 + 会话归属放行边界 3），starter 只改忽略清单常量故条数不变；
@@ -226,7 +226,11 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   凡是**不在 Web 请求里**的查库都会因缺租户上下文 fail-closed。四类都要显式处理，改动时别退回去：
   ① **无登录态的 HTTP 链路**：开放 API 走 `admin.open-api.tenant-tokens` 的令牌→租户映射、
   工作台脚本回调从令牌行读租户、登录页轮播图归入平台级忽略清单（登录前无上下文可用）；
-  ② **调度线程**：内置调度器/XXL-JOB 走 `executeFromScheduler`（跨租户定位 + 按任务租户还原上下文）；
+  ② **调度线程与轮询守护线程**：内置调度器/XXL-JOB 走 `executeFromScheduler`（跨租户定位 + 按任务租户
+  还原上下文）；内容风控词库刷新（`SensitiveWordRefreshDriver` 的守护线程）走 `CrossTenantOperations`
+  加载全量词库——**它读失败会让过滤器 fail-closed"拦截一切"，后台对话全被拦**，而异常被 Store 的
+  catch 吞成一行日志，很难联想到租户开关。代价是进程级单例过滤器用所有租户词表的并集，可能误拦，
+  方向上安全优先；要按租户精确过滤得把过滤器改成分片，那是独立的一件事；
   ③ **启动期装配**：`@Bean` 工厂方法、`@PostConstruct`、`ContextRefreshedEvent` 里的查库。
   **这一类最容易漏且后果最重——A2A 的 `@Bean` 里查 `ai_agent` 直接让应用起不来**（实测踩过）；
   `contextLoads` 照不出来，因为那条装配路径默认关着。判断依据：这类查询要么是平台级定位

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/runtime/GatewaySensitiveWordStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/runtime/GatewaySensitiveWordStore.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.contentguard.runtime;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.richard.fyoung.customeradmin.contentguard.config.ContentGuardGatewayProvider;
 import com.richard.fyoung.customerwork.safety.sensitiveword.SensitiveWord;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
 import com.richard.fyoung.customerwork.safety.sensitiveword.SensitiveWordAction;
 import com.richard.fyoung.customerwork.safety.sensitiveword.SensitiveWordCategory;
 import com.richard.fyoung.customerwork.safety.sensitiveword.SensitiveWordStore;
@@ -23,6 +24,13 @@ import java.util.Optional;
  *
  * <p>读失败一律返回 {@code Optional.empty()}，把 fail-closed 的判断权交回
  * {@code SensitiveWordFilter}——别在这一层擅自"降级成空词表"，那等于静默放行。</p>
+ *
+ * <p><b>读取跨租户，且这是刻意的</b>。两个原因：一是刷新跑在守护线程里（{@code SensitiveWordRefreshDriver}），
+ * 没有租户上下文，不显式跨租户会被拦截器 fail-closed——而这里读失败会让过滤器进入"拦截一切"，
+ * 后台对话全部被拦，比漏拦更早暴露但影响面更大；二是 {@code SensitiveWordFilter} 是进程级单例、
+ * 内存里只有一份自动机，本就没有租户维度，加载全量词库等于取所有租户词表的并集。
+ * 后果是可能误拦（A 租户的词拦到 B 租户的内容），方向上安全优先，与敏感词的既定语义一致。
+ * 要做到按租户精确过滤，需要把过滤器改成按租户分片，那是独立的一件事。</p>
  * @author owlzhangfq@gmail.com
  */
 public class GatewaySensitiveWordStore implements SensitiveWordStore {
@@ -38,7 +46,8 @@ public class GatewaySensitiveWordStore implements SensitiveWordStore {
     @Override
     public List<SensitiveWord> findAll() {
         try {
-            return toDomainList(gatewayProvider.get().wordMapper().selectList(null));
+            return CrossTenantOperations.execute(() ->
+                toDomainList(gatewayProvider.get().wordMapper().selectList(null)));
         } catch (Exception e) {
             log.error("[CONTENT-GUARD] admin word findAll failed, code={}", "CONTENTGUARD-WORD-FINDALL-FAIL", e);
             return List.of();
@@ -49,7 +58,8 @@ public class GatewaySensitiveWordStore implements SensitiveWordStore {
     public Optional<List<SensitiveWord>> findEnabled() {
         try {
             QueryWrapper<SensitiveWordEntity> wrapper = new QueryWrapper<SensitiveWordEntity>().eq("enabled", true);
-            return Optional.of(toDomainList(gatewayProvider.get().wordMapper().selectList(wrapper)));
+            return Optional.of(CrossTenantOperations.execute(() ->
+                toDomainList(gatewayProvider.get().wordMapper().selectList(wrapper))));
         } catch (Exception e) {
             log.error("[CONTENT-GUARD] admin word findEnabled failed, code={}",
                 "CONTENTGUARD-WORD-FINDENABLED-FAIL", e);
@@ -66,7 +76,8 @@ public class GatewaySensitiveWordStore implements SensitiveWordStore {
     @Override
     public Optional<String> fingerprint() {
         try {
-            return Optional.of(String.valueOf(gatewayProvider.get().wordMapper().selectFingerprint()));
+            return Optional.of(String.valueOf(CrossTenantOperations.execute(() ->
+                gatewayProvider.get().wordMapper().selectFingerprint())));
         } catch (Exception e) {
             log.error("[CONTENT-GUARD] admin word fingerprint failed, code={}",
                 "CONTENTGUARD-WORD-FINGERPRINT-FAIL", e);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/contentguard/runtime/GatewaySensitiveWordStoreTenantTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/contentguard/runtime/GatewaySensitiveWordStoreTenantTest.java
@@ -1,0 +1,80 @@
+package com.richard.fyoung.customeradmin.contentguard.runtime;
+
+import com.baomidou.mybatisplus.core.plugins.InterceptorIgnoreHelper;
+import com.richard.fyoung.customeradmin.contentguard.config.ContentGuardGatewayProvider;
+import com.richard.fyoung.customeradmin.contentguard.jdbc.ContentGuardGateway;
+import com.richard.fyoung.customerwork.safety.sensitiveword.mapper.SensitiveWordMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 敏感词词库加载的租户上下文测试。
+ *
+ * <p>刷新跑在 {@code SensitiveWordRefreshDriver} 的守护线程里，没有租户上下文。
+ * 不显式跨租户会被拦截器 fail-closed，而读失败会让 {@code SensitiveWordFilter} 进入
+ * "拦截一切"——后台对话全部被拦，且异常被 Store 的 catch 吞成一行日志，很难联想到租户开关。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class GatewaySensitiveWordStoreTenantTest {
+
+    @Test
+    void findEnabled_shouldQueryAcrossTenants() {
+        boolean[] crossTenant = {false};
+        GatewaySensitiveWordStore store = storeWith(() -> crossTenant[0] = true);
+
+        store.findEnabled();
+
+        assertTrue(crossTenant[0], "词库加载跑在守护线程里，必须显式跨租户，否则过滤器会 fail-closed 拦一切");
+        assertFalse(InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId"), "作用域退出后不得泄漏");
+    }
+
+    @Test
+    void findAll_shouldQueryAcrossTenants() {
+        boolean[] crossTenant = {false};
+        GatewaySensitiveWordStore store = storeWith(() -> crossTenant[0] = true);
+
+        store.findAll();
+
+        assertTrue(crossTenant[0]);
+    }
+
+    /** 指纹用于判断词表是否变更，同样跑在守护线程里。 */
+    @Test
+    void fingerprint_shouldQueryAcrossTenants() {
+        SensitiveWordMapper wordMapper = mock(SensitiveWordMapper.class);
+        boolean[] crossTenant = {false};
+        when(wordMapper.selectFingerprint()).thenAnswer(invocation -> {
+            crossTenant[0] = InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId");
+            return 1L;
+        });
+
+        new GatewaySensitiveWordStore(providerOf(wordMapper)).fingerprint();
+
+        assertTrue(crossTenant[0]);
+    }
+
+    private GatewaySensitiveWordStore storeWith(Runnable onCrossTenant) {
+        SensitiveWordMapper wordMapper = mock(SensitiveWordMapper.class);
+        when(wordMapper.selectList(any())).thenAnswer(invocation -> {
+            if (InterceptorIgnoreHelper.willIgnoreTenantLine("anyMapperId")) {
+                onCrossTenant.run();
+            }
+            return List.of();
+        });
+        return new GatewaySensitiveWordStore(providerOf(wordMapper));
+    }
+
+    private ContentGuardGatewayProvider providerOf(SensitiveWordMapper wordMapper) {
+        ContentGuardGatewayProvider provider = mock(ContentGuardGatewayProvider.class);
+        when(provider.get()).thenReturn(
+            new ContentGuardGateway(wordMapper, null, null, null, null));
+        return provider;
+    }
+}

--- a/docs/数据权限设计.md
+++ b/docs/数据权限设计.md
@@ -113,6 +113,7 @@ SELECT * FROM ai_project WHERE status = 1 AND (create_by = 7 OR create_by IS NUL
 | 开放 API `/api/open/**` | 走 `admin.open-api.tenant-tokens` 的 `令牌 → 租户` 映射，鉴权时顺带解析出租户并设上下文（`OpenApiAuthInterceptor`） |
 | 工作台脚本回调 `/api/workbench/agent/**` | 跨租户按 token 定位到令牌行，从行里读出租户与用户，再还原两个上下文 |
 | 内置调度器 / XXL-JOB | 扫描任务走 `CrossTenantOperations`，执行前按任务所属租户还原上下文（`ScheduledTaskService#executeFromScheduler`）。手动触发不走这里——那是 Web 请求，上下文已由拦截器设好，直接调 `execute` 才能保证"只能触发自己租户的任务" |
+| 内容风控词库刷新守护线程 | `GatewaySensitiveWordStore` 跨租户加载全量词库。读失败会让 `SensitiveWordFilter` 进入 fail-closed"拦截一切"，后台对话全被拦。进程级单例过滤器本就没有租户维度，取并集是已知取舍（可能误拦，方向安全） |
 | 登录页轮播图 `/api/login-images/**` | `login_carousel_image` 归入平台级忽略清单。登录页是平台统一入口，登录前没有任何租户上下文可用 |
 | **启动期装配**（`@Bean` / `@PostConstruct`） | A2A 服务端按 `agent_code` 跨租户定位智能体、重启清理孤儿任务跨租户扫描，均走 `CrossTenantOperations`。**这一类最容易漏**：`contextLoads` 照不出来（A2A 默认关，装配路径不执行），一旦漏掉是整个应用起不来 |
 


### PR DESCRIPTION
## 背景

这是 #118 的补漏：那个 PR 合并时，本提交还没推上去，所以这处修复没进 main。

## 问题

敏感词词库刷新跑在 `SensitiveWordRefreshDriver` 的**守护线程**里，没有租户上下文，
`admin.tenant.enabled` 打开后读 `cw_sensitive_word` 被拦截器 fail-closed：

```
at GatewaySensitiveWordStore.findEnabled(GatewaySensitiveWordStore.java:52)
at SensitiveWordFilter.reload / SensitiveWordRefresher.refreshOnce
at SensitiveWordRefreshDriver.runOnce   ← 守护线程
Caused by: TenantContextMissingException
```

比 #118 那两处更隐蔽：异常被 Store 的 `catch` 吞成一行日志，但
`SensitiveWordFilter` 读不到词表就进入 **fail-closed「拦截一切」**，
而 dev profile 默认开着 `admin.content-guard.agent-filter-enabled` ——
表现是后台对话全部被拦，看日志很难联想到租户开关。

## 修复

`GatewaySensitiveWordStore` 的三个读方法（`findAll` / `findEnabled` / `fingerprint`）走
`CrossTenantOperations` 加载全量词库。

这是**有代价的取舍**，已在类注释与文档写明：`SensitiveWordFilter` 是进程级单例、内存里只有一份
自动机，本就没有租户维度，加载全量等于取所有租户词表的并集，可能误拦（A 租户的词拦到 B 租户的内容）。
方向上安全优先，与敏感词的既定语义一致。要按租户精确过滤需把过滤器改成按租户分片，是独立的一件事。

该 Store 只服务过滤器链路（`AdminSensitiveWordFilterConfig` 装配给 `SensitiveWordFilter`），
后台的敏感词管理页面走另一套 Service，不受影响。

## 验证

- 3 个新测试**直接断言查询发生的那一刻 `InterceptorIgnoreHelper.willIgnoreTenantLine(...)` 为真**，
  并断言退出作用域后为假。做过反向验证：撤掉修复后 3 个全部失败。
- **运行时扫描**：开满 A2A + 内容风控 + 命中日志 + 内置调度器，词库刷新间隔调到 5 秒，跑 100 秒——
  零 `TenantContextMissingException`，词库加载 85 条（确认非 fail-closed），调度器正常启动。
- `admin-server 840 / 1 skip`，BUILD SUCCESS（在合入 #118 后的 main 上重跑确认）。

## 文档

CLAUDE.md 第 ② 类从「调度线程」扩写为「调度线程与轮询守护线程」，写明这处失败会让过滤器拦一切，
以及并集取舍的原因；`docs/数据权限设计.md` 的链路表同步补一行。