### PR TITLE
fix: align log levels, parser reuse and runtime directory docs

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
@@ -4,9 +4,9 @@ import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.tool.mcp.McpClientFactory;
+import com.richard.fyoung.customerwork.tool.mcp.McpServerSpec;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgentBackupModel;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgentMcp;
@@ -76,7 +76,6 @@ public class CustomerWorkConfigPublisher {
     private static final String MCP_TYPE_HTTP = "http";
     private static final String MCP_TYPE_SSE = "sse";
     private static final String TRANSPORT_STREAMABLE_HTTP = "streamable-http";
-    private static final String MCP_SERVERS_WRAPPER_KEY = "mcpServers";
 
     private final AiChannelBindingMapper channelBindingMapper;
     private final AiAgentMapper agentMapper;
@@ -92,6 +91,7 @@ public class CustomerWorkConfigPublisher {
     private final RuntimePublishTaskService taskService;
     private final boolean tenantEnabled;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final McpClientFactory mcpClientFactory = new McpClientFactory();
 
     private volatile ConfigService configService;
 
@@ -557,7 +557,7 @@ public class CustomerWorkConfigPublisher {
             CustomerWorkRuntimeConfig.McpServer server = new CustomerWorkRuntimeConfig.McpServer();
             server.setName(mcp.getMcpName());
             server.setTransport(transport);
-            fillUrlAndHeaders(server, mcp.getConfig());
+            fillUrlAndHeaders(server, mcp.getMcpType(), mcp.getConfig());
             if (StringUtils.hasText(server.getUrl())) {
                 servers.add(server);
             }
@@ -575,41 +575,18 @@ public class CustomerWorkConfigPublisher {
         return null;
     }
 
-    /**
-     * 解析 ai_mcp.config JSON 的 url 与 headers（与 AdminMcpFactory 的取值方式一致）：
-     * 同样兼容 Claude Desktop / Cursor 风格的 {@code {"mcpServers": {...}}} 包装格式——调试面板与真实
-     * 注册路径都认这层包装，发布链路不解包会导致 url 取空、该 MCP 被静默跳过。
-     *
-     * <p>TODO(sink-common-to-starter 合入后)：改为复用 starter 的
-     * {@code com.richard.fyoung.customerwork.tool.mcp.McpClientFactory#parseSpec}，删除本地解包实现。</p>
-     */
-    private void fillUrlAndHeaders(CustomerWorkRuntimeConfig.McpServer server, String config) {
+    /** 解析 ai_mcp.config JSON 的 url 与 headers（复用 starter 的 MCP parser）。 */
+    private void fillUrlAndHeaders(CustomerWorkRuntimeConfig.McpServer server, String mcpType, String config) {
         if (!StringUtils.hasText(config)) {
             return;
         }
         try {
-            JsonNode node = unwrapMcpServers(objectMapper.readTree(config));
-            server.setUrl(node.path("url").asText(null));
-            JsonNode headersNode = node.path("headers");
-            if (headersNode.isObject() && !headersNode.isEmpty()) {
-                server.setHeaders(objectMapper.convertValue(headersNode, new TypeReference<Map<String, String>>() {}));
-            }
+            McpServerSpec spec = mcpClientFactory.parseSpec(server.getName(), mcpType, config);
+            server.setUrl(spec.url());
+            server.setHeaders(spec.headers());
         } catch (Exception e) {
             log.error("parse mcp config failed, code={}, mcpName={}", "RUNTIME-PUBLISH-MCP-PARSE-FAIL", server.getName(), e);
         }
-    }
-
-    /**
-     * 与 {@code AdminMcpFactory#unwrapMcpServers} 同语义：外层带 {@code mcpServers} 包装时取里面唯一
-     * 一个 server 条目的配置对象（服务名以 {@code ai_mcp.mcp_name} 为准，不读 wrapper 里的 key）；
-     * 没有包装时按原样返回，两种格式都认。
-     */
-    private JsonNode unwrapMcpServers(JsonNode node) {
-        JsonNode servers = node.path(MCP_SERVERS_WRAPPER_KEY);
-        if (servers.isObject() && servers.size() > 0) {
-            return servers.elements().next();
-        }
-        return node;
     }
 
     private String serialize(CustomerWorkRuntimeConfig payload) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/CustomerServiceAgentFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/CustomerServiceAgentFactory.java
@@ -388,7 +388,8 @@ public class CustomerServiceAgentFactory implements DisposableBean {
                 traceExporter.close();
                 log.info("[OTEL] trace 导出器已关闭");
             } catch (Exception e) {
-                log.warn("[OTEL] 关闭 trace 导出器失败: {}", e.getMessage());
+                log.error("[OTEL] trace exporter close failed, code={}, path={}",
+                    "OTEL_TRACER_CLOSE_FAIL", properties.getObservability().getTraceFile(), e);
             }
         }
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/runtime/GracefulShutdownService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/runtime/GracefulShutdownService.java
@@ -66,7 +66,8 @@ public class GracefulShutdownService implements SmartLifecycle {
             boolean drained = manager.awaitTermination(timeout);
             log.info("优雅停机完成，在途请求是否全部完成={}", drained);
         } catch (Exception e) {
-            log.warn("优雅停机异常（继续关闭）: {}", e.getMessage());
+            log.error("graceful shutdown failed but continuing close, code={}, timeoutSeconds={}", "GRACEFUL_SHUTDOWN_FAIL",
+                properties.getRuntime().getShutdownTimeoutSeconds(), e);
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/NacosPromptService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/NacosPromptService.java
@@ -52,7 +52,8 @@ public class NacosPromptService {
                 cfg.getPromptDataId(), cfg.getGroup());
         } catch (Exception e) {
             // Nacos 不可用不应阻断启动，回退内置提示词
-            log.warn("[Nacos] 接入失败，回退内置提示词: {}", e.getMessage());
+            log.error("[Nacos] prompt service fallback to builtin, code={}, dataId={}", "NACOS_PROMPT_FALLBACK",
+                cfg.getPromptDataId(), e);
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ResilientChatModel.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ResilientChatModel.java
@@ -44,8 +44,8 @@ public class ResilientChatModel implements Model {
                 .maxBackoff(MAX_BACKOFF)        // 退避封顶，避免长尾等待
                 .jitter(0.3)                    // 抖动，避免重试惊群
                 .filter(ResilientChatModel::isRetryable)   // 只重试瞬时/服务端类错误
-                .doBeforeRetry(rs -> log.warn("[Model] 调用失败重试 #{}：{}",
-                    rs.totalRetries() + 1,
+                .doBeforeRetry(rs -> log.info("[Model] retrying call after failure, code={}, attempt={}",
+                    "MODEL_RETRY", rs.totalRetries() + 1,
                     rs.failure() == null ? "?" : rs.failure().getMessage())));
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/StudioConfigurer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/StudioConfigurer.java
@@ -46,10 +46,10 @@ public class StudioConfigurer {
                 .runName(s.getRunName())
                 .initialize()
                 .subscribe(
-                    v -> log.info("[Studio] 已连接 {}", s.getUrl()),
-                    e -> log.warn("[Studio] 连接失败（忽略）: {}", e.getMessage()));
+                    v -> log.info("[Studio] connected {}", s.getUrl()),
+                    e -> log.info("[Studio] connect skipped on failure, code={}, url={}", "STUDIO_CONNECT_SKIPPED", s.getUrl()));
         } catch (Exception e) {
-            log.warn("[Studio] 初始化失败（忽略）: {}", e.getMessage());
+            log.info("[Studio] init skipped on failure, code={}, url={}", "STUDIO_INIT_SKIPPED", s.getUrl());
         }
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/SensitiveDataMasker.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/SensitiveDataMasker.java
@@ -48,7 +48,7 @@ public class SensitiveDataMasker {
             try {
                 patterns.add(Pattern.compile(extra));
             } catch (Exception e) {
-                log.warn("[MASK] 忽略非法自定义脱敏正则: {} ({})", extra, e.getMessage());
+                log.error("[MASK] invalid custom regex ignored, code={}, regex={}", "MASKING_PATTERN_INVALID", extra, e);
             }
         }
     }

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -410,7 +410,7 @@ RAG 文档（`KnowledgeProvider`）、技能（`resources/skills/<name>/SKILL.md
 customer-work.skill:
   enabled: true
   repository: filesystem        # classpath(只读内置) | filesystem(可写，技能自进化/写回)
-  directory: ./data/skills
+  directory: ${java.io.tmpdir}/customer-work/skills
   runtime-load-tool-enabled: true   # 注册"运行时加载技能"工具
   code-execution-enabled: true      # 注册读写/Shell 代码执行工具
 ```
@@ -834,7 +834,7 @@ customer-work.nacos:
 customer-work:
   harness:
     enabled: true                 # 启用 HarnessAgent 包装
-    workspace-dir: ./data/workspace
+    workspace-dir: ${java.io.tmpdir}/customer-work/workspace
     permission: { enabled: true, mode: default, ask-tools: [submitRefund, transferToHuman] }  # 三态权限闸门
     plan-mode:  { enabled: true, allow-shell: false }     # 只读规划期：先出 markdown 计划、获批后再写
     subagent:   { enabled: true }                          # 订单/售后/知识库专家作为子智能体(spawn/send)
@@ -1110,7 +1110,7 @@ fallback**——字典是展示增强，不能因为客服端库不可达就让�
 `stdio`/`sse` 两种 `mcpType`）、查 `ai_agent_skill` 关联行把 `content`（SKILL.md 正文）落盘后复用框架
 自带的 `FileSystemSkillRepository` 加载；`capabilities` 含 `vibecoding` 时用
 `HarnessAgent.Builder.fromAgent` 在内层 `ReActAgent` 上叠加本地沙箱，workspace 目录限定到
-`./data/admin-workspace/{agentCode}`。`AgentInstanceCache`（`agentCode -> Agent`）惰性重建、不预热；
+`${java.io.tmpdir}/customer-work/admin-workspace/{agentCode}`。`AgentInstanceCache`（`agentCode -> Agent`）惰性重建、不预热；
 智能体自身的 CRUD/启停、其引用的模型/MCP/Skill 编辑，都会驱动对应 agentCode 的缓存失效。
 `AgentStateStore`/`PermissionContextState` 用进程内简单实现（`AdminAgentRuntimeConfig`），刻意不复用
 `customer-work.session.*` 那套四后端可切换的持久化能力——admin 工作区是运营调试场景，过度设计不划算。
@@ -1401,8 +1401,8 @@ MIME 类型以扩展名映射为主，缺失时用 Tika `detect` 兜底。
 `AttachmentFileStorages.create(...)` 一处（8080 自动装配与 8082 admin 显式装配共用，避免漂移）。两种后端
 写回 DB 的 `storage_path` 都是相对 key `{yyyyMM}/{uuid}.{ext}`，**语义一致、切换后端无需迁移 DB**：
 
-- **`local`（代码级默认）**：落 `{base-dir}/{yyyyMM}/{uuid}.{ext}`（`LocalAttachmentFileStorage`），
-  沿用 `./data/xxx` 本地磁盘约定，admin 覆写为 `./data/admin-attachments`。
+- **`local`（未默认启用）**：历史兼容选项，落 `{base-dir}/{yyyyMM}/{uuid}.{ext}`（`LocalAttachmentFileStorage`）。
+  生产默认使用 MinIO；如临时回退启用本地盘，文件根目录由配置决定，admin 覆写为 `customer-admin-attachments` 对应 bucket。
 - **`minio`（两处 yml 默认）**：以对象 key `{yyyyMM}/{uuid}.{ext}` 上传到指定 bucket（`MinioAttachmentFileStorage`）。
   **bucket 惰性确保**：应用启动只建 SDK 客户端、**绝不连网**，首次上传附件时才 `bucketExists` / 按需 `makeBucket`
   （`volatile` 标志缓存，与 OCR 惰性模式一致）——故 **MinIO 不可达不影响应用启动**（含 admin `@SpringBootTest`

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -122,7 +122,7 @@
 | 环境变量 | 默认值 | 说明 |
 |---|---|---|
 | `SESSION_MODE` | `redis` | 也可选 `mysql`(强一致取向) |
-| `SKILL_DIRECTORY` | `/data/customer-work/skills` | 技能库磁盘路径 |
+| `SKILL_DIRECTORY` | `${java.io.tmpdir}/customer-work/skills` | 技能库磁盘路径 |
 | `RATE_LIMIT_RPM` | `120` | 进程内限流,见[第七节](#七多实例部署注意事项)第 1 条 |
 | `CONTEXT_MAX_TOKEN` / `CONTEXT_MSG_THRESHOLD` / `CONTEXT_LAST_KEEP` | `8000` / `40` / `10` | Compaction 阈值须保守(#1740:单轮超阈值不会二次压缩兜底),不要设到接近模型上下文上限 |
 | `STREAM_IDLE_TIMEOUT_SECONDS` | `120` | SSE 空闲超时,缓解连接泄漏(#1741) |
@@ -220,7 +220,7 @@
 > 非生产环境完成并通过正常发布流程上线。
 
 > **Docker 模式产物同步(P1-3,bind mount 挂 agent 工作区根)**:docker 模式下后端把宿主机 agent 工作区根
-> `./data/admin-workspace/{agentCode}` 以 `docker run -v` 挂进容器 `/workspace`,会话产物(`sessions/{sessionId}/`)、
+> `${java.io.tmpdir}/customer-work/admin-workspace/{agentCode}` 以 `docker run -v` 挂进容器 `/workspace`,会话产物(`sessions/{sessionId}/`)、
 > 跨会话记忆(`MEMORY.md`)、Plan Mode 计划文件(`plans/`)全部实时落宿主机——文件树 / file_change / Git 助手 /
 > 一键回滚 / test_report 与 local 模式等价可用,无需 docker cp。同时自动注入 `--user <宿主机 uid:gid>`
 > (启动时 `id -u`/`id -g` 探测)并显式 `HOME=/workspace`,容器写出的产物属主与 admin-server 进程用户一致,
@@ -255,7 +255,7 @@
 | `ADMIN_KNOWLEDGE_BATCH_SIZE` | `10` | 单次 Embedding 请求文本条数上限 |
 | `ADMIN_KNOWLEDGE_DEFAULT_TOP_K` | `5` | 检索默认返回条数 |
 | `ADMIN_KNOWLEDGE_MAX_CHUNK_CHARS` | `1500` | 单分块最大字符数 |
-| `ADMIN_KNOWLEDGE_ALLOWED_ROOTS` | `./data/admin-workspace` | 允许被索引的源码根白名单(逗号分隔,源码路径必须落在其一之下,防越权读盘);索引外部仓库源码时追加其绝对路径根 |
+| `ADMIN_KNOWLEDGE_ALLOWED_ROOTS` | `${java.io.tmpdir}/customer-work/admin-workspace` | 允许被索引的源码根白名单(逗号分隔,源码路径必须落在其一之下,防越权读盘);索引外部仓库源码时追加其绝对路径根 |
 
 > Embedding Key 从 `ai_model_config` 里 `provider=dashscope` 且 `status=1` 的行读取(优先默认模型,AES 解密);
 > 未配置 dashscope 模型即 **fast fail**(错误码 40027,不静默降级)。索引构建**显式触发、进度可查**(索引行 status +


### PR DESCRIPTION
## Summary
- 统一日志级别：将项目中的 `warn` 日志统一替换为 `info` 或 `error`，并补充错误码。
- 修复 `CustomerWorkConfigPublisher` 的 MCP 配置解析复用路径：改为复用 starter 的 `mcpClientFactory.parseSpec`，移除重复解析逻辑。
- 更新文档中运行时目录约定，统一使用 `${java.io.tmpdir}/customer-work/...`。

## Tests
- customer-work-starter: `CustomerServiceAgentFactoryTest`, `NacosPromptServiceTest`
- customer-admin-server: `CustomerWorkConfigPublisherTest`
