### PR TITLE
feat(admin-web): 首页封面铺满主内容区

### DIFF
--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -89,7 +89,7 @@ async function handleLogout() {
       </el-header>
       <TabsBar />
       <AppBreadcrumb />
-      <el-main class="layout-main">
+      <el-main class="layout-main" :class="{ 'layout-main--home': route.name === 'Home' }">
         <!-- 只精确缓存 WorkspaceView：TabsBar 让"已打开的标签"在视觉上常驻，但底下的路由组件此前没配
              keep-alive，标签切走再切回其实是整个组件重新 mount——WorkspaceView 里的对话/VibeCoding
              面板state 全在组件本地 ref，一销毁就清空，进行中的 SSE 流也被 onUnmounted 里的 abortStream
@@ -209,6 +209,11 @@ async function handleLogout() {
 
 .layout-main {
   background: var(--el-bg-color-page);
+}
+
+.layout-main--home {
+  padding: 0;
+  overflow: hidden;
 }
 
 .layout-footer {

--- a/customer-admin-web/src/views/Home.vue
+++ b/customer-admin-web/src/views/Home.vue
@@ -7,38 +7,71 @@ const auth = useAuthStore()
 <template>
   <div class="home-page">
     <img src="/home-cover.jpg" alt="首页" class="home-cover" />
-    <p class="home-tip">{{ auth.nickname }}，请从左侧菜单选择要管理的模块。</p>
+    <p class="home-tip">
+      <strong>{{ auth.nickname }}</strong>，请从左侧菜单选择要管理的模块。
+    </p>
   </div>
 </template>
 
 <style scoped>
 .home-page {
+  position: relative;
+  width: 100%;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
+  overflow: hidden;
 }
 
 .home-cover {
-  max-width: 80%;
-  max-height: 70%;
-  border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
-  object-fit: contain;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
 }
 
 .home-tip {
+  position: absolute;
+  bottom: clamp(20px, 4vh, 48px);
+  left: 50%;
+  z-index: 1;
+  transform: translateX(-50%);
+  isolation: isolate;
   margin: 0;
-  font-size: 20px;
+  padding: 10px 18px;
+  width: max-content;
+  max-width: calc(100% - 32px);
+  border-radius: 999px;
+  font-size: clamp(15px, 1.1vw, 20px);
   font-weight: 700;
-  letter-spacing: 2px;
-  background: linear-gradient(90deg, #ff6b6b, #feca57, #48dbfb, #ff9ff3, #54a0ff);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
-  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.1));
+  letter-spacing: 1px;
+  overflow-wrap: anywhere;
+  text-align: center;
+  color: rgb(0 21 41 / 85%);
+}
+
+.home-tip strong {
+  color: var(--el-color-primary);
+}
+
+.home-tip::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border: 1px solid rgb(255 255 255 / 75%);
+  border-radius: inherit;
+  background: rgb(255 255 255 / 78%);
+  box-shadow: 0 6px 20px rgb(0 21 41 / 12%);
+  backdrop-filter: blur(10px);
+}
+
+@media (max-width: 768px) {
+  .home-cover {
+    object-position: 62% center;
+  }
+
+  .home-tip {
+    bottom: 16px;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更内容

- 仅在首页路由移除主内容区默认内边距
- 封面使用 `cover` 等比裁切铺满内容区，不影响其他页面
- 问候语改为叠加提示条，兼容暗色主题与长昵称

## 验证结果

- `npm ci`
- `npm run build`
- 完整 Maven 单测：2458 tests，0 failures，0 errors，6 skipped
- Playwright：覆盖 1920×1080、1366×768、768×1024，以及暗色主题与长昵称场景；图片与主内容区边界完全一致，无控制台错误
- `git diff --check`
