### PR TITLE
feat: Skill 管理支持下载技能包 zip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,13 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1441** + admin-server **851** + app 93 + customer-channel 65 + gateway 1（合计 **2451**）
+- 测试基线：starter **1441** + admin-server **858** + app 93 + customer-channel 65 + gateway 1（合计 **2458**）
+  （2026-08-19 Skill 技能包下载批次实测：starter 1441 / 5 skip、admin 858 / 1 skip，BUILD SUCCESS，
+  排除 `RedisSessionPersistenceTest`。本批次自身加 admin +7。
+  **导入/导出这类成对功能，测试要真的做一次往返**（导出的包再喂给解析器比对），
+  只断言"zip 里有哪几个条目"照不出结构漂移。
+  sys_permission 下次从 **248** 起、admin Flyway 下次 **V63**。
+  上一版基线 2026-08-19 语义缓存流式接入批次：starter 1441 + admin 851，合计 2451）
   （2026-08-19 语义缓存流式接入批次实测：starter 1441 / 5 skip、admin 851 / 1 skip，BUILD SUCCESS，
   排除 `RedisSessionPersistenceTest`。本批次自身加 starter +9。
   **Mapper 的 `resultType` 不要直接指向 record**：record 没有 setter，MyBatis 自动映射落不进去，

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/controller/SkillController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/controller/SkillController.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.aiconfig.skill.controller;
 
 import cn.dev33.satoken.annotation.SaCheckPermission;
 import cn.dev33.satoken.annotation.SaMode;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillExportPackage;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillSaveRequest;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadParseResult;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillVO;
@@ -11,6 +12,10 @@ import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.Result;
 import jakarta.validation.Valid;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Skill 管理：CRUD + 分页/搜索/筛选/排序。
@@ -73,6 +80,33 @@ public class SkillController {
     }
 
     /** 解析上传的 .md/.zip 文件为技能包（SKILL.md 正文 + 附属文件），不落库——前端回填表单后仍走 create/update 保存。 */
+    /**
+     * 下载技能包 zip。
+     *
+     * <p><b>单独发 {@code skill:export} 而不复用 {@code skill:view}</b>：查看接口返回的附属文件清单
+     * 只有路径与大小（{@code SkillFileVO} 不带内容），文件字节此前在后台任何接口都拿不到。
+     * 所以这不是"同一份数据换个格式"，而是一个新的数据出口——附属文件里可能有脚本与内网文档，
+     * "能看到有哪些文件"和"能把整包带走"是两种能力。（内容风控那批导出复用 view，
+     * 是因为那边页面上本来就能看到全部词条内容，判断标准一致、结论不同。）</p>
+     *
+     * <p>返回二进制而非 {@code Result} 包装：前端 {@code download()} 直接触发浏览器保存。
+     * 业务异常仍按 {@code Result} 返回 JSON，前端据 content-type 区分（见 request.ts 的注释）。</p>
+     */
+    @SaCheckPermission("skill:export")
+    @OperationLog(operation = "下载技能包", target = "ai_skill")
+    @GetMapping("/{id}/download")
+    public ResponseEntity<byte[]> download(@PathVariable Long id) {
+        SkillExportPackage pkg = skillService.exportZip(id);
+        // filename(name, UTF_8) 走 RFC 5987 的 filename*，中文包名才不会在下载时变成乱码或被截断
+        ContentDisposition disposition = ContentDisposition.attachment()
+            .filename(pkg.filename(), StandardCharsets.UTF_8)
+            .build();
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+            .body(pkg.content());
+    }
+
     @SaCheckPermission(value = {"skill:add", "skill:edit"}, mode = SaMode.OR)
     @PostMapping("/parse-upload")
     public Result<SkillUploadParseResult> parseUpload(@RequestParam("file") MultipartFile file) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillExportPackage.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/dto/SkillExportPackage.java
