### PR TITLE
fix: 角色编码软删除后重建撞唯一键报系统异常

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/mapper/SysRoleMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/mapper/SysRoleMapper.java
@@ -2,10 +2,33 @@ package com.richard.fyoung.customeradmin.system.role.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 /**
  * 角色 Mapper。
+ *
+ * <p>下面两个方法专门绕开 MyBatis-Plus 的逻辑删除过滤：{@code sys_role.uk_sys_role_code} 是
+ * <b>不含 deleted 列</b>的纯数据库唯一约束，被软删除的行仍然占着编码，而 {@code LambdaQueryWrapper}
+ * 会自动追加 {@code AND deleted=0} 从而查不到它——必须用原生 SQL 才能看见/复活。手法与
+ * {@code AiKnowledgeBaseMapper#selectDeletedByName}/{@code reviveDeleted} 完全一致。</p>
  * @author owlzhangfq@gmail.com
  */
 public interface SysRoleMapper extends BaseMapper<SysRole> {
+
+    /**
+     * 按编码查一条<b>已被软删除</b>的角色行（{@code deleted=1}）。用原生 {@code @Select}，
+     * 不会被自动追加 {@code AND deleted=0}，因此能看见被逻辑删除、但仍占着唯一索引的那一行。
+     */
+    @Select("SELECT * FROM sys_role WHERE role_code = #{roleCode} AND deleted = 1 LIMIT 1")
+    SysRole selectDeletedByRoleCode(@Param("roleCode") String roleCode);
+
+    /**
+     * “复活”一个被软删除的角色行：只把 {@code deleted} 置回 0，其余业务字段由调用方随后用
+     * {@code updateById} 按新的保存请求整体覆盖（复活后该行对 MyBatis-Plus 重新可见）。
+     * 同样用原生 {@code @Update} 才能命中当前 {@code deleted=1} 的目标行。
+     */
+    @Update("UPDATE sys_role SET deleted = 0 WHERE id = #{id} AND deleted = 1")
+    int reviveDeleted(@Param("id") Long id);
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/RoleService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/RoleService.java
@@ -17,6 +17,9 @@ import com.richard.fyoung.customeradmin.system.role.entity.SysRolePermission;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRolePermissionMapper;
 import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -35,6 +38,8 @@ import java.util.stream.Collectors;
  */
 @Service
 public class RoleService {
+
+    private static final Logger log = LoggerFactory.getLogger(RoleService.class);
 
     private static final String SUPER_ADMIN_ROLE_CODE = "super_admin";
 
@@ -81,7 +86,29 @@ public class RoleService {
         role.setRemark(request.remark());
         role.setStatus(request.status() == null ? 1 : request.status());
         role.setDataScope(resolveDataScope(request.dataScope()).name());
-        roleMapper.insert(role);
+
+        // 坑：sys_role.uk_sys_role_code 是不含 deleted 列的纯数据库唯一约束，delete() 走逻辑删除，
+        // 被删过的编码仍占着唯一索引。上面的 exists() 会被自动追加 deleted=0 判定“可用”，但直接
+        // insert 会撞唯一键抛 DuplicateKeyException（与 AuthService/KnowledgeBaseService 同款坑）。
+        // 先查有没有被软删除过的旧行，有就“复活”它再整体覆盖字段，而不是插新行——若只把异常兜成
+        // 友好提示，一个编码被删过一次就永久不能再用，那是功能缺陷而不只是错误信息不友好。
+        SysRole softDeleted = roleMapper.selectDeletedByRoleCode(request.roleCode());
+        if (softDeleted != null) {
+            roleMapper.reviveDeleted(softDeleted.getId());
+            role.setId(softDeleted.getId());
+            roleMapper.updateById(role);
+            replacePermissions(softDeleted.getId(), request.permissionIds());
+            log.info("revived soft-deleted role for re-create, roleCode={}, roleId={}",
+                request.roleCode(), softDeleted.getId());
+            return;
+        }
+        // 纯并发竞争（两个请求同时创建同编码角色，都没查到对方尚未提交的行）仍可能撞唯一键：兜成
+        // 友好的业务异常，不让 DuplicateKeyException 裸奔到 GlobalExceptionHandler 变成 SYSTEM_ERROR。
+        try {
+            roleMapper.insert(role);
+        } catch (DuplicateKeyException e) {
+            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "角色编码已存在");
+        }
         replacePermissions(role.getId(), request.permissionIds());
     }
 


### PR DESCRIPTION
## Summary
- 新建角色时若编码曾被软删除过，`create()` 原有的 `exists()` 判重会被 MyBatis-Plus 自动追加 `deleted=0` 而误判"可用"，`insert` 时撞 `sys_role.uk_sys_role_code`（不含 deleted 列的纯数据库唯一约束）报 `DuplicateKeyException`，裸奔到 `GlobalExceptionHandler` 变成 `SYSTEM_ERROR`，前端看到的是系统异常而非"角色编码已存在"。
- 照搬项目里 `AuthService`/`KnowledgeBaseService` 已有的同款处理范式：`SysRoleMapper` 新增 `selectDeletedByRoleCode`/`reviveDeleted` 原生 SQL 方法绕开逻辑删除过滤；`RoleService#create` 命中软删除旧行就"复活"并整体覆盖字段（避免编码删过一次就永久不能复用），纯并发竞争场景则 `catch DuplicateKeyException` 兜底转为 `BizException(RESOURCE_DUPLICATE, "角色编码已存在")`。
- 前端 `request.ts` 已有统一的非 0 code 弹 `ElMessage.error(body.message)` 拦截逻辑，未做改动即可生效。

## Test plan
- [x] `mvn -pl customer-admin-server -am compile` 编译通过
- [ ] 手工验证：新建角色 `dev` → 删除 → 再次新建同编码 `dev`，应正常复活成功而非报错
- [ ] 手工验证：两次连续用同一未删除编码新建角色，第二次应提示"角色编码已存在"而非系统异常