### PR TITLE
docs: 补齐 README 技术栈与中间件徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Java](https://img.shields.io/badge/Java-17%2B-orange.svg)](docs/新人必读.md)
 [![AgentScope](https://img.shields.io/badge/AgentScope-2.0.0%20GA-green.svg)](https://github.com/agentscope-ai/agentscope-java)
+[![Spring Boot](https://img.shields.io/badge/Spring_Boot-3.2.5-6DB33F.svg)](https://spring.io/projects/spring-boot)
+[![MyBatis-Plus](https://img.shields.io/badge/MyBatis--Plus-3.5.7-0F766E.svg)](https://baomidou.com)
+[![Sa-Token](https://img.shields.io/badge/Sa--Token-1.39.0-FF5C5C.svg)](https://sa-token.cc)
+[![Vue](https://img.shields.io/badge/Vue-3-41B883.svg)](https://vuejs.org)
+[![Element Plus](https://img.shields.io/badge/Element_Plus-2-409EFF.svg)](https://element-plus.org)
+[![Vant](https://img.shields.io/badge/Vant-4-1989FA.svg)](https://vant-ui.github.io)
+[![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1.svg)](docker-compose.yml)
+[![Redis](https://img.shields.io/badge/Redis-7-D82C20.svg)](docker-compose.yml)
+[![MinIO](https://img.shields.io/badge/MinIO-对象存储-C72E49.svg)](docker-compose.yml)
+[![Nacos](https://img.shields.io/badge/Nacos-2.3.2-21C1B9.svg)](docker-compose.yml)
+[![XXL-JOB](https://img.shields.io/badge/XXL--JOB-3.3.2-5A7D9A.svg)](docker-compose.yml)
+[![PaddleOCR](https://img.shields.io/badge/PaddleOCR-3.0-0064C8.svg)](docker/paddleocr/docker-compose.yml)
+[![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-1.61.0-F5A800.svg)](https://opentelemetry.io)
 
 > 🚀 **新人从这里开始**：[docs/新人必读.md](docs/新人必读.md)（15 分钟跑起来 + 看懂结构 + 知道改哪里）
 > 📚 **功能 / 配置 / 接口的全部细节**：[docs/功能与配置全量参考.md](docs/功能与配置全量参考.md)（本 README 只讲"是什么、长什么样"，"怎么用"都在那里）


### PR DESCRIPTION
## 变更说明 / What

README 顶部徽章区在原有 4 枚（CI / License / Java / AgentScope）基础上补齐 13 枚，按四类分组：

- **后端框架**：Spring Boot 3.2.5、MyBatis-Plus 3.5.7、Sa-Token 1.39.0
- **前端**：Vue 3、Element Plus 2、Vant 4
- **中间件**：MySQL 8.0、Redis 7、MinIO 对象存储、Nacos 2.3.2、XXL-JOB 3.3.2、PaddleOCR 3.0
- **可观测**：OpenTelemetry 1.61.0

版本全部取自仓库真实配置，无杜撰：后端取自根 `pom.xml` properties，前端取自两个前端工程 `package.json`，中间件取自 `docker-compose.yml` / `docker/paddleocr/docker-compose.yml` 的服务端版本（Nacos 标服务端 2.3.2，pom 里 3.0.2 是 client 版本）。中间件徽章链接仓库内编排文件，库类徽章链接官网。中文徽章（MinIO-对象存储）已实测 shields.io 可正常渲染。

与 PR #131（compose 中间件编排补齐）相互独立，无重叠文件行。

## 类型 / Type
- [ ] feat 新功能
- [ ] fix 修复
- [x] docs 文档
- [ ] refactor / test / chore

## 自查 / Checklist
- [x] `mvn test` 全绿（新增功能附了单元测试）——纯 README 徽章变更，零代码改动，不触及测试基线
- [x] 未在代码 / 配置中硬编码任何密钥——徽章均为静态 shields.io URL，不含凭据
- [x] 新增外部后端遵循"接口 + 默认实现（@ConditionalOnMissingBean）"约定——不涉及
- [x] 必要时更新了 README / 配置项说明——本 PR 即 README 更新
