### PR TITLE
refactor: 收敛散落在各处的重复字面量到公共常量类

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,12 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **依赖版本变更后必须 `clean`**：增量编译不检测 classpath 变化，会误报编译成功。
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
-- 测试基线：starter **1464** + admin-server **858** + app **95** + customer-channel 65 + gateway 1（合计 **2483**）
+- 测试基线：starter **1466** + admin-server **858** + app **95** + customer-channel 65 + gateway 1（合计 **2485**）
+  （2026-08-20 公共常量收敛批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，6 skip。
+  本批次自身加 starter **+2**（`SharedConstantAlignmentTest`：已收敛值不得重新声明 + 同值不得多处定义）。
+  **同值不同概念别硬合**：本批次差点把 `sys_operation_log.result` 与 `ai_coding_audit_log.result`
+  合成一个常量（都是 `1=成功`），编译报错才发现是两张表——判定标准写在下方「项目编码规范」。
+  上一版基线 2026-08-20 yml 瘦身 + 装配收敛批次：合计 2483。）
   （2026-08-20 yml 瘦身 + 装配收敛批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，6 skip。
   本批次自身加 app-server **+2**（`YmlTrimEquivalenceTest`：yml 瘦身等价性 + 规模不回弹）。
   上一版基线 2026-08-20 M1-M4 系统性修复批次：合计 2481。）
@@ -146,6 +151,30 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   ③ `AgentAssemblyAlignmentTest` 扫描源码对此下断言——**新增一条建 Agent 的路径而不装配就会红**；
   ④ admin 不走装配器（它 exclude 了 starter 自动装配），完整性由该测试的第二个用例单独盯。
   改动前先跑这个测试，它是这类缺陷唯一的机器防线。
+- **同一个字面量只允许有一个定义处**：这是「多个真相来源」的另一种形态，成因和上一条同源。
+  `private static final String STORE_MODE_JDBC = "jdbc"` 曾在 21 个装配类里各写一遍，
+  连同 `MODE_JDBC` / `JDBC` / 裸字面量共 28 处表达同一个 "jdbc" 语义。收敛后的落点：
+  ① 跨域公共值放 `customerwork.core.constant`（`StoreModes` / `ModelProviders` / `AgentFileNames` /
+  `HttpAuthConstants` / `OpenApiProtocol` / `FactTypes` / `DevDefaultCredentials`），
+  admin 侧放 `customeradmin.common.constant`（`AgentCapabilities` / `SystemRoles` /
+  `StatsGranularity` / `StarterMapperXml`）；② 只在一个域里用的放该域内（`OrderStatuses` /
+  `DevToolConstants` / `ToolConstants` / `EvalErrorCodes`）；③ **标准库/Spring 已有的不要自己造**
+  （`Authorization`、`Content-Type` 用 `HttpHeaders`，`application/json`、`application/octet-stream`
+  用 `MediaType`）；④ 跨模块共享的值定义在双方的公共依赖 starter 上，不要靠"两边各写一份、口头保持一致"
+  （`ChatModelProber` 曾在注释里写"与 admin 的 ModelProvider 编码一致"，而没有任何机制保证）。
+  **判定标准是概念而不是值**：两处如果其中一处改了值而另一处没改会出错，才是同一个概念；
+  否则是巧合（`FAILED` 分属五个状态机、`http` 既是 URL scheme 又是 MCP 传输类型），
+  合并反而把不相干的东西绑死。`SharedConstantAlignmentTest` 扫描四个模块源码对此下断言——
+  已收敛的值在别处重新声明、或任何新值出现在两个以上文件，都会红；确属巧合的加进
+  `DISTINCT_CONCEPTS` 并写明理由。
+  **数值常量同理但归属不同**：库表列值归它自己的实体或域常量类，别往公共包塞——
+  `sys_operation_log.result` 与 `ai_coding_audit_log.result` 都是 `1=成功`，却是两张表两套语义
+  （本批次差点合并，编译期才发现 `log` 变量根本不是同一个实体）。通用的只有
+  `StatusFlags.ENABLED`（18 处曾各写一遍的 `status=1`）与 `TreeConstants.ROOT_PARENT_ID`。
+  相反，**独立参数碰巧同值的不要合**：三处 `MAX_BACKOFF_SHIFT=10`、两处 `SHUTDOWN_WAIT_SECONDS=5`
+  是各自组件的调优参数，合了会让"改 outbox 退避"意外改到死信队列。
+  **`@ConfigurationProperties` 的字段默认值刻意保持字面量**：`spring-boot-configuration-processor`
+  只从字面量初始化表达式提取 `defaultValue`，改成常量引用会让那 336 项默认值元数据静默消失。
 - **改动"某条链路的能力"时，先列出全部同类链路再动手**。当前共 7 条：
   `chat()` / `chatStream()` / WS `/ws/user` / `/consult` 多 Agent / admin 工作台 / customer-channel / Harness。
   只在一条上验证通过 ≠ 修好了——前六次复发都是这么来的。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryService.java