@@ -1,0 +1,14 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.dto;
+
+/**
+ * 导出的技能包：建议文件名 + zip 字节。
+ *
+ * <p>文件名在 Service 层定（要按 skillCode 净化出合法文件名，那是业务规则），
+ * Controller 只负责把它写进 {@code Content-Disposition}。</p>
+ *
+ * @param filename 建议的下载文件名，形如 {@code my-skill.zip}
+ * @param content  zip 字节
+ * @author owlzhangfq@gmail.com
+ */
+public record SkillExportPackage(String filename, byte[] content) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillService.java
@@ -10,6 +10,7 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillFileVO;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillSaveRequest;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillExportPackage;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadParseResult;
 import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillVO;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
@@ -48,6 +49,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Skill 管理。
@@ -71,6 +73,7 @@ public class SkillService {
     private static final String ERR_TARGET_INVALID = "SKILL-STORAGE-TARGET-INVALID";
     private static final String ERR_TARGET_DISABLED = "SKILL-STORAGE-TARGET-DISABLED";
     private static final String ERR_PUBLISH_FAIL = "SKILL-STORAGE-PUBLISH-FAIL";
+    private static final String ERR_EXPORT_FAIL = "SKILL-EXPORT-FAIL";
 
     private static final String TARGET_DELIMITER = ",";
 
@@ -305,6 +308,68 @@ public class SkillService {
             SkillStorageTarget.fromCode(code).ifPresent(targets::add);
         }
         return targets;
+    }
+
+    // ---- 导出 ----
+
+    /**
+     * 导出为技能包 zip。
+     *
+     * <p><b>结构与上传解析严格对称</b>：zip 内包一层以 skillCode 命名的目录，目录里放
+     * {@code SKILL.md}（取 {@code ai_skill.content}）与全部附属文件（按各自的相对路径还原）。
+     * 这样下载下来的包能<b>原样重新上传</b>——{@link #parseSkillZip} 正是以最浅层 SKILL.md
+     * 所在目录为技能根。改这里的结构前先想清楚往返还成不成立。</p>
+     *
+     * <p>包一层目录而不是把文件铺在 zip 根：解压时不会把一堆文件散进当前目录，
+     * 也与技能包本身"一个目录就是一个技能"的形态一致。</p>
+     *
+     * <p>内容全部来自库（{@code ai_skill} + {@code ai_skill_file}），<b>不读存储目标</b>：
+     * {@code storage_targets} 是"发布到哪里去"，库才是权威副本。从 MinIO 回读既慢又可能
+     * 读到被外部改过的版本，导出的就不是后台这一份了。</p>
+     */
+    public SkillExportPackage exportZip(Long id) {
+        AiSkill skill = requireSkill(id);
+        String rootDir = sanitizeFileName(skill.getSkillCode());
+        List<SkillFileContent> files = loadFileContents(id);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOut = new ZipOutputStream(bos, StandardCharsets.UTF_8)) {
+            String content = skill.getContent() == null ? "" : skill.getContent();
+            writeZipEntry(zipOut, rootDir + "/" + SKILL_FILE_NAME, content.getBytes(StandardCharsets.UTF_8));
+            for (SkillFileContent file : files) {
+                // content 允许为空（历史数据/空文件），补空字节而不是跳过——
+                // 跳过会让重新上传后文件清单凭空少几项，导出就不是"这个 skill 的全部"了
+                byte[] bytes = file.content() == null ? new byte[0] : file.content();
+                writeZipEntry(zipOut, rootDir + "/" + file.filePath(), bytes);
+            }
+        } catch (IOException e) {
+            log.error("skill export failed, code={}, skillId={}", ERR_EXPORT_FAIL, id, e);
+            throw new BizException(ResultCode.SYSTEM_ERROR, "技能包打包失败: " + e.getMessage());
+        }
+        log.info("skill exported: skillCode={}, files={}", skill.getSkillCode(), files.size());
+        return new SkillExportPackage(rootDir + ".zip", bos.toByteArray());
+    }
+
+    private void writeZipEntry(ZipOutputStream zipOut, String entryName, byte[] bytes) throws IOException {
+        zipOut.putNextEntry(new ZipEntry(entryName));
+        zipOut.write(bytes);
+        zipOut.closeEntry();
+    }
+
+    /**
+     * 把 skillCode 净化成合法文件名。
+     *
+     * <p>skillCode 是用户填的（现网就有"Apollo查值"这种），直接拿来当 zip 内的目录名与下载文件名，
+     * 遇到 {@code /} 或 {@code ..} 会写出目录穿越的条目——那是压缩包里的经典问题，
+     * 解压方按路径还原就落到目标目录之外去了。中文本身没问题（zip 与 Content-Disposition 都按 UTF-8 处理），
+     * 只净化路径分隔符与各系统的文件名保留字符。</p>
+     */
+    private String sanitizeFileName(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return "skill";
+        }
+        String cleaned = raw.trim().replaceAll("[\\\\/:*?\"<>|\\p{Cntrl}]", "_");
+        // 全是分隔符时上面会净化成一串下划线，仍给个兜底名，避免出现 ".zip" 这种无名文件
+        return StringUtils.hasText(cleaned.replace("_", "")) ? cleaned : "skill";
     }
 
     // ---- 上传解析 ----

