### PR TITLE
feat: 补齐 compose 本地中间件编排（customer_admin 建库 + PaddleOCR 入栈）

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ stateDiagram-v2
 export DASHSCOPE_API_KEY=你的百炼密钥      # 必填，密钥仅从环境变量读取
 mvn -pl customer-work-app-server -am spring-boot:run
 
-# 方式二：Docker Compose 一键起（app + Redis + MySQL + Nacos）
+# 方式二：Docker Compose 一键起（app + Redis + MySQL(含后台库) + MinIO + Nacos + XXL-JOB + PaddleOCR）
 docker compose up -d
 
 # 发一条消息试试

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 # 一键起依赖 + 应用：docker compose up -d
-# 仅起依赖（本地用 mvn spring-boot:run 跑应用）：docker compose up -d redis mysql minio nacos xxl-job-admin
+# 仅起依赖（本地用 mvn spring-boot:run 跑应用）：docker compose up -d redis mysql minio nacos xxl-job-admin paddleocr
+# MySQL 首次初始化自动建三个库：agent_scope_customer_work（业务，MYSQL_DATABASE）、
+# customer_admin（后台，00-create-database.sql）、xxl_job（调度，xxl-job-schema.sql 内部建）；
+# 建表归各应用的 SchemaInitializer / Flyway 管，initdb 只负责建库。
+# 监控栈（Prometheus/Grafana/Tempo/Alertmanager）独立在 docker/observability/，见 docs/部署手册.md 第九节。
 services:
   redis:
     image: redis:7
@@ -19,10 +23,12 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD:-root}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-agent_scope_customer_work}
     ports: ["3306:3306"]
-    # 03-xxl-job 脚本自带 `CREATE DATABASE IF NOT EXISTS xxl_job`，随 MYSQL_DATABASE 一起在
-    # 容器首次初始化时执行；customer_admin 库由 admin-server Flyway 或 DBA 镜像脚本维护。
+    # 03-xxl-job 脚本自带 `CREATE DATABASE IF NOT EXISTS xxl_job`，02-customer-admin 脚本建
+    # customer_admin 后台库，二者随 MYSQL_DATABASE 一起在容器首次初始化时执行；
+    # 表结构由 admin-server Flyway（dev）或 DBA 镜像脚本维护，initdb 只建库。
     volumes:
       - mysql-data:/var/lib/mysql
+      - ./mysql/02-customer-admin/00-create-database.sql:/docker-entrypoint-initdb.d/00-create-customer-admin-db.sql:ro
       - ./mysql/03-xxl-job/xxl-job-schema.sql:/docker-entrypoint-initdb.d/xxl-job-schema.sql:ro
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_PASSWORD:-root}"]
@@ -68,12 +74,34 @@ services:
       timeout: 5s
       retries: 10
 
+  # PaddleOCR 开源 OCR serving：8080/8082 对话附件图片 OCR 的默认引擎（engine=paddleocr）。
+  # 与 docker/paddleocr/docker-compose.yml 同源同镜像；首次构建+模型下载耗时较长，
+  # arm64（M 系列）走 Rosetta 模拟等说明见该目录 compose 头部。OCR 为惰性调用，
+  # 不起它也不影响应用启动，只是图片 OCR 不可用。
+  paddleocr:
+    build:
+      context: ./docker/paddleocr
+      dockerfile: Dockerfile
+    image: customer-work/paddleocr-serving:3.0.0-cpu
+    platform: linux/amd64          # arm64 走 Rosetta 模拟；x86_64 主机可删除此行
+    ports: ["8868:8080"]           # 宿主 8868 → 容器 8080（避开 app 的 8080）
+    volumes:
+      - paddlex-models:/root/.paddlex   # 模型缓存卷，首次下载后复用，避免重启重下
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 300s           # 首次要下模型（数百 MB），给足冷启动时间
+
   app:
     build: .
     depends_on:
       redis: { condition: service_healthy }
       mysql: { condition: service_healthy }
       minio: { condition: service_healthy }
+      # OCR 惰性调用且模型冷启动慢，只排启动顺序、不等健康，避免拖慢 app 启动
+      paddleocr: { condition: service_started }
     ports: ["8080:8080"]
     environment:
       DASHSCOPE_API_KEY: ${DASHSCOPE_API_KEY:-}
@@ -87,8 +115,11 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
       NACOS_SERVER_ADDR: nacos:8848
+      # 容器内经 compose 服务名访问 PaddleOCR（yml 默认 localhost:8868 只在宿主机成立）
+      CUSTOMER_WORK_ATTACHMENT_OCR_PADDLE_BASE_URL: http://paddleocr:8080
 
 volumes:
   redis-data:
   mysql-data:
   minio-data:
+  paddlex-models:

--- a/mysql/02-customer-admin/00-create-database.sql
+++ b/mysql/02-customer-admin/00-create-database.sql
@@ -1,0 +1,7 @@
+-- =============================================================================
+-- compose 本地一键起中间件时的后台库初始化（mysql 容器首次初始化自动执行）。
+-- 仅建库：customer_admin 的表结构由 admin-server dev profile 的 Flyway
+-- （01-V1__init_schema.sql 起）或生产 DBA 变更流程维护，此处不越权建表。
+-- 字符集与业务库保持一致（utf8mb4）。
+-- =============================================================================
+CREATE DATABASE IF NOT EXISTS `customer_admin` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
## 变更说明 / What

补齐根编排 `docker compose up -d` 本地一键起中间件的两个缺口：

1. **MySQL 缺 `customer_admin` 后台库**：新增 `mysql/02-customer-admin/00-create-database.sql` 并挂载进 `docker-entrypoint-initdb.d`，首次初始化自动建齐业务库 / 后台库 / 调度库（xxl_job）三个库。只建库不建表——表结构仍归 admin-server Flyway（dev）/ DBA 变更流程。解决 admin-server 直连 compose MySQL 因库不存在起不来的问题。
2. **PaddleOCR 未入一键编排**：作为 8080/8082 对话附件图片 OCR 的默认引擎（`engine: paddleocr`），此前只能另跑 `docker/paddleocr/`。本次纳入根 compose，与独立编排同源同镜像（`3.0.0-cpu`、arm64 走 Rosetta、宿主 8868、模型缓存卷、300s 冷启动 healthcheck 均对齐）。`app` 服务补 `CUSTOMER_WORK_ATTACHMENT_OCR_PADDLE_BASE_URL=http://paddleocr:8080`（yml 默认 `localhost:8868` 在容器网络不成立），`depends_on` 用 `service_started` 只排启动顺序、不等健康，避免模型冷启动拖慢 app 启动。

同步更新编排头部注释（仅起依赖命令、三库初始化说明）与 README 快速开始。监控栈（Prometheus/Grafana/Tempo/Alertmanager）有独立 .env 门禁，保持独立在 `docker/observability/`，不并入根 compose；k8s 清单按既定约定不纳管中间件，未动。

## 类型 / Type
- [x] feat 新功能
- [ ] fix 修复
- [x] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（新增功能附了单元测试）——本 PR 仅编排/SQL/文档变更，零 Java 代码改动，不触及测试基线；`docker compose config` 校验通过
- [x] 未在代码 / 配置中硬编码任何密钥——凭据全部沿用既有环境变量与默认值约定（redis 123456 / mysql root / minioadmin，与原编排一致）
- [x] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定——不涉及
- [x] 必要时更新了 README / 配置项说明——已同步 README 快速开始与 compose 头部注释