@@ -8,6 +8,7 @@ import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySnapshot;
 import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryStore;
 import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -36,7 +37,6 @@ public class AgentMemoryService {
     private static final Logger log = LoggerFactory.getLogger(AgentMemoryService.class);
 
     /** 框架分层记忆的工作副本文件名（workspace 根下，路径约定来自 Harness WorkspaceManager）。 */
-    private static final String MEMORY_FILE_NAME = "MEMORY.md";
     /** 框架分层记忆的原料目录名（workspace 根下，存放按日/按会话沉淀的记忆文件）。 */
     private static final String MEMORY_DIR_NAME = "memory";
     private static final DateTimeFormatter UPDATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
@@ -80,7 +80,7 @@ public class AgentMemoryService {
         Path workspace = instanceFactory.resolveWorkspace(agentCode);
         try {
             memoryStore.delete(agentCode);
-            boolean removed = Files.deleteIfExists(workspace.resolve(MEMORY_FILE_NAME));
+            boolean removed = Files.deleteIfExists(workspace.resolve(AgentFileNames.MEMORY_MD));
             deleteRecursively(workspace.resolve(MEMORY_DIR_NAME));
             log.info("agent memory cleared: agentCode={} workspaceCopyRemoved={}", agentCode, removed);
         } catch (Exception e) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
@@ -30,12 +30,15 @@ import com.richard.fyoung.customeradmin.aiconfig.skill.mapper.AiSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystemTool;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
+import com.richard.fyoung.customeradmin.common.constant.AgentCapabilities;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.menu.service.MenuVersionHolder;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -61,20 +64,19 @@ import java.util.stream.Collectors;
 @Service
 public class AgentService {
 
+
     private static final Logger log = LoggerFactory.getLogger(AgentService.class);
 
     private static final Pattern AGENT_CODE_PATTERN = Pattern.compile("^[a-z0-9-]+$");
     private static final Set<String> VALID_CAPABILITIES =
-        Set.of("chat", "vibecoding", "subagent", "plan", "tasklist", "skill-learning", "dynamic-subagent", "memory");
-    private static final String CAPABILITY_DELIMITER = ",";
+        Set.of(AgentCapabilities.CHAT, AgentCapabilities.VIBECODING, AgentCapabilities.SUBAGENT,
+            AgentCapabilities.PLAN, AgentCapabilities.TASKLIST, AgentCapabilities.SKILL_LEARNING,
+            AgentCapabilities.DYNAMIC_SUBAGENT, AgentCapabilities.MEMORY);
     /** 保存门禁的连通性测试等待上限（秒）：给 ModelConfigService 内部 10s 硬超时留余量。 */
     private static final long MODEL_TEST_GATE_TIMEOUT_SECONDS = 12;
     /** 主模型连通性门禁失败的日志错误码。 */
     private static final String CODE_MODEL_TEST_FAIL = "AGENT-MODEL-TEST-FAIL";
-    private static final String CAPABILITY_SUBAGENT = "subagent";
     /** 启用态（知识库/资源通用）。 */
-    private static final int STATUS_ENABLED = 1;
-
     // ---- 高级参数取值范围（选填，null 不校验） ----
     private static final int MAX_ITERS_MIN = 1;
     private static final int MAX_ITERS_MAX = 100;
@@ -202,7 +204,7 @@ public class AgentService {
         try {
             ModelTestResult result = modelConfigService.testConnectivity(modelId)
                 .get(MODEL_TEST_GATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            if (result.testStatus() != ModelTestResult.STATUS_SUCCESS) {
+            if (result.testStatus() != ConnectivityTestStatus.SUCCESS) {
                 throw new BizException(ResultCode.MODEL_TEST_FAILED, "主模型连通性测试未通过: " + result.message());
             }
         } catch (BizException e) {
@@ -292,8 +294,8 @@ public class AgentService {
             throw new BizException(ResultCode.PARAM_INVALID, "存在无效的 knowledgeBaseIds");
         }
         for (AiKnowledgeBase knowledgeBase : knowledgeBases) {
-            if (!Integer.valueOf(STATUS_ENABLED).equals(knowledgeBase.getStatus())
-                || !Integer.valueOf(KnowledgeBaseTestResult.STATUS_SUCCESS).equals(knowledgeBase.getTestStatus())) {
+            if (!Integer.valueOf(StatusFlags.ENABLED).equals(knowledgeBase.getStatus())
+                || !Integer.valueOf(ConnectivityTestStatus.SUCCESS).equals(knowledgeBase.getTestStatus())) {
                 throw new BizException(ResultCode.PARAM_INVALID,
                     "仅可绑定已启用且连通性测试成功的知识库: " + knowledgeBase.getKbName());
             }
@@ -316,7 +318,7 @@ public class AgentService {
     /** 子智能体多选校验：勾选 subagent 能力后必须至少选一个（避免空转配置）；反之选了子智能体也必须勾能力；每个 id 真实存在且不含自身（update 场景）。 */
     private void validateSubAgentIds(AgentSaveRequest request, Long selfId) {
         boolean subagentChecked = !CollectionUtils.isEmpty(request.capabilities())
-            && request.capabilities().contains(CAPABILITY_SUBAGENT);
+            && request.capabilities().contains(AgentCapabilities.SUBAGENT);
         if (CollectionUtils.isEmpty(request.subAgentIds())) {
             if (subagentChecked) {
                 throw new BizException(ResultCode.PARAM_INVALID, "勾选 subagent 能力后需至少选择一个子智能体");
@@ -431,7 +433,7 @@ public class AgentService {
         agent.setModelId(request.modelId());
         agent.setSystemPrompt(request.systemPrompt());
         agent.setCapabilities(CollectionUtils.isEmpty(request.capabilities())
-            ? "chat" : String.join(CAPABILITY_DELIMITER, request.capabilities()));
+            ? AgentCapabilities.CHAT : String.join(AgentCapabilities.DELIMITER, request.capabilities()));
         agent.setIcon(request.icon());
         agent.setStatus(request.status() == null ? 1 : request.status());
         // 高级参数：null 直接落库（列可空，运行时工厂按 null=默认解释；实体上 updateStrategy=ALWAYS 保证可清空）
@@ -459,7 +461,7 @@ public class AgentService {
             .stream().map(AiAgentSystemTool::getSystemToolId).collect(Collectors.toList()));
         vo.setSystemPrompt(agent.getSystemPrompt());
         vo.setCapabilities(StringUtils.hasText(agent.getCapabilities())
-            ? Arrays.asList(agent.getCapabilities().split(CAPABILITY_DELIMITER)) : List.of());
+            ? Arrays.asList(agent.getCapabilities().split(AgentCapabilities.DELIMITER)) : List.of());
         vo.setIcon(agent.getIcon());
         vo.setStatus(agent.getStatus());
         vo.setCreateTime(agent.getCreateTime());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisher.java
@@ -5,6 +5,8 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.tool.mcp.McpClientFactory;
 import com.richard.fyoung.customerwork.tool.mcp.McpServerSpec;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
@@ -68,15 +70,11 @@ import java.util.UUID;
 @Component
 public class CustomerWorkConfigPublisher {
 
+
     private static final Logger log = LoggerFactory.getLogger(CustomerWorkConfigPublisher.class);
 
     private static final String CODE_PUBLISH_FAIL = "RUNTIME-PUBLISH-FAIL";
     private static final String CODE_PROBE_BLOCK = "RUNTIME-PUBLISH-PROBE-BLOCK";
-    private static final int STATUS_ENABLED = 1;
-    private static final String MCP_TYPE_HTTP = "http";
-    private static final String MCP_TYPE_SSE = "sse";
-    private static final String TRANSPORT_STREAMABLE_HTTP = "streamable-http";
-
     private final AiChannelBindingMapper channelBindingMapper;
     private final AiAgentMapper agentMapper;
     private final AiModelConfigMapper modelConfigMapper;
@@ -226,7 +224,7 @@ public class CustomerWorkConfigPublisher {
         List<AiChannelBinding> bindings = channelBindingMapper.selectList(
             new LambdaQueryWrapper<AiChannelBinding>()
                 .eq(AiChannelBinding::getAgentId, agentId)
-                .eq(AiChannelBinding::getStatus, STATUS_ENABLED));
+                .eq(AiChannelBinding::getStatus, StatusFlags.ENABLED));
         for (AiChannelBinding binding : bindings) {
             try {
                 doPublish(binding);
@@ -261,7 +259,7 @@ public class CustomerWorkConfigPublisher {
     private boolean hasEnabledBinding(Long agentId) {
         return channelBindingMapper.selectCount(new LambdaQueryWrapper<AiChannelBinding>()
             .eq(AiChannelBinding::getAgentId, agentId)
-            .eq(AiChannelBinding::getStatus, STATUS_ENABLED)) > 0;
+            .eq(AiChannelBinding::getStatus, StatusFlags.ENABLED)) > 0;
     }
 
     /**
@@ -391,7 +389,7 @@ public class CustomerWorkConfigPublisher {
         List<AiChannelBinding> bindings = channelBindingMapper.selectList(
             new LambdaQueryWrapper<AiChannelBinding>()
                 .eq(AiChannelBinding::getAgentId, task.getTargetId())
-                .eq(AiChannelBinding::getStatus, STATUS_ENABLED));
+                .eq(AiChannelBinding::getStatus, StatusFlags.ENABLED));
         if (CollectionUtils.isEmpty(bindings)) {
             throw new IllegalStateException("enabled channel binding not found for agent: " + task.getTargetId());
         }
@@ -457,7 +455,7 @@ public class CustomerWorkConfigPublisher {
         String apiKey = cryptoUtil.decrypt(primary.getApiKey());
         ModelTestResult result = modelFactory.testConnectivity(
             primary.getProvider(), primary.getBaseUrl(), apiKey, primary.getModel());
-        if (result.testStatus() != ModelTestResult.STATUS_SUCCESS) {
+        if (result.testStatus() != ConnectivityTestStatus.SUCCESS) {
             log.error("runtime config publish blocked by connectivity probe, code={}, model={}, msg={}",
                 CODE_PROBE_BLOCK, primary.getModelName(), result.message());
             throw new IllegalStateException("primary model connectivity probe failed: " + result.message());
@@ -547,7 +545,7 @@ public class CustomerWorkConfigPublisher {
             .sorted(Comparator.comparing(AiMcp::getId))
             .toList();
         for (AiMcp mcp : mcpConfigs) {
-            if (mcp.getStatus() != null && mcp.getStatus() != STATUS_ENABLED) {
+            if (mcp.getStatus() != null && mcp.getStatus() != StatusFlags.ENABLED) {
                 continue;
             }
             String transport = resolveTransport(mcp.getMcpType());
@@ -566,11 +564,11 @@ public class CustomerWorkConfigPublisher {
     }
 
     private String resolveTransport(String mcpType) {
-        if (MCP_TYPE_HTTP.equalsIgnoreCase(mcpType)) {
-            return TRANSPORT_STREAMABLE_HTTP;
+        if (McpServerSpec.TYPE_HTTP.equalsIgnoreCase(mcpType)) {
+            return McpServerSpec.TRANSPORT_STREAMABLE_HTTP;
         }
-        if (MCP_TYPE_SSE.equalsIgnoreCase(mcpType)) {
-            return MCP_TYPE_SSE;
+        if (McpServerSpec.TYPE_SSE.equalsIgnoreCase(mcpType)) {
+            return McpServerSpec.TYPE_SSE;
         }
         return null;
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/service/ChannelBindingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/service/ChannelBindingService.java
@@ -12,6 +12,7 @@ import com.richard.fyoung.customeradmin.aiconfig.channel.publish.entity.RuntimeP
 import com.richard.fyoung.customeradmin.aiconfig.channel.publish.mapper.RuntimePublishTaskMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -33,10 +34,8 @@ import java.util.stream.Collectors;
 @Service
 public class ChannelBindingService {
 
+
     private static final Logger log = LoggerFactory.getLogger(ChannelBindingService.class);
-
-    private static final int STATUS_ENABLED = 1;
-
     private final AiChannelBindingMapper bindingMapper;
     private final AiAgentMapper agentMapper;
     private final CustomerWorkConfigPublisher publisher;
@@ -81,7 +80,7 @@ public class ChannelBindingService {
         AiChannelBinding binding = new AiChannelBinding();
         binding.setChannelCode(request.channelCode());
         binding.setAgentId(request.agentId());
-        binding.setStatus(request.status() == null ? STATUS_ENABLED : request.status());
+        binding.setStatus(request.status() == null ? StatusFlags.ENABLED : request.status());
         bindingMapper.insert(binding);
         publisher.publishForAgentId(binding.getAgentId());
     }
@@ -95,7 +94,7 @@ public class ChannelBindingService {
         assertSingleActiveRuntimeAgent(request.agentId(), request.status(), id);
         binding.setChannelCode(request.channelCode());
         binding.setAgentId(request.agentId());
-        binding.setStatus(request.status() == null ? STATUS_ENABLED : request.status());
+        binding.setStatus(request.status() == null ? StatusFlags.ENABLED : request.status());
         bindingMapper.updateById(binding);
         publisher.publishForAgentId(binding.getAgentId());
     }
@@ -160,12 +159,12 @@ public class ChannelBindingService {
      * 多个渠道编码可以绑定同一个智能体；不同智能体必须使用独立 admin/dataId 部署。
      */
     private void assertSingleActiveRuntimeAgent(Long agentId, Integer status, Long excludeId) {
-        int effectiveStatus = status == null ? STATUS_ENABLED : status;
-        if (effectiveStatus != STATUS_ENABLED) {
+        int effectiveStatus = status == null ? StatusFlags.ENABLED : status;
+        if (effectiveStatus != StatusFlags.ENABLED) {
             return;
         }
         LambdaQueryWrapper<AiChannelBinding> wrapper = new LambdaQueryWrapper<AiChannelBinding>()
-            .eq(AiChannelBinding::getStatus, STATUS_ENABLED)
+            .eq(AiChannelBinding::getStatus, StatusFlags.ENABLED)
             .ne(AiChannelBinding::getAgentId, agentId);
         if (excludeId != null) {
             wrapper.ne(AiChannelBinding::getId, excludeId);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channelrobot/ChannelType.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channelrobot/ChannelType.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.aiconfig.channelrobot;
 
+import com.richard.fyoung.customerwork.core.constant.ChannelTypes;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -12,9 +13,9 @@ import java.util.Arrays;
 @Getter
 public enum ChannelType {
 
-    DINGTALK("dingtalk", true),
+    DINGTALK(ChannelTypes.DINGTALK, true),
     WECOM("wecom", false),
-    WECHAT("wechat", true);
+    WECHAT(ChannelTypes.WECHAT, true);
 
     private final String code;
     /** 是否已支持接入（预留渠道为 false，暂不允许创建机器人）。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channelrobot/service/ChannelRobotService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channelrobot/service/ChannelRobotService.java
@@ -14,6 +14,7 @@ import com.richard.fyoung.customeradmin.aiconfig.channelrobot.mapper.AiChannelRo
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -26,8 +27,6 @@ import org.springframework.util.StringUtils;
  */
 @Service
 public class ChannelRobotService {
-
-    private static final int STATUS_ENABLED = 1;
 
     private final AiChannelRobotMapper robotMapper;
     private final AiAgentMapper agentMapper;
@@ -102,7 +101,7 @@ public class ChannelRobotService {
         if (agent == null) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "绑定的智能体不存在: " + agentCode);
         }
-        if (agent.getStatus() == null || agent.getStatus() != STATUS_ENABLED) {
+        if (agent.getStatus() == null || agent.getStatus() != StatusFlags.ENABLED) {
             throw new BizException(ResultCode.AGENT_DISABLED, "绑定的智能体未启用: " + agentCode);
         }
     }
@@ -128,7 +127,7 @@ public class ChannelRobotService {
         robot.setAgentCode(request.agentCode());
         robot.setSessionMode(resolveSessionMode(request.sessionMode()));
         robot.setRemark(request.remark());
-        robot.setStatus(request.status() == null ? STATUS_ENABLED : request.status());
+        robot.setStatus(request.status() == null ? StatusFlags.ENABLED : request.status());
     }
 
     /** 会话模式：空值取默认 continuous，非法值 fast fail。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/config/KnowledgeGapGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/config/KnowledgeGapGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customerwork.capability.knowledgegap.KnowledgeGapService;
 import com.richard.fyoung.customerwork.capability.knowledgegap.MybatisKnowledgeGapStore;
 import com.richard.fyoung.customerwork.capability.knowledgegap.mapper.KnowledgeGapMapper;
@@ -24,12 +25,10 @@ import java.util.List;
  */
 final class KnowledgeGapGatewayFactory {
 
-    private static final String STARTER_KNOWLEDGE_GAP_XML = "classpath*:customerwork/mapper/KnowledgeGapMapper.xml";
-
     /** 该 Mapper 有 XML，靠 namespace 自动绑定，不能再登记进接口列表（同名语句会冲突）。 */
     static final List<Class<?>> MAPPER_CLASSES = List.of();
 
-    static final List<String> MAPPER_XML_LOCATIONS = List.of(STARTER_KNOWLEDGE_GAP_XML);
+    static final List<String> MAPPER_XML_LOCATIONS = List.of(StarterMapperXml.KNOWLEDGE_GAP);
 
     private KnowledgeGapGatewayFactory() {
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseTestResult.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/dto/KnowledgeBaseTestResult.java
@@ -1,28 +1,24 @@
 package com.richard.fyoung.customeradmin.aiconfig.knowledgebase.dto;
 
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import java.time.LocalDateTime;
 
 /**
  * 知识库连通性测试结果。用固定探测语句真实发一次检索请求，{@code hitCount} 为本次召回条数
  * （0 条也算连通成功——判成功的标准是 HTTP 200 且响应体 {@code code == "OK"}，与召回多寡无关）。
  *
- * @param testStatus 0未测试 / 1成功 / 2失败
+ * @param testStatus 取值见 {@link com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus}
  * @param testTime   本次测试时间
  * @param message    失败原因（成功时为 null）
  * @param hitCount   本次探测召回条数
  * @author owlzhangfq@gmail.com
  */
 public record KnowledgeBaseTestResult(int testStatus, LocalDateTime testTime, String message, int hitCount) {
-
-    public static final int STATUS_UNTESTED = 0;
-    public static final int STATUS_SUCCESS = 1;
-    public static final int STATUS_FAILED = 2;
-
     public static KnowledgeBaseTestResult success(int hitCount) {
-        return new KnowledgeBaseTestResult(STATUS_SUCCESS, LocalDateTime.now(), null, hitCount);
+        return new KnowledgeBaseTestResult(ConnectivityTestStatus.SUCCESS, LocalDateTime.now(), null, hitCount);
     }
 
     public static KnowledgeBaseTestResult failed(String message) {
-        return new KnowledgeBaseTestResult(STATUS_FAILED, LocalDateTime.now(), message, 0);
+        return new KnowledgeBaseTestResult(ConnectivityTestStatus.FAILED, LocalDateTime.now(), message, 0);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalService.java
@@ -9,7 +9,9 @@ import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKno
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeBaseEndpoint;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeNode;
 import org.slf4j.Logger;
@@ -44,11 +46,10 @@ import java.util.stream.Collectors;
 @Component
 public class KnowledgeRetrievalService {
 
+
     private static final Logger log = LoggerFactory.getLogger(KnowledgeRetrievalService.class);
 
     private static final String CODE_RETRIEVAL_FAIL = "RAG-RETRIEVAL-FAIL";
-    private static final int STATUS_ENABLED = 1;
-
     private static final String BLOCK_OPEN = "<retrieved_knowledge>";
     private static final String BLOCK_CLOSE = "</retrieved_knowledge>";
     private static final String BLOCK_HINT =
@@ -126,8 +127,8 @@ public class KnowledgeRetrievalService {
             return List.of();
         }
         return knowledgeBaseMapper.selectBatchIds(kbIds).stream()
-            .filter(kb -> Integer.valueOf(STATUS_ENABLED).equals(kb.getStatus()))
-            .filter(kb -> Integer.valueOf(KnowledgeBaseTestResult.STATUS_SUCCESS).equals(kb.getTestStatus()))
+            .filter(kb -> Integer.valueOf(StatusFlags.ENABLED).equals(kb.getStatus()))
+            .filter(kb -> Integer.valueOf(ConnectivityTestStatus.SUCCESS).equals(kb.getTestStatus()))
             .map(this::toEndpoint)
             .collect(Collectors.toList());
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseService.java
@@ -13,12 +13,14 @@ import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKno
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminRagProperties;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeBaseEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,7 @@ import java.util.stream.Collectors;
 @Service
 public class KnowledgeBaseService {
 
+
     private static final Logger log = LoggerFactory.getLogger(KnowledgeBaseService.class);
 
     /** 连通性测试专用线程池：与 Tomcat 请求线程隔离，低频操作，池子不需要大（同 ModelConfigService）。 */
@@ -59,8 +62,6 @@ public class KnowledgeBaseService {
     });
     private static final long TEST_FUTURE_TIMEOUT_SECONDS = 10;
     private static final String CODE_TEST_FAIL = "KB-TEST-FAIL";
-    private static final int STATUS_ENABLED = 1;
-
     private final AiKnowledgeBaseMapper knowledgeBaseMapper;
     private final AiAgentKnowledgeBaseMapper agentKnowledgeBaseMapper;
     private final AesGcmCryptoUtil cryptoUtil;
@@ -101,8 +102,8 @@ public class KnowledgeBaseService {
     /** 智能体表单下拉：只给可用的知识库（启用 + 连通性测试成功），不可用的不允许被绑定。 */
     public List<KnowledgeBaseOptionVO> options() {
         return knowledgeBaseMapper.selectList(new LambdaQueryWrapper<AiKnowledgeBase>()
-                .eq(AiKnowledgeBase::getStatus, STATUS_ENABLED)
-                .eq(AiKnowledgeBase::getTestStatus, KnowledgeBaseTestResult.STATUS_SUCCESS)
+                .eq(AiKnowledgeBase::getStatus, StatusFlags.ENABLED)
+                .eq(AiKnowledgeBase::getTestStatus, ConnectivityTestStatus.SUCCESS)
                 .orderByAsc(AiKnowledgeBase::getId))
             .stream()
             .map(kb -> new KnowledgeBaseOptionVO(kb.getId(), kb.getKbName()))
@@ -243,7 +244,7 @@ public class KnowledgeBaseService {
      */
     private KnowledgeBaseTestResult assertConnectivity(KnowledgeBaseEndpoint endpoint) {
         KnowledgeBaseTestResult result = probe(endpoint);
-        if (result.testStatus() != KnowledgeBaseTestResult.STATUS_SUCCESS) {
+        if (result.testStatus() != ConnectivityTestStatus.SUCCESS) {
             throw new BizException(ResultCode.KNOWLEDGE_BASE_TEST_FAILED,
                 "知识库连通性测试未通过: " + result.message());
         }
@@ -299,7 +300,7 @@ public class KnowledgeBaseService {
         entity.setTopN(request.topN() == null || request.topN() <= 0
             ? KnowledgeBaseEndpoint.DEFAULT_TOP_N : request.topN());
         entity.setScoreThreshold(request.scoreThreshold() == null ? BigDecimal.ZERO : request.scoreThreshold());
-        entity.setStatus(request.status() == null ? STATUS_ENABLED : request.status());
+        entity.setStatus(request.status() == null ? StatusFlags.ENABLED : request.status());
         entity.setRemark(request.remark());
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/dto/McpTestResult.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/dto/McpTestResult.java
@@ -5,14 +5,10 @@ import java.time.LocalDateTime;
 /**
  * MCP 连通性测试结果。
  *
- * @param testStatus 0未测试 / 1成功 / 2失败
+ * @param testStatus 取值见 {@link com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus}
  * @param testTime   本次测试时间
  * @param message    失败原因（成功时为 null）
  * @author owlzhangfq@gmail.com
  */
 public record McpTestResult(int testStatus, LocalDateTime testTime, String message) {
-
-    public static final int STATUS_UNTESTED = 0;
-    public static final int STATUS_SUCCESS = 1;
-    public static final int STATUS_FAILED = 2;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactory.java
@@ -4,6 +4,7 @@ import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugCallResult;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugImageVO;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugToolVO;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpTestResult;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customerwork.tool.mcp.McpClientFactory;
 import com.richard.fyoung.customerwork.tool.mcp.McpConnectivityResult;
 import com.richard.fyoung.customerwork.tool.mcp.McpToolCallResult;
@@ -57,7 +58,7 @@ public class AdminMcpFactory {
 
     /** 连通性结果 -&gt; 库里持久化的测试状态（0未测试/1成功/2失败）。包级可见：同包单测直接校验转换。 */
     static McpTestResult toVo(McpConnectivityResult result) {
-        return new McpTestResult(result.success() ? McpTestResult.STATUS_SUCCESS : McpTestResult.STATUS_FAILED,
+        return new McpTestResult(result.success() ? ConnectivityTestStatus.SUCCESS : ConnectivityTestStatus.FAILED,
             result.testedAt(), result.errorMessage());
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpService.java
@@ -17,6 +17,7 @@ import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpVO;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.entity.AiMcp;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.mapper.AiMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.runtime.AdminMcpFactory;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
@@ -93,7 +94,7 @@ public class McpService {
         validate(request);
         AiMcp mcp = new AiMcp();
         fillFromRequest(mcp, request);
-        mcp.setTestStatus(McpTestResult.STATUS_UNTESTED);
+        mcp.setTestStatus(ConnectivityTestStatus.UNTESTED);
         mcpMapper.insert(mcp);
     }
 
@@ -140,7 +141,7 @@ public class McpService {
                 } else {
                     log.error("mcp connectivity test unexpected error, code={}, mcpId={}", "MCP-TEST-UNEXPECTED", id, ex);
                 }
-                return new McpTestResult(McpTestResult.STATUS_FAILED, LocalDateTime.now(), "连通性测试超时或执行异常");
+                return new McpTestResult(ConnectivityTestStatus.FAILED, LocalDateTime.now(), "连通性测试超时或执行异常");
             })
             .thenApply(result -> {
                 persistTestResult(id, result);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/dto/ModelTestResult.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/dto/ModelTestResult.java
@@ -5,14 +5,10 @@ import java.time.LocalDateTime;
 /**
  * 模型连通性测试结果。
  *
- * @param testStatus 0未测试 / 1成功 / 2失败
+ * @param testStatus 取值见 {@link com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus}
  * @param testTime   本次测试时间
  * @param message    失败原因（成功时为 null）
  * @author owlzhangfq@gmail.com
  */
 public record ModelTestResult(int testStatus, LocalDateTime testTime, String message) {
-
-    public static final int STATUS_UNTESTED = 0;
-    public static final int STATUS_SUCCESS = 1;
-    public static final int STATUS_FAILED = 2;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactory.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.aiconfig.model.runtime;
 
 import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelTestResult;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customerwork.infra.config.ChatModelFactory;
 import com.richard.fyoung.customerwork.core.model.ChatModelProber;
 import io.agentscope.core.model.GenerateOptions;
@@ -45,7 +46,7 @@ public class AdminModelFactory {
         ModelProvider p = ModelProvider.of(provider);
         LocalDateTime now = LocalDateTime.now();
         ChatModelProber.ProbeResult result = prober.probe(p.getCode(), baseUrl, apiKey, modelName);
-        int status = result.success() ? ModelTestResult.STATUS_SUCCESS : ModelTestResult.STATUS_FAILED;
+        int status = result.success() ? ConnectivityTestStatus.SUCCESS : ConnectivityTestStatus.FAILED;
         return new ModelTestResult(status, now, result.message());
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/ModelProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/ModelProvider.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.aiconfig.model.runtime;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
 import java.util.Arrays;
 
 /**
@@ -16,13 +17,13 @@ import java.util.Arrays;
 public enum ModelProvider {
 
     /** OpenAI 及所有 OpenAI 兼容端点（默认厂商）。 */
-    OPENAI("openai"),
+    OPENAI(ModelProviders.OPENAI),
     /** 阿里云百炼 DashScope 原生协议（通义千问）。 */
-    DASHSCOPE("dashscope"),
+    DASHSCOPE(ModelProviders.DASHSCOPE),
     /** Anthropic Claude 原生协议。 */
-    ANTHROPIC("anthropic"),
+    ANTHROPIC(ModelProviders.ANTHROPIC),
     /** Google Gemini（Gemini Developer API，非 Vertex）。 */
-    GEMINI("gemini");
+    GEMINI(ModelProviders.GEMINI);
 
     private final String code;
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelConfigService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelConfigService.java
@@ -15,6 +15,7 @@ import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
 import com.richard.fyoung.customeradmin.aiconfig.model.mapper.AiModelConfigMapper;
 import com.richard.fyoung.customeradmin.aiconfig.channel.publish.CustomerWorkConfigPublisher;
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.AdminModelFactory;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
@@ -22,6 +23,7 @@ import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
 import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import org.slf4j.Logger;
@@ -157,7 +159,7 @@ public class ModelConfigService {
         AiModelConfig model = new AiModelConfig();
         fillFromRequest(model, request);
         model.setApiKey(cryptoUtil.encrypt(request.apiKey()));
-        model.setTestStatus(ModelTestResult.STATUS_UNTESTED);
+        model.setTestStatus(ConnectivityTestStatus.UNTESTED);
         // 本表在租户忽略清单里，拦截器不会自动补租户列，必须显式落归属
         if (tenantProperties.isEnabled()) {
             model.setTenantId(requireTenant());
@@ -237,7 +239,7 @@ public class ModelConfigService {
                 } else {
                     log.error("model connectivity test unexpected error, code={}, modelId={}", "MODEL-TEST-UNEXPECTED", id, ex);
                 }
-                return new ModelTestResult(ModelTestResult.STATUS_FAILED, LocalDateTime.now(), "连通性测试超时或执行异常");
+                return new ModelTestResult(ConnectivityTestStatus.FAILED, LocalDateTime.now(), "连通性测试超时或执行异常");
             })
             .thenApply(result -> {
                 persistTestResult(id, result);
@@ -272,7 +274,7 @@ public class ModelConfigService {
 
     private void fillFromRequest(AiModelConfig model, ModelSaveRequest request) {
         model.setModelName(request.modelName());
-        model.setProvider(StringUtils.hasText(request.provider()) ? request.provider() : "openai");
+        model.setProvider(StringUtils.hasText(request.provider()) ? request.provider() : ModelProviders.OPENAI);
         model.setBaseUrl(request.baseUrl());
         model.setModel(request.model());
         model.setIsDefault(Boolean.TRUE.equals(request.isDefault()) ? 1 : 0);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/scheduledtask/scheduler/ScheduledTaskScheduler.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/scheduledtask/scheduler/ScheduledTaskScheduler.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.aiconfig.scheduledtask.scheduler;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.richard.fyoung.customeradmin.aiconfig.scheduledtask.entity.AiScheduledTask;
 import com.richard.fyoung.customeradmin.aiconfig.scheduledtask.mapper.AiScheduledTaskMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
 import com.richard.fyoung.customeradmin.aiconfig.scheduledtask.service.ScheduledTaskService;
 import com.richard.fyoung.customeradmin.config.AdminSchedulerProperties;
@@ -43,10 +44,8 @@ import java.util.concurrent.ScheduledFuture;
 @Component
 public class ScheduledTaskScheduler implements DisposableBean {
 
+
     private static final Logger log = LoggerFactory.getLogger(ScheduledTaskScheduler.class);
-
-    private static final int ENABLED = 1;
-
     private final AiScheduledTaskMapper taskMapper;
     private final ScheduledTaskService scheduledTaskService;
     private final AdminSchedulerProperties properties;
@@ -86,7 +85,7 @@ public class ScheduledTaskScheduler implements DisposableBean {
             // 启动时把所有租户的任务都注册进来：这是明确的跨租户运维扫描，不是某个租户的查询。
             // 具体执行时再按任务所属租户还原上下文（见 ScheduledTaskService#executeFromScheduler）
             List<AiScheduledTask> tasks = CrossTenantOperations.execute(() -> taskMapper.selectList(
-                new LambdaQueryWrapper<AiScheduledTask>().eq(AiScheduledTask::getEnabled, ENABLED)));
+                new LambdaQueryWrapper<AiScheduledTask>().eq(AiScheduledTask::getEnabled, StatusFlags.ENABLED)));
             if (CollectionUtils.isEmpty(tasks)) {
                 log.info("internal scheduler started with no schedulable task");
                 return;
@@ -131,7 +130,7 @@ public class ScheduledTaskScheduler implements DisposableBean {
         if (!properties.isInternalMode()) {
             return false;
         }
-        if (task.getEnabled() == null || task.getEnabled() != ENABLED) {
+        if (task.getEnabled() == null || task.getEnabled() != StatusFlags.ENABLED) {
             return false;
         }
         if (!StringUtils.hasText(task.getCron())) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/scheduledtask/service/ScheduledTaskService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/scheduledtask/service/ScheduledTaskService.java
@@ -19,6 +19,7 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminScheduledTaskProperties;
 import com.richard.fyoung.customeradmin.config.AdminSchedulerProperties;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.ReActAgent;
@@ -53,6 +54,7 @@ import java.util.List;
 @Service
 public class ScheduledTaskService {
 
+
     private static final Logger log = LoggerFactory.getLogger(ScheduledTaskService.class);
 
     public static final String TRIGGER_TYPE_MANUAL = "MANUAL";
@@ -61,7 +63,6 @@ public class ScheduledTaskService {
 
     public static final String STATUS_SUCCESS = "SUCCESS";
     public static final String STATUS_FAILED = "FAILED";
-    private static final int STATUS_ENABLED = 1;
     private static final int OUTPUT_MAX_LENGTH = 8000;
     private static final int ERROR_MESSAGE_MAX_LENGTH = 1000;
 
@@ -129,7 +130,7 @@ public class ScheduledTaskService {
     }
 
     public void enable(Long id) {
-        setEnabled(id, STATUS_ENABLED);
+        setEnabled(id, StatusFlags.ENABLED);
     }
 
     public void disable(Long id) {
@@ -287,7 +288,7 @@ public class ScheduledTaskService {
         if (agent == null) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "智能体不存在: " + agentId);
         }
-        if (agent.getStatus() == null || agent.getStatus() != STATUS_ENABLED) {
+        if (agent.getStatus() == null || agent.getStatus() != StatusFlags.ENABLED) {
             throw new BizException(ResultCode.AGENT_DISABLED, "智能体未启用: " + agent.getAgentCode());
         }
     }
@@ -298,7 +299,7 @@ public class ScheduledTaskService {
         task.setAgentId(request.agentId());
         task.setPrompt(request.prompt());
         task.setCron(StringUtils.hasText(request.cron()) ? request.cron().trim() : null);
-        task.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : STATUS_ENABLED);
+        task.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : StatusFlags.ENABLED);
         task.setRemark(request.remark());
     }
 
@@ -312,7 +313,7 @@ public class ScheduledTaskService {
         vo.setAgentName(agent == null ? null : agent.getAgentName());
         vo.setPrompt(task.getPrompt());
         vo.setCron(task.getCron());
-        vo.setEnabled(Integer.valueOf(STATUS_ENABLED).equals(task.getEnabled()));
+        vo.setEnabled(Integer.valueOf(StatusFlags.ENABLED).equals(task.getEnabled()));
         vo.setRemark(task.getRemark());
         vo.setScheduleMode(schedulerProperties.getMode());
         vo.setCreateTime(task.getCreateTime());
@@ -349,7 +350,7 @@ public class ScheduledTaskService {
         if (task == null) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "定时任务不存在: " + taskCode);
         }
-        if (task.getEnabled() == null || task.getEnabled() != STATUS_ENABLED) {
+        if (task.getEnabled() == null || task.getEnabled() != StatusFlags.ENABLED) {
             throw new BizException(ResultCode.SCHEDULED_TASK_DISABLED, "定时任务未启用: " + taskCode);
         }
         return task;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/skill/service/SkillService.java
@@ -22,6 +22,7 @@ import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import com.richard.fyoung.customerwork.data.skill.storage.SkillContentPublisher;
 import com.richard.fyoung.customerwork.data.skill.storage.SkillFileContent;
 import com.richard.fyoung.customerwork.data.skill.storage.SkillStorageTarget;
@@ -334,7 +335,7 @@ public class SkillService {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (ZipOutputStream zipOut = new ZipOutputStream(bos, StandardCharsets.UTF_8)) {
             String content = skill.getContent() == null ? "" : skill.getContent();
-            writeZipEntry(zipOut, rootDir + "/" + SKILL_FILE_NAME, content.getBytes(StandardCharsets.UTF_8));
+            writeZipEntry(zipOut, rootDir + "/" + AgentFileNames.SKILL_MD, content.getBytes(StandardCharsets.UTF_8));
             for (SkillFileContent file : files) {
                 // content 允许为空（历史数据/空文件），补空字节而不是跳过——
                 // 跳过会让重新上传后文件清单凭空少几项，导出就不是"这个 skill 的全部"了
@@ -374,7 +375,6 @@ public class SkillService {
 
     // ---- 上传解析 ----
 
-    private static final String SKILL_FILE_NAME = "SKILL.md";
     private static final long BYTES_PER_MB = 1024L * 1024L;
     private static final long MAX_UPLOAD_BYTES = 5 * BYTES_PER_MB;
     /** zip 解压后（以及保存请求里附属文件解码后）的总字节上限，防 zip bomb。 */
@@ -486,7 +486,7 @@ public class SkillService {
         int foundDepth = Integer.MAX_VALUE;
         for (String name : entryNames) {
             String fileName = name.substring(name.lastIndexOf('/') + 1);
-            if (!SKILL_FILE_NAME.equalsIgnoreCase(fileName)) {
+            if (!AgentFileNames.SKILL_MD.equalsIgnoreCase(fileName)) {
                 continue;
             }
             int depth = (int) name.chars().filter(c -> c == '/').count();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
@@ -214,7 +214,7 @@ public class AuthService {
             entity.setOperation(operation);
             entity.setMethod(method);
             entity.setTarget("sys_user");
-            entity.setResult(success ? 1 : 0);
+            entity.setResult(success ? SysOperationLog.RESULT_SUCCESS : SysOperationLog.RESULT_FAILURE);
             entity.setErrorMsg(errorMsg);
             entity.setIp(resolveClientIp());
             entity.setCreateTime(LocalDateTime.now());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/badcase/config/BadcaseGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/badcase/config/BadcaseGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.badcase.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customerwork.capability.badcase.BadcaseService;
 import com.richard.fyoung.customerwork.capability.badcase.MybatisBadcaseStore;
 import com.richard.fyoung.customerwork.capability.badcase.mapper.BadcaseMapper;
@@ -26,15 +27,11 @@ import java.util.List;
  */
 final class BadcaseGatewayFactory {
 
-    private static final String STARTER_BADCASE_XML = "classpath*:customerwork/mapper/BadcaseMapper.xml";
-    private static final String STARTER_EVAL_CASE_XML = "classpath*:customerwork/mapper/EvalCaseMapper.xml";
-    private static final String STARTER_KNOWLEDGE_XML = "classpath*:customerwork/mapper/KnowledgeMapper.xml";
-
     /** 三张表的 Mapper 都有 XML，靠 namespace 自动绑定，不能再登记进接口列表（同名语句会冲突）。 */
     static final List<Class<?>> MAPPER_CLASSES = List.of();
 
     static final List<String> MAPPER_XML_LOCATIONS =
-        List.of(STARTER_BADCASE_XML, STARTER_EVAL_CASE_XML, STARTER_KNOWLEDGE_XML);
+        List.of(StarterMapperXml.BADCASE, StarterMapperXml.EVAL_CASE, StarterMapperXml.KNOWLEDGE);
 
     private BadcaseGatewayFactory() {
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/AgentCapabilities.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/AgentCapabilities.java
@@ -1,0 +1,30 @@
+package com.richard.fyoung.customeradmin.common.constant;
+
+/**
+ * 智能体能力标识（{@code ai_agent.capabilities} 列存的值）。
+ *
+ * <p>这列存的是逗号分隔的能力码，写入方（智能体配置）、装配方（运行时工厂）、消费方
+ * （VibeCoding / Git 助手 / 协同编码 / 菜单聚合）必须认同一套字符串。此前分隔符在 6 个类、
+ * {@code vibecoding} 在 4 个类各写一遍——改一个能力码而漏掉某处，表现是"后台勾了能力、
+ * 运行时不生效"，两侧都不报错。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class AgentCapabilities {
+
+    /** 能力码分隔符（列里是逗号分隔的字符串，不是 JSON 数组）。 */
+    public static final String DELIMITER = ",";
+
+    /** 基础对话能力（所有智能体都有，配置里显式列出便于校验）。 */
+    public static final String CHAT = "chat";
+    public static final String VIBECODING = "vibecoding";
+    public static final String PLAN = "plan";
+    public static final String SUBAGENT = "subagent";
+    public static final String TASKLIST = "tasklist";
+    public static final String SKILL_LEARNING = "skill-learning";
+    public static final String DYNAMIC_SUBAGENT = "dynamic-subagent";
+    public static final String MEMORY = "memory";
+
+    private AgentCapabilities() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/ConnectivityTestStatus.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/ConnectivityTestStatus.java
@@ -1,0 +1,24 @@
+package com.richard.fyoung.customeradmin.common.constant;
+
+/**
+ * 连通性测试结果状态（模型 / MCP / 知识库三种资源共用）。
+ *
+ * <p>三个 {@code XxxTestResult} 各自定义过一份完全相同的三个状态，而前端用同一段逻辑渲染它们——
+ * 其中一处改了编码，那一类资源的测试结果就会显示成另一种状态。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class ConnectivityTestStatus {
+
+    /** 尚未测试过。 */
+    public static final int UNTESTED = 0;
+
+    /** 测试通过。 */
+    public static final int SUCCESS = 1;
+
+    /** 测试失败。 */
+    public static final int FAILED = 2;
+
+    private ConnectivityTestStatus() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/StarterMapperXml.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/StarterMapperXml.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customeradmin.common.constant;
+
+/**
+ * starter 侧 Mapper XML 在 classpath 上的位置。
+ *
+ * <p>后台经跨库门面复用客服端库的 Mapper 时要显式登记 XML 位置。此前每个门面工厂各写一遍
+ * {@code classpath*:customerwork/mapper/} 前缀（17 处），其中两个 XML 还被两个门面各写一份——
+ * starter 换资源目录时得挨个改，漏一个的表现是<b>门面启动正常、调到那条语句才报找不到</b>。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class StarterMapperXml {
+
+    /** starter 的 Mapper XML 资源目录（与 {@code CustomerWorkPersistenceConfig} 约定一致）。 */
+    private static final String PREFIX = "classpath*:customerwork/mapper/";
+
+    public static final String AGENT_CALL_LOG = PREFIX + "AgentCallLogMapper.xml";
+    public static final String AGENT_CALL_SEGMENT = PREFIX + "AgentCallSegmentMapper.xml";
+    public static final String BADCASE = PREFIX + "BadcaseMapper.xml";
+    public static final String CSAT_SURVEY = PREFIX + "CsatSurveyMapper.xml";
+    public static final String DEAD_LETTER = PREFIX + "DeadLetterMapper.xml";
+    public static final String EVAL_CASE = PREFIX + "EvalCaseMapper.xml";
+    public static final String EVAL_RUN = PREFIX + "EvalRunMapper.xml";
+    public static final String KNOWLEDGE = PREFIX + "KnowledgeMapper.xml";
+    public static final String KNOWLEDGE_GAP = PREFIX + "KnowledgeGapMapper.xml";
+    public static final String PROMPT_VERSION = PREFIX + "PromptVersionMapper.xml";
+    public static final String RATE_LIMIT_RULE = PREFIX + "RateLimitRuleMapper.xml";
+    public static final String SEMANTIC_CACHE = PREFIX + "SemanticCacheMapper.xml";
+    public static final String SENSITIVE_WORD = PREFIX + "SensitiveWordMapper.xml";
+    public static final String SUBJECT_QUOTA_HIT = PREFIX + "SubjectQuotaHitMapper.xml";
+    public static final String SUBJECT_QUOTA_LEVEL = PREFIX + "SubjectQuotaLevelMapper.xml";
+
+    private StarterMapperXml() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/StatsGranularity.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/StatsGranularity.java
@@ -1,0 +1,17 @@
+package com.richard.fyoung.customeradmin.common.constant;
+
+/**
+ * 统计趋势的时间粒度（接口出入参取值）。
+ *
+ * <p>内容风控命中统计与智能体调用统计共用同一套粒度词汇，前端按这个字符串渲染横轴。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class StatsGranularity {
+
+    public static final String HOUR = "hour";
+    public static final String DAY = "day";
+
+    private StatsGranularity() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/SystemRoles.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/SystemRoles.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customeradmin.common.constant;
+
+/**
+ * 内置角色编码（{@code sys_role.role_code}）。
+ *
+ * <p>超管编码同时决定"鉴权时是否放行全部权限"与"建角色时是否允许选跨租户数据范围"，
+ * 两处判定必须用同一个字符串——写歪一处不是报错，而是静默失去或静默获得全部权限。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class SystemRoles {
+
+    /** 超级管理员：权限判定直接放行，且允许 {@code data_scope=ALL}（仍需校验归属平台租户）。 */
+    public static final String SUPER_ADMIN = "super_admin";
+
+    private SystemRoles() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/TreeConstants.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/constant/TreeConstants.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.common.constant;
+
+/**
+ * 树形结构（菜单树 / 权限树）的公共约定。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class TreeConstants {
+
+    /**
+     * 根节点的 {@code parent_id}。
+     *
+     * <p>建树时 {@code parentId == null} 与 {@code parentId == 0} 都当根处理——
+     * 历史数据两种写法都有，权限树与菜单聚合必须按同一个值判定，否则同一批数据在两个页面上会挂出不同的层级。</p>
+     */
+    public static final long ROOT_PARENT_ID = 0L;
+
+    private TreeConstants() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/gateway/CustomerWorkFacade.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/gateway/CustomerWorkFacade.java
@@ -51,8 +51,6 @@ public final class CustomerWorkFacade<T> {
     private static final Logger log = LoggerFactory.getLogger(CustomerWorkFacade.class);
 
     /** 跨库连接池默认大小：门面都是低频运维查询，池子不需要大。 */
-    private static final int DEFAULT_MAX_POOL_SIZE = 3;
-
     private final CustomerWorkDbConnection properties;
     private final CrossDbGatewayProvider<T> delegate;
     private final String errorCode;
@@ -99,7 +97,7 @@ public final class CustomerWorkFacade<T> {
         private final AdminCrossDbTenantPlugins tenantPlugins;
         private List<Class<?>> mapperClasses = List.of();
         private List<String> mapperXmlLocations = List.of();
-        private int maxPoolSize = DEFAULT_MAX_POOL_SIZE;
+        private int maxPoolSize = CrossDbConnectionSettings.DEFAULT_MAX_POOL_SIZE;
         private String errorCode = "CUSTOMER-WORK-DS-UNAVAILABLE";
         private String errorHint = "客服端库不可达";
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/log/OperationLogAspect.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/log/OperationLogAspect.java
@@ -52,10 +52,11 @@ public class OperationLogAspect {
 
         try {
             Object result = joinPoint.proceed();
-            recordAsync(operationLog.operation(), method, target, params, 1, null, ip);
+            recordAsync(operationLog.operation(), method, target, params, SysOperationLog.RESULT_SUCCESS, null, ip);
             return result;
         } catch (Throwable t) {
-            recordAsync(operationLog.operation(), method, target, params, 0, t.getMessage(), ip);
+            recordAsync(operationLog.operation(), method, target, params,
+                SysOperationLog.RESULT_FAILURE, t.getMessage(), ip);
             throw t;
         }
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminAttachmentConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminAttachmentConfig.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.config;
 
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.AiChatAttachmentMapper;
 import com.richard.fyoung.customeradmin.workspace.chat.store.AdminChatAttachmentStore;
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentFileStorage;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentFileStorages;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentParseService;
@@ -39,8 +40,6 @@ import java.util.function.Supplier;
 @EnableConfigurationProperties(AttachmentProperties.class)
 public class AdminAttachmentConfig {
 
-    private static final String PROVIDER_DASHSCOPE = "dashscope";
-
     /**
      * 附件存储：admin 自有 {@code ai_chat_attachment} 表实现（覆盖 starter 默认 store）。
      * 返回具体类型 {@link AdminChatAttachmentStore}，既满足 {@link AttachmentParseService} 的
@@ -61,7 +60,7 @@ public class AdminAttachmentConfig {
     public VisionOcrService visionOcrService(AttachmentProperties properties) {
         AttachmentProperties.Ocr ocr = properties.getOcr();
         Supplier<Model> modelSupplier = () -> {
-            String apiKey = PROVIDER_DASHSCOPE.equalsIgnoreCase(ocr.getProvider())
+            String apiKey = ModelProviders.DASHSCOPE.equalsIgnoreCase(ocr.getProvider())
                 ? ChatModelFactory.resolveDashScopeKey(ocr.getApiKey())
                 : ocr.getApiKey();
             return ChatModelFactory.build(ocr.getProvider(), ocr.getModelName(), apiKey, ocr.getBaseUrl(),

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminProductionReadinessValidator.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminProductionReadinessValidator.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.config;
 
+import com.richard.fyoung.customerwork.core.constant.DevDefaultCredentials;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -18,8 +19,6 @@ import java.util.Map;
 public class AdminProductionReadinessValidator implements InitializingBean {
 
     private static final String DEV_AES_KEY = "0123456789abcdef0123456789abcdef";
-    private static final String DEV_AGENT_SECRET = "dev-agent-secret-change-me-0001";
-    private static final String DEV_MINIO_CREDENTIAL = "minioadmin";
     private static final List<String> FORBIDDEN_PRODUCTION_AI_CODING_FEATURES = List.of(
         "admin.sandbox.features.command-execution-enabled",
         "admin.sandbox.features.diagnosis-enabled",
@@ -52,7 +51,7 @@ public class AdminProductionReadinessValidator implements InitializingBean {
         requireSecret(violations, "admin.customer-work.api-key");
         String agentSecret = value("admin.customer-work.agent-secret");
         require(violations, "admin.customer-work.agent-secret",
-            isProductionSecret(agentSecret) && !DEV_AGENT_SECRET.equals(agentSecret)
+            isProductionSecret(agentSecret) && !DevDefaultCredentials.AGENT_ACCESS_SECRET.equals(agentSecret)
                 && agentSecret.length() >= 32);
 
         String sandboxMode = value("admin.sandbox.mode");
@@ -68,9 +67,9 @@ public class AdminProductionReadinessValidator implements InitializingBean {
 
         requireRemote(violations, "customer-work.attachment.storage.minio.endpoint");
         requireNonDefaultSecret(violations, "customer-work.attachment.storage.minio.access-key",
-            DEV_MINIO_CREDENTIAL);
+            DevDefaultCredentials.MINIO_CREDENTIAL);
         requireNonDefaultSecret(violations, "customer-work.attachment.storage.minio.secret-key",
-            DEV_MINIO_CREDENTIAL);
+            DevDefaultCredentials.MINIO_CREDENTIAL);
         validateOpenApi(violations);
         validateRuntimePublish(violations);
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImpl.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImpl.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.config;
 
 import cn.dev33.satoken.stp.StpInterface;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.common.constant.SystemRoles;
 import com.richard.fyoung.customeradmin.system.permission.entity.SysPermission;
 import com.richard.fyoung.customeradmin.system.permission.mapper.SysPermissionMapper;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
@@ -31,8 +32,6 @@ import java.util.List;
 @Component
 public class AdminStpInterfaceImpl implements StpInterface {
 
-    private static final String SUPER_ADMIN_ROLE_CODE = "super_admin";
-
     private final UserRoleResolver userRoleResolver;
     private final SysRolePermissionMapper rolePermissionMapper;
     private final SysPermissionMapper permissionMapper;
@@ -52,7 +51,7 @@ public class AdminStpInterfaceImpl implements StpInterface {
             return List.of();
         }
         boolean isSuperAdmin = TenantSession.isPlatformOperator()
-            && roles.stream().anyMatch(r -> SUPER_ADMIN_ROLE_CODE.equals(r.getRoleCode()));
+            && roles.stream().anyMatch(r -> SystemRoles.SUPER_ADMIN.equals(r.getRoleCode()));
         if (isSuperAdmin) {
             return permissionMapper.selectList(null).stream()
                 .map(SysPermission::getPermCode)

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/config/ContentGuardGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/config/ContentGuardGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.contentguard.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customeradmin.contentguard.jdbc.ContentGuardGateway;
 import com.richard.fyoung.customeradmin.contentguard.jdbc.SensitiveWordExtMapper;
 import com.richard.fyoung.customeradmin.contentguard.jdbc.SensitiveWordHitLogExtMapper;
@@ -22,10 +23,9 @@ import java.util.List;
  */
 final class ContentGuardGatewayFactory {
 
+
     /** starter jar 内的敏感词 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
-    private static final String STARTER_WORD_XML = "classpath*:customerwork/mapper/SensitiveWordMapper.xml";
     /** starter jar 内的限流规则 Mapper XML。 */
-    private static final String STARTER_RULE_XML = "classpath*:customerwork/mapper/RateLimitRuleMapper.xml";
     /** admin 自带的读侧扩展 XML（放 /contentguard 下，避开主 MP 默认的 /mapper 扫描）。 */
     private static final String EXT_XML = "classpath*:contentguard/*.xml";
 
@@ -33,7 +33,8 @@ final class ContentGuardGatewayFactory {
     static final List<Class<?>> MAPPER_CLASSES = List.of(SensitiveWordHitLogMapper.class);
 
     /** 需加载的 Mapper XML 位置。 */
-    static final List<String> MAPPER_XML_LOCATIONS = List.of(STARTER_WORD_XML, STARTER_RULE_XML, EXT_XML);
+    static final List<String> MAPPER_XML_LOCATIONS =
+        List.of(StarterMapperXml.SENSITIVE_WORD, StarterMapperXml.RATE_LIMIT_RULE, EXT_XML);
 
     private ContentGuardGatewayFactory() {
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/service/SensitiveWordHitLogService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/service/SensitiveWordHitLogService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.contentguard.service;
 
+import com.richard.fyoung.customeradmin.common.constant.StatsGranularity;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.contentguard.config.ContentGuardGatewayProvider;
 import com.richard.fyoung.customeradmin.contentguard.dto.ContentGuardCountVO;
@@ -34,8 +35,6 @@ public class SensitiveWordHitLogService {
 
     private static final String FORMAT_HOUR = "%Y-%m-%d %H:00";
     private static final String FORMAT_DAY = "%Y-%m-%d";
-    private static final String GRANULARITY_HOUR = "hour";
-    private static final String GRANULARITY_DAY = "day";
 
     private static final String SEPARATOR = ",";
 
@@ -76,7 +75,7 @@ public class SensitiveWordHitLogService {
         stats.setByDirection(toCountVOList(mapper.countByDirection(param)));
         stats.setTopWords(toCountVOList(mapper.topWords(param, TOP_WORDS)));
         stats.setTrend(toCountVOList(mapper.trend(param, hourly ? FORMAT_HOUR : FORMAT_DAY)));
-        stats.setTrendGranularity(hourly ? GRANULARITY_HOUR : GRANULARITY_DAY);
+        stats.setTrendGranularity(hourly ? StatsGranularity.HOUR : StatsGranularity.DAY);
         return stats;
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/eval/config/EvalGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/eval/config/EvalGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.eval.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customerwork.capability.eval.EvalRunStore;
 import com.richard.fyoung.customerwork.capability.eval.MybatisEvalRunStore;
 import com.richard.fyoung.customerwork.capability.eval.mapper.EvalRunMapper;
@@ -21,13 +22,12 @@ import java.util.List;
  */
 final class EvalGatewayFactory {
 
-    /** starter jar 内的评测 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
-    private static final String STARTER_EVAL_XML = "classpath*:customerwork/mapper/EvalRunMapper.xml";
 
+    /** starter jar 内的评测 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
     /** 无需额外接口注册：EvalRunMapper 由 XML namespace 自动绑定。 */
     static final List<Class<?>> MAPPER_CLASSES = List.of();
 
-    static final List<String> MAPPER_XML_LOCATIONS = List.of(STARTER_EVAL_XML);
+    static final List<String> MAPPER_XML_LOCATIONS = List.of(StarterMapperXml.EVAL_RUN);
 
     private EvalGatewayFactory() {
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/menu/service/MenuAggregationService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/menu/service/MenuAggregationService.java
@@ -3,6 +3,8 @@ package com.richard.fyoung.customeradmin.menu.service;
 import cn.dev33.satoken.stp.StpUtil;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.service.AgentService;
+import com.richard.fyoung.customeradmin.common.constant.AgentCapabilities;
+import com.richard.fyoung.customeradmin.common.constant.TreeConstants;
 import com.richard.fyoung.customeradmin.menu.dto.MenuNode;
 import com.richard.fyoung.customeradmin.system.permission.entity.SysPermission;
 import com.richard.fyoung.customeradmin.system.permission.mapper.SysPermissionMapper;
@@ -26,9 +28,7 @@ import java.util.Set;
 public class MenuAggregationService {
 
     private static final int TYPE_MENU = 1;
-    private static final long ROOT_PARENT_ID = 0L;
     private static final String WORKSPACE_PERM_CODE = "workspace";
-    private static final String CAPABILITY_DELIMITER = ",";
 
     private final SysPermissionMapper permissionMapper;
     private final AgentService agentService;
@@ -50,7 +50,7 @@ public class MenuAggregationService {
         Map<Long, String> permCodeById = new LinkedHashMap<>();
         for (SysPermission p : menus) {
             nodeById.put(p.getId(), toNode(p));
-            parentById.put(p.getId(), p.getParentId() == null ? ROOT_PARENT_ID : p.getParentId());
+            parentById.put(p.getId(), p.getParentId() == null ? TreeConstants.ROOT_PARENT_ID : p.getParentId());
             permCodeById.put(p.getId(), p.getPermCode());
         }
 
@@ -72,7 +72,7 @@ public class MenuAggregationService {
             }
             MenuNode node = nodeById.get(p.getId());
             Long parentId = parentById.get(p.getId());
-            if (parentId == null || parentId == ROOT_PARENT_ID) {
+            if (parentId == null || parentId == TreeConstants.ROOT_PARENT_ID) {
                 roots.add(node);
             } else if (keep.contains(parentId)) {
                 nodeById.get(parentId).getChildren().add(node);
@@ -116,7 +116,7 @@ public class MenuAggregationService {
         node.setPath("/workspace/" + agent.getAgentCode());
         node.setIcon(agent.getIcon());
         node.setAgentCode(agent.getAgentCode());
-        node.setCapabilities(Arrays.asList(agent.getCapabilities().split(CAPABILITY_DELIMITER)));
+        node.setCapabilities(Arrays.asList(agent.getCapabilities().split(AgentCapabilities.DELIMITER)));
         node.setDynamic(true);
         return node;
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/openapi/OpenApiAuthInterceptor.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/openapi/OpenApiAuthInterceptor.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.openapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
+import com.richard.fyoung.customerwork.core.constant.OpenApiProtocol;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,7 +28,6 @@ import java.util.Map;
 public class OpenApiAuthInterceptor implements AsyncHandlerInterceptor {
 
     /** 开放 API 令牌请求头名。 */
-    public static final String HEADER_TOKEN = "X-Open-Api-Token";
 
     private static final String ERROR_CODE = "OPEN-API-AUTH-FAIL";
     private static final Logger log = LoggerFactory.getLogger(OpenApiAuthInterceptor.class);
@@ -43,7 +43,7 @@ public class OpenApiAuthInterceptor implements AsyncHandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String actual = request.getHeader(HEADER_TOKEN);
+        String actual = request.getHeader(OpenApiProtocol.TOKEN_HEADER);
         String tenantId = authenticate(actual);
         if (tenantId == null) {
             log.error("open api auth failed, code={}, uri={}", ERROR_CODE, request.getRequestURI());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/openapi/controller/OpenAgentChatController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/openapi/controller/OpenAgentChatController.java
@@ -5,6 +5,7 @@ import com.richard.fyoung.customeradmin.openapi.dto.OpenChatRequest;
 import com.richard.fyoung.customeradmin.openapi.service.OpenChannelService;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
 import com.richard.fyoung.customeradmin.workspace.chat.service.ChatService;
+import com.richard.fyoung.customerwork.core.constant.OpenApiProtocol;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContextThreadLocalAccessor;
 import jakarta.validation.Valid;
@@ -41,11 +42,6 @@ import reactor.core.publisher.Flux;
 @RequestMapping("/api/open/agents")
 public class OpenAgentChatController {
 
-    private static final String EVENT_MESSAGE = "message";
-    private static final String EVENT_DONE = "done";
-    private static final String EVENT_ERROR = "error";
-    private static final String DONE_PAYLOAD = "[DONE]";
-
     private static final Logger log = LoggerFactory.getLogger(OpenAgentChatController.class);
 
     /** SSE data 的 JSON 字符串编码器（窄用途，不依赖容器注入）。 */
@@ -70,14 +66,14 @@ public class OpenAgentChatController {
                 return chatService.chatStream(agentCode, request.sessionId(), request.message());
             })
             .filter(chunk -> chunk.kind() == ChatNodeKind.ANSWER)
-            .map(chunk -> ServerSentEvent.<String>builder().event(EVENT_MESSAGE).data(jsonString(chunk.text())).build());
+            .map(chunk -> ServerSentEvent.<String>builder().event(OpenApiProtocol.SSE_EVENT_MESSAGE).data(jsonString(chunk.text())).build());
 
         Flux<ServerSentEvent<String>> result = body
-            .concatWithValues(ServerSentEvent.<String>builder().event(EVENT_DONE).data(DONE_PAYLOAD).build())
+            .concatWithValues(ServerSentEvent.<String>builder().event(OpenApiProtocol.SSE_EVENT_DONE).data(OpenApiProtocol.SSE_DONE_MARKER).build())
             .onErrorResume(e -> {
                 log.error("open api agent chat failed, code={}, agentCode={}", "OPEN-API-CHAT-FAIL", agentCode, e);
                 return Flux.just(ServerSentEvent.<String>builder()
-                    .event(EVENT_ERROR).data(jsonString(errorMessage(e))).build());
+                    .event(OpenApiProtocol.SSE_EVENT_ERROR).data(jsonString(errorMessage(e))).build());
             });
         return tenantId == null ? result
             : result.contextWrite(context -> context.put(TenantContextThreadLocalAccessor.KEY, tenantId));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/openapi/service/OpenChannelService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/openapi/service/OpenChannelService.java
@@ -9,6 +9,7 @@ import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.openapi.dto.OpenChannelRobotVO;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -30,7 +31,6 @@ import java.util.UUID;
 @Service
 public class OpenChannelService {
 
-    private static final int STATUS_ENABLED = 1;
     private static final String SESSION_PREFIX = "ch-";
 
     private final AiChannelRobotMapper robotMapper;
@@ -47,7 +47,7 @@ public class OpenChannelService {
     /** 返回启用状态的渠道机器人（可选按 channelType 过滤），携带解密明文 appSecret 与版本号。 */
     public List<OpenChannelRobotVO> listRobots(String channelType) {
         LambdaQueryWrapper<AiChannelRobot> wrapper = new LambdaQueryWrapper<AiChannelRobot>()
-            .eq(AiChannelRobot::getStatus, STATUS_ENABLED);
+            .eq(AiChannelRobot::getStatus, StatusFlags.ENABLED);
         if (StringUtils.hasText(channelType)) {
             wrapper.eq(AiChannelRobot::getChannelType, channelType);
         }
@@ -106,7 +106,7 @@ public class OpenChannelService {
     public void requireAgentBound(String agentCode) {
         boolean bound = robotMapper.exists(new LambdaQueryWrapper<AiChannelRobot>()
             .eq(AiChannelRobot::getAgentCode, agentCode)
-            .eq(AiChannelRobot::getStatus, STATUS_ENABLED));
+            .eq(AiChannelRobot::getStatus, StatusFlags.ENABLED));
         if (!bound) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND,
                 "no enabled channel robot bound to agent: " + agentCode);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/config/OpsGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/config/OpsGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.ops.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customeradmin.ops.jdbc.OpsGateway;
 import com.richard.fyoung.customerwork.capability.csat.MybatisCsatStore;
 import com.richard.fyoung.customerwork.capability.csat.mapper.CsatSurveyMapper;
@@ -25,18 +26,12 @@ import java.util.List;
  */
 final class OpsGatewayFactory {
 
-    private static final String XML_SEMANTIC_CACHE = "classpath*:customerwork/mapper/SemanticCacheMapper.xml";
-    private static final String XML_PROMPT_VERSION = "classpath*:customerwork/mapper/PromptVersionMapper.xml";
-    private static final String XML_CSAT = "classpath*:customerwork/mapper/CsatSurveyMapper.xml";
-    private static final String XML_KNOWLEDGE_GAP = "classpath*:customerwork/mapper/KnowledgeGapMapper.xml";
-    private static final String XML_DEAD_LETTER = "classpath*:customerwork/mapper/DeadLetterMapper.xml";
-    /** 知识库 FAQ：盲区"一键补知识"的落点。 */
-    private static final String XML_KNOWLEDGE = "classpath*:customerwork/mapper/KnowledgeMapper.xml";
-
     static final List<Class<?>> MAPPER_CLASSES = List.of();
 
+    /** 末位的知识库 FAQ 是盲区"一键补知识"的落点，其余是运营看板自身的表。 */
     static final List<String> MAPPER_XML_LOCATIONS = List.of(
-        XML_SEMANTIC_CACHE, XML_PROMPT_VERSION, XML_CSAT, XML_KNOWLEDGE_GAP, XML_DEAD_LETTER, XML_KNOWLEDGE);
+        StarterMapperXml.SEMANTIC_CACHE, StarterMapperXml.PROMPT_VERSION, StarterMapperXml.CSAT_SURVEY,
+        StarterMapperXml.KNOWLEDGE_GAP, StarterMapperXml.DEAD_LETTER, StarterMapperXml.KNOWLEDGE);
 
     private OpsGatewayFactory() {
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/CsatBoardController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/CsatBoardController.java
@@ -5,6 +5,7 @@ import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.ops.service.OpsAdminService;
 import com.richard.fyoung.customerwork.capability.csat.CsatSummary;
 import com.richard.fyoung.customerwork.capability.csat.CsatSurvey;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,8 +28,6 @@ public class CsatBoardController {
     /** 默认窗口最近 7 天：CSAT 是按周看的指标，按天看噪声太大。 */
     private static final long DEFAULT_WINDOW_MS = Duration.ofDays(7).toMillis();
 
-    private static final String DEFAULT_SCOPE = "default";
-
     private final OpsAdminService opsAdminService;
 
     public CsatBoardController(OpsAdminService opsAdminService) {
@@ -43,7 +42,7 @@ public class CsatBoardController {
      */
     @SaCheckPermission("csat:view")
     @GetMapping("/summary")
-    public Result<CsatSummary> summary(@RequestParam(defaultValue = DEFAULT_SCOPE) String scopeId,
+    public Result<CsatSummary> summary(@RequestParam(defaultValue = TenantContext.DEFAULT) String scopeId,
                                        @RequestParam(required = false) Long windowStartMs,
                                        @RequestParam(required = false) Long windowEndMs) {
         long end = windowEndMs != null ? windowEndMs : System.currentTimeMillis();
@@ -54,7 +53,7 @@ public class CsatBoardController {
     /** 窗口内的原始评价（含低分留言——那才是能拿来改进的东西）。 */
     @SaCheckPermission("csat:view")
     @GetMapping("/list")
-    public Result<List<CsatSurvey>> list(@RequestParam(defaultValue = DEFAULT_SCOPE) String scopeId,
+    public Result<List<CsatSurvey>> list(@RequestParam(defaultValue = TenantContext.DEFAULT) String scopeId,
                                          @RequestParam(required = false) Long windowStartMs,
                                          @RequestParam(required = false) Long windowEndMs) {
         long end = windowEndMs != null ? windowEndMs : System.currentTimeMillis();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/KnowledgeGapController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/KnowledgeGapController.java
@@ -6,6 +6,7 @@ import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.ops.dto.FillKnowledgeGapRequest;
 import com.richard.fyoung.customeradmin.ops.service.OpsAdminService;
 import com.richard.fyoung.customerwork.capability.knowledgegap.KnowledgeGap;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,7 +29,6 @@ import java.util.List;
 public class KnowledgeGapController {
 
     private static final int DEFAULT_LIMIT = 50;
-    private static final String DEFAULT_SCOPE = "default";
 
     private final OpsAdminService opsAdminService;
 
@@ -39,7 +39,7 @@ public class KnowledgeGapController {
     /** 盲区排行：未命中次数降序，越靠前越该优先补。 */
     @SaCheckPermission("knowledge-gap:view")
     @GetMapping("/top")
-    public Result<List<KnowledgeGap>> top(@RequestParam(defaultValue = DEFAULT_SCOPE) String scopeId,
+    public Result<List<KnowledgeGap>> top(@RequestParam(defaultValue = TenantContext.DEFAULT) String scopeId,
                                           @RequestParam(defaultValue = "" + DEFAULT_LIMIT) int limit) {
         return Result.success(opsAdminService.topKnowledgeGaps(scopeId, limit));
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/SemanticCacheController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/controller/SemanticCacheController.java
@@ -6,6 +6,7 @@ import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.ops.service.OpsAdminService;
 import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheEntry;
 import com.richard.fyoung.customerwork.capability.semanticcache.SemanticCacheScope;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +28,6 @@ import java.util.List;
 public class SemanticCacheController {
 
     private static final int DEFAULT_LIMIT = 50;
-    private static final String DEFAULT_SCOPE = "default";
 
     /** 分区选择器一次最多列多少个：分区数随活跃用户数增长，不能全量拉。 */
     private static final int DEFAULT_SCOPE_LIMIT = 100;
@@ -55,7 +55,7 @@ public class SemanticCacheController {
     @SaCheckPermission("semantic-cache:view")
     @GetMapping("/list")
     public Result<List<SemanticCacheEntry>> list(
-            @RequestParam(defaultValue = DEFAULT_SCOPE) String scopeId,
+            @RequestParam(defaultValue = TenantContext.DEFAULT) String scopeId,
             @RequestParam(defaultValue = "" + DEFAULT_LIMIT) int limit) {
         return Result.success(opsAdminService.listCache(scopeId, limit));
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlDatasourceConnectionManager.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlDatasourceConnectionManager.java
@@ -5,6 +5,7 @@ import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.sqlconfig.entity.SqlDatasource;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDatasourceMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.zaxxer.hikari.HikariDataSource;
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
@@ -26,13 +27,12 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class SqlDatasourceConnectionManager {
 
+
     private static final Logger log = LoggerFactory.getLogger(SqlDatasourceConnectionManager.class);
 
     private static final int MAX_POOL_SIZE = 5;
     private static final int MIN_IDLE = 0;
     private static final long CONNECTION_TIMEOUT_MS = 5000;
-    private static final int ENABLED = 1;
-
     private final ConcurrentHashMap<Long, HikariDataSource> pools = new ConcurrentHashMap<>();
 
     private final SqlDatasourceMapper datasourceMapper;
@@ -63,7 +63,7 @@ public class SqlDatasourceConnectionManager {
         if (datasource == null) {
             throw new BizException(ResultCode.SQL_DATASOURCE_UNAVAILABLE, "数据源不存在: " + datasourceId);
         }
-        if (datasource.getEnabled() == null || datasource.getEnabled() != ENABLED) {
+        if (datasource.getEnabled() == null || datasource.getEnabled() != StatusFlags.ENABLED) {
             throw new BizException(ResultCode.SQL_DATASOURCE_UNAVAILABLE, "数据源已禁用: " + datasource.getName());
         }
         HikariDataSource dataSource = new HikariDataSource();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlQueryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/engine/SqlQueryService.java
@@ -15,6 +15,7 @@ import com.richard.fyoung.customeradmin.sqlconfig.entity.SqlFieldTransform;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDefineMapper;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDefineParamMapper;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlFieldTransformMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.infra.sqlkit.DefaultValueResolver;
 import com.richard.fyoung.customerwork.infra.sqlkit.ParamType;
 import org.slf4j.Logger;
@@ -50,9 +51,9 @@ import java.util.stream.Collectors;
 @Service
 public class SqlQueryService {
 
+
     private static final Logger log = LoggerFactory.getLogger(SqlQueryService.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final int ENABLED = 1;
     private static final int MAX_ERROR_MESSAGE_LENGTH = 300;
     // 即席查询结果的时间列格式化：MySQL DATETIME 经 JDBC 取出是 LocalDateTime，
     // Jackson 默认按 ISO-8601 序列化会带 'T'（2026-07-20T10:00:05），统一成无 T 的常用格式
@@ -357,7 +358,7 @@ public class SqlQueryService {
     private SqlDefine requireEnabledDefine(String defineKey) {
         SqlDefine define = defineMapper.selectOne(
             new LambdaQueryWrapper<SqlDefine>().eq(SqlDefine::getDefineKey, defineKey));
-        if (define == null || define.getEnabled() == null || define.getEnabled() != ENABLED) {
+        if (define == null || define.getEnabled() == null || define.getEnabled() != StatusFlags.ENABLED) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "SQL 定义不存在或未启用: " + defineKey);
         }
         return define;
@@ -379,7 +380,7 @@ public class SqlQueryService {
     }
 
     private boolean isFlag(Integer value) {
-        return value != null && value == ENABLED;
+        return value != null && value == StatusFlags.ENABLED;
     }
 
     private boolean isFlag(Boolean value) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDatasourceService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDatasourceService.java
@@ -16,6 +16,7 @@ import com.richard.fyoung.customeradmin.sqlconfig.entity.SqlDatasource;
 import com.richard.fyoung.customeradmin.sqlconfig.entity.SqlDefine;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDatasourceMapper;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDefineMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 @Service
 public class SqlDatasourceService {
 
+
     private static final Logger log = LoggerFactory.getLogger(SqlDatasourceService.class);
 
     /** 连通性测试专用线程池：与 Tomcat 请求线程隔离（同 ModelConfigService 手法）。 */
@@ -54,8 +56,6 @@ public class SqlDatasourceService {
     });
     private static final long TEST_FUTURE_TIMEOUT_SECONDS = 8;
     private static final int TEST_LOGIN_TIMEOUT_SECONDS = 5;
-    private static final int ENABLED = 1;
-
     private final SqlDatasourceMapper datasourceMapper;
     private final SqlDefineMapper defineMapper;
     private final AesGcmCryptoUtil cryptoUtil;
@@ -86,7 +86,7 @@ public class SqlDatasourceService {
     /** 仅启用数据源（供 SQL 定义表单下拉选择）。 */
     public List<SqlDatasourceVO> listEnabled() {
         return datasourceMapper.selectList(new LambdaQueryWrapper<SqlDatasource>()
-                .eq(SqlDatasource::getEnabled, ENABLED)
+                .eq(SqlDatasource::getEnabled, StatusFlags.ENABLED)
                 .orderByDesc(SqlDatasource::getCreateTime))
             .stream().map(this::toVo).collect(Collectors.toList());
     }
@@ -176,7 +176,7 @@ public class SqlDatasourceService {
         datasource.setName(request.name());
         datasource.setJdbcUrl(request.jdbcUrl());
         datasource.setUsername(request.username());
-        datasource.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : ENABLED);
+        datasource.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : StatusFlags.ENABLED);
         datasource.setRemark(request.remark());
     }
 
@@ -187,7 +187,7 @@ public class SqlDatasourceService {
         vo.setJdbcUrl(datasource.getJdbcUrl());
         vo.setUsername(datasource.getUsername());
         vo.setPasswordMasked(AesGcmCryptoUtil.mask(cryptoUtil.decrypt(datasource.getPassword())));
-        vo.setEnabled(datasource.getEnabled() != null && datasource.getEnabled() == ENABLED);
+        vo.setEnabled(datasource.getEnabled() != null && datasource.getEnabled() == StatusFlags.ENABLED);
         vo.setRemark(datasource.getRemark());
         vo.setCreateTime(datasource.getCreateTime());
         vo.setUpdateTime(datasource.getUpdateTime());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDefineService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/sqlconfig/service/SqlDefineService.java
@@ -24,6 +24,7 @@ import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDatasourceMapper;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDefineMapper;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlDefineParamMapper;
 import com.richard.fyoung.customeradmin.sqlconfig.mapper.SqlFieldTransformMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.infra.sqlkit.ParamType;
 import com.richard.fyoung.customerwork.infra.sqlkit.TransformType;
 import org.springframework.stereotype.Service;
@@ -44,8 +45,8 @@ import java.util.stream.Collectors;
 @Service
 public class SqlDefineService {
 
+
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final int ENABLED = 1;
     private static final String COPY_SUFFIX = "-copy";
 
     private final SqlDefineMapper defineMapper;
@@ -290,8 +291,8 @@ public class SqlDefineService {
         define.setSqlDescribe(request.sqlDescribe());
         define.setQuerySql(request.querySql());
         define.setCountSql(request.countSql());
-        define.setAutoLoad(Boolean.TRUE.equals(request.autoLoad()) ? ENABLED : 0);
-        define.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : ENABLED);
+        define.setAutoLoad(Boolean.TRUE.equals(request.autoLoad()) ? StatusFlags.ENABLED : 0);
+        define.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : StatusFlags.ENABLED);
         define.setRemark(request.remark());
     }
 
@@ -300,11 +301,11 @@ public class SqlDefineService {
         param.setParamDesc(request.paramDesc());
         param.setParamType(request.paramType().toUpperCase());
         param.setDateFormat(request.dateFormat());
-        param.setRequired(Boolean.TRUE.equals(request.required()) ? ENABLED : 0);
+        param.setRequired(Boolean.TRUE.equals(request.required()) ? StatusFlags.ENABLED : 0);
         param.setDefaultValue(request.defaultValue());
         param.setDropDown(request.dropDown());
-        param.setIsPageNum(Boolean.TRUE.equals(request.isPageNum()) ? ENABLED : 0);
-        param.setIsPageSize(Boolean.TRUE.equals(request.isPageSize()) ? ENABLED : 0);
+        param.setIsPageNum(Boolean.TRUE.equals(request.isPageNum()) ? StatusFlags.ENABLED : 0);
+        param.setIsPageSize(Boolean.TRUE.equals(request.isPageSize()) ? StatusFlags.ENABLED : 0);
         param.setSort(request.sort() == null ? 0 : request.sort());
     }
 
@@ -335,8 +336,8 @@ public class SqlDefineService {
         vo.setSqlDescribe(define.getSqlDescribe());
         vo.setQuerySql(define.getQuerySql());
         vo.setCountSql(define.getCountSql());
-        vo.setAutoLoad(define.getAutoLoad() != null && define.getAutoLoad() == ENABLED);
-        vo.setEnabled(define.getEnabled() != null && define.getEnabled() == ENABLED);
+        vo.setAutoLoad(define.getAutoLoad() != null && define.getAutoLoad() == StatusFlags.ENABLED);
+        vo.setEnabled(define.getEnabled() != null && define.getEnabled() == StatusFlags.ENABLED);
         vo.setRemark(define.getRemark());
         vo.setCreateTime(define.getCreateTime());
         vo.setUpdateTime(define.getUpdateTime());
@@ -351,11 +352,11 @@ public class SqlDefineService {
         vo.setParamDesc(param.getParamDesc());
         vo.setParamType(param.getParamType());
         vo.setDateFormat(param.getDateFormat());
-        vo.setRequired(param.getRequired() != null && param.getRequired() == ENABLED);
+        vo.setRequired(param.getRequired() != null && param.getRequired() == StatusFlags.ENABLED);
         vo.setDefaultValue(param.getDefaultValue());
         vo.setDropDown(param.getDropDown());
-        vo.setIsPageNum(param.getIsPageNum() != null && param.getIsPageNum() == ENABLED);
-        vo.setIsPageSize(param.getIsPageSize() != null && param.getIsPageSize() == ENABLED);
+        vo.setIsPageNum(param.getIsPageNum() != null && param.getIsPageNum() == StatusFlags.ENABLED);
+        vo.setIsPageSize(param.getIsPageSize() != null && param.getIsPageSize() == StatusFlags.ENABLED);
         vo.setSort(param.getSort());
         return vo;
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.subjectquota.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customeradmin.subjectquota.jdbc.SubjectQuotaGateway;
 import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
 import com.richard.fyoung.customerwork.infra.gateway.CrossDbGateway;
@@ -18,15 +19,14 @@ import java.util.List;
  */
 final class SubjectQuotaGatewayFactory {
 
-    /** starter jar 内的等级 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
-    private static final String STARTER_LEVEL_XML = "classpath*:customerwork/mapper/SubjectQuotaLevelMapper.xml";
-    /** starter jar 内的命中记录 Mapper XML。 */
-    private static final String STARTER_HIT_XML = "classpath*:customerwork/mapper/SubjectQuotaHitMapper.xml";
 
+    /** starter jar 内的等级 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
+    /** starter jar 内的命中记录 Mapper XML。 */
     /** 无 XML、只用 BaseMapper CRUD 的 Mapper 接口。 */
     static final List<Class<?>> MAPPER_CLASSES = List.of(UserMapper.class);
 
-    static final List<String> MAPPER_XML_LOCATIONS = List.of(STARTER_LEVEL_XML, STARTER_HIT_XML);
+    static final List<String> MAPPER_XML_LOCATIONS =
+        List.of(StarterMapperXml.SUBJECT_QUOTA_LEVEL, StarterMapperXml.SUBJECT_QUOTA_HIT);
 
     private SubjectQuotaGatewayFactory() {
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/log/entity/SysOperationLog.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/log/entity/SysOperationLog.java
@@ -15,6 +15,11 @@ import java.time.LocalDateTime;
 @TableName("sys_operation_log")
 public class SysOperationLog {
 
+    /** 结果：操作成功。 */
+    public static final int RESULT_SUCCESS = 1;
+    /** 结果：操作失败（错误信息落 {@code errorMsg}）。 */
+    public static final int RESULT_FAILURE = 0;
+
     @TableId(type = IdType.AUTO)
     private Long id;
 
@@ -24,7 +29,7 @@ public class SysOperationLog {
     private String method;
     private String target;
     private String params;
-    /** 1成功 / 0失败。 */
+    /** {@link #RESULT_SUCCESS} / {@link #RESULT_FAILURE}。 */
     private Integer result;
     private String errorMsg;
     private String ip;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginCarouselImageService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/loginimage/service/LoginCarouselImageService.java
@@ -7,6 +7,7 @@ import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginCarouselImage
 import com.richard.fyoung.customeradmin.system.loginimage.dto.LoginImageReorderRequest;
 import com.richard.fyoung.customeradmin.system.loginimage.entity.LoginCarouselImage;
 import com.richard.fyoung.customeradmin.system.loginimage.mapper.LoginCarouselImageMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,7 +28,6 @@ import java.util.stream.Collectors;
 @Service
 public class LoginCarouselImageService {
 
-    private static final int ENABLED = 1;
     /** 轮播图数量上限：登录页轮播超过这个数没有展示价值，也防目录被无限制堆积。 */
     private static final int MAX_IMAGE_COUNT = 10;
 
@@ -47,7 +47,7 @@ public class LoginCarouselImageService {
     /** 登录页免鉴权实时拉取：仅启用图的访问 URL，按 sortOrder 升序。 */
     public List<String> listEnabledUrls() {
         return listOrdered().stream()
-            .filter(image -> image.getEnabled() != null && image.getEnabled() == ENABLED)
+            .filter(image -> image.getEnabled() != null && image.getEnabled() == StatusFlags.ENABLED)
             .map(LoginCarouselImage::getImageUrl)
             .collect(Collectors.toList());
     }
@@ -64,14 +64,14 @@ public class LoginCarouselImageService {
         image.setImageName(file.getOriginalFilename());
         image.setImageUrl(imageUrl);
         image.setSortOrder(existing.isEmpty() ? 1 : existing.get(existing.size() - 1).getSortOrder() + 1);
-        image.setEnabled(ENABLED);
+        image.setEnabled(StatusFlags.ENABLED);
         imageMapper.insert(image);
         return toVo(image);
     }
 
     public void updateEnabled(Long id, boolean enabled) {
         LoginCarouselImage image = requireImage(id);
-        image.setEnabled(enabled ? ENABLED : 0);
+        image.setEnabled(enabled ? StatusFlags.ENABLED : 0);
         imageMapper.updateById(image);
     }
 
@@ -121,7 +121,7 @@ public class LoginCarouselImageService {
         vo.setImageName(image.getImageName());
         vo.setImageUrl(image.getImageUrl());
         vo.setSortOrder(image.getSortOrder());
-        vo.setEnabled(image.getEnabled() != null && image.getEnabled() == ENABLED);
+        vo.setEnabled(image.getEnabled() != null && image.getEnabled() == StatusFlags.ENABLED);
         vo.setCreateTime(image.getCreateTime());
         vo.setUpdateTime(image.getUpdateTime());
         return vo;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/permission/service/PermissionService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/permission/service/PermissionService.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.system.permission.service;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.common.constant.TreeConstants;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.menu.service.MenuVersionHolder;
@@ -34,8 +35,6 @@ import java.util.Map;
  */
 @Service
 public class PermissionService {
-
-    private static final long ROOT_PARENT_ID = 0L;
     private static final String ACTION_CREATE = "CREATE";
     private static final String ACTION_UPDATE = "UPDATE";
     private static final String ACTION_DELETE = "DELETE";
@@ -76,7 +75,7 @@ public class PermissionService {
         List<PermissionVO> roots = new java.util.ArrayList<>();
         for (SysPermission p : all) {
             PermissionVO node = nodeById.get(p.getId());
-            if (p.getParentId() == null || p.getParentId() == ROOT_PARENT_ID) {
+            if (p.getParentId() == null || p.getParentId() == TreeConstants.ROOT_PARENT_ID) {
                 roots.add(node);
             } else {
                 PermissionVO parent = nodeById.get(p.getParentId());
@@ -162,7 +161,7 @@ public class PermissionService {
     }
 
     private void fillFromRequest(SysPermission p, PermissionSaveRequest request) {
-        p.setParentId(request.parentId() == null ? ROOT_PARENT_ID : request.parentId());
+        p.setParentId(request.parentId() == null ? TreeConstants.ROOT_PARENT_ID : request.parentId());
         p.setPermName(request.permName());
         p.setPermCode(request.permCode());
         p.setType(request.type());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/RoleService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/RoleService.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.system.role.service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.richard.fyoung.customeradmin.common.constant.SystemRoles;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
@@ -40,8 +41,6 @@ import java.util.stream.Collectors;
 public class RoleService {
 
     private static final Logger log = LoggerFactory.getLogger(RoleService.class);
-
-    private static final String SUPER_ADMIN_ROLE_CODE = "super_admin";
 
     private final SysRoleMapper roleMapper;
     private final SysRolePermissionMapper rolePermissionMapper;
@@ -147,7 +146,7 @@ public class RoleService {
     }
 
     private void guardSuperAdmin(SysRole role, String action) {
-        if (SUPER_ADMIN_ROLE_CODE.equals(role.getRoleCode())) {
+        if (SystemRoles.SUPER_ADMIN.equals(role.getRoleCode())) {
             throw new BizException(ResultCode.FORBIDDEN, "超级管理员角色不可" + action);
         }
     }
@@ -179,7 +178,7 @@ public class RoleService {
                 Collectors.mapping(SysRolePermission::getPermissionId, Collectors.toList())));
 
         for (RoleVO vo : roles) {
-            if (SUPER_ADMIN_ROLE_CODE.equals(vo.getRoleCode())) {
+            if (SystemRoles.SUPER_ADMIN.equals(vo.getRoleCode())) {
                 vo.setPermissionIds(superAdminAllIds);
             } else {
                 vo.setPermissionIds(permissionIdsByRole.getOrDefault(vo.getId(), List.of()));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ticket/config/CustomerWorkClientConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ticket/config/CustomerWorkClientConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.ticket.config;
 
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.safety.security.AgentAccessCredential;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.springframework.context.annotation.Bean;
@@ -21,7 +22,6 @@ import org.springframework.web.client.RestClient;
 public class CustomerWorkClientConfig {
 
     /** 坐席令牌请求头名（与 8080 契约一致）。 */
-    private static final String AGENT_TOKEN_HEADER = "X-Agent-Token";
 
     /** 单次请求令牌有效期（毫秒）：只需覆盖一次 HTTP 往返，短有效期收紧被截获后的可用窗口。 */
     private static final long REQUEST_TOKEN_TTL_MS = 120_000L;
@@ -40,7 +40,7 @@ public class CustomerWorkClientConfig {
             String token = tenantId == null
                 ? AgentAccessCredential.sign(agentId, expiresAtMs, properties.getAgentSecret())
                 : AgentAccessCredential.sign(agentId, tenantId, expiresAtMs, properties.getAgentSecret());
-            request.getHeaders().set(AGENT_TOKEN_HEADER, token);
+            request.getHeaders().set(HttpAuthConstants.AGENT_TOKEN_HEADER, token);
             return execution.execute(request, body);
         };
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ticket/config/CustomerWorkClientProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ticket/config/CustomerWorkClientProperties.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.ticket.config;
 
+import com.richard.fyoung.customerwork.core.constant.DevDefaultCredentials;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -27,7 +28,7 @@ public class CustomerWorkClientProperties {
     private String wsUrl = "ws://localhost:8080/ws/agent";
 
     /** 坐席令牌签名密钥：必须与 8080 侧共享同一值。 */
-    private String agentSecret = "dev-agent-secret-change-me-0001";
+    private String agentSecret = DevDefaultCredentials.AGENT_ACCESS_SECRET;
 
     /**
      * 运营侧 API Key：调 8080 的运营类端点（如评测触发）时带在 {@code X-API-Key} 头上。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workbench/controller/WorkbenchAgentController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workbench/controller/WorkbenchAgentController.java
@@ -27,9 +27,6 @@ import java.time.LocalDateTime;
 @RestController
 @RequestMapping("/api/workbench/agent")
 public class WorkbenchAgentController {
-
-    private static final int RESULT_SUCCESS = 1;
-
     private final WorkbenchTokenService tokenService;
     private final WorkbenchSiteService siteService;
     private final OperationLogMapper operationLogMapper;
@@ -71,7 +68,7 @@ public class WorkbenchAgentController {
         log.setOperation("脚本读取站点密码 host=" + host);
         log.setMethod("GET /api/workbench/agent/site");
         log.setTarget("workbench_site");
-        log.setResult(RESULT_SUCCESS);
+        log.setResult(SysOperationLog.RESULT_SUCCESS);
         log.setIp(request.getRemoteAddr());
         log.setCreateTime(LocalDateTime.now());
         operationLogMapper.insert(log);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workbench/service/WorkbenchSiteService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workbench/service/WorkbenchSiteService.java
@@ -14,6 +14,7 @@ import com.richard.fyoung.customeradmin.workbench.dto.WorkbenchSiteSaveRequest;
 import com.richard.fyoung.customeradmin.workbench.dto.WorkbenchSiteVO;
 import com.richard.fyoung.customeradmin.workbench.entity.WorkbenchSite;
 import com.richard.fyoung.customeradmin.workbench.mapper.WorkbenchSiteMapper;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -33,8 +34,6 @@ import java.util.Set;
  */
 @Service
 public class WorkbenchSiteService {
-
-    private static final int ENABLED = 1;
 
     private final WorkbenchSiteMapper siteMapper;
     private final AesGcmCryptoUtil cryptoUtil;
@@ -105,7 +104,7 @@ public class WorkbenchSiteService {
             throw new BizException(ResultCode.PARAM_MISSING, "host 不能为空");
         }
         LambdaQueryWrapper<WorkbenchSite> wrapper = new LambdaQueryWrapper<WorkbenchSite>()
-            .eq(WorkbenchSite::getEnabled, ENABLED)
+            .eq(WorkbenchSite::getEnabled, StatusFlags.ENABLED)
             .like(WorkbenchSite::getUrl, host);
         List<WorkbenchSite> candidates = siteMapper.selectList(wrapper);
         WorkbenchSite matched = candidates.stream()
@@ -118,7 +117,7 @@ public class WorkbenchSiteService {
     /** 所有启用站点的 host 去重列表，供脚本生成 @match。 */
     public List<String> listEnabledHosts() {
         LambdaQueryWrapper<WorkbenchSite> wrapper = new LambdaQueryWrapper<WorkbenchSite>()
-            .eq(WorkbenchSite::getEnabled, ENABLED);
+            .eq(WorkbenchSite::getEnabled, StatusFlags.ENABLED);
         List<WorkbenchSite> sites = siteMapper.selectList(wrapper);
         if (CollectionUtils.isEmpty(sites)) {
             return new ArrayList<>();
@@ -176,7 +175,7 @@ public class WorkbenchSiteService {
         site.setUrl(request.url());
         site.setAccount(request.account());
         site.setRemark(request.remark());
-        site.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : ENABLED);
+        site.setEnabled(Boolean.FALSE.equals(request.enabled()) ? 0 : StatusFlags.ENABLED);
 
         // 自动登录配置：选择器留空即存 null（脚本走启发式）；模式/时序留空落默认值
         site.setUsernameSelector(request.usernameSelector());
@@ -203,7 +202,7 @@ public class WorkbenchSiteService {
         vo.setHasPassword(hasPassword);
         vo.setPasswordMasked(hasPassword ? AesGcmCryptoUtil.mask(cryptoUtil.decrypt(site.getPassword())) : "");
         vo.setRemark(site.getRemark());
-        vo.setEnabled(site.getEnabled() != null && site.getEnabled() == ENABLED);
+        vo.setEnabled(site.getEnabled() != null && site.getEnabled() == StatusFlags.ENABLED);
         vo.setUsernameSelector(site.getUsernameSelector());
         vo.setPasswordSelector(site.getPasswordSelector());
         vo.setSubmitSelector(site.getSubmitSelector());

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsGatewayFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AgentCallStatsGatewayFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.callstats.config;
 
+import com.richard.fyoung.customeradmin.common.constant.StarterMapperXml;
 import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsExtMapper;
 import com.richard.fyoung.customeradmin.workspace.callstats.jdbc.AgentCallStatsGateway;
 import com.richard.fyoung.customerwork.data.calllog.AgentCallLogStore;
@@ -23,10 +24,9 @@ import java.util.List;
  */
 final class AgentCallStatsGatewayFactory {
 
+
     /** starter jar 内的调用日志主表 Mapper XML（classpath*: 才能命中 jar 内资源）。 */
-    private static final String STARTER_LOG_XML = "classpath*:customerwork/mapper/AgentCallLogMapper.xml";
     /** starter jar 内的调用分段 Mapper XML。 */
-    private static final String STARTER_SEGMENT_XML = "classpath*:customerwork/mapper/AgentCallSegmentMapper.xml";
     /** admin 自带的读侧扩展 Mapper XML（放 /callstats 下，避开主 MP 默认的 /mapper 扫描）。 */
     private static final String EXT_XML = "classpath*:callstats/AgentCallStatsExtMapper.xml";
 
@@ -34,7 +34,8 @@ final class AgentCallStatsGatewayFactory {
     static final List<Class<?>> MAPPER_CLASSES = List.of();
 
     /** 需加载的 Mapper XML 位置。 */
-    static final List<String> MAPPER_XML_LOCATIONS = List.of(STARTER_LOG_XML, STARTER_SEGMENT_XML, EXT_XML);
+    static final List<String> MAPPER_XML_LOCATIONS =
+        List.of(StarterMapperXml.AGENT_CALL_LOG, StarterMapperXml.AGENT_CALL_SEGMENT, EXT_XML);
 
     /** ADMIN 主数据源上的门面标识（借用宿主数据源，不自建池）。 */
     private static final String ADMIN_GATEWAY_NAME = "agent-call-stats-admin";

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.callstats.service;
 
+import com.richard.fyoung.customeradmin.common.constant.StatsGranularity;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.workspace.callstats.config.AppAgentCallStatsGatewayProvider;
@@ -50,7 +51,6 @@ public class AgentCallStatsService {
     private static final int PREVIEW_MAX_LENGTH = 200;
     private static final int DEFAULT_PAGE_NUM = 1;
     private static final int DEFAULT_PAGE_SIZE = 10;
-    private static final String GRANULARITY_HOUR = "hour";
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final ZoneId ZONE = ZoneId.systemDefault();
 
@@ -98,7 +98,7 @@ public class AgentCallStatsService {
     /** 趋势聚合（按天/小时，含各段平均耗时）。 */
     public List<AgentCallTrendVO> trend(AgentCallStatsQuery query) {
         AgentCallStatsGateway gateway = gatewayOf(query.getSource());
-        TrendGranularity granularity = GRANULARITY_HOUR.equalsIgnoreCase(query.getGranularity())
+        TrendGranularity granularity = StatsGranularity.HOUR.equalsIgnoreCase(query.getGranularity())
             ? TrendGranularity.HOUR : TrendGranularity.DAY;
         List<AgentCallStatsTrendRow> rows = gateway.extMapper().trend(toParam(query, false), granularity.mysqlFormat());
         List<AgentCallTrendVO> result = new ArrayList<>();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatAttachmentService.java
@@ -10,6 +10,7 @@ import com.richard.fyoung.customerwork.data.attachment.AttachmentParseService;
 import com.richard.fyoung.customerwork.data.attachment.ChatAttachment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -37,7 +38,6 @@ public class ChatAttachmentService {
     private static final Logger log = LoggerFactory.getLogger(ChatAttachmentService.class);
 
     /** MIME 兜底：库中 mime 为空时按二进制流下发，交由前端/浏览器不做类型嗅探（配合 nosniff）。 */
-    private static final String DEFAULT_MIME = "application/octet-stream";
 
     private final AttachmentParseService attachmentParseService;
     private final AdminChatAttachmentStore attachmentStore;
@@ -128,7 +128,7 @@ public class ChatAttachmentService {
         ChatAttachment attachment = requireOwned(agentCode, attachmentId, ownerUserId);
         try {
             byte[] bytes = attachmentFileStorage.read(attachment.getStoragePath());
-            String mime = StringUtils.hasText(attachment.getMimeType()) ? attachment.getMimeType() : DEFAULT_MIME;
+            String mime = StringUtils.hasText(attachment.getMimeType()) ? attachment.getMimeType() : MediaType.APPLICATION_OCTET_STREAM_VALUE;
             return new LoadedFile(bytes, mime, attachment.getFileName());
         } catch (IOException e) {
             log.error("chat attachment read file failed, code={}, id={}", "ADMIN-ATTACHMENT-READ-FILE-FAIL", attachmentId, e);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/embedding/DashScopeEmbeddingClient.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/embedding/DashScopeEmbeddingClient.java
@@ -7,6 +7,8 @@ import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminKnowledgeProperties;
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.data.knowledge.embedding.EmbeddingClient;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -30,8 +32,6 @@ import java.util.List;
 @Component
 public class DashScopeEmbeddingClient implements EmbeddingClient {
 
-    private static final String PROVIDER_DASHSCOPE = "dashscope";
-    private static final int STATUS_ENABLED = 1;
     private static final int IS_DEFAULT = 1;
 
     private final AiModelConfigMapper modelConfigMapper;
@@ -86,8 +86,8 @@ public class DashScopeEmbeddingClient implements EmbeddingClient {
      */
     String resolveApiKey() {
         List<AiModelConfig> candidates = modelConfigMapper.selectList(new LambdaQueryWrapper<AiModelConfig>()
-            .eq(AiModelConfig::getProvider, PROVIDER_DASHSCOPE)
-            .eq(AiModelConfig::getStatus, STATUS_ENABLED)
+            .eq(AiModelConfig::getProvider, ModelProviders.DASHSCOPE)
+            .eq(AiModelConfig::getStatus, StatusFlags.ENABLED)
             .orderByDesc(AiModelConfig::getIsDefault)
             .orderByAsc(AiModelConfig::getId));
         if (CollectionUtils.isEmpty(candidates)) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySyncService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/AgentMemorySyncService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.memory;
 
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -29,8 +30,6 @@ public class AgentMemorySyncService {
 
     private static final Logger log = LoggerFactory.getLogger(AgentMemorySyncService.class);
 
-    private static final String MEMORY_FILE_NAME = "MEMORY.md";
-
     private final AgentMemoryStore memoryStore;
 
     public AgentMemorySyncService(AgentMemoryStore memoryStore) {
@@ -40,7 +39,7 @@ public class AgentMemorySyncService {
     /** 水合：权威存储 → workspace/MEMORY.md（构建实例时调用）；权威侧为空且 workspace 有存量文件时反向入库。 */
     public void hydrate(String agentCode, Path workspace) {
         try {
-            Path memoryFile = workspace.resolve(MEMORY_FILE_NAME);
+            Path memoryFile = workspace.resolve(AgentFileNames.MEMORY_MD);
             Optional<AgentMemorySnapshot> snapshot = memoryStore.load(agentCode);
             if (snapshot.isPresent()) {
                 Files.writeString(memoryFile, snapshot.get().content(), StandardCharsets.UTF_8);
@@ -60,7 +59,7 @@ public class AgentMemorySyncService {
     /** 回写：workspace/MEMORY.md → 权威存储（对话轮次结束后调用）；文件不存在或内容未变化时跳过。 */
     public void persistIfChanged(String agentCode, Path workspace) {
         try {
-            Path memoryFile = workspace.resolve(MEMORY_FILE_NAME);
+            Path memoryFile = workspace.resolve(AgentFileNames.MEMORY_MD);
             if (!Files.exists(memoryFile)) {
                 return;
             }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/DiskAgentMemoryStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/memory/DiskAgentMemoryStore.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.memory;
 
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -16,8 +17,6 @@ import java.util.Optional;
  * @author owlzhangfq@gmail.com
  */
 public class DiskAgentMemoryStore implements AgentMemoryStore {
-
-    private static final String MEMORY_FILE_NAME = "MEMORY.md";
 
     private final Path root;
 
@@ -63,6 +62,6 @@ public class DiskAgentMemoryStore implements AgentMemoryStore {
     }
 
     private Path memoryFile(String agentCode) {
-        return root.resolve(agentCode).resolve(MEMORY_FILE_NAME);
+        return root.resolve(agentCode).resolve(AgentFileNames.MEMORY_MD);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -12,6 +12,9 @@ import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSkillMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentSubAgentMapper;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.config.AdminKnowledgeGapRecorder;
+import com.richard.fyoung.customeradmin.common.constant.AgentCapabilities;
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.core.middleware.MaskingMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.PromptInjectionGuardMiddleware;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.runtime.KnowledgeRetrievalMiddleware;
@@ -112,17 +115,8 @@ import java.util.stream.Stream;
 @Component
 public class AdminAgentInstanceFactory {
 
-    private static final Logger log = LoggerFactory.getLogger(AdminAgentInstanceFactory.class);
 
-    private static final String CAPABILITY_VIBECODING = "vibecoding";
-    private static final String CAPABILITY_PLAN = "plan";
-    private static final String CAPABILITY_SUBAGENT = "subagent";
-    private static final String CAPABILITY_TASKLIST = "tasklist";
-    private static final String CAPABILITY_SKILL_LEARNING = "skill-learning";
-    private static final String CAPABILITY_DYNAMIC_SUBAGENT = "dynamic-subagent";
-    private static final String CAPABILITY_MEMORY = "memory";
-    private static final String CAPABILITY_DELIMITER = ",";
-    private static final int STATUS_ENABLED = 1;
+    private static final Logger log = LoggerFactory.getLogger(AdminAgentInstanceFactory.class);
     private static final int DEFAULT_MAX_ITERS = 10;
     /** compress_trigger_msgs 已填但 compress_keep_msgs 未填时的保留消息数默认值。 */
     private static final int DEFAULT_COMPRESS_KEEP_MSGS = 10;
@@ -316,12 +310,12 @@ public class AdminAgentInstanceFactory {
      * 抽成纯函数便于单测（不依赖任何注入的协作对象）。
      */
     static boolean requiresHarness(List<String> capabilities, Integer compressTriggerMsgs) {
-        return capabilities.contains(CAPABILITY_VIBECODING)
-            || capabilities.contains(CAPABILITY_PLAN)
-            || capabilities.contains(CAPABILITY_SUBAGENT)
-            || capabilities.contains(CAPABILITY_SKILL_LEARNING)
-            || capabilities.contains(CAPABILITY_DYNAMIC_SUBAGENT)
-            || capabilities.contains(CAPABILITY_MEMORY)
+        return capabilities.contains(AgentCapabilities.VIBECODING)
+            || capabilities.contains(AgentCapabilities.PLAN)
+            || capabilities.contains(AgentCapabilities.SUBAGENT)
+            || capabilities.contains(AgentCapabilities.SKILL_LEARNING)
+            || capabilities.contains(AgentCapabilities.DYNAMIC_SUBAGENT)
+            || capabilities.contains(AgentCapabilities.MEMORY)
             || compressTriggerMsgs != null;
     }
 
@@ -383,16 +377,16 @@ public class AdminAgentInstanceFactory {
         // 召回内容由 KnowledgeRetrievalMiddleware 自己包，工具结果由框架产出、只能在这里拦。
         // 两者的系统提示词规则走同一个幂等追加方法，不会写重复。
         builder.middleware(indirectInjectionGuardMiddleware);
-        if (capabilities.contains(CAPABILITY_VIBECODING)) {
+        if (capabilities.contains(AgentCapabilities.VIBECODING)) {
             // 只有 vibecoding 能力的 agent 才会跑到文件系统/shell 工具，护栏只对这类 agent 挂载作最后防线——
             // 即便高风险被人工批准/放行，catastrophic 命令仍会被护栏改写，护栏不被绕过（需求 §4.4.2.5「两者叠加」）。
             builder.middleware(sandboxGuardMiddleware);
         }
-        if (capabilities.contains(CAPABILITY_TASKLIST)) {
+        if (capabilities.contains(AgentCapabilities.TASKLIST)) {
             // 任务列表：内层 ReActAgent 自带能力，不依赖 Harness
             builder.enableTaskList(true);
         }
-        if (capabilities.contains(CAPABILITY_SKILL_LEARNING)) {
+        if (capabilities.contains(AgentCapabilities.SKILL_LEARNING)) {
             // 互动学习新技能（内层半边）：MetaTool 允许 Agent 自主编排技能；Harness 半边见 buildHarnessAgent
             builder.enableMetaTool(true);
         }
@@ -437,7 +431,7 @@ public class AdminAgentInstanceFactory {
     private HarnessAgent buildHarnessAgent(AiAgent agent, List<String> capabilities, ReActAgent inner,
                                            Model model, Set<String> visited) {
         String agentCode = agent.getAgentCode();
-        boolean vibecoding = capabilities.contains(CAPABILITY_VIBECODING);
+        boolean vibecoding = capabilities.contains(AgentCapabilities.VIBECODING);
 
         // Docker 模式下 HarnessAgent 内部的 SessionSandboxStateStore 会给沙箱状态槽位拼出带 "/"
         // 的 sessionId（IsolationScope 四种取值全部如此，框架侧硬编码），而 MysqlAgentStateStore
@@ -465,18 +459,18 @@ public class AdminAgentInstanceFactory {
                 harnessBuilder.filesystem(buildLocalFilesystemSpec());
             }
         }
-        if (capabilities.contains(CAPABILITY_PLAN)) {
+        if (capabilities.contains(AgentCapabilities.PLAN)) {
             // 计划模式：只读规划期禁 shell，计划文件持久化到 workspace/plans
             harnessBuilder.enablePlanMode()
                 .allowShellInPlanMode(false)
                 .planFileDirectory(workspace.resolve(PLAN_DIR_NAME).toString());
         }
-        if (capabilities.contains(CAPABILITY_SKILL_LEARNING)) {
+        if (capabilities.contains(AgentCapabilities.SKILL_LEARNING)) {
             // 互动学习新技能（Harness 半边）：技能管理工具 + SkillCurator 自动沉淀成功模式
             harnessBuilder.enableSkillManageTool(true)
                 .enableSkillCurator(SkillCuratorConfig.defaults());
         }
-        if (capabilities.contains(CAPABILITY_MEMORY)) {
+        if (capabilities.contains(AgentCapabilities.MEMORY)) {
             // 跨会话长期记忆（分层记忆）：对话事实自动 flush 到 workspace/MEMORY.md 并定期 consolidation，
             // 按 agentCode 隔离（一个智能体一份记忆，全部会话共享）。workspace 文件只是框架的工作副本，
             // 权威存储在 AgentMemoryStore（默认落库）：构建时水合到 workspace，对话轮次结束后由
@@ -494,10 +488,10 @@ public class AdminAgentInstanceFactory {
                 .model(model)
                 .build());
         }
-        if (capabilities.contains(CAPABILITY_SUBAGENT)) {
+        if (capabilities.contains(AgentCapabilities.SUBAGENT)) {
             registerSubagents(harnessBuilder, agent, visited);
         }
-        if (capabilities.contains(CAPABILITY_DYNAMIC_SUBAGENT)) {
+        if (capabilities.contains(AgentCapabilities.DYNAMIC_SUBAGENT)) {
             // 动态子Agent：框架在 HarnessAgent 上默认开启（DynamicSubagentsMiddleware），勾选时保留默认，
             // 主 Agent 可在运行时按任务临时声明子 Agent（SubagentSpecGenerator 现场生成规格，无需预注册）
             log.info("[workspace] dynamic subagents enabled: agentCode={}", agentCode);
@@ -527,7 +521,7 @@ public class AdminAgentInstanceFactory {
         }
         for (Long subAgentId : subAgentIds) {
             AiAgent sub = agentMapper.selectById(subAgentId);
-            if (sub == null || sub.getStatus() == null || sub.getStatus() != STATUS_ENABLED) {
+            if (sub == null || sub.getStatus() == null || sub.getStatus() != StatusFlags.ENABLED) {
                 // 子智能体已删除/已停用：跳过注册，不阻断父智能体装配
                 log.error("[workspace] subagent unavailable (skip registration), code={}, parentAgentCode={}, subAgentId={}",
                     "SUBAGENT_UNAVAILABLE", agent.getAgentCode(), subAgentId);
@@ -751,7 +745,7 @@ public class AdminAgentInstanceFactory {
         if (agent == null) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "智能体不存在: " + agentCode);
         }
-        if (agent.getStatus() == null || agent.getStatus() != STATUS_ENABLED) {
+        if (agent.getStatus() == null || agent.getStatus() != StatusFlags.ENABLED) {
             throw new BizException(ResultCode.AGENT_DISABLED, "智能体未启用: " + agentCode);
         }
         return agent;
@@ -849,7 +843,7 @@ public class AdminAgentInstanceFactory {
             return;
         }
         for (AiSystemTool tool : systemToolMapper.selectBatchIds(toolIds)) {
-            if (tool.getEnabled() == null || tool.getEnabled() != STATUS_ENABLED) {
+            if (tool.getEnabled() == null || tool.getEnabled() != StatusFlags.ENABLED) {
                 continue;
             }
             try {
@@ -882,7 +876,7 @@ public class AdminAgentInstanceFactory {
                 Path skillSubDir = skillDir.resolve(skill.getSkillCode());
                 deleteRecursively(skillSubDir);
                 Files.createDirectories(skillSubDir);
-                Files.writeString(skillSubDir.resolve("SKILL.md"), skill.getContent());
+                Files.writeString(skillSubDir.resolve(AgentFileNames.SKILL_MD), skill.getContent());
                 // 附属文件路径合法性在 SkillService 保存时已统一校验，此处直接落盘
                 for (AiSkillFile skillFile : skillFileMapper.selectList(
                         new LambdaQueryWrapper<AiSkillFile>().eq(AiSkillFile::getSkillId, skill.getId()))) {
@@ -924,6 +918,6 @@ public class AdminAgentInstanceFactory {
 
     private List<String> parseCapabilities(String capabilities) {
         return StringUtils.hasText(capabilities)
-            ? Arrays.asList(capabilities.split(CAPABILITY_DELIMITER)) : List.of();
+            ? Arrays.asList(capabilities.split(AgentCapabilities.DELIMITER)) : List.of();
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.common.constant.AgentCapabilities;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminCollaborationProperties;
@@ -68,8 +69,6 @@ import java.util.stream.Collectors;
 public class CollaborativeCodingService {
 
     private static final Logger log = LoggerFactory.getLogger(CollaborativeCodingService.class);
-    private static final String CAPABILITY_VIBECODING = "vibecoding";
-    private static final String CAPABILITY_DELIMITER = ",";
     private static final String ERR_ROLE_FAILED = "COLLAB-ROLE-FAILED";
     /** 送入审查角色的 diff 上限，超过截断，避免撑爆上下文。 */
     private static final int MAX_DIFF_CHARS_FOR_REVIEW = 60_000;
@@ -348,8 +347,8 @@ public class CollaborativeCodingService {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "智能体不存在: " + agentCode);
         }
         List<String> capabilities = StringUtils.hasText(agent.getCapabilities())
-            ? Arrays.asList(agent.getCapabilities().split(CAPABILITY_DELIMITER)) : List.of();
-        if (!capabilities.contains(CAPABILITY_VIBECODING)) {
+            ? Arrays.asList(agent.getCapabilities().split(AgentCapabilities.DELIMITER)) : List.of();
+        if (!capabilities.contains(AgentCapabilities.VIBECODING)) {
             throw new BizException(ResultCode.AGENT_CAPABILITY_NOT_SUPPORTED, "智能体未开启 vibecoding 能力: " + agentCode);
         }
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.common.constant.AgentCapabilities;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.message.service.SiteMessageService;
@@ -64,8 +65,6 @@ import java.util.stream.Collectors;
 public class GitAssistantService {
 
     private static final Logger log = LoggerFactory.getLogger(GitAssistantService.class);
-    private static final String CAPABILITY_VIBECODING = "vibecoding";
-    private static final String CAPABILITY_DELIMITER = ",";
     /** 送入模型的 diff 文本上限，超过截断并提示，避免撑爆上下文。 */
     private static final int MAX_DIFF_CHARS_FOR_MODEL = 20_000;
     /** Review 场景的 diff 上限（需求 §4.2.3：超大 diff 截断并在 summary 中声明）。 */
@@ -455,8 +454,8 @@ public class GitAssistantService {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "智能体不存在: " + agentCode);
         }
         List<String> capabilities = StringUtils.hasText(agent.getCapabilities())
-            ? Arrays.asList(agent.getCapabilities().split(CAPABILITY_DELIMITER)) : List.of();
-        if (!capabilities.contains(CAPABILITY_VIBECODING)) {
+            ? Arrays.asList(agent.getCapabilities().split(AgentCapabilities.DELIMITER)) : List.of();
+        if (!capabilities.contains(AgentCapabilities.VIBECODING)) {
             throw new BizException(ResultCode.AGENT_CAPABILITY_NOT_SUPPORTED, "智能体未开启 vibecoding 能力: " + agentCode);
         }
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitWorkspaceService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitWorkspaceService.java
@@ -32,7 +32,8 @@ public class GitWorkspaceService {
     private static final long GIT_TIMEOUT_SECONDS = 15;
     private static final String BASELINE_COMMIT_MESSAGE = "vibecoding-session-baseline";
     /** 会话现场建立的 git 仓库目录名，回滚前据此校验 workspace 拥有自己的仓库（防越界删父级仓库文件）。 */
-    private static final String GIT_DIR_NAME = ".git";
+    /** git 仓库目录名（同包的 {@code VibeCodingService} 遍历工作区时要跳过它）。 */
+    static final String GIT_DIR_NAME = ".git";
     /** baseline 是会话内唯一提交，故 HEAD 恒等于 baseline，回滚以 HEAD 为恢复基准。 */
     private static final String HEAD_REF = "HEAD";
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
+import com.richard.fyoung.customeradmin.common.constant.AgentCapabilities;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminSandboxProperties;
@@ -70,12 +71,9 @@ import java.util.concurrent.atomic.AtomicReference;
 public class VibeCodingService {
 
     private static final Logger log = LoggerFactory.getLogger(VibeCodingService.class);
-    private static final String CAPABILITY_VIBECODING = "vibecoding";
-    private static final String CAPABILITY_DELIMITER = ",";
     /** 文件内容读取的最大字节数（4MB），超过此限制返回截断提示，防止超大文件撑爆内存。 */
     private static final long MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024;
     /** {@link GitWorkspaceService} 在会话目录里现场建的 git 仓库目录名，产物文件树/快照均需跳过。 */
-    private static final String GIT_DIR_NAME = ".git";
     /**
      * 失败自动修复的轮数上限（需求 P0-3 §4.3.2）：Agent 侧由 prompt 约束"最多重试 3 轮"，
      * 服务侧据此统计失败次数——第 3 次仍失败的 test_report 标注 {@code exhausted=true}，
@@ -418,8 +416,8 @@ public class VibeCodingService {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "智能体不存在: " + agentCode);
         }
         List<String> capabilities = StringUtils.hasText(agent.getCapabilities())
-            ? Arrays.asList(agent.getCapabilities().split(CAPABILITY_DELIMITER)) : List.of();
-        if (!capabilities.contains(CAPABILITY_VIBECODING)) {
+            ? Arrays.asList(agent.getCapabilities().split(AgentCapabilities.DELIMITER)) : List.of();
+        if (!capabilities.contains(AgentCapabilities.VIBECODING)) {
             throw new BizException(ResultCode.AGENT_CAPABILITY_NOT_SUPPORTED, "智能体未开启 vibecoding 能力: " + agentCode);
         }
     }
@@ -537,7 +535,7 @@ public class VibeCodingService {
             Files.walkFileTree(workspace, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-                    return GIT_DIR_NAME.equals(dir.getFileName().toString())
+                    return GitWorkspaceService.GIT_DIR_NAME.equals(dir.getFileName().toString())
                         ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
                 }
 
@@ -563,7 +561,7 @@ public class VibeCodingService {
     private List<WorkspaceFileNode> buildFileTree(Path root, Path current) {
         List<WorkspaceFileNode> nodes = new ArrayList<>();
         try (var stream = Files.list(current)) {
-            stream.filter(path -> !GIT_DIR_NAME.equals(path.getFileName().toString()))
+            stream.filter(path -> !GitWorkspaceService.GIT_DIR_NAME.equals(path.getFileName().toString()))
                 .sorted(Comparator
                     .comparing((Path p) -> Files.isDirectory(p) ? 0 : 1)  // 目录优先
                     .thenComparing(p -> p.getFileName().toString()))

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentServiceTest.java
@@ -30,6 +30,7 @@ import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiAgentSystem
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.entity.AiSystemTool;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiAgentSystemToolMapper;
 import com.richard.fyoung.customeradmin.aiconfig.systemtool.mapper.AiSystemToolMapper;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.menu.service.MenuVersionHolder;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
@@ -112,7 +113,7 @@ class AgentServiceTest {
         when(modelConfigMapper.selectById(1L)).thenReturn(new AiModelConfig());
         // 默认主模型连通性门禁通过（个别用例覆写为失败）
         when(modelConfigService.testConnectivity(any())).thenReturn(
-            CompletableFuture.completedFuture(new ModelTestResult(ModelTestResult.STATUS_SUCCESS, LocalDateTime.now(), null)));
+            CompletableFuture.completedFuture(new ModelTestResult(ConnectivityTestStatus.SUCCESS, LocalDateTime.now(), null)));
     }
 
     private AgentSaveRequest validRequest() {
@@ -320,7 +321,7 @@ class AgentServiceTest {
     @Test
     void create_shouldRejectWhenPrimaryModelConnectivityFails() {
         when(modelConfigService.testConnectivity(any())).thenReturn(CompletableFuture.completedFuture(
-            new ModelTestResult(ModelTestResult.STATUS_FAILED, LocalDateTime.now(), "HTTP 401")));
+            new ModelTestResult(ConnectivityTestStatus.FAILED, LocalDateTime.now(), "HTTP 401")));
         AgentSaveRequest request = new AgentSaveRequest("客服助手", "customer-helper", 1L, null, null, null, null,
             null, null, null, 1, null, null, null, null, null, null, null);
 
@@ -523,7 +524,7 @@ class AgentServiceTest {
         kb.setId(id);
         kb.setKbName(name);
         kb.setStatus(1);
-        kb.setTestStatus(KnowledgeBaseTestResult.STATUS_SUCCESS);
+        kb.setTestStatus(ConnectivityTestStatus.SUCCESS);
         return kb;
     }
 
@@ -562,7 +563,7 @@ class AgentServiceTest {
     @Test
     void create_shouldRejectUntestedKnowledgeBase() {
         AiKnowledgeBase untested = usableKnowledgeBase(40L, "未测试知识库");
-        untested.setTestStatus(KnowledgeBaseTestResult.STATUS_FAILED);
+        untested.setTestStatus(ConnectivityTestStatus.FAILED);
         when(knowledgeBaseMapper.selectBatchIds(List.of(40L))).thenReturn(List.of(untested));
 
         assertThrows(BizException.class, () -> service.create(requestWithKnowledgeBases(List.of(40L))));

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisherTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/CustomerWorkConfigPublisherTest.java
@@ -16,6 +16,7 @@ import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelTestResult;
 import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
 import com.richard.fyoung.customeradmin.aiconfig.model.mapper.AiModelConfigMapper;
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.AdminModelFactory;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkRuntimeConfig;
 import org.junit.jupiter.api.Test;
@@ -175,7 +176,7 @@ class CustomerWorkConfigPublisherTest {
         when(modelConfigMapper.selectById(100L)).thenReturn(primary);
         when(cryptoUtil.decrypt("CIPHER")).thenReturn("sk-plain");
         when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
-            .thenReturn(new ModelTestResult(ModelTestResult.STATUS_SUCCESS, LocalDateTime.now(), "ok"));
+            .thenReturn(new ModelTestResult(ConnectivityTestStatus.SUCCESS, LocalDateTime.now(), "ok"));
         when(backupModelMapper.selectList(any())).thenReturn(List.of());
         when(agentMcpMapper.selectList(any())).thenReturn(List.of());
         RuntimePublishTask task = new RuntimePublishTask();
@@ -200,7 +201,7 @@ class CustomerWorkConfigPublisherTest {
         when(modelConfigMapper.selectById(100L)).thenReturn(model(100L, "openai", "gpt-4o", "CIPHER"));
         when(cryptoUtil.decrypt("CIPHER")).thenReturn("sk-plain");
         when(modelFactory.testConnectivity(eq("openai"), anyString(), eq("sk-plain"), eq("gpt-4o")))
-            .thenReturn(new ModelTestResult(ModelTestResult.STATUS_FAILED, LocalDateTime.now(), "401 unauthorized"));
+            .thenReturn(new ModelTestResult(ConnectivityTestStatus.FAILED, LocalDateTime.now(), "401 unauthorized"));
 
         // 探测不过：抛异常，绝不进入 publishConfig（不触达 Nacos）
         assertThrows(IllegalStateException.class, () -> publisher.republishByChannel("default"));

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/runtime/KnowledgeRetrievalServiceTest.java
@@ -9,6 +9,7 @@ import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKno
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeBaseEndpoint;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeNode;
@@ -93,7 +94,7 @@ class KnowledgeRetrievalServiceTest {
         kb.setTopN(5);
         kb.setScoreThreshold(BigDecimal.ZERO);
         kb.setStatus(1);
-        kb.setTestStatus(KnowledgeBaseTestResult.STATUS_SUCCESS);
+        kb.setTestStatus(ConnectivityTestStatus.SUCCESS);
         return kb;
     }
 
@@ -162,7 +163,7 @@ class KnowledgeRetrievalServiceTest {
     @Test
     void retrieve_shouldSkipUntestedKnowledgeBase() {
         AiKnowledgeBase untested = usableKnowledgeBase();
-        untested.setTestStatus(KnowledgeBaseTestResult.STATUS_FAILED);
+        untested.setTestStatus(ConnectivityTestStatus.FAILED);
         bindKnowledgeBase(untested);
 
         assertNull(service.retrieve(AGENT_CODE, "问题"));

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseServiceTest.java
@@ -10,6 +10,7 @@ import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiAgentKno
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.entity.AiKnowledgeBase;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiAgentKnowledgeBaseMapper;
 import com.richard.fyoung.customeradmin.aiconfig.knowledgebase.mapper.AiKnowledgeBaseMapper;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
@@ -91,7 +92,7 @@ class KnowledgeBaseServiceTest {
         kb.setTopN(5);
         kb.setScoreThreshold(BigDecimal.ZERO);
         kb.setStatus(1);
-        kb.setTestStatus(KnowledgeBaseTestResult.STATUS_SUCCESS);
+        kb.setTestStatus(ConnectivityTestStatus.SUCCESS);
         return kb;
     }
 
@@ -171,7 +172,7 @@ class KnowledgeBaseServiceTest {
         service.create(request("产品知识库", "sk-1"));
 
         verify(knowledgeBaseMapper).insert(captor.capture());
-        assertEquals(KnowledgeBaseTestResult.STATUS_SUCCESS, captor.getValue().getTestStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, captor.getValue().getTestStatus());
     }
 
     @Test
@@ -270,7 +271,7 @@ class KnowledgeBaseServiceTest {
 
         KnowledgeBaseTestResult result = service.testConnectivity(1L).get();
 
-        assertEquals(KnowledgeBaseTestResult.STATUS_SUCCESS, result.testStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, result.testStatus());
         assertEquals(1, result.hitCount());
         verify(knowledgeBaseMapper).updateById(any(AiKnowledgeBase.class));
     }
@@ -283,7 +284,7 @@ class KnowledgeBaseServiceTest {
 
         KnowledgeBaseTestResult result = service.testConnectivity(1L).get();
 
-        assertEquals(KnowledgeBaseTestResult.STATUS_FAILED, result.testStatus());
+        assertEquals(ConnectivityTestStatus.FAILED, result.testStatus());
         verify(knowledgeBaseMapper).updateById(any(AiKnowledgeBase.class));
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactoryTest.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customeradmin.aiconfig.mcp.runtime;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugCallResult;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugToolVO;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpTestResult;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customerwork.tool.mcp.McpConnectivityResult;
 import com.richard.fyoung.customerwork.tool.mcp.McpImageContent;
 import com.richard.fyoung.customerwork.tool.mcp.McpToolCallResult;
@@ -46,7 +47,7 @@ class AdminMcpFactoryTest {
 
         McpTestResult vo = AdminMcpFactory.toVo(new McpConnectivityResult(true, testedAt, null));
 
-        assertEquals(McpTestResult.STATUS_SUCCESS, vo.testStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, vo.testStatus());
         assertEquals(testedAt, vo.testTime());
         assertNull(vo.message());
     }
@@ -55,7 +56,7 @@ class AdminMcpFactoryTest {
     void toVo_shouldMapConnectivityFailureToStatusFailed() {
         McpTestResult vo = AdminMcpFactory.toVo(new McpConnectivityResult(false, LocalDateTime.now(), "connect timed out"));
 
-        assertEquals(McpTestResult.STATUS_FAILED, vo.testStatus());
+        assertEquals(ConnectivityTestStatus.FAILED, vo.testStatus());
         assertEquals("connect timed out", vo.message());
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpServiceTest.java
@@ -11,6 +11,7 @@ import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpVO;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.entity.AiMcp;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.mapper.AiMcpMapper;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.runtime.AdminMcpFactory;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,13 +82,13 @@ class McpServiceTest {
         mcp.setMcpName("测试MCP");
         mcp.setMcpType("sse");
         mcp.setConfig("{\"url\": \"https://mcp.example.com/sse\"}");
-        mcp.setTestStatus(McpTestResult.STATUS_SUCCESS);
+        mcp.setTestStatus(ConnectivityTestStatus.SUCCESS);
         mcp.setTestTime(LocalDateTime.now());
         when(mcpMapper.selectById(1L)).thenReturn(mcp);
 
         McpVO vo = service.get(1L);
 
-        assertEquals(McpTestResult.STATUS_SUCCESS, vo.getTestStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, vo.getTestStatus());
     }
 
     @Test
@@ -99,12 +100,12 @@ class McpServiceTest {
         mcp.setConfig("{\"url\": \"https://mcp.example.com/mcp\"}");
         when(mcpMapper.selectById(1L)).thenReturn(mcp);
         when(mcpFactory.testConnectivity(anyString(), anyString(), anyString()))
-            .thenReturn(new McpTestResult(McpTestResult.STATUS_SUCCESS, LocalDateTime.now(), null));
+            .thenReturn(new McpTestResult(ConnectivityTestStatus.SUCCESS, LocalDateTime.now(), null));
 
         CompletableFuture<McpTestResult> future = service.testConnectivity(1L);
         McpTestResult result = future.get();
 
-        assertEquals(McpTestResult.STATUS_SUCCESS, result.testStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, result.testStatus());
         verify(mcpMapper).updateById(org.mockito.ArgumentMatchers.any(AiMcp.class));
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactoryTest.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.aiconfig.model.runtime;
 
 import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelTestResult;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.sun.net.httpserver.HttpServer;
 import io.agentscope.core.model.Model;
@@ -51,7 +52,7 @@ class AdminModelFactoryTest {
         AdminModelFactory factory = new AdminModelFactory(Duration.ofSeconds(5));
         ModelTestResult result = factory.testConnectivity("openai", baseUrl(), "sk-test", "gpt-4o-mini");
 
-        assertEquals(ModelTestResult.STATUS_SUCCESS, result.testStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, result.testStatus());
         assertNotNull(result.testTime());
         assertNull(result.message());
     }
@@ -63,7 +64,7 @@ class AdminModelFactoryTest {
         AdminModelFactory factory = new AdminModelFactory(Duration.ofSeconds(5));
         ModelTestResult result = factory.testConnectivity("anthropic", baseUrl(), "sk-test", "claude");
 
-        assertEquals(ModelTestResult.STATUS_FAILED, result.testStatus());
+        assertEquals(ConnectivityTestStatus.FAILED, result.testStatus());
         assertNotNull(result.testTime());
         assertTrue(result.message().contains("401"));
     }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelConfigServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelConfigServiceTest.java
@@ -9,6 +9,7 @@ import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelVO;
 import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
 import com.richard.fyoung.customeradmin.aiconfig.model.mapper.AiModelConfigMapper;
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.AdminModelFactory;
+import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
 import com.richard.fyoung.customeradmin.common.crypto.AesGcmCryptoUtil;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
@@ -172,12 +173,12 @@ class ModelConfigServiceTest {
         existing.setModel("gpt-4o-mini");
         when(mapper.selectById(1L)).thenReturn(existing);
         when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
-            .thenReturn(new ModelTestResult(ModelTestResult.STATUS_SUCCESS, LocalDateTime.now(), null));
+            .thenReturn(new ModelTestResult(ConnectivityTestStatus.SUCCESS, LocalDateTime.now(), null));
 
         CompletableFuture<ModelTestResult> future = service.testConnectivity(1L);
         ModelTestResult result = future.get();
 
-        assertEquals(ModelTestResult.STATUS_SUCCESS, result.testStatus());
+        assertEquals(ConnectivityTestStatus.SUCCESS, result.testStatus());
         verify(mapper).updateById(any(AiModelConfig.class));
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/openapi/OpenApiAuthInterceptorTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/openapi/OpenApiAuthInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customeradmin.openapi;
 
 import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
+import com.richard.fyoung.customerwork.core.constant.OpenApiProtocol;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ class OpenApiAuthInterceptorTest {
     private MockHttpServletRequest requestWithToken(String token) {
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/open/channel/robots");
         if (token != null) {
-            req.addHeader(OpenApiAuthInterceptor.HEADER_TOKEN, token);
+            req.addHeader(OpenApiProtocol.TOKEN_HEADER, token);
         }
         return req;
     }

--- a/customer-channel/src/main/java/com/richard/fyoung/customerchannel/DingTalkChannelConfigurer.java
+++ b/customer-channel/src/main/java/com/richard/fyoung/customerchannel/DingTalkChannelConfigurer.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerchannel;
 
+import com.richard.fyoung.customerchannel.access.ChannelAccessConstants;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.extensions.channel.dingtalk.DingTalkChannel;
@@ -29,7 +30,6 @@ import java.util.Map;
 public class DingTalkChannelConfigurer {
 
     private static final Logger log = LoggerFactory.getLogger(DingTalkChannelConfigurer.class);
-    private static final String CHANNEL_ID = "dingtalk";
 
     private final ReActAgent customerServiceAgent;
     private final AgentStateStore agentStateStore;
@@ -63,7 +63,7 @@ public class DingTalkChannelConfigurer {
             // 客服 ReActAgent 包成 HarnessAgent（Channel 经 HarnessAgent 的 gateway 路由）
             harnessAgent = HarnessAgent.Builder.fromAgent(customerServiceAgent)
                 .stateStore(agentStateStore)
-                .defaultSessionId(CHANNEL_ID)
+                .defaultSessionId(ChannelAccessConstants.CHANNEL_TYPE_DINGTALK)
                 .build();
 
             Map<String, Object> raw = new LinkedHashMap<>();
@@ -71,7 +71,7 @@ public class DingTalkChannelConfigurer {
             raw.put("appSecret", properties.getAppSecret());
             raw.put("robotCode", properties.getRobotCode());
 
-            channel = DingTalkChannel.fromProperties(CHANNEL_ID, ChannelConfig.of(CHANNEL_ID), raw);
+            channel = DingTalkChannel.fromProperties(ChannelAccessConstants.CHANNEL_TYPE_DINGTALK, ChannelConfig.of(ChannelAccessConstants.CHANNEL_TYPE_DINGTALK), raw);
             harnessAgent.channel(channel);   // 挂到 HarnessAgent gateway
             channel.start();                 // Stream 模式：出站连接钉钉网关
             log.info("[DingTalk] channel started (stream mode), robotCode={}", properties.getRobotCode());

--- a/customer-channel/src/main/java/com/richard/fyoung/customerchannel/access/AdminOpenApiClient.java
+++ b/customer-channel/src/main/java/com/richard/fyoung/customerchannel/access/AdminOpenApiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customerchannel.access.model.ChannelRobot;
 import com.richard.fyoung.customerchannel.access.support.WebClients;
+import com.richard.fyoung.customerwork.core.constant.OpenApiProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -46,7 +47,7 @@ public class AdminOpenApiClient {
     public AdminOpenApiClient(String baseUrl, String token) {
         this.webClient = WebClients.builder()
             .baseUrl(baseUrl)
-            .defaultHeader(ChannelAccessConstants.OPEN_API_TOKEN_HEADER, token == null ? "" : token)
+            .defaultHeader(OpenApiProtocol.TOKEN_HEADER, token == null ? "" : token)
             // SSE 单条 event 上限放宽，防止长回复被 buffer 上限截断
             .codecs(c -> c.defaultCodecs().maxInMemorySize(4 * 1024 * 1024))
             .build();
@@ -160,16 +161,16 @@ public class AdminOpenApiClient {
     }
 
     private boolean isTerminal(ServerSentEvent<String> event) {
-        return ChannelAccessConstants.SSE_EVENT_DONE.equals(event.event())
-            || ChannelAccessConstants.SSE_DONE_MARKER.equals(event.data());
+        return OpenApiProtocol.SSE_EVENT_DONE.equals(event.event())
+            || OpenApiProtocol.SSE_DONE_MARKER.equals(event.data());
     }
 
     private void aggregate(ServerSentEvent<String> event, StringBuilder answer) {
         String type = event.event();
-        if (ChannelAccessConstants.SSE_EVENT_ERROR.equals(type)) {
+        if (OpenApiProtocol.SSE_EVENT_ERROR.equals(type)) {
             throw new IllegalStateException("open api chat error event: " + decode(event.data()));
         }
-        if (ChannelAccessConstants.SSE_EVENT_MESSAGE.equals(type) && event.data() != null) {
+        if (OpenApiProtocol.SSE_EVENT_MESSAGE.equals(type) && event.data() != null) {
             answer.append(decode(event.data()));
         }
     }

--- a/customer-channel/src/main/java/com/richard/fyoung/customerchannel/access/ChannelAccessConstants.java
+++ b/customer-channel/src/main/java/com/richard/fyoung/customerchannel/access/ChannelAccessConstants.java
@@ -1,9 +1,15 @@
 package com.richard.fyoung.customerchannel.access;
 
+import com.richard.fyoung.customerwork.core.constant.ChannelTypes;
+import com.richard.fyoung.customerwork.core.constant.OpenApiProtocol;
+
 /**
  * 渠道接入层常量（避免魔法值）。
  *
- * <p>集中定义：开放 API 头/路径、指令关键字、回复话术、SSE 事件名、错误码。</p>
+ * <p>集中定义：开放 API 路径、指令关键字、回复话术、错误码。</p>
+ *
+ * <p>鉴权头与 SSE 事件名<b>不在这里</b>：那是与后台服务端共用的协议，定义在 starter 的
+ * {@link OpenApiProtocol}，两侧引用同一处，避免改了服务端忘了客户端。</p>
  * @author owlzhangfq@gmail.com
  */
 public final class ChannelAccessConstants {
@@ -11,13 +17,10 @@ public final class ChannelAccessConstants {
     private ChannelAccessConstants() {
     }
 
-    /** 开放 API 鉴权头。 */
-    public static final String OPEN_API_TOKEN_HEADER = "X-Open-Api-Token";
-
-    /** 渠道类型：钉钉。 */
-    public static final String CHANNEL_TYPE_DINGTALK = "dingtalk";
+    /** 渠道类型：钉钉（编码与后台 {@code ChannelType} 共用 {@link ChannelTypes} 一处定义）。 */
+    public static final String CHANNEL_TYPE_DINGTALK = ChannelTypes.DINGTALK;
     /** 渠道类型：微信公众号。 */
-    public static final String CHANNEL_TYPE_WECHAT = "wechat";
+    public static final String CHANNEL_TYPE_WECHAT = ChannelTypes.WECHAT;
 
     // ===== 开放 API 路径 =====
     public static final String PATH_ROBOTS = "/api/open/channel/robots";
@@ -42,12 +45,6 @@ public final class ChannelAccessConstants {
     public static final String HINT_PER_MESSAGE_NO_RESET = "当前为单次问答模式，每条消息都是全新上下文，无需重置";
     public static final String HINT_NON_TEXT = "目前只支持文本消息";
     public static final String HINT_ERROR = "抱歉，服务暂时不可用，请稍后再试";
-
-    // ===== SSE 事件名 =====
-    public static final String SSE_EVENT_MESSAGE = "message";
-    public static final String SSE_EVENT_DONE = "done";
-    public static final String SSE_EVENT_ERROR = "error";
-    public static final String SSE_DONE_MARKER = "[DONE]";
 
     // ===== 微信公众号（入站回调 + 客服消息主动推送）=====
     /** 微信 API 基地址。 */

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchService.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchService.java
@@ -53,14 +53,6 @@ public class ChatDispatchService {
     /** 主体配额的触发位置标识：与 HTTP 侧的路径同位，用于在命中记录里区分是哪条链路被限。 */
     private static final String QUOTA_RESOURCE_WS_CHAT = "ws:chat";
 
-    private static final String KEY_MESSAGE_ID = "messageId";
-    private static final String KEY_SESSION_ID = "sessionId";
-    private static final String KEY_TICKET_ID = "ticketId";
-    private static final String KEY_SENDER_TYPE = "senderType";
-    private static final String KEY_SENDER_ID = "senderId";
-    private static final String KEY_CONTENT = "content";
-    private static final String KEY_TS = "ts";
-
     private final TicketService ticketService;
     private final ChatLogService chatLogService;
     private final CustomerServiceService customerServiceService;
@@ -274,13 +266,13 @@ public class ChatDispatchService {
     /** 由已落库消息构造 chat 帧载荷（与前端契约字段一致：messageId/sessionId/ticketId/senderType/senderId/content/ts）。 */
     private Map<String, Object> chatData(ChatMessage message) {
         Map<String, Object> data = new LinkedHashMap<>();
-        data.put(KEY_MESSAGE_ID, message.messageId());
-        data.put(KEY_SESSION_ID, message.sessionId());
-        data.put(KEY_TICKET_ID, message.ticketId());
-        data.put(KEY_SENDER_TYPE, message.senderType().name());
-        data.put(KEY_SENDER_ID, message.senderId());
-        data.put(KEY_CONTENT, message.content());
-        data.put(KEY_TS, message.createdAtMs());
+        data.put(WsFrame.KEY_MESSAGE_ID, message.messageId());
+        data.put(WsFrame.KEY_SESSION_ID, message.sessionId());
+        data.put(WsFrame.KEY_TICKET_ID, message.ticketId());
+        data.put(WsFrame.KEY_SENDER_TYPE, message.senderType().name());
+        data.put(WsFrame.KEY_SENDER_ID, message.senderId());
+        data.put(WsFrame.KEY_CONTENT, message.content());
+        data.put(WsFrame.KEY_TS, message.createdAtMs());
         return data;
     }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/chat/WsTicketEventListener.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/chat/WsTicketEventListener.java
@@ -24,7 +24,6 @@ import java.util.Map;
 @Component
 public class WsTicketEventListener implements TicketEventListener {
 
-    private static final String KEY_TICKET_ID = "ticketId";
     private static final String KEY_USER_ID = "userId";
     private static final String KEY_TITLE = "title";
     private static final String KEY_PRIORITY = "priority";
@@ -36,7 +35,6 @@ public class WsTicketEventListener implements TicketEventListener {
     private static final String KEY_TO_STATUS = "toStatus";
     private static final String KEY_ACTOR_TYPE = "actorType";
     private static final String KEY_ASSIGNEE = "assignee";
-    private static final String KEY_TS = "ts";
 
     private final WsSessionRegistry registry;
 
@@ -60,7 +58,7 @@ public class WsTicketEventListener implements TicketEventListener {
 
     private Map<String, Object> eventData(Ticket ticket, TicketEvent event) {
         Map<String, Object> data = new LinkedHashMap<>();
-        data.put(KEY_TICKET_ID, ticket.getId());
+        data.put(WsFrame.KEY_TICKET_ID, ticket.getId());
         data.put(KEY_EVENT_ID, event.id());
         data.put(KEY_EVENT_TYPE, event.eventType().name());
         data.put(KEY_FROM_STATUS, event.fromStatus() == null ? null : event.fromStatus().name());
@@ -68,19 +66,19 @@ public class WsTicketEventListener implements TicketEventListener {
         data.put(KEY_ACTOR_TYPE, event.actorType() == null ? null : event.actorType().name());
         data.put(KEY_STATUS, ticket.getStatus().name());
         data.put(KEY_ASSIGNEE, ticket.getAssignee());
-        data.put(KEY_TS, event.createdAtMs());
+        data.put(WsFrame.KEY_TS, event.createdAtMs());
         return data;
     }
 
     private Map<String, Object> newTicketData(Ticket ticket, TicketEvent event) {
         Map<String, Object> data = new LinkedHashMap<>();
-        data.put(KEY_TICKET_ID, ticket.getId());
+        data.put(WsFrame.KEY_TICKET_ID, ticket.getId());
         data.put(KEY_EVENT_ID, event.id());
         data.put(KEY_USER_ID, ticket.getUserId());
         data.put(KEY_TITLE, ticket.getTitle());
         data.put(KEY_PRIORITY, ticket.getPriority().name());
         data.put(KEY_CATEGORY, ticket.getCategory().name());
-        data.put(KEY_TS, System.currentTimeMillis());
+        data.put(WsFrame.KEY_TS, System.currentTimeMillis());
         return data;
     }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/config/ProductionReadinessValidator.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/config/ProductionReadinessValidator.java
@@ -1,6 +1,9 @@
 package com.richard.fyoung.customerworkapp.config;
 
 import com.richard.fyoung.customerwork.capability.approval.ApprovalExecutionHandler;
+import com.richard.fyoung.customerwork.core.constant.DevDefaultCredentials;
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentProperties;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.infra.config.properties.NacosProperties;
@@ -28,10 +31,6 @@ import java.util.Map;
 @Component
 @Profile("prod")
 public class ProductionReadinessValidator implements InitializingBean {
-
-    static final String DEV_USER_JWT_SECRET = "dev-secret-change-me-in-production-0001";
-    static final String DEV_AGENT_ACCESS_SECRET = "dev-agent-secret-change-me-0001";
-    static final String DEV_MINIO_CREDENTIAL = "minioadmin";
 
     private final CustomerWorkProperties properties;
     private final AttachmentProperties attachmentProperties;
@@ -76,7 +75,7 @@ public class ProductionReadinessValidator implements InitializingBean {
     }
 
     private void validateModel(List<String> violations) {
-        if (!"ollama".equalsIgnoreCase(properties.getModel().getProvider())) {
+        if (!ModelProviders.OLLAMA.equalsIgnoreCase(properties.getModel().getProvider())) {
             requireSecret(violations, "customer-work.model.api-key", properties.getModel().getApiKey());
         }
     }
@@ -88,7 +87,7 @@ public class ProductionReadinessValidator implements InitializingBean {
             properties.getSession().getMysql().getPassword());
         require(violations, "customer-work.human-approval.store-mode",
             !properties.getHumanApproval().isEnabled()
-                || "jdbc".equalsIgnoreCase(properties.getHumanApproval().getStoreMode()));
+                || StoreModes.isJdbc(properties.getHumanApproval().getStoreMode()));
     }
 
     private void validateAuthentication(List<String> violations) {
@@ -105,18 +104,18 @@ public class ProductionReadinessValidator implements InitializingBean {
 
         String jwtSecret = properties.getUserAuth().getJwtSecret();
         require(violations, "customer-work.user-auth.jwt-secret",
-            isProductionSecret(jwtSecret) && !DEV_USER_JWT_SECRET.equals(jwtSecret) && jwtSecret.length() >= 32);
+            isProductionSecret(jwtSecret) && !DevDefaultCredentials.USER_JWT_SECRET.equals(jwtSecret) && jwtSecret.length() >= 32);
         String agentSecret = properties.getAgentAccess().getSecret();
         require(violations, "customer-work.agent-access.secret",
-            isProductionSecret(agentSecret) && !DEV_AGENT_ACCESS_SECRET.equals(agentSecret)
+            isProductionSecret(agentSecret) && !DevDefaultCredentials.AGENT_ACCESS_SECRET.equals(agentSecret)
                 && agentSecret.length() >= 32);
     }
 
     private void validateDistributedRuntime(List<String> violations) {
         require(violations, "customer-work.distributed.counter-mode",
-            "redis".equalsIgnoreCase(properties.getDistributed().getCounterMode()));
+            StoreModes.isRedis(properties.getDistributed().getCounterMode()));
         require(violations, "customer-work.distributed.session-lock-mode",
-            "redis".equalsIgnoreCase(properties.getDistributed().getSessionLockMode()));
+            StoreModes.isRedis(properties.getDistributed().getSessionLockMode()));
     }
 
     private void validateStorage(List<String> violations) {
@@ -128,9 +127,9 @@ public class ProductionReadinessValidator implements InitializingBean {
         AttachmentProperties.Minio minio = attachmentProperties.getStorage().getMinio();
         requireText(violations, "customer-work.attachment.storage.minio.endpoint", minio.getEndpoint());
         require(violations, "customer-work.attachment.storage.minio.access-key",
-            isProductionSecret(minio.getAccessKey()) && !DEV_MINIO_CREDENTIAL.equals(minio.getAccessKey()));
+            isProductionSecret(minio.getAccessKey()) && !DevDefaultCredentials.MINIO_CREDENTIAL.equals(minio.getAccessKey()));
         require(violations, "customer-work.attachment.storage.minio.secret-key",
-            isProductionSecret(minio.getSecretKey()) && !DEV_MINIO_CREDENTIAL.equals(minio.getSecretKey()));
+            isProductionSecret(minio.getSecretKey()) && !DevDefaultCredentials.MINIO_CREDENTIAL.equals(minio.getSecretKey()));
     }
 
     private void validateRuntimeConfig(List<String> violations) {

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserAuthController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserAuthController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.data.user.UserAccount;
 import com.richard.fyoung.customerwork.data.user.UserAccountService;
 import com.richard.fyoung.customerwork.safety.security.UserJwtService;
@@ -42,8 +43,6 @@ import java.util.Map;
 @RequestMapping("/api/customer/auth")
 @Tag(name = "用户账户", description = "注册 / 登录 / 当前登录信息")
 public class UserAuthController {
-
-    private static final String BEARER_PREFIX = "Bearer ";
 
     private final UserAccountService userAccountService;
     private final UserJwtService jwtService;
@@ -165,10 +164,10 @@ public class UserAuthController {
 
     /** 手动验签取登录态主体（本控制器不在 {@code /user/**} 之下，故不经 UserAuthWebFilter，令牌无效即 401）。 */
     private UserPrincipal requirePrincipal(String authorization) {
-        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+        if (authorization == null || !authorization.startsWith(HttpAuthConstants.BEARER_PREFIX)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "missing bearer token");
         }
-        return jwtService.verify(authorization.substring(BEARER_PREFIX.length()))
+        return jwtService.verify(authorization.substring(HttpAuthConstants.BEARER_PREFIX.length()))
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid or expired token"));
     }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/service/DemoOrderSeeder.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/service/DemoOrderSeeder.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.service;
 
+import com.richard.fyoung.customerwork.data.order.OrderStatuses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -39,8 +40,6 @@ public class DemoOrderSeeder {
 
     private static final String PRODUCT_SHIPPED = "P001";
     private static final String PRODUCT_PENDING = "P002";
-    private static final String STATUS_SHIPPED = "已发货";
-    private static final String STATUS_PENDING = "待发货";
     private static final String DEMO_ADDR = "北京市海淀区中关村大街 1 号（演示地址）";
     private static final String SHIPPED_TRACE = "[已揽收]→[到达分拨中心]→[派送中]";
     private static final BigDecimal FALLBACK_PRICE = new BigDecimal("0.00");
@@ -68,8 +67,8 @@ public class DemoOrderSeeder {
         }
         try (Connection conn = dataSource.getConnection()) {
             long now = System.currentTimeMillis();
-            insertOrder(conn, userId, PRODUCT_SHIPPED, STATUS_SHIPPED, SHIPPED_TRACE, now - 2 * ONE_DAY_MS);
-            insertOrder(conn, userId, PRODUCT_PENDING, STATUS_PENDING, null, now);
+            insertOrder(conn, userId, PRODUCT_SHIPPED, OrderStatuses.SHIPPED, SHIPPED_TRACE, now - 2 * ONE_DAY_MS);
+            insertOrder(conn, userId, PRODUCT_PENDING, OrderStatuses.PENDING_SHIPMENT, null, now);
             log.info("demo orders seeded for new user, userId={}", userId);
         } catch (Exception e) {
             log.error("demo order seeding failed, code={}, userId={}", SEED_ERROR_CODE, userId, e);

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/ws/AgentChatWebSocketHandler.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/ws/AgentChatWebSocketHandler.java
@@ -36,12 +36,6 @@ public class AgentChatWebSocketHandler implements WebSocketHandler {
 
     private static final Logger log = LoggerFactory.getLogger(AgentChatWebSocketHandler.class);
 
-    private static final String QUERY_TOKEN = "token";
-    private static final String FIELD_TYPE = "type";
-    private static final String FIELD_DATA = "data";
-    private static final String FIELD_TICKET_ID = "ticketId";
-    private static final String FIELD_CONTENT = "content";
-
     private final CustomerWorkProperties properties;
     private final ChatDispatchService dispatch;
     private final WsSessionRegistry registry;
@@ -108,11 +102,11 @@ public class AgentChatWebSocketHandler implements WebSocketHandler {
         } catch (Exception e) {
             return Mono.error(e);
         }
-        String type = root.path(FIELD_TYPE).asText("");
-        JsonNode data = root.path(FIELD_DATA);
+        String type = root.path(WsFrame.KEY_TYPE).asText("");
+        JsonNode data = root.path(WsFrame.KEY_DATA);
         switch (type) {
             case WsFrame.TYPE_CHAT:
-                return dispatch.onAgentMessage(agent, text(data, FIELD_TICKET_ID), text(data, FIELD_CONTENT));
+                return dispatch.onAgentMessage(agent, text(data, WsFrame.KEY_TICKET_ID), text(data, WsFrame.KEY_CONTENT));
             case WsFrame.TYPE_PING:
                 registry.pushToAgent(agent, WsFrame.pong());
                 return Mono.empty();
@@ -129,6 +123,6 @@ public class AgentChatWebSocketHandler implements WebSocketHandler {
 
     private Optional<String> tokenOf(WebSocketSession session) {
         return Optional.ofNullable(UriComponentsBuilder.fromUri(session.getHandshakeInfo().getUri())
-            .build().getQueryParams().getFirst(QUERY_TOKEN));
+            .build().getQueryParams().getFirst(WsConstants.QUERY_TOKEN));
     }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/ws/UserChatWebSocketHandler.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/ws/UserChatWebSocketHandler.java
@@ -37,11 +37,6 @@ public class UserChatWebSocketHandler implements WebSocketHandler {
 
     private static final Logger log = LoggerFactory.getLogger(UserChatWebSocketHandler.class);
 
-    private static final String QUERY_TOKEN = "token";
-    private static final String FIELD_TYPE = "type";
-    private static final String FIELD_DATA = "data";
-    private static final String FIELD_SESSION_ID = "sessionId";
-    private static final String FIELD_CONTENT = "content";
     private static final String FIELD_REASON = "reason";
 
     private final UserJwtService jwtService;
@@ -107,13 +102,13 @@ public class UserChatWebSocketHandler implements WebSocketHandler {
         } catch (Exception e) {
             return Mono.error(e);
         }
-        String type = root.path(FIELD_TYPE).asText("");
-        JsonNode data = root.path(FIELD_DATA);
+        String type = root.path(WsFrame.KEY_TYPE).asText("");
+        JsonNode data = root.path(WsFrame.KEY_DATA);
         switch (type) {
             case WsFrame.TYPE_CHAT:
-                return dispatch.onUserMessage(user, text(data, FIELD_SESSION_ID), text(data, FIELD_CONTENT));
+                return dispatch.onUserMessage(user, text(data, WsFrame.KEY_SESSION_ID), text(data, WsFrame.KEY_CONTENT));
             case "handoff":
-                return dispatch.requestHandoff(user, text(data, FIELD_SESSION_ID), text(data, FIELD_REASON));
+                return dispatch.requestHandoff(user, text(data, WsFrame.KEY_SESSION_ID), text(data, FIELD_REASON));
             case WsFrame.TYPE_PING:
                 registry.pushToUser(user.userId(), WsFrame.pong());
                 return Mono.empty();
@@ -130,6 +125,6 @@ public class UserChatWebSocketHandler implements WebSocketHandler {
 
     private Optional<String> tokenOf(WebSocketSession session) {
         return Optional.ofNullable(UriComponentsBuilder.fromUri(session.getHandshakeInfo().getUri())
-            .build().getQueryParams().getFirst(QUERY_TOKEN));
+            .build().getQueryParams().getFirst(WsConstants.QUERY_TOKEN));
     }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/ws/WsConstants.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/ws/WsConstants.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customerworkapp.ws;
+
+/**
+ * WebSocket 接入层公共字面量（帧内字段名见 {@code WsFrame}，那才是帧协议的定义处）。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class WsConstants {
+
+    /**
+     * 握手 URL 上携带令牌的查询参数名。
+     *
+     * <p>浏览器的 WebSocket API 不支持自定义请求头，令牌只能挂在 URL 上；
+     * 用户端 {@code /ws/user} 与坐席端 {@code /ws/agent} 两条路径必须用同一个参数名。</p>
+     */
+    public static final String QUERY_TOKEN = "token";
+
+    private WsConstants() {
+    }
+}

--- a/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/config/ProductionReadinessValidatorTest.java
+++ b/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/config/ProductionReadinessValidatorTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.config;
 
+import com.richard.fyoung.customerwork.core.constant.DevDefaultCredentials;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentProperties;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,8 @@ class ProductionReadinessValidatorTest {
     @Test
     void developmentDefaults_shouldFailWithoutLeakingSecretValues() {
         CustomerWorkProperties properties = new CustomerWorkProperties();
-        properties.getUserAuth().setJwtSecret(ProductionReadinessValidator.DEV_USER_JWT_SECRET);
-        properties.getAgentAccess().setSecret(ProductionReadinessValidator.DEV_AGENT_ACCESS_SECRET);
+        properties.getUserAuth().setJwtSecret(DevDefaultCredentials.USER_JWT_SECRET);
+        properties.getAgentAccess().setSecret(DevDefaultCredentials.AGENT_ACCESS_SECRET);
         AttachmentProperties attachment = new AttachmentProperties();
 
         IllegalStateException error = assertThrows(IllegalStateException.class,
@@ -35,8 +36,8 @@ class ProductionReadinessValidatorTest {
         assertTrue(error.getMessage().contains("customer-work.security.auth.enabled"));
         assertTrue(error.getMessage().contains("customer-work.user-auth.jwt-secret"));
         assertTrue(error.getMessage().contains("customer-work.attachment.storage.minio.secret-key"));
-        assertFalse(error.getMessage().contains(ProductionReadinessValidator.DEV_USER_JWT_SECRET));
-        assertFalse(error.getMessage().contains(ProductionReadinessValidator.DEV_MINIO_CREDENTIAL));
+        assertFalse(error.getMessage().contains(DevDefaultCredentials.USER_JWT_SECRET));
+        assertFalse(error.getMessage().contains(DevDefaultCredentials.MINIO_CREDENTIAL));
     }
 
     @Test

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/approval/ApprovalConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/approval/ApprovalConfig.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.capability.approval;
 
 import com.richard.fyoung.customerwork.capability.approval.mapper.ApprovalMapper;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,14 +27,12 @@ public class ApprovalConfig {
 
     private static final Logger log = LoggerFactory.getLogger(ApprovalConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(ApprovalStore.class)
     public ApprovalStore approvalStore(CustomerWorkProperties properties,
                                        ObjectProvider<ApprovalMapper> mapperProvider) {
         String mode = properties.getHumanApproval().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("approval store: jdbc (MyBatis-Plus 实现, table=cw_approval)");
             return new MybatisApprovalStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/badcase/BadcaseConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/badcase/BadcaseConfig.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.capability.badcase;
 
 import com.richard.fyoung.customerwork.capability.badcase.mapper.BadcaseMapper;
 import com.richard.fyoung.customerwork.capability.eval.EvalCaseStore;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.chatlog.ChatMessageStore;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.tool.backend.mapper.KnowledgeMapper;
@@ -24,14 +25,12 @@ public class BadcaseConfig {
 
     private static final Logger log = LoggerFactory.getLogger(BadcaseConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(BadcaseStore.class)
     public BadcaseStore badcaseStore(CustomerWorkProperties properties,
                                      ObjectProvider<BadcaseMapper> mapperProvider) {
         String mode = properties.getBadcase().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("badcase store: jdbc (MyBatis-Plus 实现, table=cw_badcase)");
             return new MybatisBadcaseStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/csat/CsatConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/csat/CsatConfig.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.capability.csat;
 
 import com.richard.fyoung.customerwork.capability.csat.mapper.CsatSurveyMapper;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.core.support.OpsScopeResolver;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
@@ -21,14 +22,12 @@ public class CsatConfig {
 
     private static final Logger log = LoggerFactory.getLogger(CsatConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(CsatStore.class)
     public CsatStore csatStore(CustomerWorkProperties properties,
                                ObjectProvider<CsatSurveyMapper> mapperProvider) {
         String mode = properties.getCsat().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("csat store: jdbc (MyBatis-Plus 实现, table=cw_csat_survey)");
             return new MybatisCsatStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/deadletter/DeadLetterConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/deadletter/DeadLetterConfig.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.capability.deadletter;
 
 import com.richard.fyoung.customerwork.capability.deadletter.mapper.DeadLetterMapper;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,14 +25,12 @@ public class DeadLetterConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DeadLetterConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(DeadLetterStore.class)
     public DeadLetterStore deadLetterStore(CustomerWorkProperties properties,
                                            ObjectProvider<DeadLetterMapper> mapperProvider) {
         String mode = properties.getDeadLetter().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("dead letter store: jdbc (MyBatis-Plus 实现, table=cw_dead_letter)");
             return new MybatisDeadLetterStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/dialog/DialogStageConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/dialog/DialogStageConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.dialog;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.capability.dialog.mapper.DialogStageMapper;
 import org.slf4j.Logger;
@@ -23,14 +24,12 @@ public class DialogStageConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DialogStageConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(DialogStageStore.class)
     public DialogStageStore dialogStageStore(CustomerWorkProperties properties,
                                              ObjectProvider<DialogStageMapper> mapperProvider) {
         String mode = properties.getDialog().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("dialog stage store: jdbc (MyBatis-Plus 实现, table=cw_dialog_stage)");
             return new MybatisDialogStageStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/EvalConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/EvalConfig.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.capability.eval;
 
 import com.richard.fyoung.customerwork.capability.eval.mapper.EvalCaseMapper;
 import com.richard.fyoung.customerwork.capability.eval.mapper.EvalRunMapper;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -36,14 +37,12 @@ public class EvalConfig {
 
     private static final Logger log = LoggerFactory.getLogger(EvalConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(EvalRunStore.class)
     public EvalRunStore evalRunStore(CustomerWorkProperties properties,
                                      ObjectProvider<EvalRunMapper> mapperProvider) {
         String mode = properties.getEval().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("eval run store: jdbc (MyBatis-Plus 实现, table=cw_eval_run)");
             return new MybatisEvalRunStore(mapperProvider.getObject());
         }
@@ -62,7 +61,7 @@ public class EvalConfig {
     public EvalCaseStore evalCaseStore(CustomerWorkProperties properties,
                                        ObjectProvider<EvalCaseMapper> mapperProvider) {
         String mode = properties.getEval().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("eval case store: jdbc (MyBatis-Plus 实现, table=cw_eval_case)");
             return new MybatisEvalCaseStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/EvalErrorCodes.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/EvalErrorCodes.java
@@ -1,0 +1,15 @@
+package com.richard.fyoung.customerwork.capability.eval;
+
+/**
+ * 评测链路的日志错误码。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class EvalErrorCodes {
+
+    /** 评测数据集加载失败（意图与质量两个 Runner 共用同一个码，便于一次捞全）。 */
+    public static final String LOAD_FAIL = "EVAL-LOAD-FAIL";
+
+    private EvalErrorCodes() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/IntentEvalRunner.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/IntentEvalRunner.java
@@ -30,7 +30,6 @@ public class IntentEvalRunner {
     private static final Logger log = LoggerFactory.getLogger(IntentEvalRunner.class);
 
     private static final String DATASET_PATH = "eval/intent-eval-cases.json";
-    private static final String ERR_LOAD = "EVAL-LOAD-FAIL";
 
     private final MultiAgentOrchestrator orchestrator;
     private final EvalCaseStore caseStore;
@@ -69,7 +68,7 @@ public class IntentEvalRunner {
             }
             return result;
         } catch (Exception e) {
-            log.error("load eval dataset failed, errorCode={}, path={}", ERR_LOAD, DATASET_PATH, e);
+            log.error("load eval dataset failed, errorCode={}, path={}", EvalErrorCodes.LOAD_FAIL, DATASET_PATH, e);
             throw new IllegalStateException("eval dataset not loadable: " + DATASET_PATH, e);
         }
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/QualityEvalRunner.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/QualityEvalRunner.java
@@ -39,7 +39,6 @@ public class QualityEvalRunner {
     private static final int PASS_THRESHOLD = 3;
 
     private static final String DATASET_PATH = "eval/quality-eval-cases.json";
-    private static final String ERR_LOAD = "EVAL-LOAD-FAIL";
 
     private final JudgeModel judgeModel;
     private final EvalCaseStore caseStore;
@@ -82,7 +81,7 @@ public class QualityEvalRunner {
             }
             return result;
         } catch (Exception e) {
-            log.error("load quality eval dataset failed, errorCode={}, path={}", ERR_LOAD, DATASET_PATH, e);
+            log.error("load quality eval dataset failed, errorCode={}, path={}", EvalErrorCodes.LOAD_FAIL, DATASET_PATH, e);
             throw new IllegalStateException("quality eval dataset not loadable: " + DATASET_PATH, e);
         }
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/feedback/FeedbackConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/feedback/FeedbackConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.feedback;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.capability.feedback.mapper.FeedbackMapper;
 import org.slf4j.Logger;
@@ -23,13 +24,11 @@ public class FeedbackConfig {
 
     private static final Logger log = LoggerFactory.getLogger(FeedbackConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(FeedbackStore.class)
     public FeedbackStore feedbackStore(CustomerWorkProperties properties, ObjectProvider<FeedbackMapper> mapperProvider) {
         String mode = properties.getFeedback().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("feedback store: jdbc (MyBatis-Plus 实现, table=cw_message_feedback)");
             return new MybatisFeedbackStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/feedback/FeedbackService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/feedback/FeedbackService.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerwork.capability.feedback;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customerwork.capability.badcase.BadcaseService;
 import com.richard.fyoung.customerwork.capability.badcase.BadcaseSource;
+import com.richard.fyoung.customerwork.core.constant.FactTypes;
 import com.richard.fyoung.customerwork.core.memory.FactLog;
 import com.richard.fyoung.customerwork.core.support.TenantResolver;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
@@ -38,8 +39,6 @@ import java.util.Optional;
 public class FeedbackService {
 
     private static final Logger log = LoggerFactory.getLogger(FeedbackService.class);
-
-    private static final String FACT_TYPE = "negative-feedback";
 
     private final FeedbackStore store;
     private final FactLog factLog;
@@ -82,7 +81,7 @@ public class FeedbackService {
     private void recordNegativeFeedback(MessageFeedback feedback) {
         try {
             Map<String, Object> fact = new LinkedHashMap<>();
-            fact.put("type", FACT_TYPE);
+            fact.put("type", FactTypes.NEGATIVE_FEEDBACK);
             fact.put("sessionId", feedback.sessionId());
             fact.put("messageId", feedback.messageId());
             fact.put("comment", feedback.comment());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/handoff/HandoffConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/handoff/HandoffConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.handoff;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.capability.handoff.mapper.HandoffMapper;
 import org.slf4j.Logger;
@@ -26,13 +27,11 @@ public class HandoffConfig {
 
     private static final Logger log = LoggerFactory.getLogger(HandoffConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(HandoffStore.class)
     public HandoffStore handoffStore(CustomerWorkProperties properties, ObjectProvider<HandoffMapper> mapperProvider) {
         String mode = properties.getHumanHandoff().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("handoff store: jdbc (MyBatis-Plus 实现, table=cw_handoff_ticket)");
             return new MybatisHandoffStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/knowledgegap/KnowledgeGapConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/knowledgegap/KnowledgeGapConfig.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.capability.knowledgegap;
 
 import com.richard.fyoung.customerwork.capability.knowledgegap.mapper.KnowledgeGapMapper;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.core.support.OpsScopeResolver;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
@@ -19,14 +20,12 @@ public class KnowledgeGapConfig {
 
     private static final Logger log = LoggerFactory.getLogger(KnowledgeGapConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(KnowledgeGapStore.class)
     public KnowledgeGapStore knowledgeGapStore(CustomerWorkProperties properties,
                                                ObjectProvider<KnowledgeGapMapper> mapperProvider) {
         String mode = properties.getKnowledgeGap().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("knowledge gap store: jdbc (MyBatis-Plus 实现, table=cw_knowledge_gap)");
             return new MybatisKnowledgeGapStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/prompt/PromptVersionConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/prompt/PromptVersionConfig.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.capability.prompt;
 
 import com.richard.fyoung.customerwork.capability.prompt.mapper.PromptVersionMapper;
 import com.richard.fyoung.customerwork.core.agent.CustomerServiceAgentFactory;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,14 +22,12 @@ public class PromptVersionConfig {
 
     private static final Logger log = LoggerFactory.getLogger(PromptVersionConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(PromptVersionStore.class)
     public PromptVersionStore promptVersionStore(CustomerWorkProperties properties,
                                                  ObjectProvider<PromptVersionMapper> mapperProvider) {
         String mode = properties.getPromptVersion().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("prompt version store: jdbc (MyBatis-Plus 实现, table=cw_prompt_version)");
             return new MybatisPromptVersionStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/quality/QualityFeedbackRecorder.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/quality/QualityFeedbackRecorder.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerwork.capability.quality;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customerwork.capability.badcase.BadcaseService;
 import com.richard.fyoung.customerwork.capability.badcase.BadcaseSource;
+import com.richard.fyoung.customerwork.core.constant.FactTypes;
 import com.richard.fyoung.customerwork.core.memory.FactLog;
 import com.richard.fyoung.customerwork.core.support.TenantResolver;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
@@ -35,8 +36,6 @@ public class QualityFeedbackRecorder {
 
     private static final Logger log = LoggerFactory.getLogger(QualityFeedbackRecorder.class);
 
-    private static final String FACT_TYPE = "quality-failure";
-
     private final QualityInspectionService qualityService;
     private final FactLog factLog;
     private final TenantResolver tenantResolver;
@@ -67,7 +66,7 @@ public class QualityFeedbackRecorder {
     private void recordFailure(String sessionId, List<String> replies, QualityReport report) {
         try {
             Map<String, Object> fact = new LinkedHashMap<>();
-            fact.put("type", FACT_TYPE);
+            fact.put("type", FactTypes.QUALITY_FAILURE);
             fact.put("sessionId", sessionId);
             fact.put("score", report.getScore());
             fact.put("issues", report.getIssues());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/routing/SeatAgentConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/routing/SeatAgentConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.routing;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.capability.routing.mapper.SeatAgentMapper;
 import org.slf4j.Logger;
@@ -27,14 +28,12 @@ public class SeatAgentConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SeatAgentConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(SeatAgentStore.class)
     public SeatAgentStore seatAgentStore(CustomerWorkProperties properties,
                                          ObjectProvider<SeatAgentMapper> mapperProvider) {
         String mode = properties.getRouting().getSeatStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("seat-agent store: jdbc (MyBatis-Plus, table=cw_seat_agent)");
             return new MybatisSeatAgentStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/semanticcache/SemanticCacheConfig.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customerwork.capability.semanticcache;
 
 import com.richard.fyoung.customerwork.capability.semanticcache.mapper.SemanticCacheMapper;
 import com.richard.fyoung.customerwork.core.agent.MultiAgentOrchestrator;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.core.support.TenantResolver;
 import com.richard.fyoung.customerwork.data.knowledge.embedding.DashScopeEmbeddingClient;
 import com.richard.fyoung.customerwork.data.knowledge.embedding.EmbeddingClient;
@@ -33,14 +34,12 @@ public class SemanticCacheConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SemanticCacheConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(SemanticCacheStore.class)
     public SemanticCacheStore semanticCacheStore(CustomerWorkProperties properties,
                                                  ObjectProvider<SemanticCacheMapper> mapperProvider) {
         String mode = properties.getSemanticCache().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("semantic cache store: jdbc (MyBatis-Plus 实现, table=cw_semantic_cache)");
             return new MybatisSemanticCacheStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/slotfilling/SlotFillingConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/slotfilling/SlotFillingConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.slotfilling;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.capability.slotfilling.mapper.SlotFillingMapper;
 import org.slf4j.Logger;
@@ -23,14 +24,12 @@ public class SlotFillingConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SlotFillingConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(SlotFillingStore.class)
     public SlotFillingStore slotFillingStore(CustomerWorkProperties properties,
                                              ObjectProvider<SlotFillingMapper> mapperProvider) {
         String mode = properties.getSlotFilling().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("slot-filling store: jdbc (MyBatis-Plus 实现, table=cw_slot_filling_progress)");
             return new MybatisSlotFillingStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/common/crypto/AesGcmCrypto.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/common/crypto/AesGcmCrypto.java
@@ -27,7 +27,8 @@ import java.util.Base64;
 public class AesGcmCrypto {
 
     private static final String ALGORITHM = "AES/GCM/NoPadding";
-    private static final int GCM_IV_LENGTH = 12;
+    /** GCM 推荐 IV 长度（字节）：RFC 5116 定的 96 位，改这个值会让历史密文全部解不开。 */
+    public static final int GCM_IV_LENGTH = 12;
     private static final int GCM_TAG_LENGTH_BITS = 128;
     /** 掩码保留的末尾明文位数。 */
     private static final int MASK_KEEP_LENGTH = 4;

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/AgentFileNames.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/AgentFileNames.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 智能体运行时约定的文件名。
+ *
+ * <p>这些名字是<b>框架与技能包格式的契约</b>而非本项目可自由更改的配置：框架只按固定文件名读取，
+ * 改一处不改另一处的后果是"上传成功但加载不到"，链路全程不报错。故集中一处定义，
+ * 客服端与后台共用（后台依赖 starter）。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class AgentFileNames {
+
+    /** 技能包描述文件：zip 中最浅层的这个文件所在目录即技能根目录。 */
+    public static final String SKILL_MD = "SKILL.md";
+
+    /** Harness 分层记忆的落盘文件：MySQL 为权威副本，此文件由同步服务水合/回写。 */
+    public static final String MEMORY_MD = "MEMORY.md";
+
+    private AgentFileNames() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/ChannelTypes.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/ChannelTypes.java
@@ -1,0 +1,21 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 外部渠道类型编码（{@code ai_channel_robot.channel_type} 列存的值）。
+ *
+ * <p>后台按它配置机器人、渠道模块按它挑连接器，两个模块互不依赖、只共同依赖 starter，
+ * 故编码落在这里。改一边的后果是后台配好的机器人在渠道侧找不到连接器，静默不响应。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class ChannelTypes {
+
+    /** 钉钉（Stream 模式接入）。 */
+    public static final String DINGTALK = "dingtalk";
+
+    /** 微信公众号。 */
+    public static final String WECHAT = "wechat";
+
+    private ChannelTypes() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/DevDefaultCredentials.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/DevDefaultCredentials.java
@@ -1,0 +1,29 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 开发期默认凭据（生产必须覆盖）。
+ *
+ * <p>这些值同时出现在两个角色上：一边是<b>代码/yml 里的兜底默认值</b>，另一边是
+ * <b>生产就绪校验器的黑名单</b>——校验器靠"当前值是否等于开发默认值"判断有没有人忘了改。
+ * 两边此前各写一份字面量，改了默认值而漏改校验器的后果是：校验器再也检不出这一项，
+ * 而它<b>照样返回通过</b>，等于生产环境揣着开发密钥上线且无人告警。</p>
+ *
+ * <p>集中在此不降低安全性——它们本来就明文躺在源码与 yml 里；集中反而让"哪些值属于必须覆盖"
+ * 一目了然，便于审计。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class DevDefaultCredentials {
+
+    /** 用户端 JWT 签名密钥的开发默认值。 */
+    public static final String USER_JWT_SECRET = "dev-secret-change-me-in-production-0001";
+
+    /** 服务间智能体访问密钥的开发默认值。 */
+    public static final String AGENT_ACCESS_SECRET = "dev-agent-secret-change-me-0001";
+
+    /** MinIO 的出厂默认账号与密码（accessKey 与 secretKey 同值）。 */
+    public static final String MINIO_CREDENTIAL = "minioadmin";
+
+    private DevDefaultCredentials() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/FactTypes.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/FactTypes.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 事实日志（L3 记忆，{@code cw_fact_log.type}）的类型编码。
+ *
+ * <p>写入方与统计方靠这个字符串对齐：质量兜底由 {@code QualityFeedbackRecorder} 写、
+ * 由 {@code BusinessAnalyticsService} 按类型过滤统计。两边此前各写一份字面量，
+ * 改一处的表现是<b>看板指标变 0 而链路不报错</b>——最难发现的那类缺陷。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class FactTypes {
+
+    /** 回答质量不达标触发兜底。 */
+    public static final String QUALITY_FAILURE = "quality-failure";
+
+    /** 用户负向反馈。 */
+    public static final String NEGATIVE_FEEDBACK = "negative-feedback";
+
+    private FactTypes() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/HttpAuthConstants.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/HttpAuthConstants.java
@@ -1,0 +1,26 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * HTTP 鉴权相关的公共字面量。
+ *
+ * <p>只放标准库/Spring 没有提供的那部分：{@code Authorization}、{@code Content-Type} 这类请求头名
+ * 一律用 {@code org.springframework.http.HttpHeaders} 的常量，不在这里重复定义。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class HttpAuthConstants {
+
+    /** Bearer 令牌前缀（含尾部空格，截取令牌时直接用 {@code length()} 偏移）。 */
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    /**
+     * 服务间调用的智能体令牌请求头。
+     *
+     * <p>客服端 {@code AgentAuthWebFilter} 验、后台的工单客户端发，两侧此前各写一份字面量：
+     * 改一处的后果是整条服务间调用 401，而两边代码看上去都对。</p>
+     */
+    public static final String AGENT_TOKEN_HEADER = "X-Agent-Token";
+
+    private HttpAuthConstants() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/ModelProviders.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/ModelProviders.java
@@ -1,0 +1,32 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 大模型厂商标识常量。
+ *
+ * <p>取值即后台 {@code ai_model_config.provider} 列存的编码，客服端与后台必须认同一套字符串——
+ * 此前 {@code ChatModelFactory}（建模型）与 {@code ChatModelProber}（探活）各写一份，
+ * 后者注释里写着"与 admin 的 ModelProvider 编码一致"却无任何机制保证：三方任意一处新增厂商而另两处不跟，
+ * 表现是"后台能配、探活通过、真跑起来落到兜底厂商"，链路上不报错。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class ModelProviders {
+
+    /** 阿里云百炼（provider 为空时的兜底厂商）。 */
+    public static final String DASHSCOPE = "dashscope";
+
+    /** OpenAI 及其兼容协议端点。 */
+    public static final String OPENAI = "openai";
+
+    /** Anthropic 原生 Messages 协议。 */
+    public static final String ANTHROPIC = "anthropic";
+
+    /** Google Gemini。 */
+    public static final String GEMINI = "gemini";
+
+    /** Ollama 本地私有化部署（无需 API Key）。 */
+    public static final String OLLAMA = "ollama";
+
+    private ModelProviders() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/OpenApiProtocol.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/OpenApiProtocol.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 开放 API 的协议字面量（鉴权头 + 流式事件名）。
+ *
+ * <p>服务端在后台（{@code OpenAgentChatController}）、客户端在渠道模块（{@code AdminOpenApiClient}），
+ * 两个模块互不依赖、只共同依赖 starter，故协议常量落在这里。此前两侧各写一份：
+ * 事件名改一边，另一边收到的流会被当成未知事件默默丢弃，不抛异常也不打日志。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class OpenApiProtocol {
+
+    /** 开放 API 令牌请求头。 */
+    public static final String TOKEN_HEADER = "X-Open-Api-Token";
+
+    /** SSE 事件名：一个回复增量。 */
+    public static final String SSE_EVENT_MESSAGE = "message";
+    /** SSE 事件名：流正常结束。 */
+    public static final String SSE_EVENT_DONE = "done";
+    /** SSE 事件名：流以错误结束。 */
+    public static final String SSE_EVENT_ERROR = "error";
+    /** 结束事件的负载标记（沿用 OpenAI 兼容协议的写法，便于既有客户端直接对接）。 */
+    public static final String SSE_DONE_MARKER = "[DONE]";
+
+    private OpenApiProtocol() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/StatusFlags.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/StatusFlags.java
@@ -1,0 +1,23 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 库表通用启用状态列（{@code status}）的取值。
+ *
+ * <p>客服端与后台的绝大多数配置表都用同一个 {@code tinyint status} 表达"启不启用"，
+ * 这个 {@code 1} 此前在 18 个类里以 {@code STATUS_ENABLED} / {@code ENABLED} 两种命名各写一遍。
+ * 数字本身不会写歪，但"到底哪个值是启用"这件事散在 18 处、没有一处说明，
+ * 新写一张表时只能靠翻别的类去猜——集中一处是为了让这个约定有个可引用的答案。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class StatusFlags {
+
+    /** 启用。 */
+    public static final int ENABLED = 1;
+
+    /** 停用。 */
+    public static final int DISABLED = 0;
+
+    private StatusFlags() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/StoreModes.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/StoreModes.java
@@ -1,0 +1,47 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+/**
+ * 存储 / 实现模式取值常量。
+ *
+ * <p>本项目所有"选实现"的开关共用同一套取值词汇：各业务域的 {@code store-mode}、
+ * {@code tool-backend.mode}、分布式设施的 {@code counter-mode} / {@code session-lock-mode}
+ * 都在 {@code memory} / {@code jdbc} / {@code redis} 之间取值。此前这套词汇在 30 余处
+ * 以 {@code STORE_MODE_JDBC} / {@code MODE_JDBC} / {@code JDBC} 三种命名各写一遍，
+ * 还有几处直接写字面量比较——同一个概念有多个真相来源，改起来必漏。</p>
+ *
+ * <p>判定一律走 {@link #isJdbc(String)} 等方法：装配侧的语义是"没配就按默认走"，
+ * 大小写不敏感由这里统一兜住，不要在调用处再各写一遍 {@code equalsIgnoreCase}。
+ * 需要编译期常量的场合（{@code @ConditionalOnProperty} 的 {@code havingValue}、
+ * {@code switch} 分支）直接引用字段本身。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class StoreModes {
+
+    /** 进程内实现：重启即清零，仅适合离线测试与开发期。 */
+    public static final String MEMORY = "memory";
+
+    /** MyBatis-Plus 落库实现：生产默认形态。 */
+    public static final String JDBC = "jdbc";
+
+    /** Redis 实现：仅分布式设施（计数器 / 会话锁）使用。 */
+    public static final String REDIS = "redis";
+
+    private StoreModes() {
+    }
+
+    /** 是否 jdbc 模式（大小写不敏感，null 视为否）。 */
+    public static boolean isJdbc(String mode) {
+        return JDBC.equalsIgnoreCase(mode);
+    }
+
+    /** 是否 memory 模式（大小写不敏感，null 视为否）。 */
+    public static boolean isMemory(String mode) {
+        return MEMORY.equalsIgnoreCase(mode);
+    }
+
+    /** 是否 redis 模式（大小写不敏感，null 视为否）。 */
+    public static boolean isRedis(String mode) {
+        return REDIS.equalsIgnoreCase(mode);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/memory/HarnessMemoryStoreConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/memory/HarnessMemoryStoreConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.core.memory;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.core.memory.mapper.HarnessMemoryMapper;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
@@ -22,13 +23,11 @@ public class HarnessMemoryStoreConfig {
 
     private static final Logger log = LoggerFactory.getLogger(HarnessMemoryStoreConfig.class);
 
-    private static final String STORE_MODE_MEMORY = "memory";
-
     @Bean
     @ConditionalOnMissingBean(HarnessMemoryStore.class)
     public HarnessMemoryStore harnessMemoryStore(CustomerWorkProperties properties,
                                                   ObjectProvider<HarnessMemoryMapper> mapperProvider) {
-        if (STORE_MODE_MEMORY.equalsIgnoreCase(properties.getHarness().getMemoryStoreMode())) {
+        if (StoreModes.isMemory(properties.getHarness().getMemoryStoreMode())) {
             log.info("harness memory store: memory (进程内，重启不保留，生产建议 memory-store-mode=jdbc)");
             return new InMemoryHarnessMemoryStore();
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/memory/HarnessMemorySyncService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/memory/HarnessMemorySyncService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.core.memory;
 
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,6 @@ public class HarnessMemorySyncService {
     private static final Logger log = LoggerFactory.getLogger(HarnessMemorySyncService.class);
 
     /** 框架分层记忆的工作副本文件名（workspace 根下，路径约定来自 Harness WorkspaceManager）。 */
-    private static final String MEMORY_FILE_NAME = "MEMORY.md";
 
     private final HarnessMemoryStore memoryStore;
 
@@ -43,7 +43,7 @@ public class HarnessMemorySyncService {
     public void hydrate(Path workspace) {
         String scopeId = scopeOf(workspace);
         try {
-            Path memoryFile = workspace.resolve(MEMORY_FILE_NAME);
+            Path memoryFile = workspace.resolve(AgentFileNames.MEMORY_MD);
             Optional<String> stored = memoryStore.load(scopeId);
             if (stored.isPresent()) {
                 Files.createDirectories(workspace);
@@ -66,7 +66,7 @@ public class HarnessMemorySyncService {
     public void persistIfChanged(Path workspace) {
         String scopeId = scopeOf(workspace);
         try {
-            Path memoryFile = workspace.resolve(MEMORY_FILE_NAME);
+            Path memoryFile = workspace.resolve(AgentFileNames.MEMORY_MD);
             if (!Files.exists(memoryFile)) {
                 return;
             }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/memory/LongTermMemoryStoreConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/memory/LongTermMemoryStoreConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.core.memory;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.core.memory.mapper.LongTermMemoryMapper;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.infra.config.properties.MemoryProperties;
@@ -28,14 +29,12 @@ public class LongTermMemoryStoreConfig {
 
     private static final Logger log = LoggerFactory.getLogger(LongTermMemoryStoreConfig.class);
 
-    private static final String STORE_MODE_MEMORY = "memory";
-
     @Bean
     @ConditionalOnMissingBean(LongTermMemoryStore.class)
     public LongTermMemoryStore longTermMemoryStore(CustomerWorkProperties properties,
                                                    ObjectProvider<LongTermMemoryMapper> mapperProvider) {
         MemoryProperties cfg = properties.getMemory();
-        if (STORE_MODE_MEMORY.equalsIgnoreCase(cfg.getStoreMode())) {
+        if (StoreModes.isMemory(cfg.getStoreMode())) {
             log.info("long-term memory store: memory (进程内，重启不保留，生产建议 store-mode=jdbc)");
             return new InMemoryLongTermMemoryStore();
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/model/ChatModelProber.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/model/ChatModelProber.java
@@ -2,6 +2,8 @@ package com.richard.fyoung.customerwork.core.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +16,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 /**
  * 模型连通性探活器：按厂商各自的<b>最小探活协议</b>直连一次，验证 baseUrl / apiKey / modelName 是否可用。
@@ -42,24 +46,15 @@ public class ChatModelProber {
     private static final int TEST_MAX_TOKENS = 8;
     private static final int MAX_ERROR_MESSAGE_LENGTH = 500;
 
-    // ---- 厂商协议标识（与 admin 的 ModelProvider 编码一致）----
-    private static final String PROVIDER_DASHSCOPE = "dashscope";
-    private static final String PROVIDER_ANTHROPIC = "anthropic";
-    private static final String PROVIDER_GEMINI = "gemini";
-
-    // ---- 各厂商探活端点路径 / 鉴权头常量（避免魔法值）----
+    // ---- 各厂商探活端点路径 / 专有鉴权头（通用头名走 Spring HttpHeaders）----
     private static final String OPENAI_CHAT_COMPLETIONS_PATH = "/chat/completions";
     private static final String DASHSCOPE_TEXT_GENERATION_PATH = "/api/v1/services/aigc/text-generation/generation";
     private static final String ANTHROPIC_MESSAGES_PATH = "/v1/messages";
     private static final String GEMINI_GENERATE_CONTENT_PATH_TEMPLATE = "/v1beta/models/%s:generateContent";
 
-    private static final String HEADER_CONTENT_TYPE = "Content-Type";
-    private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String HEADER_ANTHROPIC_API_KEY = "x-api-key";
     private static final String HEADER_ANTHROPIC_VERSION = "anthropic-version";
     private static final String HEADER_GEMINI_API_KEY = "x-goog-api-key";
-    private static final String CONTENT_TYPE_JSON = "application/json";
-    private static final String BEARER_PREFIX = "Bearer ";
     /** Anthropic Messages API 版本（原生协议必填头）。 */
     private static final String ANTHROPIC_VERSION = "2023-06-01";
 
@@ -106,11 +101,11 @@ public class ChatModelProber {
     private HttpRequest buildProbeRequest(String provider, String baseUrl, String apiKey, String modelName)
             throws Exception {
         switch (provider) {
-            case PROVIDER_DASHSCOPE:
+            case ModelProviders.DASHSCOPE:
                 return dashScopeProbe(baseUrl, apiKey, modelName);
-            case PROVIDER_ANTHROPIC:
+            case ModelProviders.ANTHROPIC:
                 return anthropicProbe(baseUrl, apiKey, modelName);
-            case PROVIDER_GEMINI:
+            case ModelProviders.GEMINI:
                 return geminiProbe(baseUrl, apiKey, modelName);
             default:
                 return openAiProbe(baseUrl, apiKey, modelName);
@@ -124,7 +119,7 @@ public class ChatModelProber {
             "messages", List.of(Map.of("role", "user", "content", TEST_PROMPT)),
             "max_tokens", TEST_MAX_TOKENS));
         return baseRequest(appendPath(baseUrl, OPENAI_CHAT_COMPLETIONS_PATH), body)
-            .header(HEADER_AUTHORIZATION, BEARER_PREFIX + apiKey)
+            .header(HttpHeaders.AUTHORIZATION, HttpAuthConstants.BEARER_PREFIX + apiKey)
             .build();
     }
 
@@ -135,7 +130,7 @@ public class ChatModelProber {
             "input", Map.of("messages", List.of(Map.of("role", "user", "content", TEST_PROMPT))),
             "parameters", Map.of("max_tokens", TEST_MAX_TOKENS, "result_format", "message")));
         return baseRequest(appendPath(baseUrl, DASHSCOPE_TEXT_GENERATION_PATH), body)
-            .header(HEADER_AUTHORIZATION, BEARER_PREFIX + apiKey)
+            .header(HttpHeaders.AUTHORIZATION, HttpAuthConstants.BEARER_PREFIX + apiKey)
             .build();
     }
 
@@ -170,7 +165,7 @@ public class ChatModelProber {
         return HttpRequest.newBuilder()
             .uri(URI.create(url))
             .timeout(testTimeout)
-            .header(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .POST(HttpRequest.BodyPublishers.ofString(body));
     }
 
@@ -180,13 +175,13 @@ public class ChatModelProber {
         try {
             JsonNode node = mapper.readTree(responseBody);
             switch (provider) {
-                case PROVIDER_DASHSCOPE:
+                case ModelProviders.DASHSCOPE:
                     // 原生响应体形如 {"output":{...},"usage":{...}}
                     return node.has("output") && node.get("output").isObject();
-                case PROVIDER_ANTHROPIC:
+                case ModelProviders.ANTHROPIC:
                     // 原生响应体形如 {"content":[...],"role":"assistant"}
                     return node.has("content") && node.get("content").isArray();
-                case PROVIDER_GEMINI:
+                case ModelProviders.GEMINI:
                     // 原生响应体形如 {"candidates":[...]}
                     return node.has("candidates") && node.get("candidates").isArray();
                 default:

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentConfig.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customerwork.data.attachment;
 
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.attachment.mapper.ChatAttachmentMapper;
 import com.richard.fyoung.customerwork.infra.config.ChatModelFactory;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
@@ -33,8 +35,6 @@ public class AttachmentConfig {
 
     private static final Logger log = LoggerFactory.getLogger(AttachmentConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     /**
      * 附件存储：默认 jdbc（业务数据一律真实库）。jdbc 需持久化环境（{@code CustomerWorkPersistenceConfig}）已激活
      * 提供 Mapper；若声明 jdbc 但持久化环境未激活（无其它域触发），惰性取不到 Mapper 则降级内存并告警，避免启动失败。
@@ -43,7 +43,7 @@ public class AttachmentConfig {
     @ConditionalOnMissingBean(AttachmentStore.class)
     public AttachmentStore attachmentStore(AttachmentProperties properties,
                                            ObjectProvider<ChatAttachmentMapper> mapperProvider) {
-        if (STORE_MODE_JDBC.equalsIgnoreCase(properties.getStoreMode())) {
+        if (StoreModes.isJdbc(properties.getStoreMode())) {
             ChatAttachmentMapper mapper = mapperProvider.getIfAvailable();
             if (mapper != null) {
                 log.info("attachment store: jdbc (MyBatis-Plus 实现, table=cw_chat_attachment)");
@@ -71,7 +71,7 @@ public class AttachmentConfig {
         Supplier<Model> modelSupplier = () -> {
             String configured = StringUtils.hasText(ocr.getApiKey()) ? ocr.getApiKey() : modelApiKey;
             // dashscope 走工厂的 Key 解析（回落 DASHSCOPE_API_KEY 环境变量）；其它厂商直接用配置值
-            String apiKey = "dashscope".equalsIgnoreCase(ocr.getProvider())
+            String apiKey = ModelProviders.DASHSCOPE.equalsIgnoreCase(ocr.getProvider())
                 ? ChatModelFactory.resolveDashScopeKey(configured)
                 : configured;
             return ChatModelFactory.build(ocr.getProvider(), ocr.getModelName(), apiKey, ocr.getBaseUrl(),

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentParseService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentParseService.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerwork.data.attachment;
 import org.apache.tika.Tika;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -188,7 +189,7 @@ public class AttachmentParseService {
         try {
             return tika.detect(data, fileName);
         } catch (Exception e) {
-            return "application/octet-stream";
+            return MediaType.APPLICATION_OCTET_STREAM_VALUE;
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/MinioAttachmentFileStorage.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/MinioAttachmentFileStorage.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import org.springframework.http.MediaType;
 
 /**
  * 附件 MinIO 对象存储：把上传字节以对象 key {@code {yyyyMM}/{uuid}.{ext}} 上传到指定 bucket，返回该 key。
@@ -31,7 +32,6 @@ public class MinioAttachmentFileStorage implements AttachmentFileStorage {
     private static final DateTimeFormatter MONTH_FMT = DateTimeFormatter.ofPattern("yyyyMM");
 
     /** 上传对象的 content-type（统一按二进制流，解析侧凭扩展名 / Tika 识别，不依赖对象元数据）。 */
-    private static final String OBJECT_CONTENT_TYPE = "application/octet-stream";
 
     private final MinioClient client;
     private final String bucket;
@@ -61,7 +61,7 @@ public class MinioAttachmentFileStorage implements AttachmentFileStorage {
             client.putObject(PutObjectArgs.builder()
                 .bucket(bucket)
                 .object(objectKey)
-                .contentType(OBJECT_CONTENT_TYPE)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM_VALUE)
                 .stream(new ByteArrayInputStream(data), data.length, -1)
                 .build());
         } catch (Exception e) {
@@ -79,7 +79,7 @@ public class MinioAttachmentFileStorage implements AttachmentFileStorage {
             client.putObject(PutObjectArgs.builder()
                 .bucket(bucket)
                 .object(storagePath)
-                .contentType(OBJECT_CONTENT_TYPE)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM_VALUE)
                 .stream(new ByteArrayInputStream(data), data.length, -1)
                 .build());
         } catch (Exception e) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/calllog/AgentCallLogConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/calllog/AgentCallLogConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.calllog;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.calllog.mapper.AgentCallLogMapper;
 import com.richard.fyoung.customerwork.data.calllog.mapper.AgentCallSegmentMapper;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
@@ -24,15 +25,13 @@ public class AgentCallLogConfig {
 
     private static final Logger log = LoggerFactory.getLogger(AgentCallLogConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(AgentCallLogStore.class)
     public AgentCallLogStore agentCallLogStore(CustomerWorkProperties properties,
                                                ObjectProvider<AgentCallLogMapper> callLogMapperProvider,
                                                ObjectProvider<AgentCallSegmentMapper> segmentMapperProvider) {
         String mode = properties.getCallLog().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("agent call log store: jdbc (MyBatis-Plus, tables=cw_agent_call_log/cw_agent_call_segment)");
             return new MybatisAgentCallLogStore(callLogMapperProvider.getObject(), segmentMapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/chatlog/ChatLogConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/chatlog/ChatLogConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.chatlog;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.chatlog.mapper.ChatMessageMapper;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.slf4j.Logger;
@@ -22,14 +23,12 @@ public class ChatLogConfig {
 
     private static final Logger log = LoggerFactory.getLogger(ChatLogConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(ChatMessageStore.class)
     public ChatMessageStore chatMessageStore(CustomerWorkProperties properties,
                                              ObjectProvider<ChatMessageMapper> chatMessageMapperProvider) {
         String mode = properties.getChatLog().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("chat log store: jdbc (MyBatis-Plus 实现, table=cw_chat_message)");
             return new MybatisChatMessageStore(chatMessageMapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/dict/DictConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/dict/DictConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.dict;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.data.dict.mapper.DictItemMapper;
 import com.richard.fyoung.customerwork.data.dict.mapper.DictTypeMapper;
@@ -24,15 +25,13 @@ public class DictConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DictConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(DictStore.class)
     public DictStore dictStore(CustomerWorkProperties properties,
                                ObjectProvider<DictTypeMapper> typeMapperProvider,
                                ObjectProvider<DictItemMapper> itemMapperProvider) {
         String mode = properties.getDict().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("dict store: jdbc (MyBatis-Plus 实现, tables=cw_dict_type/cw_dict_item)");
             return new MybatisDictStore(typeMapperProvider.getObject(), itemMapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/dict/InMemoryDictStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/dict/InMemoryDictStore.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.dict;
 
+import com.richard.fyoung.customerwork.data.order.OrderStatuses;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
@@ -22,7 +23,8 @@ public class InMemoryDictStore implements DictStore {
     public InMemoryDictStore() {
         this.types = List.of(new DictType("order_status", "订单状态", "用户订单状态筛选项（与后端返回的中文文案一致）", true));
         List<DictItem> seeds = new ArrayList<>();
-        String[] statuses = {"待支付", "已支付", "待发货", "已发货", "已签收", "已取消", "已退款"};
+        String[] statuses = {OrderStatuses.PENDING_PAYMENT, OrderStatuses.PAID, OrderStatuses.PENDING_SHIPMENT,
+            OrderStatuses.SHIPPED, OrderStatuses.RECEIVED, OrderStatuses.CANCELLED, OrderStatuses.REFUNDED};
         for (int i = 0; i < statuses.length; i++) {
             seeds.add(new DictItem((long) (i + 1), "order_status", statuses[i], statuses[i], i + 1, true, null));
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/knowledge/embedding/DashScopeEmbeddingClient.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/knowledge/embedding/DashScopeEmbeddingClient.java
@@ -2,8 +2,10 @@ package com.richard.fyoung.customerwork.data.knowledge.embedding;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -116,7 +118,7 @@ public class DashScopeEmbeddingClient implements EmbeddingClient {
                 .uri(URI.create(url))
                 .timeout(CALL_TIMEOUT)
                 .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + apiKey)
+                .header(HttpHeaders.AUTHORIZATION, HttpAuthConstants.BEARER_PREFIX + apiKey)
                 .POST(HttpRequest.BodyPublishers.ofString(body))
                 .build();
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/order/OrderDirectoryService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/order/OrderDirectoryService.java
@@ -28,10 +28,9 @@ import java.util.Optional;
 public class OrderDirectoryService {
 
     /** 取消终态（与 {@code MybatisOrderBackend} 保持一致）。 */
-    private static final String STATUS_CANCELLED = "已取消";
 
     /** 可取消的状态集合（未发货阶段）。 */
-    private static final List<String> CANCELLABLE_STATUSES = List.of("待支付", "已支付", "待发货");
+    private static final List<String> CANCELLABLE_STATUSES = OrderStatuses.CANCELLABLE;
 
     private final OrderMapper orderMapper;
 
@@ -79,7 +78,7 @@ public class OrderDirectoryService {
             return OrderMutationResult.STATE_CONFLICT;
         }
         orderMapper.update(null, new LambdaUpdateWrapper<OrderDO>()
-            .set(OrderDO::getStatus, STATUS_CANCELLED)
+            .set(OrderDO::getStatus, OrderStatuses.CANCELLED)
             .eq(OrderDO::getOrderId, orderId));
         return OrderMutationResult.OK;
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/order/OrderStatuses.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/order/OrderStatuses.java
@@ -1,0 +1,28 @@
+package com.richard.fyoung.customerwork.data.order;
+
+import java.util.List;
+
+/**
+ * 订单状态字面量（{@code cw_order.status} 列存的值）。
+ *
+ * <p>取消状态此前在订单目录服务与订单工具后端各写一份中文字面量：两处必须逐字相同，
+ * 差一个字就是"工具说取消成功、列表里还是待发货"，SQL 不会报错。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class OrderStatuses {
+
+    public static final String PENDING_PAYMENT = "待支付";
+    public static final String PAID = "已支付";
+    public static final String PENDING_SHIPMENT = "待发货";
+    public static final String SHIPPED = "已发货";
+    public static final String RECEIVED = "已签收";
+    public static final String CANCELLED = "已取消";
+    public static final String REFUNDED = "已退款";
+
+    /** 允许用户自助取消的状态：已发货之后只能走售后，不能直接取消。 */
+    public static final List<String> CANCELLABLE = List.of(PENDING_PAYMENT, PAID, PENDING_SHIPMENT);
+
+    private OrderStatuses() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/outbox/OutboxConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/outbox/OutboxConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.outbox;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.outbox.mapper.OutboxMessageMapper;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.capability.deadletter.DeadLetterStore;
@@ -24,8 +25,8 @@ public class OutboxConfig {
     public OutboxStore outboxStore(CustomerWorkProperties properties,
                                    ObjectProvider<OutboxMessageMapper> mapperProvider) {
         String configured = properties.getOutbox().getStoreMode();
-        boolean ticketJdbc = "jdbc".equalsIgnoreCase(properties.getTicket().getStoreMode());
-        boolean jdbc = "jdbc".equalsIgnoreCase(configured)
+        boolean ticketJdbc = StoreModes.isJdbc(properties.getTicket().getStoreMode());
+        boolean jdbc = StoreModes.isJdbc(configured)
             || ("auto".equalsIgnoreCase(configured) && ticketJdbc);
         if (ticketJdbc && !jdbc) {
             throw new IllegalStateException(

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/rag/search/KnowledgeBaseEndpoint.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/rag/search/KnowledgeBaseEndpoint.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.data.rag.search;
 
 import java.math.BigDecimal;
+import org.springframework.http.MediaType;
 
 /**
  * 一次检索所需的知识库连接参数（apiKey 已解密）。刻意与任何持久化实体解耦：
@@ -24,7 +25,7 @@ public record KnowledgeBaseEndpoint(Long id, String kbName, String baseUrl, Stri
     /** 默认返回条数（配置留空时用）。 */
     public static final int DEFAULT_TOP_N = 5;
     /** 默认 Content-Type（配置留空时用）。 */
-    public static final String DEFAULT_CONTENT_TYPE = "application/json";
+    public static final String DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_JSON_VALUE;
 
     public int effectiveTopN() {
         return topN == null || topN <= 0 ? DEFAULT_TOP_N : topN;

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/rag/search/KnowledgeSearchOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/rag/search/KnowledgeSearchOps.java
@@ -2,10 +2,12 @@ package com.richard.fyoung.customerwork.data.rag.search;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.safety.security.HttpTargetForbiddenException;
 import com.richard.fyoung.customerwork.safety.security.HttpTargetGuard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -67,9 +69,6 @@ public class KnowledgeSearchOps {
 
     private static final String SEARCH_PATH = "/api/v1/knowledge/search";
     private static final String RESPONSE_CODE_OK = "OK";
-    private static final String HEADER_AUTHORIZATION = "Authorization";
-    private static final String HEADER_CONTENT_TYPE = "Content-Type";
-    private static final String BEARER_PREFIX = "Bearer ";
     private static final String CODE_SEARCH_FAIL = "RAG-SEARCH-FAIL";
     /** 非 JSON 错误响应体透出的最大字符数（避免把网关 HTML 错误页整页塞进提示）。 */
     private static final int ERROR_BODY_MAX_CHARS = 200;
@@ -80,7 +79,7 @@ public class KnowledgeSearchOps {
      * JDK HttpRequest 的 {@code header()} 是追加而非覆盖，重复设置会产生两个同名头，行为不可控。
      */
     private static final Set<String> RESERVED_HEADERS =
-        Set.of(HEADER_AUTHORIZATION.toLowerCase(Locale.ROOT), HEADER_CONTENT_TYPE.toLowerCase(Locale.ROOT));
+        Set.of(HttpHeaders.AUTHORIZATION.toLowerCase(Locale.ROOT), HttpHeaders.CONTENT_TYPE.toLowerCase(Locale.ROOT));
 
     /**
      * 多库并发检索专用线程池：与 Tomcat 请求线程、以及 ForkJoin common pool 都隔离——
@@ -131,8 +130,8 @@ public class KnowledgeSearchOps {
             HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(trimTrailingSlash(endpoint.baseUrl()) + SEARCH_PATH))
                 .timeout(Duration.ofSeconds(settings.getRequestTimeoutSeconds()))
-                .header(HEADER_CONTENT_TYPE, endpoint.effectiveContentType())
-                .header(HEADER_AUTHORIZATION, BEARER_PREFIX + endpoint.apiKey())
+                .header(HttpHeaders.CONTENT_TYPE, endpoint.effectiveContentType())
+                .header(HttpHeaders.AUTHORIZATION, HttpAuthConstants.BEARER_PREFIX + endpoint.apiKey())
                 .POST(HttpRequest.BodyPublishers.ofString(body));
             parseExtraHeaders(objectMapper, endpoint.extraHeaders()).forEach(builder::header);
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/skill/MysqlSkillMaterializer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/skill/MysqlSkillMaterializer.java
@@ -1,6 +1,8 @@
 package com.richard.fyoung.customerwork.data.skill;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
+import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.data.skill.entity.SkillDO;
 import com.richard.fyoung.customerwork.data.skill.entity.SkillFileDO;
 import com.richard.fyoung.customerwork.data.skill.mapper.SkillFileMapper;
@@ -33,15 +35,11 @@ import java.util.stream.Stream;
  */
 public class MysqlSkillMaterializer {
 
-    private static final Logger log = LoggerFactory.getLogger(MysqlSkillMaterializer.class);
 
-    private static final String SKILL_FILE_NAME = "SKILL.md";
+    private static final Logger log = LoggerFactory.getLogger(MysqlSkillMaterializer.class);
 
     /** skillCode 白名单：它直接作为目录名，只允许字母/数字/连字符/下划线。 */
     private static final Pattern SAFE_SKILL_CODE = Pattern.compile("[A-Za-z0-9_-]+");
-
-    private static final int ENABLED = 1;
-
     private final SkillMapper skillMapper;
     private final SkillFileMapper skillFileMapper;
 
@@ -59,7 +57,7 @@ public class MysqlSkillMaterializer {
      */
     public int materializeTo(Path targetDir) throws IOException {
         List<SkillDO> skills = skillMapper.selectList(
-            new LambdaQueryWrapper<SkillDO>().eq(SkillDO::getEnabled, ENABLED));
+            new LambdaQueryWrapper<SkillDO>().eq(SkillDO::getEnabled, StatusFlags.ENABLED));
 
         // 全量重建：先清空再写，避免上一版残留（已删除的技能、改名的附属文件）混进技能包
         deleteRecursively(targetDir);
@@ -74,7 +72,7 @@ public class MysqlSkillMaterializer {
             }
             Path skillDir = targetDir.resolve(skill.getSkillCode());
             Files.createDirectories(skillDir);
-            Files.writeString(skillDir.resolve(SKILL_FILE_NAME),
+            Files.writeString(skillDir.resolve(AgentFileNames.SKILL_MD),
                 skill.getContent() == null ? "" : skill.getContent(), StandardCharsets.UTF_8);
             materializeFiles(skill, skillDir);
             materialized++;

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/skill/storage/MinioSkillPublisher.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/skill/storage/MinioSkillPublisher.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.skill.storage;
 
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import io.minio.BucketExistsArgs;
 import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
@@ -16,6 +17,7 @@ import java.io.UncheckedIOException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.springframework.http.MediaType;
 
 /**
  * MinIO 对象存储目标：把 SKILL.md 发布为对象 {@code {prefix}{skillCode}/SKILL.md}，
@@ -31,9 +33,6 @@ import java.util.List;
 public class MinioSkillPublisher implements SkillContentPublisher {
 
     private static final Logger log = LoggerFactory.getLogger(MinioSkillPublisher.class);
-
-    private static final String SKILL_FILE_NAME = "SKILL.md";
-    private static final String OBJECT_CONTENT_TYPE = "application/octet-stream";
 
     private final MinioClient client;
     private final String bucket;
@@ -59,7 +58,7 @@ public class MinioSkillPublisher implements SkillContentPublisher {
 
     @Override
     public void publish(String skillCode, String content) {
-        putObject(objectKey(skillCode, SKILL_FILE_NAME), content.getBytes(StandardCharsets.UTF_8));
+        putObject(objectKey(skillCode, AgentFileNames.SKILL_MD), content.getBytes(StandardCharsets.UTF_8));
         log.info("minio skill published, skillCode={}, bucket={}", skillCode, bucket);
     }
 
@@ -98,7 +97,7 @@ public class MinioSkillPublisher implements SkillContentPublisher {
             client.putObject(PutObjectArgs.builder()
                 .bucket(bucket)
                 .object(objectKey)
-                .contentType(OBJECT_CONTENT_TYPE)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM_VALUE)
                 .stream(new ByteArrayInputStream(data), data.length, -1)
                 .build());
         } catch (Exception e) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/skill/storage/SftpSkillPublisher.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/skill/storage/SftpSkillPublisher.java
@@ -3,6 +3,7 @@ package com.richard.fyoung.customerwork.data.skill.storage;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
+import com.richard.fyoung.customerwork.core.constant.AgentFileNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +25,6 @@ public class SftpSkillPublisher implements SkillContentPublisher {
 
     private static final Logger log = LoggerFactory.getLogger(SftpSkillPublisher.class);
 
-    private static final String SKILL_FILE_NAME = "SKILL.md";
     private static final String PATH_SEPARATOR = "/";
 
     private final SkillStorageSettings.Sftp config;
@@ -168,7 +168,7 @@ public class SftpSkillPublisher implements SkillContentPublisher {
 
     /** {remote-dir}/{skillCode}/SKILL.md。 */
     static String remoteSkillFile(String remoteDir, String skillCode) {
-        return remoteSkillDir(remoteDir, skillCode) + PATH_SEPARATOR + SKILL_FILE_NAME;
+        return remoteSkillDir(remoteDir, skillCode) + PATH_SEPARATOR + AgentFileNames.SKILL_MD;
     }
 
     /** 远端文件路径的父目录（附属文件路径必含 skillCode 层级，必有 {@code /}）。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/ticket/TicketConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/ticket/TicketConfig.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.data.ticket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.data.outbox.OutboxHandler;
 import com.richard.fyoung.customerwork.data.outbox.OutboxService;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
@@ -28,15 +29,13 @@ public class TicketConfig {
 
     private static final Logger log = LoggerFactory.getLogger(TicketConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(TicketStore.class)
     public TicketStore ticketStore(CustomerWorkProperties properties,
                                    ObjectProvider<TicketMapper> ticketMapperProvider,
                                    ObjectProvider<TicketEventMapper> ticketEventMapperProvider) {
         String mode = properties.getTicket().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("ticket store: jdbc (MyBatis-Plus 实现, table=cw_ticket/cw_ticket_event)");
             return new MybatisTicketStore(ticketMapperProvider.getObject(), ticketEventMapperProvider.getObject());
         }
@@ -50,7 +49,7 @@ public class TicketConfig {
                                                       ObjectProvider<TicketEventListener> listenerProvider,
                                                       OutboxService outboxService,
                                                       ObjectProvider<ObjectMapper> objectMapperProvider) {
-        if (STORE_MODE_JDBC.equalsIgnoreCase(properties.getTicket().getStoreMode())) {
+        if (StoreModes.isJdbc(properties.getTicket().getStoreMode())) {
             log.info("ticket event publisher: database outbox");
             return new OutboxTicketEventPublisher(outboxService,
                 objectMapperProvider.getIfAvailable(ObjectMapper::new));

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/user/UserAccountConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.user;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.data.user.mapper.UserMapper;
 import com.richard.fyoung.customerwork.safety.subjectquota.SubjectLevelBinding;
@@ -24,13 +25,11 @@ public class UserAccountConfig {
 
     private static final Logger log = LoggerFactory.getLogger(UserAccountConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(UserAccountStore.class)
     public UserAccountStore userAccountStore(CustomerWorkProperties properties, ObjectProvider<UserMapper> mapperProvider) {
         String mode = properties.getUserAuth().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("user store: jdbc (MyBatis-Plus 实现, table=cw_user)");
             return new MybatisUserAccountStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/CodecDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/CodecDevToolOps.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.devtool;
 
+import com.richard.fyoung.customerwork.core.common.crypto.AesGcmCrypto;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -65,15 +66,11 @@ public final class CodecDevToolOps {
     private static final int KEY_LEN_256 = 32;
     /** 分组模式的 IV 长度即 AES 块长；GCM 用推荐的 12 字节 nonce。 */
     private static final int BLOCK_IV_LENGTH = 16;
-    private static final int GCM_IV_LENGTH = 12;
     private static final int GCM_TAG_BITS = 128;
     /** AES 块长，NoPadding 时明文长度须为其整数倍。 */
     private static final int AES_BLOCK_SIZE = 16;
 
     /** 二进制内容的文本编码（用于密钥/IV 的解析与密文的输出）。 */
-    private static final String ENCODING_UTF8 = "UTF8";
-    private static final String ENCODING_HEX = "HEX";
-    private static final String ENCODING_BASE64 = "BASE64";
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
 
@@ -276,10 +273,10 @@ public final class CodecDevToolOps {
         resolved.mode = normalizeMode(params.getMode());
         resolved.jcePadding = resolvePadding(params.getPadding(), resolved.mode);
         resolved.transform = AES + "/" + resolved.mode + "/" + resolved.jcePadding;
-        resolved.ivEncoding = normalizeEncoding(params.getIvEncoding(), ENCODING_BASE64, "ivEncoding");
+        resolved.ivEncoding = normalizeEncoding(params.getIvEncoding(), DevToolConstants.ENCODING_BASE64, "ivEncoding");
         resolved.outputFormat = normalizeOutputFormat(params.getOutputFormat());
         resolved.keyBytes = validateKey(params.getKey(),
-            normalizeEncoding(params.getKeyEncoding(), ENCODING_UTF8, "keyEncoding"));
+            normalizeEncoding(params.getKeyEncoding(), DevToolConstants.ENCODING_UTF8, "keyEncoding"));
         return resolved;
     }
 
@@ -344,7 +341,7 @@ public final class CodecDevToolOps {
 
     /** 各模式的 IV 字节长度（ECB 不使用 IV，不会走到这里）。 */
     private int ivLengthOf(String mode) {
-        return MODE_GCM.equals(mode) ? GCM_IV_LENGTH : BLOCK_IV_LENGTH;
+        return MODE_GCM.equals(mode) ? AesGcmCrypto.GCM_IV_LENGTH : BLOCK_IV_LENGTH;
     }
 
     /** 规范化二进制文本编码，为空取默认值。 */
@@ -353,7 +350,7 @@ public final class CodecDevToolOps {
             return defaultEncoding;
         }
         String upper = encoding.trim().toUpperCase(Locale.ROOT).replace("-", "").replace("_", "");
-        if (!ENCODING_UTF8.equals(upper) && !ENCODING_HEX.equals(upper) && !ENCODING_BASE64.equals(upper)) {
+        if (!DevToolConstants.ENCODING_UTF8.equals(upper) && !DevToolConstants.ENCODING_HEX.equals(upper) && !DevToolConstants.ENCODING_BASE64.equals(upper)) {
             throw new IllegalArgumentException(fieldName + " 仅支持 utf8/hex/base64，当前 " + encoding);
         }
         return upper;
@@ -362,10 +359,10 @@ public final class CodecDevToolOps {
     /** 规范化密文输入输出格式，为空默认 base64（密文是二进制，不能按 utf8 呈现）。 */
     private String normalizeOutputFormat(String outputFormat) {
         if (outputFormat == null || outputFormat.trim().isEmpty()) {
-            return ENCODING_BASE64;
+            return DevToolConstants.ENCODING_BASE64;
         }
         String upper = outputFormat.trim().toUpperCase(Locale.ROOT);
-        if (!ENCODING_HEX.equals(upper) && !ENCODING_BASE64.equals(upper)) {
+        if (!DevToolConstants.ENCODING_HEX.equals(upper) && !DevToolConstants.ENCODING_BASE64.equals(upper)) {
             throw new IllegalArgumentException("outputFormat 仅支持 hex/base64，当前 " + outputFormat);
         }
         return upper;
@@ -374,11 +371,11 @@ public final class CodecDevToolOps {
     /** 按指定编码把文本解析成字节。 */
     private byte[] decodeBinary(String raw, String encoding, String fieldName) {
         switch (encoding) {
-            case ENCODING_UTF8:
+            case DevToolConstants.ENCODING_UTF8:
                 return raw.getBytes(UTF_8);
-            case ENCODING_HEX:
+            case DevToolConstants.ENCODING_HEX:
                 return decodeHex(raw, fieldName);
-            case ENCODING_BASE64:
+            case DevToolConstants.ENCODING_BASE64:
             default:
                 try {
                     return Base64.getDecoder().decode(raw.trim());
@@ -390,7 +387,7 @@ public final class CodecDevToolOps {
 
     /** 按指定编码把字节输出成文本（仅 hex/base64；utf8 用于密钥输入，不用于输出）。 */
     private String encodeBinary(byte[] bytes, String encoding) {
-        return ENCODING_HEX.equals(encoding) ? toHexLower(bytes) : Base64.getEncoder().encodeToString(bytes);
+        return DevToolConstants.ENCODING_HEX.equals(encoding) ? toHexLower(bytes) : Base64.getEncoder().encodeToString(bytes);
     }
 
     /** hex 文本转字节：忽略空白，校验字符集与偶数长度。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/CronDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/CronDevToolOps.java
@@ -26,7 +26,6 @@ import java.util.List;
 public final class CronDevToolOps {
 
     /** 默认时区：与调度中心、业务库时间口径一致。 */
-    private static final String DEFAULT_ZONE = "Asia/Shanghai";
 
     /** 推算执行时间的条数：默认与上限。 */
     private static final int DEFAULT_NEXT_COUNT = 5;
@@ -179,7 +178,7 @@ public final class CronDevToolOps {
     /** 时区取值：null/空取默认，非法 ID fast-fail。 */
     private ZoneId resolveZone(String timezone) {
         if (timezone == null || timezone.trim().isEmpty()) {
-            return ZoneId.of(DEFAULT_ZONE);
+            return ZoneId.of(DevToolConstants.DEFAULT_ZONE);
         }
         try {
             return ZoneId.of(timezone.trim());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/DevToolConstants.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/DevToolConstants.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customerwork.devtool;
+
+/**
+ * 开发者工具箱公共字面量。
+ *
+ * <p>编码名是<b>对外接口契约</b>（前端下拉框传什么、后端认什么），JWT 与编解码两个工具必须认同一套；
+ * 此前各写一份，加一种编码只改一处的话，另一个工具会把它当非法值拒掉。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class DevToolConstants {
+
+    /** 时间展示与 cron 推演的默认时区。 */
+    public static final String DEFAULT_ZONE = "Asia/Shanghai";
+
+    public static final String ENCODING_UTF8 = "UTF8";
+    public static final String ENCODING_HEX = "HEX";
+    public static final String ENCODING_BASE64 = "BASE64";
+
+    private DevToolConstants() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/JwtDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/JwtDevToolOps.java
@@ -37,7 +37,6 @@ public final class JwtDevToolOps {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /** 展示时间用的时区与格式（与工具箱其它工具一致）。 */
-    private static final String DEFAULT_ZONE = "Asia/Shanghai";
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     /** JWT 的三段结构。 */
@@ -53,9 +52,6 @@ public final class JwtDevToolOps {
     private static final String ALG_NONE = "none";
 
     /** 密钥文本编码。 */
-    private static final String ENCODING_UTF8 = "UTF8";
-    private static final String ENCODING_HEX = "HEX";
-    private static final String ENCODING_BASE64 = "BASE64";
 
     /** 时间戳换算。 */
     private static final long MILLIS_PER_SECOND = 1000L;
@@ -80,7 +76,7 @@ public final class JwtDevToolOps {
         JsonNode header = parseSegment(parts[0], "header");
         JsonNode payload = parseSegment(parts[1], "payload");
         String algorithm = header.path("alg").asText(null);
-        ZoneId zoneId = ZoneId.of(DEFAULT_ZONE);
+        ZoneId zoneId = ZoneId.of(DevToolConstants.DEFAULT_ZONE);
 
         Long expSeconds = readNumericDate(payload, "exp");
         Long nbfSeconds = readNumericDate(payload, "nbf");
@@ -192,10 +188,10 @@ public final class JwtDevToolOps {
     /** 规范化密钥编码。 */
     private String normalizeEncoding(String encoding) {
         if (encoding == null || encoding.trim().isEmpty()) {
-            return ENCODING_UTF8;
+            return DevToolConstants.ENCODING_UTF8;
         }
         String upper = encoding.trim().toUpperCase(Locale.ROOT).replace("-", "").replace("_", "");
-        if (!ENCODING_UTF8.equals(upper) && !ENCODING_HEX.equals(upper) && !ENCODING_BASE64.equals(upper)) {
+        if (!DevToolConstants.ENCODING_UTF8.equals(upper) && !DevToolConstants.ENCODING_HEX.equals(upper) && !DevToolConstants.ENCODING_BASE64.equals(upper)) {
             throw new IllegalArgumentException("secretEncoding 仅支持 utf8/hex/base64，当前 " + encoding);
         }
         return upper;
@@ -204,7 +200,7 @@ public final class JwtDevToolOps {
     /** 按编码解出密钥字节。 */
     private byte[] decodeSecret(String secret, String encoding) {
         switch (encoding) {
-            case ENCODING_HEX:
+            case DevToolConstants.ENCODING_HEX:
                 String cleaned = secret.replaceAll("\\s", "");
                 if (!cleaned.matches("[0-9a-fA-F]+") || cleaned.length() % 2 != 0) {
                     throw new IllegalArgumentException("secret 不是合法的 hex（只允许 0-9、a-f，且长度为偶数）");
@@ -214,13 +210,13 @@ public final class JwtDevToolOps {
                     bytes[i] = (byte) Integer.parseInt(cleaned.substring(i * 2, i * 2 + 2), 16);
                 }
                 return bytes;
-            case ENCODING_BASE64:
+            case DevToolConstants.ENCODING_BASE64:
                 try {
                     return Base64.getDecoder().decode(secret.trim());
                 } catch (IllegalArgumentException e) {
                     throw new IllegalArgumentException("secret 不是合法的 Base64：" + e.getMessage(), e);
                 }
-            case ENCODING_UTF8:
+            case DevToolConstants.ENCODING_UTF8:
             default:
                 return secret.getBytes(StandardCharsets.UTF_8);
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/TimestampDevToolOps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/devtool/TimestampDevToolOps.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 public final class TimestampDevToolOps {
 
     /** 默认时区。 */
-    private static final String DEFAULT_TIMEZONE = "Asia/Shanghai";
 
     /** 纯数字按秒解析的位数。 */
     private static final int EPOCH_SECONDS_DIGITS = 10;
@@ -65,7 +64,7 @@ public final class TimestampDevToolOps {
 
     /** 解析时区，非法直接抛出。 */
     private ZoneId resolveZone(String timezone) {
-        String tz = StringUtils.hasText(timezone) ? timezone.trim() : DEFAULT_TIMEZONE;
+        String tz = StringUtils.hasText(timezone) ? timezone.trim() : DevToolConstants.DEFAULT_ZONE;
         try {
             return ZoneId.of(tz);
         } catch (Exception e) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ChatModelFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ChatModelFactory.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.config;
 
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.extensions.model.anthropic.AnthropicChatModel;
@@ -25,12 +26,6 @@ public final class ChatModelFactory {
     /** 百炼 API Key 的兜底环境变量名。 */
     private static final String ENV_DASHSCOPE_API_KEY = "DASHSCOPE_API_KEY";
 
-    private static final String PROVIDER_DASHSCOPE = "dashscope";
-    private static final String PROVIDER_OPENAI = "openai";
-    private static final String PROVIDER_ANTHROPIC = "anthropic";
-    private static final String PROVIDER_GEMINI = "gemini";
-    private static final String PROVIDER_OLLAMA = "ollama";
-
     private ChatModelFactory() {
     }
 
@@ -49,9 +44,9 @@ public final class ChatModelFactory {
     public static Model build(String provider, String modelName, String apiKey, String baseUrl,
                               boolean stream, GenerateOptions options,
                               Boolean enableSearch, Boolean enableThinking) {
-        String p = provider == null ? PROVIDER_DASHSCOPE : provider.toLowerCase();
+        String p = provider == null ? ModelProviders.DASHSCOPE : provider.toLowerCase();
         switch (p) {
-            case PROVIDER_OPENAI: {
+            case ModelProviders.OPENAI: {
                 OpenAIChatModel.Builder b = OpenAIChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).stream(stream).generateOptions(options);
                 if (StringUtils.hasText(baseUrl)) {
@@ -59,7 +54,7 @@ public final class ChatModelFactory {
                 }
                 return b.build();
             }
-            case PROVIDER_ANTHROPIC: {
+            case ModelProviders.ANTHROPIC: {
                 AnthropicChatModel.Builder b = AnthropicChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).stream(stream).defaultOptions(options);
                 if (StringUtils.hasText(baseUrl)) {
@@ -67,7 +62,7 @@ public final class ChatModelFactory {
                 }
                 return b.build();
             }
-            case PROVIDER_GEMINI: {
+            case ModelProviders.GEMINI: {
                 // 注意：Gemini 需额外引入 google-genai 依赖
                 GeminiChatModel.Builder b = GeminiChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).streamEnabled(stream).defaultOptions(options);
@@ -76,7 +71,7 @@ public final class ChatModelFactory {
                 }
                 return b.build();
             }
-            case PROVIDER_OLLAMA: {
+            case ModelProviders.OLLAMA: {
                 // Ollama 本地私有化：使用 OllamaOptions（生成参数另行配置），默认 localhost:11434
                 OllamaChatModel.Builder b = OllamaChatModel.builder().modelName(modelName);
                 if (StringUtils.hasText(baseUrl)) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ModelConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ModelConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.config;
 
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
 import com.richard.fyoung.customerwork.core.model.failover.FailoverModel;
 import com.richard.fyoung.customerwork.core.model.failover.ModelCircuitBreakerRegistry;
 import com.richard.fyoung.customerwork.core.model.tiered.ModelTierPolicy;
@@ -103,13 +104,13 @@ public class ModelConfig {
 
     /** DashScope 的 Key 支持环境变量兜底，其余厂商按配置原样取（与 {@link #buildPrimary} 同一口径）。 */
     private String resolveKey(String provider, String configuredKey) {
-        return "dashscope".equalsIgnoreCase(provider)
+        return ModelProviders.DASHSCOPE.equalsIgnoreCase(provider)
             ? ChatModelFactory.resolveDashScopeKey(configuredKey)
             : configuredKey;
     }
 
     private Model buildPrimary(ModelProperties cfg) {
-        String apiKey = "dashscope".equalsIgnoreCase(cfg.getProvider())
+        String apiKey = ModelProviders.DASHSCOPE.equalsIgnoreCase(cfg.getProvider())
             ? ChatModelFactory.resolveDashScopeKey(cfg.getApiKey())
             : cfg.getApiKey();
         Model model = buildByProvider(cfg.getProvider(), cfg.getName(), apiKey, cfg.getBaseUrl(), cfg);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcCondition.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcCondition.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.config;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.env.Environment;
@@ -22,8 +23,6 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * @author owlzhangfq@gmail.com
  */
 public class PersistenceJdbcCondition implements Condition {
-
-    private static final String JDBC = "jdbc";
 
     /** 各域的 store-mode 配置键 + 工具后端 mode 配置键（任一为 jdbc 即激活持久化环境）。 */
     private static final String[] STORE_MODE_KEYS = {
@@ -68,12 +67,12 @@ public class PersistenceJdbcCondition implements Condition {
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         Environment env = context.getEnvironment();
         for (String key : STORE_MODE_KEYS) {
-            if (JDBC.equalsIgnoreCase(env.getProperty(key))) {
+            if (StoreModes.isJdbc(env.getProperty(key))) {
                 return true;
             }
         }
         for (String key : JDBC_BY_DEFAULT_KEYS) {
-            if (JDBC.equalsIgnoreCase(env.getProperty(key, JDBC))) {
+            if (StoreModes.isJdbc(env.getProperty(key, StoreModes.JDBC))) {
                 return true;
             }
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/RuntimeConfigAckOutboxHandler.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/RuntimeConfigAckOutboxHandler.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.config;
 
+import com.richard.fyoung.customerwork.core.constant.OpenApiProtocol;
 import com.richard.fyoung.customerwork.data.outbox.OutboxHandler;
 import com.richard.fyoung.customerwork.data.outbox.OutboxMessage;
 import com.richard.fyoung.customerwork.infra.config.properties.NacosProperties;
@@ -40,7 +41,7 @@ public class RuntimeConfigAckOutboxHandler implements OutboxHandler {
             .header("Content-Type", "application/json")
             .POST(HttpRequest.BodyPublishers.ofString(message.getPayload()));
         if (StringUtils.hasText(nacos.getRuntimeConfigAckToken())) {
-            builder.header("X-Open-Api-Token", nacos.getRuntimeConfigAckToken());
+            builder.header(OpenApiProtocol.TOKEN_HEADER, nacos.getRuntimeConfigAckToken());
         }
         HttpResponse<Void> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.discarding());
         if (response.statusCode() < 200 || response.statusCode() >= 300) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/SessionConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/SessionConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.config;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.zaxxer.hikari.HikariDataSource;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.InMemoryAgentStateStore;
@@ -44,9 +45,9 @@ public class SessionConfig {
 
     /** 按配置构建 AgentStateStore（抽出以便单测）。 */
     AgentStateStore buildStateStore(SessionProperties cfg) {
-        String mode = cfg.getMode() == null ? "memory" : cfg.getMode().trim().toLowerCase();
+        String mode = cfg.getMode() == null ? StoreModes.MEMORY : cfg.getMode().trim().toLowerCase();
         switch (mode) {
-            case "redis": {
+            case StoreModes.REDIS: {
                 SessionProperties.Redis r = cfg.getRedis();
                 log.info("State persistence: JedisAgentStateStore, {}:{} keyPrefix={}",
                     r.getHost(), r.getPort(), r.getKeyPrefix());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ToolBackendConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ToolBackendConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.config;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.tool.backend.AfterSalesBackend;
 import com.richard.fyoung.customerwork.tool.backend.ComplaintBackend;
 import com.richard.fyoung.customerwork.tool.backend.KnowledgeBackend;
@@ -48,26 +49,25 @@ import org.springframework.context.annotation.Configuration;
 public class ToolBackendConfig {
 
     private static final String MODE_KEY = "customer-work.tool-backend.mode";
-    private static final String MODE_JDBC = "jdbc";
 
     // ==================== jdbc 模式：MyBatis-Plus 后端（tool-backend.mode=jdbc 时装配） ====================
 
     @Bean
-    @ConditionalOnProperty(name = MODE_KEY, havingValue = MODE_JDBC)
+    @ConditionalOnProperty(name = MODE_KEY, havingValue = StoreModes.JDBC)
     @ConditionalOnMissingBean(OrderBackend.class)
     public OrderBackend jdbcOrderBackend(OrderMapper orderMapper) {
         return new MybatisOrderBackend(orderMapper);
     }
 
     @Bean
-    @ConditionalOnProperty(name = MODE_KEY, havingValue = MODE_JDBC)
+    @ConditionalOnProperty(name = MODE_KEY, havingValue = StoreModes.JDBC)
     @ConditionalOnMissingBean(ProductBackend.class)
     public ProductBackend jdbcProductBackend(ProductMapper productMapper) {
         return new MybatisProductBackend(productMapper);
     }
 
     @Bean
-    @ConditionalOnProperty(name = MODE_KEY, havingValue = MODE_JDBC)
+    @ConditionalOnProperty(name = MODE_KEY, havingValue = StoreModes.JDBC)
     @ConditionalOnMissingBean(AfterSalesBackend.class)
     public AfterSalesBackend jdbcAfterSalesBackend(RefundMapper refundMapper,
                                                    InvoiceRequestMapper invoiceRequestMapper,
@@ -76,7 +76,7 @@ public class ToolBackendConfig {
     }
 
     @Bean
-    @ConditionalOnProperty(name = MODE_KEY, havingValue = MODE_JDBC)
+    @ConditionalOnProperty(name = MODE_KEY, havingValue = StoreModes.JDBC)
     @ConditionalOnMissingBean(MemberBackend.class)
     public MemberBackend jdbcMemberBackend(MemberMapper memberMapper,
                                            MemberAccountLogMapper memberAccountLogMapper) {
@@ -84,14 +84,14 @@ public class ToolBackendConfig {
     }
 
     @Bean
-    @ConditionalOnProperty(name = MODE_KEY, havingValue = MODE_JDBC)
+    @ConditionalOnProperty(name = MODE_KEY, havingValue = StoreModes.JDBC)
     @ConditionalOnMissingBean(ComplaintBackend.class)
     public ComplaintBackend jdbcComplaintBackend(ComplaintMapper complaintMapper) {
         return new MybatisComplaintBackend(complaintMapper);
     }
 
     @Bean
-    @ConditionalOnProperty(name = MODE_KEY, havingValue = MODE_JDBC)
+    @ConditionalOnProperty(name = MODE_KEY, havingValue = StoreModes.JDBC)
     @ConditionalOnMissingBean(KnowledgeBackend.class)
     public KnowledgeBackend jdbcKnowledgeBackend(KnowledgeMapper knowledgeMapper) {
         return new MybatisKnowledgeBackend(knowledgeMapper);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/WindowCounterConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/counter/WindowCounterConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.counter;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.redisson.api.RedissonClient;
 import org.slf4j.Logger;
@@ -21,15 +22,13 @@ public class WindowCounterConfig {
 
     private static final Logger log = LoggerFactory.getLogger(WindowCounterConfig.class);
 
-    private static final String MODE_REDIS = "redis";
-
     @Bean
     @ConditionalOnMissingBean
     public WindowCounter windowCounter(CustomerWorkProperties properties,
                                        ObjectProvider<RedissonClient> redissonProvider) {
         DistributedProperties cfg = properties.getDistributed();
         InMemoryWindowCounter inMemory = new InMemoryWindowCounter();
-        if (!MODE_REDIS.equalsIgnoreCase(cfg.getCounterMode())) {
+        if (!StoreModes.isRedis(cfg.getCounterMode())) {
             return inMemory;
         }
         RedissonClient redisson = redissonProvider.getIfAvailable();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/gateway/CrossDbConnectionSettings.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/gateway/CrossDbConnectionSettings.java
@@ -24,7 +24,8 @@ public record CrossDbConnectionSettings(String poolName,
     public static final String DEFAULT_DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
 
     /** 默认池上限（跨库访问是旁路读写，不该跟主库抢连接）。 */
-    private static final int DEFAULT_MAX_POOL_SIZE = 3;
+    /** 跨库门面的连接池默认上限：门面只做低频运维查询，池子开大反而占着客服端库的连接配额。 */
+    public static final int DEFAULT_MAX_POOL_SIZE = 3;
 
     /** 默认连接超时：库不可达时 5s 内失败返回。 */
     private static final long DEFAULT_CONNECTION_TIMEOUT_MS = 5000L;

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/lock/DistributedLockConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/lock/DistributedLockConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.infra.lock;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -27,8 +28,6 @@ public class DistributedLockConfig {
 
     private static final Logger log = LoggerFactory.getLogger(DistributedLockConfig.class);
 
-    private static final String MODE_REDIS = "redis";
-
     @Bean(destroyMethod = "shutdown")
     @ConditionalOnMissingBean
     public RedissonClient redissonClient(CustomerWorkProperties properties) {
@@ -52,7 +51,7 @@ public class DistributedLockConfig {
     public SessionLock sessionLock(CustomerWorkProperties properties, RedissonClient redissonClient) {
         DistributedProperties cfg = properties.getDistributed();
         InMemorySessionLock inMemory = new InMemorySessionLock(cfg.getSessionLockWaitSeconds());
-        if (!MODE_REDIS.equalsIgnoreCase(cfg.getSessionLockMode())) {
+        if (!StoreModes.isRedis(cfg.getSessionLockMode())) {
             return inMemory;
         }
         log.info("distributed session lock enabled, waitSeconds={}, leaseSeconds={}",

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/notification/WebhookNotificationChannel.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/notification/WebhookNotificationChannel.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.infra.notification;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.infra.config.properties.NotificationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.StringUtils;
@@ -55,7 +56,7 @@ public class WebhookNotificationChannel implements NotificationChannel {
                     .header(IDEMPOTENCY_KEY, operationId)
                     .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)));
                 if (StringUtils.hasText(properties.getAuthToken())) {
-                    builder.header(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getAuthToken());
+                    builder.header(HttpHeaders.AUTHORIZATION, HttpAuthConstants.BEARER_PREFIX + properties.getAuthToken());
                 }
                 HttpResponse<Void> response = httpClient.send(
                     builder.build(), HttpResponse.BodyHandlers.discarding());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/ws/WsFrame.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/ws/WsFrame.java
@@ -32,13 +32,22 @@ public record WsFrame(String type, Object data) {
     /** 心跳响应。 */
     public static final String TYPE_PONG = "pong";
 
-    private static final String KEY_CONTENT = "content";
-    private static final String KEY_MESSAGE_ID = "messageId";
-    private static final String KEY_SESSION_ID = "sessionId";
-    private static final String KEY_TICKET_ID = "ticketId";
-    private static final String KEY_TS = "ts";
-    private static final String KEY_CODE = "code";
-    private static final String KEY_MESSAGE = "message";
+    // ---- 帧字段名：与 TYPE_* 同为前端契约的一部分，接入方拼 data 时一律引用这里，不要各自写字面量 ----
+
+    /** 信封字段：帧类型。 */
+    public static final String KEY_TYPE = "type";
+    /** 信封字段：帧负载。 */
+    public static final String KEY_DATA = "data";
+
+    public static final String KEY_CONTENT = "content";
+    public static final String KEY_MESSAGE_ID = "messageId";
+    public static final String KEY_SESSION_ID = "sessionId";
+    public static final String KEY_TICKET_ID = "ticketId";
+    public static final String KEY_SENDER_TYPE = "senderType";
+    public static final String KEY_SENDER_ID = "senderId";
+    public static final String KEY_TS = "ts";
+    public static final String KEY_CODE = "code";
+    public static final String KEY_MESSAGE = "message";
 
     /** 对话转发帧（data 结构与前端契约对齐：messageId/sessionId/ticketId/senderType/senderId/content/ts）。 */
     public static WsFrame chat(Object data) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/analytics/BusinessAnalyticsService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/observability/analytics/BusinessAnalyticsService.java
@@ -8,6 +8,7 @@ import com.richard.fyoung.customerwork.capability.approval.PendingApprovalServic
 import com.richard.fyoung.customerwork.capability.handoff.HandoffService;
 import com.richard.fyoung.customerwork.capability.handoff.HandoffStatus;
 import com.richard.fyoung.customerwork.capability.handoff.HandoffTicket;
+import com.richard.fyoung.customerwork.core.constant.FactTypes;
 import com.richard.fyoung.customerwork.core.memory.FactLog;
 import com.richard.fyoung.customerwork.core.memory.FactRecord;
 import org.slf4j.Logger;
@@ -36,8 +37,6 @@ import java.util.stream.Collectors;
 public class BusinessAnalyticsService {
 
     private static final Logger log = LoggerFactory.getLogger(BusinessAnalyticsService.class);
-
-    private static final String QUALITY_FAILURE_TYPE = "quality-failure";
 
     private final PendingApprovalService approvalService;
     private final HandoffService handoffService;
@@ -139,7 +138,7 @@ public class BusinessAnalyticsService {
     private Integer parseQualityFailureScore(FactRecord record) {
         try {
             JsonNode node = mapper.readTree(record.fact());
-            if (!QUALITY_FAILURE_TYPE.equals(node.path("type").asText())) {
+            if (!FactTypes.QUALITY_FAILURE.equals(node.path("type").asText())) {
                 return null;
             }
             return node.path("score").asInt();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/quota/TenantQuotaConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/quota/TenantQuotaConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.quota;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.infra.counter.InMemoryWindowCounter;
 import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
@@ -21,14 +22,12 @@ public class TenantQuotaConfig {
 
     private static final Logger log = LoggerFactory.getLogger(TenantQuotaConfig.class);
 
-    private static final String MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean
     public TenantQuotaStore tenantQuotaStore(CustomerWorkProperties properties,
                                              ObjectProvider<TenantQuotaMapper> mapperProvider) {
         QuotaProperties cfg = properties.getQuota();
-        if (!MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode())) {
+        if (!StoreModes.isJdbc(cfg.getStoreMode())) {
             return new InMemoryTenantQuotaStore();
         }
         TenantQuotaMapper mapper = mapperProvider.getIfAvailable();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/AgentAuthWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/AgentAuthWebFilter.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.security;
 
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.safety.security.AgentAccessCredential.AgentIdentity;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
@@ -31,8 +32,6 @@ public class AgentAuthWebFilter implements WebFilter {
     /** 坐席 ID 在 exchange 属性中的键。 */
     public static final String AGENT_ID_ATTR = "cw.agent.id";
 
-    private static final String TOKEN_HEADER = "X-Agent-Token";
-
     private final CustomerWorkProperties properties;
 
     public AgentAuthWebFilter(CustomerWorkProperties properties) {
@@ -45,7 +44,7 @@ public class AgentAuthWebFilter implements WebFilter {
         if (!CustomerSecurityPaths.requiresAgentToken(path)) {
             return chain.filter(exchange);
         }
-        String token = exchange.getRequest().getHeaders().getFirst(TOKEN_HEADER);
+        String token = exchange.getRequest().getHeaders().getFirst(HttpAuthConstants.AGENT_TOKEN_HEADER);
         Optional<AgentIdentity> identity = AgentAccessCredential.verifyIdentity(
             token, properties.getAgentAccess().getSecret(), System.currentTimeMillis());
         if (identity.isEmpty()) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/UserAuthWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/UserAuthWebFilter.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.security;
 
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContextThreadLocalAccessor;
 import org.springframework.core.Ordered;
@@ -32,8 +33,6 @@ public class UserAuthWebFilter implements WebFilter {
     /** 用户主体在 exchange 属性中的键。 */
     public static final String PRINCIPAL_ATTR = "cw.user.principal";
 
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final UserJwtService jwtService;
 
     public UserAuthWebFilter(UserJwtService jwtService) {
@@ -47,10 +46,10 @@ public class UserAuthWebFilter implements WebFilter {
             return chain.filter(exchange);
         }
         String header = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+        if (header == null || !header.startsWith(HttpAuthConstants.BEARER_PREFIX)) {
             return AuthResponses.unauthorized(exchange, "missing bearer token");
         }
-        Optional<UserPrincipal> principal = jwtService.verify(header.substring(BEARER_PREFIX.length()));
+        Optional<UserPrincipal> principal = jwtService.verify(header.substring(HttpAuthConstants.BEARER_PREFIX.length()));
         if (principal.isEmpty()) {
             return AuthResponses.unauthorized(exchange, "invalid or expired token");
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/UserJwtService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/UserJwtService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.security;
 
+import com.richard.fyoung.customerwork.core.constant.DevDefaultCredentials;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.jsonwebtoken.Claims;
@@ -35,7 +36,6 @@ public class UserJwtService {
     private static final Logger log = LoggerFactory.getLogger(UserJwtService.class);
 
     /** 开发用默认密钥（生产必须用 env CW_USER_JWT_SECRET 覆盖，见 application.yml）。 */
-    private static final String DEV_DEFAULT_SECRET = "dev-secret-change-me-in-production-0001";
 
     private static final String CLAIM_USERNAME = "username";
     private static final String CLAIM_NICKNAME = "nickname";
@@ -49,7 +49,7 @@ public class UserJwtService {
         UserAuthProperties userAuth = properties.getUserAuth();
         String secret = userAuth.getJwtSecret();
         if (secret == null || secret.isBlank()) {
-            secret = DEV_DEFAULT_SECRET;
+            secret = DevDefaultCredentials.USER_JWT_SECRET;
             log.info("user jwt secret not configured, using dev default (override via CW_USER_JWT_SECRET in prod)");
         }
         this.signingKey = Keys.hmacShaKeyFor(sha256(secret));

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/ratelimit/RateLimitRuleConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/ratelimit/RateLimitRuleConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.security.ratelimit;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.safety.security.ratelimit.mapper.RateLimitRuleMapper;
 import org.slf4j.Logger;
@@ -27,14 +28,12 @@ public class RateLimitRuleConfig {
 
     private static final Logger log = LoggerFactory.getLogger(RateLimitRuleConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(RateLimitRuleStore.class)
     public RateLimitRuleStore rateLimitRuleStore(CustomerWorkProperties properties,
                                                  ObjectProvider<RateLimitRuleMapper> mapperProvider) {
         String mode = properties.getSecurity().getRateLimit().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("rate-limit rule store: jdbc (MyBatis-Plus, table=cw_rate_limit_rule)");
             return new MybatisRateLimitRuleStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.sensitiveword;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.safety.sensitiveword.mapper.SensitiveWordHitLogMapper;
 import com.richard.fyoung.customerwork.safety.sensitiveword.mapper.SensitiveWordMapper;
@@ -31,14 +32,12 @@ public class SensitiveWordConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SensitiveWordConfig.class);
 
-    private static final String STORE_MODE_JDBC = "jdbc";
-
     @Bean
     @ConditionalOnMissingBean(SensitiveWordStore.class)
     public SensitiveWordStore sensitiveWordStore(CustomerWorkProperties properties,
                                                  ObjectProvider<SensitiveWordMapper> mapperProvider) {
         String mode = properties.getSensitiveWord().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("sensitive-word store: jdbc (MyBatis-Plus, table=cw_sensitive_word)");
             return new MybatisSensitiveWordStore(mapperProvider.getObject());
         }
@@ -83,7 +82,7 @@ public class SensitiveWordConfig {
             CustomerWorkProperties properties,
             ObjectProvider<SensitiveWordHitLogMapper> mapperProvider) {
         String mode = properties.getSensitiveWord().getHitLog().getStoreMode();
-        if (STORE_MODE_JDBC.equalsIgnoreCase(mode)) {
+        if (StoreModes.isJdbc(mode)) {
             log.info("sensitive-word hit-log store: jdbc (table=cw_sensitive_word_hit_log)");
             return new MybatisSensitiveWordHitLogStore(mapperProvider.getObject());
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.subjectquota;
 
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
 import com.richard.fyoung.customerwork.infra.counter.InMemoryWindowCounter;
@@ -30,8 +31,6 @@ public class SubjectQuotaConfig {
 
     private static final Logger log = LoggerFactory.getLogger(SubjectQuotaConfig.class);
 
-    private static final String MODE_JDBC = "jdbc";
-
     @PostConstruct
     public void registerContextAccessor() {
         ContextRegistry.getInstance().registerThreadLocalAccessor(new QuotaSubjectContextThreadLocalAccessor());
@@ -42,7 +41,7 @@ public class SubjectQuotaConfig {
     public SubjectQuotaLevelStore subjectQuotaLevelStore(CustomerWorkProperties properties,
                                                          ObjectProvider<SubjectQuotaLevelMapper> mapperProvider) {
         SubjectQuotaProperties cfg = properties.getSubjectQuota();
-        if (!MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode())) {
+        if (!StoreModes.isJdbc(cfg.getStoreMode())) {
             return new InMemorySubjectQuotaLevelStore();
         }
         SubjectQuotaLevelMapper mapper = mapperProvider.getIfAvailable();
@@ -62,7 +61,7 @@ public class SubjectQuotaConfig {
     public SubjectQuotaHitStore subjectQuotaHitStore(CustomerWorkProperties properties,
                                                      ObjectProvider<SubjectQuotaHitMapper> mapperProvider) {
         SubjectQuotaProperties cfg = properties.getSubjectQuota();
-        if (!MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode())) {
+        if (!StoreModes.isJdbc(cfg.getStoreMode())) {
             return new InMemorySubjectQuotaHitStore();
         }
         SubjectQuotaHitMapper mapper = mapperProvider.getIfAvailable();
@@ -80,7 +79,7 @@ public class SubjectQuotaConfig {
                                                                SubjectQuotaLevelStore store) {
         SubjectQuotaProperties cfg = properties.getSubjectQuota();
         // 只有 jdbc 模式才需要轮询：内存 Store 的变更是同进程的，写入即生效，轮询纯属空转
-        boolean refreshEnabled = cfg.isEnabled() && MODE_JDBC.equalsIgnoreCase(cfg.getStoreMode());
+        boolean refreshEnabled = cfg.isEnabled() && StoreModes.isJdbc(cfg.getStoreMode());
         return new SubjectQuotaLevelProvider(store, refreshEnabled);
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaWebFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/subjectquota/SubjectQuotaWebFilter.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.safety.subjectquota;
 
+import com.richard.fyoung.customerwork.core.constant.HttpAuthConstants;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
 import com.richard.fyoung.customerwork.infra.config.properties.SubjectQuotaProperties;
 import com.richard.fyoung.customerwork.safety.security.UserAuthWebFilter;
@@ -49,7 +50,6 @@ public class SubjectQuotaWebFilter implements WebFilter {
      * 偏偏那正是用户最需要看到它的时刻。</p>
      */
     private static final String PATH_MY_QUOTA = "/api/customer/user/quota";
-    private static final String BEARER_PREFIX = "Bearer ";
 
     private final CustomerWorkProperties properties;
     private final SubjectQuotaGuard guard;
@@ -112,11 +112,11 @@ public class SubjectQuotaWebFilter implements WebFilter {
             return null;
         }
         String header = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+        if (header == null || !header.startsWith(HttpAuthConstants.BEARER_PREFIX)) {
             return null;
         }
         // 验签失败不报错：这里只是想认出"他是谁"，令牌无效自有鉴权过滤器去拒，本类只管退回按 IP 限
-        return jwtService.verify(header.substring(BEARER_PREFIX.length())).orElse(null);
+        return jwtService.verify(header.substring(HttpAuthConstants.BEARER_PREFIX.length())).orElse(null);
     }
 
     private static String remoteAddress(ServerWebExchange exchange) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/AfterSalesTools.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/AfterSalesTools.java
@@ -18,8 +18,6 @@ import reactor.core.publisher.Mono;
  */
 public class AfterSalesTools {
 
-    private static final String TOOL_SESSION = "agent-tool";
-
     private final AfterSalesBackend backend;
     /** 可空：未注入时不登记审批单，保持纯工具可用。 */
     private final PendingApprovalService approvalService;
@@ -56,7 +54,7 @@ public class AfterSalesTools {
                     return result;
                 }
                 ApprovalRequest req = approvalService.submit(
-                    ApprovalType.REFUND, TOOL_SESSION, orderId, amount, reason);
+                    ApprovalType.REFUND, ToolConstants.AGENT_TOOL_SESSION, orderId, amount, reason);
                 return result + "（审批单号 " + req.getId() + "，需人工坐席放行后执行打款）";
             });
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/HigressToolkitConfigurer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/HigressToolkitConfigurer.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.tool;
 
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.tool.mcp.McpServerSpec;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.extensions.higress.HigressMcpClientBuilder;
 import io.agentscope.extensions.higress.HigressMcpClientWrapper;
@@ -63,7 +64,7 @@ public class HigressToolkitConfigurer {
             HigressProperties h) {
         HigressMcpClientBuilder builder = HigressMcpClientBuilder.create(h.getName())
             .timeout(Duration.ofSeconds(h.getTimeoutSeconds()));
-        if ("streamable-http".equalsIgnoreCase(h.getTransport())) {
+        if (McpServerSpec.TRANSPORT_STREAMABLE_HTTP.equalsIgnoreCase(h.getTransport())) {
             builder.streamableHttpEndpoint(h.getEndpoint());
         } else {
             builder.sseEndpoint(h.getEndpoint());

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/HumanHandoffTools.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/HumanHandoffTools.java
@@ -36,7 +36,6 @@ public class HumanHandoffTools {
     private static final Logger log = LoggerFactory.getLogger(HumanHandoffTools.class);
 
     /** 无真实会话上下文时的占位会话（沿用历史语义，保证纯工具可用）。 */
-    private static final String TOOL_SESSION = "agent-tool";
 
     /** 可空：未注入时不登记 handoff 工单，保持纯工具可用。 */
     private final HandoffService handoffService;
@@ -69,7 +68,8 @@ public class HumanHandoffTools {
                     String fallbackId = "HO" + System.currentTimeMillis();
                     return replyText(fallbackId, reason);
                 }
-                String session = (sessionId != null && !sessionId.isBlank()) ? sessionId : TOOL_SESSION;
+                String session = (sessionId != null && !sessionId.isBlank())
+                    ? sessionId : ToolConstants.AGENT_TOOL_SESSION;
                 HandoffTicket ticket = handoffService.create(session, reason);
                 return replyText(ticket.getId(), reason);
             })

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurer.java
@@ -30,7 +30,6 @@ public class McpToolkitConfigurer {
     private static final Logger log = LoggerFactory.getLogger(McpToolkitConfigurer.class);
 
     /** yml 里表示 streamable http 传输的取值（其余取值一律按 sse 处理）。 */
-    private static final String TRANSPORT_STREAMABLE_HTTP = "streamable-http";
     /** 启动期注册的连接超时。 */
     private static final Duration CLIENT_TIMEOUT = Duration.ofSeconds(30);
 
@@ -86,7 +85,7 @@ public class McpToolkitConfigurer {
      */
     private reactor.core.publisher.Mono<McpClientWrapper> buildClient(
             McpProperties.Server server) {
-        String type = TRANSPORT_STREAMABLE_HTTP.equalsIgnoreCase(server.getTransport())
+        String type = McpServerSpec.TRANSPORT_STREAMABLE_HTTP.equalsIgnoreCase(server.getTransport())
             ? McpServerSpec.TYPE_HTTP
             : McpServerSpec.TYPE_SSE;
         return mcpClientFactory

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/ToolConstants.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/ToolConstants.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customerwork.tool;
+
+/**
+ * 工具层公共字面量。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class ToolConstants {
+
+    /**
+     * 工具内部发起的操作所用的会话标识占位。
+     *
+     * <p>@Tool 方法拿不到真实会话（框架不透传），落审批单/转人工单时用它占位。
+     * 这个值会写进业务表并被运营检索，两处工具写得不一样就会漏查。</p>
+     */
+    public static final String AGENT_TOOL_SESSION = "agent-tool";
+
+    private ToolConstants() {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/ComplaintBackend.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/ComplaintBackend.java
@@ -9,6 +9,12 @@ import reactor.core.publisher.Mono;
  */
 public interface ComplaintBackend {
 
+    /**
+     * 投诉单号前缀：属于本 SPI 的输出契约而不是某个实现的内部细节——
+     * 调用方按这个前缀识别单号类型，Mock 与落库两个实现必须一致。
+     */
+    String ID_PREFIX = "CP";
+
     /** 创建投诉工单，返回工单号与受理说明。 */
     Mono<String> fileComplaint(String orderId, String content);
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MockComplaintBackend.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MockComplaintBackend.java
@@ -15,15 +15,13 @@ public class MockComplaintBackend implements ComplaintBackend {
 
     private static final Logger log = LoggerFactory.getLogger(MockComplaintBackend.class);
 
-    private static final String ID_PREFIX = "CP";
-
     /** ticketId -> 工单内容（演示用内存存储）。 */
     private final ConcurrentHashMap<String, String> tickets = new ConcurrentHashMap<>();
 
     @Override
     public Mono<String> fileComplaint(String orderId, String content) {
         return Mono.fromSupplier(() -> {
-            String ticketId = ID_PREFIX + System.currentTimeMillis();
+            String ticketId = ComplaintBackend.ID_PREFIX + System.currentTimeMillis();
             tickets.put(ticketId, "订单=" + orderId + "，内容=" + content);
             log.info("[MockComplaintBackend] file complaint: ticket={}, order={}", ticketId, orderId);
             return "已为您创建投诉工单 " + ticketId + "（订单 " + orderId + "），"

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MockOrderBackend.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MockOrderBackend.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.tool.backend;
 
+import com.richard.fyoung.customerwork.data.order.OrderStatuses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -17,7 +18,7 @@ public class MockOrderBackend implements OrderBackend {
     private static final Logger log = LoggerFactory.getLogger(MockOrderBackend.class);
 
     private static final Map<String, Map<String, String>> MOCK_ORDERS = Map.of(
-        "20260613001", Map.of("status", "已发货", "amount", "299.00", "createTime", "2026-06-10"),
+        "20260613001", Map.of("status", OrderStatuses.SHIPPED, "amount", "299.00", "createTime", "2026-06-10"),
         "20260613002", Map.of("status", "已签收", "amount", "1599.00", "createTime", "2026-05-20")
     );
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MybatisAfterSalesBackend.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MybatisAfterSalesBackend.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.tool.backend;
 
+import com.richard.fyoung.customerwork.data.order.OrderStatuses;
 import com.richard.fyoung.customerwork.tool.backend.entity.InvoiceRequestDO;
 import com.richard.fyoung.customerwork.tool.backend.entity.OrderDO;
 import com.richard.fyoung.customerwork.tool.backend.entity.RefundDO;
@@ -36,8 +37,6 @@ public class MybatisAfterSalesBackend implements AfterSalesBackend {
     private static final String STATUS_APPROVED = "APPROVED";
 
     /** 不可再退款的订单终态。 */
-    private static final String ORDER_STATUS_REFUNDED = "已退款";
-    private static final String ORDER_STATUS_CANCELLED = "已取消";
 
     private static final String TRUE_FLAG = "true";
 
@@ -95,7 +94,7 @@ public class MybatisAfterSalesBackend implements AfterSalesBackend {
                 return "未查询到订单 " + orderId + "，无法校验退款资格，请核对订单号。";
             }
             String status = order.getStatus();
-            if (ORDER_STATUS_REFUNDED.equals(status) || ORDER_STATUS_CANCELLED.equals(status)) {
+            if (OrderStatuses.REFUNDED.equals(status) || OrderStatuses.CANCELLED.equals(status)) {
                 return "订单 " + orderId + " 当前状态为" + status + "，不可重复退款。";
             }
             if (!TRUE_FLAG.equalsIgnoreCase(withinSevenDays)) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MybatisComplaintBackend.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MybatisComplaintBackend.java
@@ -18,8 +18,6 @@ public class MybatisComplaintBackend implements ComplaintBackend {
 
     private static final Logger log = LoggerFactory.getLogger(MybatisComplaintBackend.class);
 
-    private static final String ID_PREFIX = "CP";
-
     /** 工单状态：处理中 / 已回复。 */
     private static final String STATUS_PROCESSING = "PROCESSING";
     private static final String STATUS_RESOLVED = "RESOLVED";
@@ -41,7 +39,7 @@ public class MybatisComplaintBackend implements ComplaintBackend {
     }
 
     private String doFileComplaint(String orderId, String content) {
-        String complaintNo = ID_PREFIX + System.currentTimeMillis();
+        String complaintNo = ComplaintBackend.ID_PREFIX + System.currentTimeMillis();
         try {
             ComplaintDO record = new ComplaintDO();
             record.setComplaintNo(complaintNo);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MybatisOrderBackend.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/backend/MybatisOrderBackend.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.tool.backend;
 
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.richard.fyoung.customerwork.data.order.OrderStatuses;
 import com.richard.fyoung.customerwork.tool.backend.entity.OrderDO;
 import com.richard.fyoung.customerwork.tool.backend.mapper.OrderMapper;
 import org.slf4j.Logger;
@@ -26,7 +27,6 @@ public class MybatisOrderBackend implements OrderBackend {
     private static final Logger log = LoggerFactory.getLogger(MybatisOrderBackend.class);
 
     /** 订单取消终态。 */
-    private static final String STATUS_CANCELLED = "已取消";
 
     private final OrderMapper orderMapper;
 
@@ -105,7 +105,7 @@ public class MybatisOrderBackend implements OrderBackend {
     private String doCancelOrder(String orderId, String reason) {
         int affected = runUpdate(() -> orderMapper.update(null,
             new LambdaUpdateWrapper<OrderDO>()
-                .set(OrderDO::getStatus, STATUS_CANCELLED)
+                .set(OrderDO::getStatus, OrderStatuses.CANCELLED)
                 .eq(OrderDO::getOrderId, orderId)),
             "ORDER-BACKEND-CANCEL-FAIL", orderId);
         return affected > 0

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpServerSpec.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpServerSpec.java
@@ -32,6 +32,14 @@ public record McpServerSpec(
     /** SSE 传输（默认）。 */
     public static final String TYPE_SSE = "sse";
 
+    /**
+     * 配置侧的 transport 取值，映射到 {@link #TYPE_HTTP}。
+     *
+     * <p>放在 type 旁边是为了让"配置写什么 → spec 里是什么"一眼可见：客服端按它选传输，
+     * 后台发布配置时按它输出，两处此前各写一份字面量。</p>
+     */
+    public static final String TRANSPORT_STREAMABLE_HTTP = "streamable-http";
+
     /** 构造一个 http/sse 传输的规格（无 stdio 相关字段）。 */
     public static McpServerSpec remote(String name, String type, String url, Map<String, String> headers) {
         return new McpServerSpec(name, type, url, null, List.of(), headers);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/constant/SharedConstantAlignmentTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/constant/SharedConstantAlignmentTest.java
@@ -1,0 +1,281 @@
+package com.richard.fyoung.customerwork.core.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>公共常量门禁</b>：同一个字面量不得在多处各定义一遍。
+ *
+ * <p><b>为什么需要这个测试</b>：{@code private static final String STORE_MODE_JDBC = "jdbc"} 这一行
+ * 曾出现在 21 个装配类里，同一个 "jdbc" 语义在 28 处、三种命名下各写一遍。这类重复不会编译失败、
+ * 不会有任何测试变红，只会在某天有人"改了一处忘了另一处"时，以最难查的方式发作——
+ * 装配走了另一条分支、统计过滤不到数据、协议两端对不上，全程不报错。</p>
+ *
+ * <p>常规单测照不出这类问题：每一份重复定义单独看都是对的。因此本测试<b>直接扫描源码</b>，
+ * 对"同一个值有几个真相来源"下断言。新增一处重复定义，这里就会红。</p>
+ *
+ * <p><b>刻意不管 {@code @ConfigurationProperties} 的字段默认值</b>（{@code private String storeMode = "jdbc";}）：
+ * {@code spring-boot-configuration-processor} 是源码级注解处理器，只从<b>字面量</b>初始化表达式里提取
+ * {@code defaultValue}，换成常量引用后那 336 项默认值元数据会静默消失，IDE 自动补全里就再也看不到
+ * "默认多少"。判定侧统一走 {@link StoreModes#isJdbc(String)} 已经够了：默认值写歪会被绑定测试与
+ * 装配测试直接照出来，不是那种"静默漂移"的形状。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class SharedConstantAlignmentTest {
+
+    private static final List<String> MODULE_SOURCE_ROOTS = List.of(
+        "customer-work-starter/src/main/java",
+        "customer-admin-server/src/main/java",
+        "customer-work-app-server/src/main/java",
+        "customer-channel/src/main/java");
+
+    /** {@code static final String NAME = "字面量";}（含 private / public / 接口字段等各种修饰）。 */
+    private static final Pattern DECLARATION =
+        Pattern.compile("static final String\\s+([A-Z_0-9]+)\\s*=\\s*\"([^\"]*)\"\\s*;");
+
+    /** 太短的值（单字符、空串）不参与判定：巧合率高、收敛收益低。 */
+    private static final int MIN_VALUE_LENGTH = 2;
+
+    /**
+     * 已经有公共定义处的值：<b>值 -&gt; 应当引用的常量</b>。
+     *
+     * <p>与下面的 {@link #DISTINCT_CONCEPTS} 是两种判定：那份管"同一个值出现在多个文件"，
+     * 这份更严——只要在别处<b>再声明一次</b>就算违规，哪怕只有一处。复制粘贴一个新的装配类
+     * 正是这么开始的：先多出一份看起来无害的私有常量，等第二个人照着抄时已经晚了。</p>
+     */
+    private static final Map<String, String> ALREADY_CONSOLIDATED = alreadyConsolidated();
+
+    /** 各值允许的唯一定义处（文件名）。 */
+    private static final Map<String, String> DEFINITION_SITES = definitionSites();
+
+    /**
+     * 同值不同概念的豁免清单：值一样纯属巧合，合并反而会把不相干的东西绑死。
+     *
+     * <p>往这里加东西前先回答一个问题：这两处如果<b>其中一处改了值而另一处没改</b>，
+     * 系统会不会出错？会 —— 那它们是同一个概念，该收敛；不会 —— 才是真的巧合。</p>
+     */
+    private static final Set<String> DISTINCT_CONCEPTS = Set.of(
+        // 五个互不相干的状态机各有自己的成功/失败态（配置版本、代码评审、知识索引、角色阶段、定时任务）
+        "FAILED", "SUCCESS", "APPROVED",
+        // 文件操作类型 / 沙箱危险动作 / 权限动作，三套动作词汇
+        "DELETE", "CREATE",
+        // Nacos 注册的 URL scheme 与 MCP 的传输类型，值撞了而已
+        "http",
+        // WS 帧字段 / MDC 日志键 / 开放 API 响应字段
+        "sessionId",
+        // store-mode 取值 / 智能体能力码 / 记忆目录名
+        "memory",
+        // 默认租户码 / 默认会话名
+        "default",
+        // 未知主体 / 未知调用类型 / 缺省会话 ID
+        "unknown",
+        // WS 帧类型 / 指标标签名
+        "type",
+        // WS 系统帧类型 / 注入消息名
+        "system",
+        // WS 错误帧类型与 SSE 错误事件名，两套协议
+        "error", "message",
+        // 两个 WebFilter 各自决定跳过哪些路径，是独立策略而非共享契约
+        "/actuator",
+        // JWT claim 名 / 会话属性键
+        "username",
+        // 诊断模式 / 填充模式
+        "auto",
+        // 定时任务触发方式 / 评测触发来源
+        "MANUAL",
+        // 微信消息类型 / 钉钉消息类型，两个平台各自的协议值
+        "text",
+        // WS 对话帧类型 / 智能体的基础对话能力码
+        "chat");
+
+    @Test
+    @DisplayName("已收敛的字面量不得在别处重新声明")
+    void consolidatedLiteralsAreNotRedeclared() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        for (Path file : mainSources()) {
+            String fileName = file.getFileName().toString();
+            Matcher m = DECLARATION.matcher(Files.readString(file, StandardCharsets.UTF_8));
+            while (m.find()) {
+                String value = m.group(2);
+                String canonical = ALREADY_CONSOLIDATED.get(value);
+                if (canonical == null || fileName.equals(DEFINITION_SITES.get(value))) {
+                    continue;
+                }
+                offenders.add(String.format("%s 里的 %s = \"%s\"，应改用 %s", fileName, m.group(1), value, canonical));
+            }
+        }
+        if (!offenders.isEmpty()) {
+            fail("这些字面量已有公共定义，不要再各写一份：\n  " + String.join("\n  ", offenders));
+        }
+    }
+
+    @Test
+    @DisplayName("同一个字面量不得在多个文件各定义一遍")
+    void noLiteralIsDeclaredInMoreThanOneFile() throws IOException {
+        Map<String, Map<String, String>> byValue = new TreeMap<>();
+        for (Path file : mainSources()) {
+            String fileName = file.getFileName().toString();
+            Matcher m = DECLARATION.matcher(Files.readString(file, StandardCharsets.UTF_8));
+            while (m.find()) {
+                if (m.group(2).length() < MIN_VALUE_LENGTH || DISTINCT_CONCEPTS.contains(m.group(2))) {
+                    continue;
+                }
+                byValue.computeIfAbsent(m.group(2), k -> new LinkedHashMap<>()).put(fileName, m.group(1));
+            }
+        }
+
+        List<String> offenders = new ArrayList<>();
+        byValue.forEach((value, sites) -> {
+            if (sites.size() < 2) {
+                return;
+            }
+            List<String> where = new ArrayList<>();
+            sites.forEach((fileName, constantName) -> where.add(fileName + ":" + constantName));
+            offenders.add(String.format("\"%s\" 被 %d 处各定义一遍 -> %s", value, sites.size(), String.join(", ", where)));
+        });
+
+        if (!offenders.isEmpty()) {
+            fail("同一个字面量有多个真相来源，请收敛到公共常量类（若确属同值不同概念，"
+                + "加进 DISTINCT_CONCEPTS 并写明理由）：\n  " + String.join("\n  ", offenders));
+        }
+    }
+
+    // ==================== 清单 ====================
+
+    private static Map<String, String> alreadyConsolidated() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put(StoreModes.JDBC, "StoreModes.JDBC");
+        map.put(StoreModes.REDIS, "StoreModes.REDIS");
+        map.put(AgentFileNames.SKILL_MD, "AgentFileNames.SKILL_MD");
+        map.put(AgentFileNames.MEMORY_MD, "AgentFileNames.MEMORY_MD");
+        map.put(HttpAuthConstants.BEARER_PREFIX, "HttpAuthConstants.BEARER_PREFIX");
+        map.put(HttpAuthConstants.AGENT_TOKEN_HEADER, "HttpAuthConstants.AGENT_TOKEN_HEADER");
+        map.put(OpenApiProtocol.TOKEN_HEADER, "OpenApiProtocol.TOKEN_HEADER");
+        map.put(OpenApiProtocol.SSE_DONE_MARKER, "OpenApiProtocol.SSE_DONE_MARKER");
+        map.put(ModelProviders.DASHSCOPE, "ModelProviders.DASHSCOPE");
+        map.put(ModelProviders.OPENAI, "ModelProviders.OPENAI");
+        map.put(ModelProviders.ANTHROPIC, "ModelProviders.ANTHROPIC");
+        map.put(ModelProviders.GEMINI, "ModelProviders.GEMINI");
+        map.put(ModelProviders.OLLAMA, "ModelProviders.OLLAMA");
+        map.put(FactTypes.QUALITY_FAILURE, "FactTypes.QUALITY_FAILURE");
+        map.put(FactTypes.NEGATIVE_FEEDBACK, "FactTypes.NEGATIVE_FEEDBACK");
+        map.put(DevDefaultCredentials.USER_JWT_SECRET, "DevDefaultCredentials.USER_JWT_SECRET");
+        map.put(DevDefaultCredentials.AGENT_ACCESS_SECRET, "DevDefaultCredentials.AGENT_ACCESS_SECRET");
+        map.put(DevDefaultCredentials.MINIO_CREDENTIAL, "DevDefaultCredentials.MINIO_CREDENTIAL");
+        // 下面几处的公共定义在别的包/模块，这里按值登记即可
+        map.put("streamable-http", "McpServerSpec.TRANSPORT_STREAMABLE_HTTP");
+        map.put("agent-tool", "ToolConstants.AGENT_TOOL_SESSION");
+        map.put("EVAL-LOAD-FAIL", "EvalErrorCodes.LOAD_FAIL");
+        map.put("Asia/Shanghai", "DevToolConstants.DEFAULT_ZONE");
+        map.put("UTF8", "DevToolConstants.ENCODING_UTF8");
+        map.put("HEX", "DevToolConstants.ENCODING_HEX");
+        map.put("BASE64", "DevToolConstants.ENCODING_BASE64");
+        map.put("已取消", "OrderStatuses.CANCELLED");
+        map.put("已发货", "OrderStatuses.SHIPPED");
+        map.put("待发货", "OrderStatuses.PENDING_SHIPMENT");
+        map.put("已退款", "OrderStatuses.REFUNDED");
+        map.put("CP", "ComplaintBackend.ID_PREFIX");
+        map.put(".git", "GitWorkspaceService.GIT_DIR_NAME");
+        map.put("vibecoding", "AgentCapabilities.VIBECODING");
+        map.put("subagent", "AgentCapabilities.SUBAGENT");
+        map.put("skill-learning", "AgentCapabilities.SKILL_LEARNING");
+        map.put("dynamic-subagent", "AgentCapabilities.DYNAMIC_SUBAGENT");
+        map.put("tasklist", "AgentCapabilities.TASKLIST");
+        map.put("super_admin", "SystemRoles.SUPER_ADMIN");
+        map.put(ChannelTypes.DINGTALK, "ChannelTypes.DINGTALK");
+        map.put(ChannelTypes.WECHAT, "ChannelTypes.WECHAT");
+        map.put("Authorization", "org.springframework.http.HttpHeaders.AUTHORIZATION");
+        map.put("Content-Type", "org.springframework.http.HttpHeaders.CONTENT_TYPE");
+        map.put("application/json", "org.springframework.http.MediaType.APPLICATION_JSON_VALUE");
+        map.put("application/octet-stream", "org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE");
+        return map;
+    }
+
+    /** 每个值唯一被允许的声明处（文件名）；不在此表的值意味着"任何地方都不许再声明"。 */
+    private static Map<String, String> definitionSites() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put(StoreModes.JDBC, "StoreModes.java");
+        map.put(StoreModes.REDIS, "StoreModes.java");
+        map.put(AgentFileNames.SKILL_MD, "AgentFileNames.java");
+        map.put(AgentFileNames.MEMORY_MD, "AgentFileNames.java");
+        map.put(HttpAuthConstants.BEARER_PREFIX, "HttpAuthConstants.java");
+        map.put(HttpAuthConstants.AGENT_TOKEN_HEADER, "HttpAuthConstants.java");
+        map.put(OpenApiProtocol.TOKEN_HEADER, "OpenApiProtocol.java");
+        map.put(OpenApiProtocol.SSE_DONE_MARKER, "OpenApiProtocol.java");
+        map.put(ModelProviders.DASHSCOPE, "ModelProviders.java");
+        map.put(ModelProviders.OPENAI, "ModelProviders.java");
+        map.put(ModelProviders.ANTHROPIC, "ModelProviders.java");
+        map.put(ModelProviders.GEMINI, "ModelProviders.java");
+        map.put(ModelProviders.OLLAMA, "ModelProviders.java");
+        map.put(FactTypes.QUALITY_FAILURE, "FactTypes.java");
+        map.put(FactTypes.NEGATIVE_FEEDBACK, "FactTypes.java");
+        map.put(DevDefaultCredentials.USER_JWT_SECRET, "DevDefaultCredentials.java");
+        map.put(DevDefaultCredentials.AGENT_ACCESS_SECRET, "DevDefaultCredentials.java");
+        map.put(DevDefaultCredentials.MINIO_CREDENTIAL, "DevDefaultCredentials.java");
+        map.put("streamable-http", "McpServerSpec.java");
+        map.put("agent-tool", "ToolConstants.java");
+        map.put("EVAL-LOAD-FAIL", "EvalErrorCodes.java");
+        map.put("Asia/Shanghai", "DevToolConstants.java");
+        map.put("UTF8", "DevToolConstants.java");
+        map.put("HEX", "DevToolConstants.java");
+        map.put("BASE64", "DevToolConstants.java");
+        map.put("已取消", "OrderStatuses.java");
+        map.put("已发货", "OrderStatuses.java");
+        map.put("待发货", "OrderStatuses.java");
+        map.put("已退款", "OrderStatuses.java");
+        map.put("CP", "ComplaintBackend.java");
+        map.put(".git", "GitWorkspaceService.java");
+        map.put("vibecoding", "AgentCapabilities.java");
+        map.put("subagent", "AgentCapabilities.java");
+        map.put("skill-learning", "AgentCapabilities.java");
+        map.put("dynamic-subagent", "AgentCapabilities.java");
+        map.put("tasklist", "AgentCapabilities.java");
+        map.put("super_admin", "SystemRoles.java");
+        map.put(ChannelTypes.DINGTALK, "ChannelTypes.java");
+        map.put(ChannelTypes.WECHAT, "ChannelTypes.java");
+        return map;
+    }
+
+    // ==================== 扫描 ====================
+
+    private List<Path> mainSources() throws IOException {
+        List<Path> result = new ArrayList<>();
+        for (String moduleRelative : MODULE_SOURCE_ROOTS) {
+            Path root = sourceRoot(moduleRelative);
+            if (!Files.isDirectory(root)) {
+                continue;
+            }
+            try (Stream<Path> stream = Files.walk(root)) {
+                stream.filter(p -> p.toString().endsWith(".java")).forEach(result::add);
+            }
+        }
+        if (result.isEmpty()) {
+            fail("没有扫描到任何源码文件，检查 MODULE_SOURCE_ROOTS 与工作目录");
+        }
+        return result;
+    }
+
+    /** 测试的工作目录是模块目录，仓库根在其上一层；两种布局都兼容（与装配门禁测试一致）。 */
+    private Path sourceRoot(String moduleRelative) {
+        Path fromRepoRoot = Paths.get(moduleRelative);
+        return Files.exists(fromRepoRoot) ? fromRepoRoot : Paths.get("..").resolve(moduleRelative);
+    }
+}


### PR DESCRIPTION
## 背景

`private static final String STORE_MODE_JDBC = "jdbc";` 在 starter 的 **21 个装配类**里各写一遍，连同 `MODE_JDBC` / `JDBC` / 裸字面量比较共 **28 处**表达同一个语义。

这类重复不会编译失败、不会有任何测试变红，只在某天有人「改了一处忘了另一处」时以最难查的方式发作——装配走错分支、统计过滤不到数据、协议两端对不上，全程不报错。和已复发六次的「能力只接在用户不走的那条路上」是同一个病根：**同一件事有多个真相来源**。

顺带全项目扫了一遍同类问题（按常量名 + 按常量值两个维度各扫一次，后者抓出了前者看不见的 `ORDER_STATUS_CANCELLED` 这种同值异名的情况）。

## 收敛落点

| 位置 | 常量类 |
|---|---|
| starter `core.constant`（跨域/跨模块公共） | `StoreModes`、`ModelProviders`、`AgentFileNames`、`HttpAuthConstants`、`OpenApiProtocol`、`FactTypes`、`DevDefaultCredentials`、`ChannelTypes`、`StatusFlags` |
| starter 域内 | `OrderStatuses`、`DevToolConstants`、`ToolConstants`、`EvalErrorCodes` |
| admin `common.constant` | `AgentCapabilities`、`SystemRoles`、`StatsGranularity`、`StarterMapperXml`、`ConnectivityTestStatus`、`TreeConstants` |
| app-server | `WsConstants` |

另有 7 处**没有新建类**，而是把私有常量提升为它所属类的对外契约：`WsFrame.KEY_*`（帧字段名与 `TYPE_*` 同为前端契约）、`McpServerSpec.TRANSPORT_STREAMABLE_HTTP`、`ComplaintBackend.ID_PREFIX`、`AesGcmCrypto.GCM_IV_LENGTH`、`CrossDbConnectionSettings.DEFAULT_MAX_POOL_SIZE`、`SysOperationLog.RESULT_*`、`GitWorkspaceService.GIT_DIR_NAME`。

标准库已有的不自己造：`Authorization` / `Content-Type` 改用 Spring `HttpHeaders`，`application/json` / `application/octet-stream` 改用 `MediaType`。

### 几个值得单独说的收敛

- **`ModelProviders`**：`ChatModelProber` 的注释里写着「与 admin 的 ModelProvider 编码一致」，却没有任何机制保证。现在客服端建模型（`ChatModelFactory`）、探活（`ChatModelProber`）、后台枚举（`ModelProvider`）三处引用同一份定义。
- **`OpenApiProtocol`**：开放 API 的 SSE 事件名，服务端在 admin、客户端在 channel，两个模块互不依赖。此前各写一份，改一边另一边会把收到的流当成未知事件默默丢弃。
- **`DevDefaultCredentials`**：开发默认密钥同时是「兜底默认值」和「生产就绪校验器的黑名单」。改了默认值而漏改校验器，校验器**照样返回通过**——等于揣着开发密钥上线且无人告警。
- **`FactTypes`**：`quality-failure` 由 `QualityFeedbackRecorder` 写、由 `BusinessAnalyticsService` 按类型过滤统计。改一处的表现是看板指标变 0 而链路不报错。
- **`StatusFlags.ENABLED`**：`status = 1` 在 18 个类里以两种命名各写一遍。数字本身不会写歪，但「哪个值是启用」这件事散在 18 处、没有一处说明，新写一张表只能翻别的类去猜。

## 判定标准是概念，不是值

同值不同概念的**一律不动**，并在门禁清单里逐条写明理由：

- `FAILED` ×5 / `SUCCESS` ×2 —— 分属配置版本、代码评审、角色阶段、知识索引、定时任务五个独立状态机
- `http` —— Nacos 注册的 URL scheme vs MCP 传输类型
- `sessionId` —— WS 帧字段 / MDC 日志键 / 开放 API 响应字段
- `DELETE`、`CREATE` —— 文件操作 / 沙箱危险动作 / 权限动作，三套动作词汇
- `MAX_BACKOFF_SHIFT=10` ×3、`SHUTDOWN_WAIT_SECONDS=5` ×2 —— 各自组件的调优参数，合了会让「改 outbox 退避」意外改到死信队列

**踩了一次**：`RESULT_SUCCESS = 1` 看着是同一概念，实际 `AiCodingAuditLog` 写 `ai_coding_audit_log`、`WorkbenchAgentController` 写 `sys_operation_log`，是两张表两套语义。编译报错才发现（`log` 变量根本不是那个实体）。已改成各自归属自己的实体。

## 机器防线

新增 `SharedConstantAlignmentTest`（2 个用例，仿 `AgentAssemblyAlignmentTest` 扫描四个模块主源码）：

1. **已收敛的值不得在别处重新声明**——哪怕只有一处。复制粘贴一个新装配类正是这么开始的：先多出一份看起来无害的私有常量。
2. **同一个值不得在多个文件各定义一遍**——兜住还没收敛的新重复；确属巧合的加进 `DISTINCT_CONCEPTS` 并写明理由。

它上线当天就抓出了本批次自身的两处疏漏：`dingtalk` 定义处迁移到 starter 后没更新清单、`WsFrame.TYPE_CHAT` 与 `AgentCapabilities.CHAT` 撞值。

## 刻意没做的

`@ConfigurationProperties` 的字段默认值（`private String storeMode = "jdbc";`）保持字面量：`spring-boot-configuration-processor` 是源码级注解处理器，只从**字面量**初始化表达式提取 `defaultValue`，换成常量引用会让那 336 项默认值元数据静默消失，IDE 自动补全里再也看不到「默认多少」。判定侧统一走 `StoreModes.isJdbc()` 已经够了——默认值写歪会被绑定测试直接照出来，不是「静默漂移」那种形状。

## 验证

全量测试 **BUILD SUCCESS**，0 失败 0 错误：

| 模块 | 用例数 |
|---|---|
| customer-work-starter | 1466（5 skip） |
| customer-admin-server | 858（1 skip） |
| customer-work-app-server | 95 |
| customer-channel | 65 |
| customer-work-gateway | 1 |
| **合计** | **2485**（上一版基线 2483，本批次 +2） |

排除 `RedisSessionPersistenceTest`（本机 Redis 无密码，已知环境不一致）。另核对 `spring-configuration-metadata.json` 仍为 371 项、336 项带默认值，未退化。

CLAUDE.md 已补「同一个字面量只允许有一个定义处」规范条目与本批次的三个坑。