--- a/customer-admin-server/src/main/resources/db/migration/V62__skill_export_permission.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V62__skill_export_permission.sql
@@ -1,0 +1,21 @@
+-- Skill 技能包下载的权限点。
+--
+-- 单独发权限点，没有复用 skill:view——判断标准与 V44（内容风控"导出复用 view"）一致，只是结论相反：
+-- 那边页面上本来就能看到全部词条内容，导出只是同一份数据换个格式；而这里 skill:view 返回的附属文件
+-- 清单只有路径与大小（SkillFileVO 不带内容），文件字节此前在后台任何接口都拿不到。
+-- 附属文件里可能有脚本与内网文档，"能看到有哪些文件"和"能把整包带走"是两种能力。
+--
+-- 命名取 skill:export 而非 skill:download，与既有的 billing:export / sql-console:export / sql-query:export 一致。
+--
+-- id 247：本机 sys_permission 已用到 246，247 起是既定约定。
+-- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接返回全部权限点
+-- （沿用 V35/V36/V38/V41 同款做法，普通角色需在角色管理页手工授权）。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+
+SET NAMES utf8mb4;
+
+-- parent_id=22 是"Skill 管理"菜单（同级已有 41 view / 42 add / 43 edit / 44 delete，本项 sort=5 排在最后）
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (247, 22, '下载技能包', 'skill:export', 2, 5);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillExportTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillExportTest.java
@@ -1,0 +1,189 @@
+package com.richard.fyoung.customeradmin.aiconfig.skill.service;
+
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillExportPackage;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.dto.SkillUploadParseResult;
+import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
+import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkillFile;
+import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillFileMapper;
+import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 技能包导出（{@code exportZip}）。
+ *
+ * <p>核心约束是<b>与上传解析往返对称</b>：导出的 zip 必须能被 {@code parseUploadContent} 原样解析回来，
+ * 否则"下载一个 skill 拿到别的环境导入"这条路走不通——而那正是这个功能的主要用途。
+ * 因此本测试不只断言 zip 里有哪些条目，而是真的把导出结果再解析一遍比对。</p>
+ * @author owlzhangfq@gmail.com
+ */
+class SkillExportTest {
+
+    private static final long SKILL_ID = 7L;
+
+    private AiSkillMapper skillMapper;
+    private AiSkillFileMapper skillFileMapper;
+    private SkillService service;
+
+    @BeforeEach
+    void setUp() {
+        skillMapper = mock(AiSkillMapper.class);
+        skillFileMapper = mock(AiSkillFileMapper.class);
+        service = new SkillService(skillMapper, skillFileMapper, mock(AiAgentSkillMapper.class),
+            mock(AiAgentMapper.class), mock(AgentInstanceCache.class), List.of());
+    }
+
+    @Test
+    void shouldPackSkillMdAndFilesUnderCodeDirectory() {
+        givenSkill("my-skill", "# 我的技能\n正文");
+        givenFiles(file("references/api.md", "接口说明"), file("scripts/run.sh", "echo hi"));
+
+        SkillExportPackage pkg = service.exportZip(SKILL_ID);
+
+        assertEquals("my-skill.zip", pkg.filename());
+        Map<String, byte[]> entries = unzip(pkg.content());
+        assertEquals(List.of("my-skill/SKILL.md", "my-skill/references/api.md", "my-skill/scripts/run.sh"),
+            List.copyOf(entries.keySet()));
+        assertEquals("# 我的技能\n正文", new String(entries.get("my-skill/SKILL.md"), StandardCharsets.UTF_8));
+        assertEquals("接口说明", new String(entries.get("my-skill/references/api.md"), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void exportedZip_shouldBeReimportable() {
+        // 往返对称是这个功能的立身之本：导出的包必须能从"新建 Skill"的上传入口原样导回
+        givenSkill("my-skill", "# 我的技能\n正文");
+        givenFiles(file("references/api.md", "接口说明"), file("scripts/run.sh", "echo hi"));
+
+        SkillExportPackage pkg = service.exportZip(SKILL_ID);
+        SkillUploadParseResult parsed = service.parseUploadContent(
+            new MockMultipartFile("file", "my-skill.zip", "application/zip", pkg.content()));
+
+        assertEquals("# 我的技能\n正文", parsed.content(), "SKILL.md 正文必须原样还原");
+        Map<String, String> files = new LinkedHashMap<>();
+        for (SkillUploadFile f : parsed.files()) {
+            files.put(f.filePath(), new String(Base64.getDecoder().decode(f.contentBase64()), StandardCharsets.UTF_8));
+        }
+        assertEquals(2, files.size());
+        assertEquals("接口说明", files.get("references/api.md"), "附属文件路径与内容都要还原");
+        assertEquals("echo hi", files.get("scripts/run.sh"));
+    }
+
+    @Test
+    void binaryFile_shouldSurviveRoundTrip() {
+        // 附属文件是 LONGBLOB，可能是图片/字体这类二进制，不能按文本处理
+        byte[] binary = new byte[]{0x00, (byte) 0xFF, 0x10, (byte) 0x89, 0x50, 0x4E, 0x47};
+        givenSkill("bin-skill", "# 正文");
+        AiSkillFile row = new AiSkillFile();
+        row.setFilePath("assets/logo.png");
+        row.setContent(binary);
+        givenFiles(row);
+
+        Map<String, byte[]> entries = unzip(service.exportZip(SKILL_ID).content());
+
+        assertArrayEquals(binary, entries.get("bin-skill/assets/logo.png"));
+    }
+
+    @Test
+    void nullContentFile_shouldStillBeIncludedAsEmpty() {
+        // 跳过空内容的文件会让重新导入后清单凭空少几项，导出就不是"这个 skill 的全部"了
+        givenSkill("my-skill", "# 正文");
+        AiSkillFile empty = new AiSkillFile();
+        empty.setFilePath("references/placeholder.md");
+        empty.setContent(null);
+        givenFiles(empty);
+
+        Map<String, byte[]> entries = unzip(service.exportZip(SKILL_ID).content());
+
+        assertTrue(entries.containsKey("my-skill/references/placeholder.md"));
+        assertEquals(0, entries.get("my-skill/references/placeholder.md").length);
+    }
+
+    @Test
+    void chineseCode_shouldBeKept() {
+        // 中文包名本身合法（zip 与 Content-Disposition 都按 UTF-8 处理），不该被净化掉
+        givenSkill("Apollo查值", "# 正文");
+        givenFiles();
+
+        SkillExportPackage pkg = service.exportZip(SKILL_ID);
+
+        assertEquals("Apollo查值.zip", pkg.filename());
+        assertTrue(unzip(pkg.content()).containsKey("Apollo查值/SKILL.md"));
+    }
+
+    @Test
+    void codeWithPathSeparator_shouldBeSanitized() {
+        // skillCode 是用户填的，带 / 或 .. 会写出目录穿越的 zip 条目，解压方按路径还原就落到目标目录之外
+        givenSkill("../../etc/passwd", "# 正文");
+        givenFiles();
+
+        SkillExportPackage pkg = service.exportZip(SKILL_ID);
+
+        assertFalse(pkg.filename().contains("/"), "文件名里不能留下路径分隔符");
+        assertTrue(unzip(pkg.content()).keySet().stream().noneMatch(name -> name.contains("../")),
+            "zip 条目里不能出现目录穿越");
+    }
+
+    @Test
+    void missingSkill_shouldFailFast() {
+        when(skillMapper.selectById(SKILL_ID)).thenReturn(null);
+
+        assertThrows(BizException.class, () -> service.exportZip(SKILL_ID));
+    }
+
+    private void givenSkill(String code, String content) {
+        AiSkill skill = new AiSkill();
+        skill.setId(SKILL_ID);
+        skill.setSkillCode(code);
+        skill.setSkillName(code);
+        skill.setContent(content);
+        when(skillMapper.selectById(SKILL_ID)).thenReturn(skill);
+    }
+
+    private void givenFiles(AiSkillFile... files) {
+        when(skillFileMapper.selectList(any())).thenReturn(List.of(files));
+    }
+
+    private AiSkillFile file(String path, String content) {
+        AiSkillFile row = new AiSkillFile();
+        row.setFilePath(path);
+        row.setContent(content.getBytes(StandardCharsets.UTF_8));
+        return row;
+    }
+
+    private Map<String, byte[]> unzip(byte[] zipBytes) {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        try (ZipInputStream in = new ZipInputStream(new ByteArrayInputStream(zipBytes), StandardCharsets.UTF_8)) {
+            ZipEntry entry;
+            while ((entry = in.getNextEntry()) != null) {
+                entries.put(entry.getName(), in.readAllBytes());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("解压失败", e);
+        }
+        return entries;
+    }
+}

--- a/customer-admin-web/src/api/skill.ts
+++ b/customer-admin-web/src/api/skill.ts
@@ -1,4 +1,4 @@
-import { request } from './request'
+import { download, request } from './request'
 import type { PageQuery, PageResult, SkillSaveRequest, SkillUploadParseResult, SkillVO } from '@/types/api'
 
 export function pageSkills(query: PageQuery) {
@@ -19,6 +19,16 @@ export function updateSkill(id: number, data: SkillSaveRequest) {
 
 export function deleteSkill(id: number) {
   return request<void>({ url: `/aiconfig/skill/${id}`, method: 'delete' })
+}
+
+/**
+ * 下载技能包 zip（SKILL.md + 全部附属文件，zip 内包一层以 skillCode 命名的目录）。
+ *
+ * 下载下来的包可以直接用「新建 Skill」的上传入口原样导回——后端导出结构与上传解析是对称的。
+ * 文件名以响应头 Content-Disposition 为准，这里的兜底只在响应头缺失时生效。
+ */
+export function downloadSkill(id: number, skillCode: string) {
+  return download({ url: `/aiconfig/skill/${id}/download`, method: 'get' }, `${skillCode}.zip`)
 }
 
 /** 解析上传的 .md/.zip 文件为技能包（SKILL.md 正文 + 附属文件）；不落库，由调用方回填表单后仍走 create/update 保存。 */

--- a/customer-admin-web/src/views/aiconfig/SkillManage.vue
+++ b/customer-admin-web/src/views/aiconfig/SkillManage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import type { FormInstance, UploadRequestOptions } from 'element-plus'
-import { createSkill, deleteSkill, pageSkills, parseSkillUpload, updateSkill } from '@/api/skill'
+import { createSkill, deleteSkill, downloadSkill, pageSkills, parseSkillUpload, updateSkill } from '@/api/skill'
 import { useCrudPage } from '@/composables/useCrudPage'
 import type { PageQuery, SkillSaveRequest, SkillVO } from '@/types/api'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
@@ -44,6 +44,24 @@ const {
 
 const previewVisible = ref(false)
 const previewSkill = ref<SkillVO | null>(null)
+
+/** 正在下载的行 id：同一行的按钮转 loading，避免大包重复点。 */
+const downloadingId = ref<number | null>(null)
+
+/**
+ * 下载技能包 zip。
+ *
+ * 下载下来的包能直接从「新建 Skill」的上传入口导回——后端导出结构与上传解析是对称的，
+ * 所以这个按钮也是「复制一个 skill 到别的环境」的路径。
+ */
+async function handleDownload(row: SkillVO) {
+  downloadingId.value = row.id
+  try {
+    await downloadSkill(row.id, row.skillCode)
+  } finally {
+    downloadingId.value = null
+  }
+}
 
 function openPreview(row: SkillVO) {
   previewSkill.value = row
@@ -119,9 +137,18 @@ onMounted(loadList)
           </template>
         </el-table-column>
         <el-table-column prop="createTime" label="创建时间" width="180" />
-        <el-table-column label="操作" width="220" fixed="right">
+        <el-table-column label="操作" width="270" fixed="right">
           <template #default="{ row }">
             <el-button link type="primary" @click="openPreview(row)">查看</el-button>
+            <el-button
+              v-permission="'skill:export'"
+              link
+              type="primary"
+              :loading="downloadingId === row.id"
+              @click="handleDownload(row)"
+            >
+              下载
+            </el-button>
             <el-button v-permission="'skill:edit'" link type="primary" @click="openEditWithRow(row)">编辑</el-button>
             <el-button v-permission="'skill:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
           </template>

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -926,7 +926,7 @@ cd customer-admin-web && npm install && npm run dev
 | `/api/system/{user,role,permission,log}` | 用户/角色权限/权限树/操作日志 CRUD（`@SaCheckPermission` 权限点校验） |
 | `/api/aiconfig/model` | 模型配置 CRUD（AppKey 加密存储/脱敏回显/默认模型互斥） |
 | `POST /api/aiconfig/model/{id}/test-connectivity` | 连通性测试（异步 `CompletableFuture` 返回，独立线程池执行，不占 Tomcat 请求线程，硬性超时兜底） |
-| `/api/aiconfig/mcp` / `/api/aiconfig/skill` | MCP / Skill 管理 CRUD（删除前校验是否被智能体引用，编辑后自动失效引用它的智能体运行时缓存） |
+| `/api/aiconfig/mcp` / `/api/aiconfig/skill` | MCP / Skill 管理 CRUD（删除前校验是否被智能体引用，编辑后自动失效引用它的智能体运行时缓存）；Skill 另有 `/{id}/download` 导出技能包 zip（`skill:export`） |
 | `/api/aiconfig/agent` | 智能体 CRUD（modelId 必填/mcpIds·skillIds 可选多选，关联表整体替换式维护） |
 | `PUT /api/aiconfig/agent/{id}/enable` / `disable` | 智能体启用/停用（联动动态菜单 + 运行时缓存失效） |
 | `GET /api/aiconfig/agent/{id}/memory` / `DELETE …/memory` | 智能体跨会话长期记忆查看/清空（`capabilities` 含 `memory` 时生效；权威存储默认落库 `ai_agent_memory`，配置 `admin.agent-memory.disk-root` 后改存磁盘） |
@@ -1178,6 +1178,17 @@ evict 后重建）、`VibeCodingServiceTest`（能力校验/流式对话委托/w
   `FileSystemSkillRepository` 加载，SKILL.md 里引用的脚本/文档真正生效；存储目标发布走
   `SkillContentPublisher#publishFiles`（local/sftp 全量发布，nacos 面向文本配置仍只发 SKILL.md）。
   历史说明：批次六首版 zip 只是 `content` 字段的另一种录入方式、丢弃附属文件，2026-07 已按完整技能包补齐。
+- **Skill 支持下载技能包 zip**（`GET /api/aiconfig/skill/{id}/download`，权限 `skill:export`）：
+  导出结构与上传解析<b>严格对称</b>——zip 内包一层以 `skillCode` 命名的目录，里面是 `SKILL.md` 与全部
+  附属文件（按各自相对路径还原），因此下载下来的包能从「新建 Skill」的上传入口原样导回，
+  这也是"把一个 skill 复制到别的环境"的路径。改导出结构前先确认往返还成不成立（有回归用例守着）。
+  三条约定：① 内容全部取自库（`ai_skill` + `ai_skill_file`），**不回读存储目标**——`storage_targets`
+  是"发布到哪里去"，库才是权威副本，从 MinIO 回读既慢又可能读到被外部改过的版本；
+  ② `skillCode` 是用户填的（现网有「Apollo查值」这种），做目录名与文件名前必须净化路径分隔符，
+  否则会写出目录穿越的 zip 条目；中文本身合法，不净化（zip 与 `Content-Disposition` 都按 UTF-8 处理）；
+  ③ **单独发 `skill:export` 而不复用 `skill:view`**：查看接口返回的附属文件清单只有路径与大小
+  （`SkillFileVO` 不带内容），文件字节此前在后台任何接口都拿不到——这是新的数据出口，不是同一份数据
+  换个格式。（内容风控那批"导出复用 view"是因为页面上本来就能看到全部词条内容，判断标准一致、结论不同。）
 - **智能体图标库选择 + 新建 session + 工作区空状态**：`IconPicker.vue`（新组件）复用全局注册的
   Element Plus 图标集做弹出选择器；`ChatPanel.vue`/`VibeCodingPanel.vue` 新增"新建会话"按钮
   （`crypto.randomUUID()` 换 sessionId、清空消息列表）；`workspace` 路由新增静态空状态页

--- a/mysql/02-customer-admin/62-V62__skill_export_permission.sql
+++ b/mysql/02-customer-admin/62-V62__skill_export_permission.sql
@@ -1,0 +1,21 @@
+-- Skill 技能包下载的权限点。
+--
+-- 单独发权限点，没有复用 skill:view——判断标准与 V44（内容风控"导出复用 view"）一致，只是结论相反：
+-- 那边页面上本来就能看到全部词条内容，导出只是同一份数据换个格式；而这里 skill:view 返回的附属文件
+-- 清单只有路径与大小（SkillFileVO 不带内容），文件字节此前在后台任何接口都拿不到。
+-- 附属文件里可能有脚本与内网文档，"能看到有哪些文件"和"能把整包带走"是两种能力。
+--
+-- 命名取 skill:export 而非 skill:download，与既有的 billing:export / sql-console:export / sql-query:export 一致。
+--
+-- id 247：本机 sys_permission 已用到 246，247 起是既定约定。
+-- 超级管理员（super_admin）无需 sys_role_permission 记录——AdminStpInterfaceImpl 对超管直接返回全部权限点
+-- （沿用 V35/V36/V38/V41 同款做法，普通角色需在角色管理页手工授权）。
+--
+-- 手工同步注意：走 stdin 管道 apply 时客户端字符集可能回退 latin1 导致中文 COMMENT 字节级写坏，
+-- 故首行显式 SET NAMES utf8mb4（Flyway JDBC 连接不受影响，此行对其无害）。
+
+SET NAMES utf8mb4;
+
+-- parent_id=22 是"Skill 管理"菜单（同级已有 41 view / 42 add / 43 edit / 44 delete，本项 sort=5 排在最后）
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `sort`) VALUES
+    (247, 22, '下载技能包', 'skill:export', 2, 5);


### PR DESCRIPTION
## 做了什么

Skill 管理列表操作列加「下载」，把一个 skill 打成 zip 交给浏览器保存。

```
my-skill.zip
└── my-skill/
    ├── SKILL.md            ← ai_skill.content
    ├── references/api.md   ← ai_skill_file
    └── scripts/run.sh
```

## 核心约束：与上传解析往返对称

`parseUploadContent` 是以**最浅层 SKILL.md 所在目录**为技能根来解析的，所以导出时包一层 `skillCode` 目录、附属文件按原相对路径还原，下载下来的包就能从「新建 Skill」的上传入口**原样导回**——这也是「把一个 skill 复制到别的环境」的路径。

回归用例真的做了一次往返（`exportedZip_shouldBeReimportable`：导出结果再喂给 `parseUploadContent` 比对正文与每个附属文件），而不是只断言 zip 里有哪几个条目——后者照不出结构漂移。

包一层目录而非把文件铺在 zip 根：解压不会把一堆文件散进当前目录，也与技能包本身「一个目录就是一个技能」的形态一致。

## 三个决定

**① 内容全部取自库，不回读存储目标。** `storage_targets` 是「发布到哪里去」，`ai_skill` + `ai_skill_file` 才是权威副本。从 MinIO 回读既慢，又可能读到被外部改过的版本——那导出的就不是后台这一份了。

**② `skillCode` 做目录名/文件名前先净化路径分隔符。** 它是用户填的，现网就有「Apollo查值」这种；带 `/` 或 `..` 会写出目录穿越的 zip 条目，解压方按路径还原就落到目标目录之外。中文**不**净化——zip 与 `Content-Disposition` 都按 UTF-8 处理，后者走 RFC 5987 的 `filename*`。

**③ 单独发 `skill:export`，不复用 `skill:view`。**

| | 能拿到什么 |
|---|---|
| `skill:view` | SKILL.md 正文 + 附属文件的**路径与大小**（`SkillFileVO` 不带内容） |
| `skill:export` | 附属文件的**实际字节** |

文件字节此前在后台任何接口都拿不到，这是新的数据出口，不是同一份数据换个格式；附属文件里可能有脚本与内网文档，「能看到有哪些文件」和「能把整包带走」是两种能力。

判断标准与 V44（内容风控「导出复用 view，不单独发权限点」）一致，只是结论相反——那边页面上本来就能看到全部词条内容。命名取 `skill:export` 而非 `skill:download`，与既有的 `billing:export` / `sql-console:export` / `sql-query:export` 对齐。

## 迁移

`V62__skill_export_permission.sql` 插权限点（id 247，parent_id 22，与同级 41 view / 42 add / 43 edit / 44 delete 并列），已同步 `mysql/02-customer-admin/` 镜像。超管自动可见（`AdminStpInterfaceImpl` 对超管直接返回全部权限点），**普通角色需要在角色管理页手工勾选**这一项才能看到按钮。

## 测试

`starter 1441 / admin 858 / app 93 / channel 65 / gateway 1 = 2458`，BUILD SUCCESS（排除 `RedisSessionPersistenceTest`）。本批次加 admin **+7**：

- 打包结构（一层目录 + SKILL.md + 附属文件按相对路径）
- **往返导入**（导出的包能被解析回原正文与全部附属文件）
- 二进制文件（LONGBLOB 里可能是图片/字体）字节不变
- `content` 为 null 的附属文件仍进包（跳过会让重新导入后清单凭空少几项）
- 中文 skillCode 保留、含 `../` 的 skillCode 被净化且 zip 里无穿越条目
- skill 不存在 fast fail

`customer-admin-web` 的 `vue-tsc -b && vite build` 通过。

## 合并后

admin-server 启动会自动跑 V62。如果用非超管账号看不到「下载」按钮，去角色管理页给对应角色勾上「下载技能包」。