### PR TITLE
feat: 语义缓存接入流式路径 + 看板分区可选

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,15 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1432** + admin-server **851** + app 93 + customer-channel 65 + gateway 1（合计 **2442**）
+- 测试基线：starter **1441** + admin-server **851** + app 93 + customer-channel 65 + gateway 1（合计 **2451**）
+  （2026-08-19 语义缓存流式接入批次实测：starter 1441 / 5 skip、admin 851 / 1 skip，BUILD SUCCESS，
+  排除 `RedisSessionPersistenceTest`。本批次自身加 starter +9。
+  **Mapper 的 `resultType` 不要直接指向 record**：record 没有 setter，MyBatis 自动映射落不进去，
+  得靠构造器映射（依赖编译期 `-parameters`）。项目一律"贫血 DO 接结果、Store 转领域对象"，
+  聚合查询也照此办（`SemanticCacheScopeDO`）。
+  **新加的 Mapper XML 若没有门控测试覆盖，手工在临时库跑一遍**——语义缓存没有 Mybatis 门控测试，
+  `selectScopes` 的聚合与租户改写是手工验的。
+  上一版基线 2026-08-19 CSAT 看板修复批次：starter 1432 + admin 851，合计 2442）
   （2026-08-19 CSAT 看板修复批次实测：starter 1432 / 5 skip、admin 851 / 1 skip，BUILD SUCCESS，
   排除 `RedisSessionPersistenceTest`。本批次自身加 starter +11。
   **加纯数据迁移前先想清楚它幂等不幂等**：幂等的（如 V6 归一）可以不给 `resolveBaselineVersion` 补判定，
@@ -176,7 +184,17 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   连跑两次会落在同一毫秒，按时间戳取基线会让第二次找不到上一版，CI 里必踩（`cw_fact_log` 早有此约定）；
   ③ **语义缓存默认关闭且只缓存通用问答**：无差别缓存会把 A 用户的订单信息返回给 B。三道闸门收口在
   `SemanticCacheService#cacheable` 一处——意图白名单（默认仅 `consult`）+ 个人标识过滤（6 位以上连续数字）
-  + 双层隔离。放宽前先回答"两个不同用户问同一句话，答案是否必然相同"；
+  + 双层隔离。放宽前先回答"两个不同用户问同一句话，答案是否必然相同"。
+  ③.1 **查缓存/写缓存必须两条路径都接**（2026-08-19 修）：此前只做在非流式 `chat()` 上，而用户端 H5 走的是
+  WS 流式（`ChatDispatchService` → `chatStream`）——真实流量一条缓存都产生不了、一次都命中不了，
+  开着开关配着 jdbc 表却永远是空的。同 CSAT 那批的病根：**能力接在了用户不走的那条路上**。
+  流式侧三条约定：缓存的必须是**出站敏感词过滤之后**的文本（否则下次命中会把未过滤内容直吐）；
+  命中后仍要再过一遍过滤器（写入时合规不代表现在合规，词库会变）；写缓存用 `doOnComplete` 而非
+  `doFinally`，且要靠降级标志排除"半截回答 + 兜底文案"——`doFinally` 在错误路径也会跑，
+  把那段缓存下来，之后每个问到同类问题的人都会收到残缺回复。
+  ③.2 **语义缓存的分区键刻意保持用户级，不要跟着 CSAT 改成租户级**：那是隔离底线。
+  运营看板的可用性靠 `listScopes` 把实际分区列出来给人选（`GET /api/ops/semantic-cache/scopes`），
+  而不是让人手填一个猜不到的用户 ID；
   ④ **分级路由能力取交集**：`TieredRoutingModel` 的结构化输出支持性与上下文窗口按两档中较弱的报，
   路由是动态的，按主模型报会让走经济档那次当场崩；判定保守（只有单轮且简短才降级），
   判错的代价因此是"没省到钱"而非"答得差"；

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/SemanticCacheController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/SemanticCacheController.java
@@ -5,6 +5,7 @@ import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.ops.service.OpsAdminService;
 import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheEntry;
+import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheScope;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,10 +29,26 @@ public class SemanticCacheController {
     private static final int DEFAULT_LIMIT = 50;
     private static final String DEFAULT_SCOPE = "default";
 
+    /** 分区选择器一次最多列多少个：分区数随活跃用户数增长，不能全量拉。 */
+    private static final int DEFAULT_SCOPE_LIMIT = 100;
+
     private final OpsAdminService opsAdminService;
 
     public SemanticCacheController(OpsAdminService opsAdminService) {
         this.opsAdminService = opsAdminService;
+    }
+
+    /**
+     * 实际存在的缓存分区（按条目数降序），供看板做分区选择。
+     *
+     * <p>分区键是用户级隔离键（两个用户问同一句话答案未必相同，按用户隔离是安全底线），
+     * 运营既猜不到有哪些分区，也不知道哪个里面有东西——列出来让他选，而不是让他手填。</p>
+     */
+    @SaCheckPermission("semantic-cache:view")
+    @GetMapping("/scopes")
+    public Result<List<SemanticCacheScope>> scopes(
+            @RequestParam(defaultValue = "" + DEFAULT_SCOPE_LIMIT) int limit) {
+        return Result.success(opsAdminService.listCacheScopes(limit));
     }
 
     /** 缓存条目，按命中次数降序——一眼看出哪些真在被复用、哪些只是白占容量。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/service/OpsAdminService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/service/OpsAdminService.java
@@ -10,6 +10,7 @@ import com.richard.fyoung.customerwork.capability.deadletter.DeadLetterStatus;
 import com.richard.fyoung.customerwork.capability.knowledgegap.KnowledgeGap;
 import com.richard.fyoung.customerwork.capability.prompt.PromptVersion;
 import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheEntry;
+import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheScope;
 import com.richard.fyoung.customerwork.tool.backend.entity.KnowledgeDO;
 import com.richard.fyoung.customerwork.tool.backend.mapper.KnowledgeMapper;
 import org.slf4j.Logger;
@@ -45,6 +46,17 @@ public class OpsAdminService {
     /** 缓存条目（按命中次数降序）：看清楚缓存了什么、哪些真的在被复用。 */
     public List<SemanticCacheEntry> listCache(String scopeId, int limit) {
         return gatewayProvider.get().semanticCache().listByHits(scopeId, limit);
+    }
+
+    /**
+     * 列出实际存在的缓存分区（按条目数降序）。
+     *
+     * <p>缓存分区键是用户级隔离键，运营在看板上猜不到该填什么——这个接口就是为了把
+     * "手填一个猜不到的 ID"换成"从实际有数据的分区里选"。跨库门面挂了租户拦截器，
+     * 只看得到本租户的分区。</p>
+     */
+    public List<SemanticCacheScope> listCacheScopes(int limit) {
+        return gatewayProvider.get().semanticCache().listScopes(limit);
     }
 
     /** 定点删除单条缓存（某条答得不对时不必清空整个分区）。 */

--- a/customer-admin-web/src/api/ops.ts
+++ b/customer-admin-web/src/api/ops.ts
@@ -19,6 +19,26 @@ export interface SemanticCacheEntry {
   lastHitAtMs: number
 }
 
+/** 一个缓存分区及其条目数（分区选择器用）。 */
+export interface SemanticCacheScope {
+  scopeId: string
+  entries: number
+}
+
+/**
+ * 实际存在的缓存分区，按条目数降序。
+ *
+ * 分区键是用户级隔离键（两个用户问同一句话答案未必相同，按用户隔离是安全底线），
+ * 运营既猜不到有哪些分区、也不知道哪个里面有东西——列出来让他选，而不是让他手填。
+ */
+export function listCacheScopes(limit = 100) {
+  return request<SemanticCacheScope[]>({
+    url: '/ops/semantic-cache/scopes',
+    method: 'get',
+    params: { limit },
+  })
+}
+
 /** 缓存条目，按命中次数降序。 */
 export function listCacheEntries(scopeId = 'default', limit = 50) {
   return request<SemanticCacheEntry[]>({

--- a/customer-admin-web/src/views/ops/SemanticCacheBoard.vue
+++ b/customer-admin-web/src/views/ops/SemanticCacheBoard.vue
@@ -5,7 +5,9 @@ import {
   clearCacheScope,
   evictCacheEntry,
   listCacheEntries,
+  listCacheScopes,
   type SemanticCacheEntry,
+  type SemanticCacheScope,
 } from '@/api/ops'
 
 // 语义缓存看板：看清楚缓存了什么、哪些真的在被复用、清掉答得不对的。
@@ -14,16 +16,44 @@ import {
 // 相似度是在应用层逐条算的，容量越大查缓存越慢。
 
 const loading = ref(false)
+const scopesLoading = ref(false)
 const list = ref<SemanticCacheEntry[]>([])
-const scopeId = ref('default')
+const scopes = ref<SemanticCacheScope[]>([])
+// 分区键是用户级隔离键（形如 u42），运营手填是猜不出来的，故进页面先把实际存在的分区拉回来。
+// 留空而不是预填 'default'：预填一个多半查不到东西的值，只会让人以为"缓存没在工作"。
+const scopeId = ref('')
+
+/** 拉分区列表并默认选中条目最多的那个——运营多半就是想看它。 */
+async function loadScopes() {
+  scopesLoading.value = true
+  try {
+    scopes.value = await listCacheScopes()
+    if (!scopeId.value && scopes.value.length > 0) {
+      scopeId.value = scopes.value[0].scopeId
+    }
+  } finally {
+    scopesLoading.value = false
+  }
+}
 
 async function loadList() {
+  // 没有任何分区时不必空跑一次查询
+  if (!scopeId.value) {
+    list.value = []
+    return
+  }
   loading.value = true
   try {
     list.value = await listCacheEntries(scopeId.value)
   } finally {
     loading.value = false
   }
+}
+
+/** 清空/删除之后分区可能整个消失，得连选择器一起刷新。 */
+async function reload() {
+  await loadScopes()
+  await loadList()
 }
 
 function formatTime(ms: number): string {
@@ -48,7 +78,7 @@ async function handleEvict(row: SemanticCacheEntry) {
     )
     await evictCacheEntry(row.id)
     ElMessage.success('已删除')
-    await loadList()
+    await reload()
   } catch (error) {
     if (error !== 'cancel') throw error
   }
@@ -63,13 +93,15 @@ async function handleClear() {
     )
     const removed = await clearCacheScope(scopeId.value)
     ElMessage.success(`已清空 ${removed} 条`)
-    await loadList()
+    // 分区已空，选择器里那一项会消失，得重新挑一个
+    scopeId.value = ''
+    await reload()
   } catch (error) {
     if (error !== 'cancel') throw error
   }
 }
 
-onMounted(loadList)
+onMounted(reload)
 </script>
 
 <template>
@@ -104,10 +136,38 @@ onMounted(loadList)
 
     <el-card shadow="never">
       <div class="toolbar">
-        <el-input v-model="scopeId" placeholder="分区键" style="width: 180px" />
-        <el-button type="primary" @click="loadList">查询</el-button>
+        <!-- filterable + allow-create：分区多时能搜，也允许手填一个列表外的分区
+             （列表有 100 条上限，长尾分区不在里面） -->
+        <el-select
+          v-model="scopeId"
+          :loading="scopesLoading"
+          filterable
+          allow-create
+          default-first-option
+          placeholder="选择分区"
+          style="width: 240px"
+          @change="loadList"
+        >
+          <el-option
+            v-for="scope in scopes"
+            :key="scope.scopeId"
+            :label="`${scope.scopeId}（${scope.entries} 条）`"
+            :value="scope.scopeId"
+          />
+        </el-select>
+        <el-button type="primary" :loading="loading" @click="loadList">查询</el-button>
+        <el-button :loading="scopesLoading" @click="loadScopes">刷新分区</el-button>
+        <span v-if="!scopesLoading && scopes.length === 0" class="hint">
+          当前还没有任何缓存分区
+        </span>
         <div class="spacer" />
-        <el-button v-permission="'semantic-cache:evict'" type="danger" plain @click="handleClear">
+        <el-button
+          v-permission="'semantic-cache:evict'"
+          type="danger"
+          plain
+          :disabled="!scopeId"
+          @click="handleClear"
+        >
           清空该分区
         </el-button>
       </div>
@@ -167,6 +227,11 @@ onMounted(loadList)
 
 .stat-warn {
   color: var(--el-color-warning);
+}
+
+.hint {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
 }
 
 .stat-label {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/InMemorySemanticCacheStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/InMemorySemanticCacheStore.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.capability.semanticcache;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -98,6 +99,20 @@ public class InMemorySemanticCacheStore implements SemanticCacheStore {
     @Override
     public boolean remove(Long id) {
         return entries.remove(id) != null;
+    }
+
+    @Override
+    public List<SemanticCacheScope> listScopes(int limit) {
+        Map<String, Long> counts = new HashMap<>();
+        for (SemanticCacheEntry entry : entries.values()) {
+            counts.merge(entry.scopeId(), 1L, Long::sum);
+        }
+        List<SemanticCacheScope> scopes = new ArrayList<>(counts.size());
+        counts.forEach((scopeId, count) -> scopes.add(new SemanticCacheScope(scopeId, count)));
+        // 与 jdbc 实现同序：条目多的在前，同数按分区键字典序，保证两种模式看板顺序一致
+        scopes.sort(Comparator.comparingLong(SemanticCacheScope::entries).reversed()
+            .thenComparing(SemanticCacheScope::scopeId));
+        return List.copyOf(scopes.subList(0, Math.min(Math.max(limit, 0), scopes.size())));
     }
 
     @Override

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/MybatisSemanticCacheStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/MybatisSemanticCacheStore.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.capability.semanticcache;
 
 import com.richard.fyoung.customerwork.capability.semanticcache.entity.SemanticCacheDO;
+import com.richard.fyoung.customerwork.capability.semanticcache.entity.SemanticCacheScopeDO;
 import com.richard.fyoung.customerwork.capability.semanticcache.mapper.SemanticCacheMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +123,22 @@ public class MybatisSemanticCacheStore implements SemanticCacheStore {
         } catch (Exception e) {
             log.error("[MybatisSemanticCacheStore] listByHits failed, errorCode={}, scopeId={}",
                 "SEMCACHE-STORE-LIST-FAIL", scopeId, e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public List<SemanticCacheScope> listScopes(int limit) {
+        try {
+            List<SemanticCacheScopeDO> rows = mapper.selectScopes(limit);
+            List<SemanticCacheScope> result = new ArrayList<>(rows.size());
+            for (SemanticCacheScopeDO row : rows) {
+                result.add(new SemanticCacheScope(row.getScopeId(), row.getEntries()));
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("[MybatisSemanticCacheStore] listScopes failed, errorCode={}, limit={}",
+                "SEMCACHE-STORE-SCOPES-FAIL", limit, e);
             return List.of();
         }
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheScope.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheScope.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customerwork.capability.semanticcache;
+
+/**
+ * 一个缓存分区及其条目数（运营看板的分区选择器用）。
+ *
+ * <p><b>为什么需要它</b>：语义缓存的分区键是数据隔离键（由 {@code TenantResolver} 从 sessionId 前缀解析，
+ * 用户端解析出来的是 {@code u{userId}} 这样的用户标识）。这个隔离粒度是刻意的——两个用户问同一句话
+ * 答案未必相同，按用户分区是安全底线，不能像 CSAT 那样改成租户级。</p>
+ *
+ * <p>但代价是运营在看板上根本猜不到该填什么：他既不知道有哪些分区，也不知道哪个分区里有东西。
+ * 与其让人手填一个猜不到的用户 ID，不如把实际存在的分区列出来给他选。</p>
+ *
+ * @param scopeId 分区键
+ * @param entries 该分区当前的缓存条目数——运营据此判断哪个分区值得点进去看
+ * @author owlzhangfq@gmail.com
+ */
+public record SemanticCacheScope(String scopeId, long entries) {
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheStore.java
@@ -52,4 +52,12 @@ public interface SemanticCacheStore {
 
     /** 删除单条缓存（运营发现某条答得不对时定点清除，不必清空整个分区）。 */
     boolean remove(Long id);
+
+    /**
+     * 列出当前存在的分区及条目数，按条目数降序，最多 {@code limit} 个。
+     *
+     * <p><b>必须限额</b>：分区键是用户级隔离键（见 {@link SemanticCacheScope}），
+     * 分区数量随活跃用户数增长，无上限地全量返回会在用户一多时把看板拖垮。</p>
+     */
+    List<SemanticCacheScope> listScopes(int limit);
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/entity/SemanticCacheScopeDO.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/entity/SemanticCacheScopeDO.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.capability.semanticcache.entity;
+
+import lombok.Data;
+
+/**
+ * 分区聚合结果（贫血数据袋）：{@code SELECT scope_id, COUNT(*) GROUP BY scope_id} 的一行。
+ *
+ * <p>不直接把
+ * {@link com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheScope}
+ * 当 {@code resultType}：那是 record，没有 setter，MyBatis 的自动映射落不进去，
+ * 得靠构造器映射（依赖编译期 {@code -parameters}）才行——项目里所有查询都是"贫血 DO 接结果、
+ * Store 转领域对象"，这里没有理由破例去赌一个编译参数。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+public class SemanticCacheScopeDO {
+
+    /** 分区键。 */
+    private String scopeId;
+
+    /** 该分区当前条目数。 */
+    private long entries;
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/mapper/SemanticCacheMapper.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/mapper/SemanticCacheMapper.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.capability.semanticcache.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.richard.fyoung.customerwork.capability.semanticcache.entity.SemanticCacheDO;
+import com.richard.fyoung.customerwork.capability.semanticcache.entity.SemanticCacheScopeDO;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
@@ -44,4 +45,7 @@ public interface SemanticCacheMapper extends BaseMapper<SemanticCacheDO> {
 
     /** 运营视角列出条目，按命中次数降序（"哪些缓存真的在被复用"）。 */
     List<SemanticCacheDO> selectByHits(@Param("scopeId") String scopeId, @Param("limit") int limit);
+
+    /** 列出分区及条目数，按条目数降序限额（看板的分区选择器）。 */
+    List<SemanticCacheScopeDO> selectScopes(@Param("limit") int limit);
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/service/CustomerServiceService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/service/CustomerServiceService.java
@@ -32,6 +32,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -80,6 +81,14 @@ public class CustomerServiceService {
     private static final String M_CHAT_FALLBACK = "customerwork.chat.fallback";
     /** 语义缓存命中计数指标名：省下的每一次模型调用都记在这里，用来算这个功能到底值不值。 */
     private static final String M_CACHE_HIT = "customerwork.chat.cache.hit";
+
+    /**
+     * 命中缓存后下发的切片长度（字符）。
+     *
+     * <p>只为让前端行为与真实流式一致，不掺人为延迟——取值大小只影响气泡撑开的观感，
+     * 不影响任何正确性。</p>
+     */
+    private static final int CACHED_ANSWER_CHUNK_SIZE = 24;
 
     private final CustomerServiceAgentFactory agentFactory;
     private final SessionStateManager sessionStateManager;
@@ -309,6 +318,63 @@ public class CustomerServiceService {
             return Flux.just(QUOTA_EXCEEDED_REPLY);
         }
         touchSession(sessionId);
+        if (semanticCache == null) {
+            return streamFromAgent(sessionId, userText, new AtomicBoolean(false));
+        }
+        // 查缓存要调 Embedding（阻塞 HTTP），必须挪到弹性线程池，理由同非流式路径
+        return Mono.fromCallable(() -> semanticCache.lookup(sessionId, userText))
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMapMany(cached -> cached
+                .map(this::streamCachedAnswer)
+                .orElseGet(() -> streamFromAgentAndCache(sessionId, userText)));
+    }
+
+    /**
+     * 命中缓存后的下发：切片推出，<b>不</b>人为加延迟。
+     *
+     * <p>切片是为了让前端行为与真实流式一致（一个超长 chunk 会让消息气泡突然撑开），
+     * 而不是为了模拟打字效果——缓存的价值就是快，把省下来的时间再睡回去是自欺。</p>
+     *
+     * <p><b>命中的内容仍要过一遍出站敏感词过滤</b>：写入时合规不代表现在合规，词库是会变的。
+     * 过滤器对已经干净的文本是幂等的，这一遍纯内存操作，成本可以忽略。</p>
+     */
+    private Flux<String> streamCachedAnswer(String answer) {
+        incr(M_CACHE_HIT);
+        List<String> chunks = new ArrayList<>();
+        for (int i = 0; i < answer.length(); i += CACHED_ANSWER_CHUNK_SIZE) {
+            chunks.add(answer.substring(i, Math.min(i + CACHED_ANSWER_CHUNK_SIZE, answer.length())));
+        }
+        return applyOutboundGuard(Flux.fromIterable(chunks), newOutboundGuard());
+    }
+
+    /**
+     * 走 Agent 并在流正常结束后异步写缓存。
+     *
+     * <p>累积的是<b>过滤后</b>的文本——缓存的必须是真正发给用户的那一份，
+     * 否则下次命中会把未过滤内容直接吐出去。</p>
+     *
+     * <p>用 {@code doOnComplete} 而不是 {@code doFinally}：后者在错误路径上也会跑，
+     * 而中途失败的流里累积的是"半截回答 + 兜底文案"，把它缓存下来，之后每个问到同类问题的人
+     * 都会收到这段残缺的回复。降级标志由 {@link #streamFromAgent} 在兜底时置位。</p>
+     */
+    private Flux<String> streamFromAgentAndCache(String sessionId, String userText) {
+        StringBuilder accumulated = new StringBuilder();
+        AtomicBoolean degraded = new AtomicBoolean(false);
+        return streamFromAgent(sessionId, userText, degraded)
+            .doOnNext(accumulated::append)
+            .doOnComplete(() -> {
+                if (!degraded.get()) {
+                    cacheReply(sessionId, userText, accumulated.toString());
+                }
+            });
+    }
+
+    /**
+     * 真正走一遍 Agent 的流式链路——缓存未命中时才发生。
+     *
+     * @param degraded 出参：走了兜底（超时 / 调用失败）时置位，调用方据此决定不写缓存
+     */
+    private Flux<String> streamFromAgent(String sessionId, String userText, AtomicBoolean degraded) {
         ReActAgent agent = resolveAgent(sessionId);
         RuntimeContext ctx = agentFactory.contextFor(sessionId);
         bindCallMeta(ctx, agent, userText);
@@ -349,6 +415,7 @@ public class CustomerServiceService {
         }
 
         return flux.onErrorResume(e -> {
+            degraded.set(true);
             if (e instanceof TimeoutException) {
                 log.error("[session {}] stream idle timeout after {}s, closing, code={}",
                     sessionId, idle, "STREAM_IDLE_TIMEOUT");

--- a/customer-work-starter/src/main/resources/customerwork/mapper/SemanticCacheMapper.xml
+++ b/customer-work-starter/src/main/resources/customerwork/mapper/SemanticCacheMapper.xml
@@ -57,4 +57,15 @@
         ORDER BY hit_count DESC, last_hit_at_ms DESC
         LIMIT #{limit}
     </select>
+
+    <!-- 分区选择器：分区键是用户级隔离键，运营猜不到该填什么，只能把实际存在的列出来让他选。
+         tenant_id 由拦截器补进 WHERE，故这里天然只看得到本租户的分区。
+         必须限额——分区数随活跃用户数增长。 -->
+    <select id="selectScopes" resultType="com.richard.fyoung.customerwork.capability.semanticcache.entity.SemanticCacheScopeDO">
+        SELECT scope_id AS scopeId, COUNT(*) AS entries
+        FROM cw_semantic_cache
+        GROUP BY scope_id
+        ORDER BY entries DESC, scope_id ASC
+        LIMIT #{limit}
+    </select>
 </mapper>

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheScopeListTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheScopeListTest.java
@@ -1,0 +1,75 @@
+package com.richard.fyoung.customerwork.capability.semanticcache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 分区列表：给运营看板的分区选择器供数。
+ *
+ * <p>语义缓存的分区键是<b>用户级</b>隔离键（{@code u42} 这样的），这个粒度是安全底线不能动——
+ * 但代价是运营在看板上根本猜不到该填什么，看板因此长期显示"No Data"。
+ * 与其让人手填一个猜不到的 ID，不如把实际存在的分区列出来让他选。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class SemanticCacheScopeListTest {
+
+    private SemanticCacheStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemorySemanticCacheStore();
+    }
+
+    @Test
+    void shouldAggregateByScopeAndRankByEntries() {
+        save("u1", "怎么退货");
+        save("u1", "运费怎么算");
+        save("u1", "能开专票吗");
+        save("u2", "怎么退货");
+
+        List<SemanticCacheScope> scopes = store.listScopes(10);
+
+        assertEquals(2, scopes.size(), "同一分区聚合成一条，不是逐条流水");
+        assertEquals("u1", scopes.get(0).scopeId(), "条目多的排前面——运营多半就是想看它");
+        assertEquals(3, scopes.get(0).entries());
+        assertEquals(1, scopes.get(1).entries());
+    }
+
+    @Test
+    void shouldRespectLimit() {
+        // 分区数随活跃用户数增长，全量返回会在用户一多时把看板拖垮
+        for (int i = 0; i < 20; i++) {
+            save("u" + i, "怎么退货");
+        }
+
+        assertEquals(5, store.listScopes(5).size());
+    }
+
+    @Test
+    void emptyStore_shouldReturnEmptyList() {
+        assertTrue(store.listScopes(10).isEmpty());
+    }
+
+    @Test
+    void clearedScope_shouldDisappear() {
+        // 清空分区后它会从选择器里消失，前端据此重新挑一个
+        save("u1", "怎么退货");
+        save("u2", "运费怎么算");
+
+        store.clear("u1");
+
+        List<SemanticCacheScope> scopes = store.listScopes(10);
+        assertEquals(1, scopes.size());
+        assertEquals("u2", scopes.get(0).scopeId());
+    }
+
+    private void save(String scopeId, String question) {
+        store.save(SemanticCacheEntry.of(scopeId, "consult", question, "0.1,0.2", "答案",
+            System.currentTimeMillis()));
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/service/CustomerServiceStreamCacheTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/service/CustomerServiceStreamCacheTest.java
@@ -1,0 +1,143 @@
+package com.richard.fyoung.customerwork.core.service;
+
+import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheService;
+import com.richard.fyoung.customerwork.core.agent.CustomerServiceAgentFactory;
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 流式路径的语义缓存。
+ *
+ * <p>这条线此前是断的：查缓存与写缓存都只做在非流式的 {@code chat()} 上，而用户端 H5 走的是
+ * WebSocket 流式（{@code ChatDispatchService} → {@code chatStream}）——真实流量一条缓存都
+ * 产生不了，也一次都命中不了。开着开关、配着 jdbc，表却永远是空的。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class CustomerServiceStreamCacheTest {
+
+    private static final String SESSION_ID = "u42:conv-1";
+
+    private CustomerServiceAgentFactory factory;
+    private ReActAgent agent;
+    private SemanticCacheService cache;
+    private CustomerServiceService service;
+
+    @BeforeEach
+    void setUp() {
+        factory = mock(CustomerServiceAgentFactory.class);
+        agent = mock(ReActAgent.class);
+        cache = mock(SemanticCacheService.class);
+        SessionStateManager stateManager = mock(SessionStateManager.class);
+        when(factory.createAgent(anyString())).thenReturn(agent);
+        when(factory.contextFor(anyString())).thenAnswer(inv ->
+            RuntimeContext.builder().userId("tenant").sessionId(inv.getArgument(0)).build());
+        service = new CustomerServiceService(factory, stateManager, new CustomerWorkProperties(),
+            empty(), empty(), empty(), empty(), providerOf(cache), empty());
+    }
+
+    @Test
+    void cacheHit_shouldNotInvokeAgent() {
+        when(cache.lookup(eq(SESSION_ID), anyString())).thenReturn(Optional.of("七天无理由从签收次日算起。"));
+
+        String joined = String.join("", service.chatStream(SESSION_ID, "几天无理由怎么算")
+            .collectList().block());
+
+        assertEquals("七天无理由从签收次日算起。", joined, "切片拼回去必须与缓存原文完全一致");
+        // 命中的意义就在这里：Agent 装配、知识检索、模型调用全都不发生
+        verify(agent, never()).streamEvents(anyList(), any(RuntimeContext.class));
+        verify(factory, never()).createAgent(anyString());
+    }
+
+    @Test
+    void cacheHit_shouldEmitMultipleChunks_forLongAnswer() {
+        // 一个超长 chunk 会让前端消息气泡突然撑开，与真实流式的观感差太多
+        String answer = "七".repeat(100);
+        when(cache.lookup(eq(SESSION_ID), anyString())).thenReturn(Optional.of(answer));
+
+        List<String> chunks = service.chatStream(SESSION_ID, "几天无理由怎么算").collectList().block();
+
+        assertEquals(answer, String.join("", chunks), "切片拼回去必须与缓存原文完全一致");
+        assertTrue(chunks.size() > 1, "长答案要切开下发，不能一个巨大 chunk 砸过去");
+    }
+
+    @Test
+    void cacheMiss_shouldInvokeAgentAndWriteCache() {
+        when(cache.lookup(eq(SESSION_ID), anyString())).thenReturn(Optional.empty());
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(delta("运费"), delta("满 99 包邮。")));
+
+        String joined = String.join("", service.chatStream(SESSION_ID, "运费怎么算")
+            .collectList().block());
+
+        assertEquals("运费满 99 包邮。", joined);
+        // 缓存的必须是完整回复，不是最后一个增量
+        verify(cache, timeout(2000)).put(eq(SESSION_ID), eq("运费怎么算"), eq("运费满 99 包邮。"));
+    }
+
+    @Test
+    void streamFailure_shouldNotCacheHalfAnswer() {
+        when(cache.lookup(eq(SESSION_ID), anyString())).thenReturn(Optional.empty());
+        // 已经吐了半句才失败：兜底文案会接在半句后面，把这段缓存下来，
+        // 之后每个问到同类问题的人都会收到这段残缺回复
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+            .thenReturn(Flux.concat(Flux.just(delta("运费满")),
+                Flux.error(new IllegalStateException("model down"))));
+
+        service.chatStream(SESSION_ID, "运费怎么算").collectList().block();
+
+        verify(cache, never()).put(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void withoutCache_shouldBehaveAsBefore() {
+        CustomerServiceService plain = new CustomerServiceService(factory,
+            mock(SessionStateManager.class), new CustomerWorkProperties(),
+            empty(), empty(), empty(), empty(), empty(), empty());
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+            .thenReturn(Flux.just(delta("您好")));
+
+        StepVerifier.create(plain.chatStream(SESSION_ID, "你好"))
+            .expectNext("您好")
+            .verifyComplete();
+    }
+
+    private TextBlockDeltaEvent delta(String text) {
+        return new TextBlockDeltaEvent("r1", "b1", text);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> ObjectProvider<T> empty() {
+        ObjectProvider<T> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        return provider;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> ObjectProvider<T> providerOf(T bean) {
+        ObjectProvider<T> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(bean);
+        return provider;
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -1686,6 +1686,7 @@ POST   /api/ops/knowledge-gap/fill          标记已补
 GET    /api/ops/dead-letter/list  /stats    死信列表 / 统计
 POST   /api/ops/dead-letter/{id}/reopen     手工重投
 GET    /api/ops/prompt-version/list  /{fingerprint}
+GET    /api/ops/semantic-cache/scopes       实际存在的分区及条目数（看板选择器）
 GET    /api/ops/semantic-cache/list
 DELETE /api/ops/semantic-cache/{id}  /scope/{scopeId}
 ```
@@ -1701,6 +1702,15 @@ DELETE /api/ops/semantic-cache/{id}  /scope/{scopeId}
   6 位以上连续数字即跳过）+ 双层隔离。往 `cacheable-intents` 加意图前，先回答
   "两个不同用户问同一句话，答案是否必然相同"。相似度阈值 0.95 偏保守：
   "怎么退货"与"怎么换货"能到 0.9 上下，定低了会把换货答成退货——宁可少命中，不可答错。
+- **查缓存与写缓存必须流式、非流式两条路径都接**：此前只做在非流式 `chat()` 上，而用户端 H5 走的是
+  WS 流式（`ChatDispatchService` → `chatStream`），真实流量一条缓存都产生不了、一次都命中不了——
+  开着开关、配着 jdbc，表却永远是空的。流式侧三条：缓存的必须是**出站敏感词过滤之后**的文本；
+  命中后仍要再过一遍过滤器（写入时合规不代表现在合规，词库会变）；写缓存用 `doOnComplete` 并靠降级标志
+  排除"半截回答 + 兜底文案"（`doFinally` 在错误路径也会跑，缓存下来之后人人都收到那段残缺回复）。
+  命中后切片下发只为让前端观感与真实流式一致，**不掺人为延迟**——缓存的价值就是快。
+- **语义缓存的分区键保持用户级，不要跟着 CSAT 改成租户级**：那是隔离底线（两个用户问同一句话答案未必相同）。
+  看板的可用性靠 `GET /api/ops/semantic-cache/scopes` 把实际存在的分区列出来给运营选，
+  而不是让人手填一个猜不到的用户 ID。分区数随活跃用户数增长，故该接口必须限额（默认 100）。
 - **提示词版本用内容指纹而非外部版本号**：Nacos 下发的是内容、没有随行版本号。指纹让
   `EvalComparison#promptChanged` 成为归因支点——指标掉了先看这一位，没变就别再对着提示词逐字看。
   记的是「运行时实际生效」的那份，与配置中心记的「发布了什么」会不一致。


### PR DESCRIPTION
## 问题

语义缓存 `enabled: true`、`store-mode: jdbc` 都配好了，`cw_semantic_cache` 却永远是空的，看板三个数字全是 0。

## 缺陷一：真实流量根本不经过这条链路

查缓存与写缓存**都只做在非流式的 `chat()` 上**，而用户端 H5 走的是 WebSocket 流式：

```
H5 → WS → ChatDispatchService:241 → customerServiceService.chatStream(...)
```

`chatStream` 全文没有任何 `semanticCache` 调用。目前还在调 `chat()` 的只有 `POST /api/customer/chat`（演示接口，H5 不用）、`EvalService`（评测）、`SyntheticMonitor`（探针）——**真实用户一条缓存都产生不了、一次都命中不了**。

与上一批 CSAT（PR #122）是同一个病根：能力做完了，但接在了用户不走的那条路上。

### 流式接入的三个约定

| 约定 | 不这么做会怎样 |
|---|---|
| 缓存**出站敏感词过滤之后**的文本 | 下次命中会把未过滤内容直接吐给用户 |
| 命中的内容**仍要再过一遍**过滤器 | 写入时合规不代表现在合规，词库是会变的 |
| 写缓存用 `doOnComplete` + 降级标志 | `doFinally` 在错误路径也会跑，缓存下"半截回答 + 兜底文案"后，之后每个问到同类问题的人都会收到这段残缺回复 |

命中后**切片下发**，只为让前端观感与真实流式一致（一个超长 chunk 会让消息气泡突然撑开），**不掺人为延迟**——缓存的价值就是快，把省下来的时间再睡回去是自欺。命中时连 Agent 装配都不发生，省的是整条链路。

## 缺陷二：看板该填什么，运营根本猜不到

缓存分区键是**用户级**隔离键（`u42` 这样的）。这个粒度是刻意的，也是安全底线——两个用户问同一句话答案未必相同，**不能像 CSAT 那样改成租户级**。

但代价是运营在看板上猜不到该填什么，于是长期显示 No Data。修法不是改分区，是让人能选：

- 新增 `GET /api/ops/semantic-cache/scopes`，返回实际存在的分区及条目数（按条目数降序）
- 看板换成 `el-select`（`filterable` + `allow-create`），默认选中条目最多的那个；清空分区后自动重挑
- 跨库门面挂了 `AdminCrossDbTenantPlugins`，只看得到本租户的分区
- 分区数随活跃用户数增长，接口**必须限额**（默认 100），列表外的长尾分区仍可手填

## 实现注意

聚合结果走贫血 DO（`SemanticCacheScopeDO`）而不是直接把 `resultType` 指向 record——record 没有 setter，MyBatis 自动映射落不进去，得靠构造器映射（依赖编译期 `-parameters`）。项目里所有查询都是"贫血 DO 接结果、Store 转领域对象"，这里没理由破例去赌一个编译参数。

语义缓存没有 Mybatis 门控测试，`selectScopes` 的 SQL 已在临时库手工验证（聚合正确、租户条件生效、跨租户数据不出现）。

## 测试

`starter 1441 / admin 851 / app 93 / channel 65 / gateway 1 = 2451`，BUILD SUCCESS（排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+9**：

- `CustomerServiceStreamCacheTest` 5：命中不调 Agent、长答案切片、未命中写完整回复、**中途失败不缓存半截**、未装配缓存时行为不变
- `SemanticCacheScopeListTest` 4：聚合排序、限额、空库、清空后分区消失

`customer-admin-web` 的 `vue-tsc -b && vite build` 通过。

## 合并后验证

开启语义缓存需要 `model.api-key` 可用（Embedding 走 DashScope）。在 H5 上连问两次「几天无理由怎么算」这类**政策咨询**问题（必须命中 `consult` 快车道关键词：发票 / 运费 / 政策 / 几天无理由 / 保修 / 能不能开票），第二次应秒回，看板分区选择器里会出现 `u<你的用户ID>` 那一项。