### PR TITLE
feat(schema): add audit timestamps to legacy tables

### DIFF
--- a/customer-admin-server/src/main/resources/db/migration/V64__add_audit_timestamps.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V64__add_audit_timestamps.sql
@@ -1,0 +1,111 @@
+SET NAMES utf8mb4;
+
+-- 为同时缺少创建时间与修改时间的存量表补齐数据库级审计时间。
+-- MySQL DDL 不可事务回滚：先确认九张目标表全部存在，再按实际缺列生成 ALTER，确保 repair 后可安全重试。
+
+SET @v64_table_count = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_type = 'BASE TABLE'
+      AND table_name IN (
+          'sys_user_role',
+          'sys_role_permission',
+          'ai_agent_mcp',
+          'ai_agent_skill',
+          'ai_agent_sub_agent',
+          'ai_agent_system_tool',
+          'ai_agent_knowledge_base',
+          'ai_scheduled_task_run',
+          'cw_agent_call_segment'
+      )
+);
+SET @v64_preflight_sql = IF(
+    @v64_table_count = 9,
+    'SELECT 1',
+    'SELECT * FROM `__customer_admin_v64_required_table_preflight_failed__`'
+);
+PREPARE v64_preflight_stmt FROM @v64_preflight_sql;
+EXECUTE v64_preflight_stmt;
+DEALLOCATE PREPARE v64_preflight_stmt;
+
+-- target: sys_user_role
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_user_role' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_user_role' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `sys_user_role` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: sys_role_permission
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_role_permission' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_role_permission' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `sys_role_permission` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_mcp
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_mcp' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_mcp' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_mcp` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_skill
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_skill' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_skill' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_skill` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_sub_agent
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_sub_agent' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_sub_agent' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_sub_agent` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_system_tool
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_system_tool' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_system_tool' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_system_tool` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_knowledge_base
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_knowledge_base' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_knowledge_base' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_knowledge_base` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_scheduled_task_run
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_scheduled_task_run' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_scheduled_task_run' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_scheduled_task_run` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: cw_agent_call_segment
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'cw_agent_call_segment' AND column_name = 'created_at'), '', 'ADD COLUMN `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'cw_agent_call_segment' AND column_name = 'updated_at'), '', 'ADD COLUMN `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `cw_agent_call_segment` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/audit/AuditTimestampMigrationIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/audit/AuditTimestampMigrationIntegrationTest.java
@@ -1,0 +1,518 @@
+package com.richard.fyoung.customeradmin.audit;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** V64 真库迁移测试：补齐九张存量表的数据库自动维护审计时间。 */
+class AuditTimestampMigrationIntegrationTest {
+
+    private static final String HOST = System.getenv().getOrDefault("MYSQL_HOST", "localhost");
+    private static final int PORT = Integer.parseInt(System.getenv().getOrDefault("MYSQL_PORT", "3306"));
+    private static final String USERNAME = env("ADMIN_MYSQL_USERNAME", "root");
+    private static final String PASSWORD = env("ADMIN_MYSQL_PASSWORD", "root");
+
+    private static final long EXISTING_ROW_ID = 9_640_000_000_001L;
+    private static final long NEW_ROW_ID = 9_640_000_000_002L;
+    private static final LocalDateTime BASELINE_UPDATE_TIME = LocalDateTime.of(2000, 1, 1, 0, 0);
+    private static final String RENAMED_LAST_TABLE = "cw_agent_call_segment_v64_preflight";
+    private static final List<AuditTable> AUDIT_TABLES = List.of(
+        new AuditTable("sys_user_role", "create_time", "update_time", 0),
+        new AuditTable("sys_role_permission", "create_time", "update_time", 0),
+        new AuditTable("ai_agent_mcp", "create_time", "update_time", 0),
+        new AuditTable("ai_agent_skill", "create_time", "update_time", 0),
+        new AuditTable("ai_agent_sub_agent", "create_time", "update_time", 0),
+        new AuditTable("ai_agent_system_tool", "create_time", "update_time", 0),
+        new AuditTable("ai_agent_knowledge_base", "create_time", "update_time", 0),
+        new AuditTable("ai_scheduled_task_run", "create_time", "update_time", 0),
+        new AuditTable("cw_agent_call_segment", "created_at", "updated_at", 3));
+    private static final Set<String> TARGET_TABLES = AUDIT_TABLES.stream()
+        .map(AuditTable::table)
+        .collect(Collectors.toUnmodifiableSet());
+
+    @Test
+    void v64ShouldCoverExactlyNineTablesAndMatchDbaMirror() throws Exception {
+        String sql;
+        try (var input = new ClassPathResource(
+            "db/migration/V64__add_audit_timestamps.sql").getInputStream()) {
+            sql = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        Matcher matcher = Pattern.compile("CONCAT\\('ALTER TABLE `([^`]+)` '").matcher(sql);
+        Set<String> alteredTables = new HashSet<>();
+        int statementCount = 0;
+        while (matcher.find()) {
+            alteredTables.add(matcher.group(1));
+            statementCount++;
+        }
+
+        assertTrue(sql.startsWith("SET NAMES utf8mb4;\n"), "含中文注释的手工镜像必须显式声明字符集");
+        assertTrue(sql.contains("@v64_table_count = 9"), "任何 ALTER 前必须预检九张目标表全部存在");
+        assertEquals(9, statementCount, "V64 必须且只能修改九张目标表");
+        assertEquals(TARGET_TABLES, alteredTables, "V64 目标表集合必须与扫描结果一致");
+        for (AuditTable table : AUDIT_TABLES) {
+            assertSqlDefinition(sql, table);
+        }
+
+        String mirrorSql = Files.readString(repositoryRoot().resolve(
+            "mysql/02-customer-admin/64-V64__add_audit_timestamps.sql"));
+        assertEquals(sql, mirrorSql, "Flyway 迁移与 DBA 镜像必须逐字一致");
+    }
+
+    @Test
+    void v64ShouldBackfillDefaultsAndAdvanceUpdateTimestamp() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过 V64 真库迁移测试");
+        String database = "admin_v64_" + randomSuffix();
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过 V64 真库迁移测试");
+
+        try {
+            migrate(database, "63");
+            try (Connection connection = connection(database)) {
+                assertEquals(TARGET_TABLES, tablesMissingBothAuditTimestamps(connection),
+                    "V63 快照中同时缺少两类审计时间的表必须与扫描清单一致");
+                for (AuditTable table : AUDIT_TABLES) {
+                    assertFalse(columnExists(connection, table.table(), table.createdColumn()),
+                        table.table() + " 在 V63 不应已有创建时间");
+                    assertFalse(columnExists(connection, table.table(), table.updatedColumn()),
+                        table.table() + " 在 V63 不应已有修改时间");
+                    insertRow(connection, table.table(), EXISTING_ROW_ID);
+                }
+            }
+
+            migrate(database, "64");
+
+            try (Connection connection = connection(database)) {
+                Map<String, AuditTimes> existingTimes = new HashMap<>();
+                for (AuditTable table : AUDIT_TABLES) {
+                    assertColumnDefinition(connection, table, table.createdColumn(), false);
+                    assertColumnDefinition(connection, table, table.updatedColumn(), true);
+
+                    AuditTimes backfilled = auditTimes(connection, table, EXISTING_ROW_ID);
+                    assertNotNull(backfilled.createdAt(), table.table() + " 存量行创建时间必须回填");
+                    assertNotNull(backfilled.updatedAt(), table.table() + " 存量行修改时间必须回填");
+
+                    insertRow(connection, table.table(), NEW_ROW_ID);
+                    AuditTimes defaults = auditTimes(connection, table, NEW_ROW_ID);
+                    assertNotNull(defaults.createdAt(), table.table() + " 新增行创建时间必须由数据库生成");
+                    assertNotNull(defaults.updatedAt(), table.table() + " 新增行修改时间必须由数据库生成");
+
+                    setBaselineUpdateTime(connection, table, EXISTING_ROW_ID);
+                    AuditTimes baseline = auditTimes(connection, table, EXISTING_ROW_ID);
+                    assertEquals(backfilled.createdAt(), baseline.createdAt(),
+                        table.table() + " 显式设置修改时间不得改写创建时间");
+                    assertEquals(BASELINE_UPDATE_TIME, baseline.updatedAt(),
+                        table.table() + " 必须接受显式修改时间作为推进前基线");
+                    existingTimes.put(table.table(), baseline);
+                }
+
+                for (AuditTable table : AUDIT_TABLES) {
+                    updateTenant(connection, table.table(), EXISTING_ROW_ID);
+                }
+
+                for (AuditTable table : AUDIT_TABLES) {
+                    AuditTimes before = existingTimes.get(table.table());
+                    AuditTimes after = auditTimes(connection, table, EXISTING_ROW_ID);
+                    assertEquals(before.createdAt(), after.createdAt(),
+                        table.table() + " 真实 UPDATE 不得改写创建时间");
+                    assertTrue(after.updatedAt().isAfter(before.updatedAt()),
+                        table.table() + " 真实 UPDATE 必须推进修改时间");
+                }
+
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM `flyway_schema_history` "
+                        + "WHERE `version` = '64' AND `success` = 1"));
+                assertTrue(tablesMissingBothAuditTimestamps(connection).isEmpty(),
+                    "V64 完成后不得残留同时缺少两类审计时间的后台业务表");
+            }
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    @Test
+    void v64ShouldPreflightAllTablesAndResumeSafelyAfterRepair() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过 V64 真库迁移测试");
+        String database = "admin_v64_retry_" + randomSuffix();
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过 V64 真库迁移测试");
+
+        AuditTable firstTable = AUDIT_TABLES.get(0);
+        AuditTable secondTable = AUDIT_TABLES.get(1);
+        AuditTable thirdTable = AUDIT_TABLES.get(2);
+        AuditTable lastTable = AUDIT_TABLES.get(AUDIT_TABLES.size() - 1);
+        try {
+            migrate(database, "63");
+            Map<String, Integer> columnsBeforeFailedMigration = new HashMap<>();
+            try (Connection connection = connection(database)) {
+                addAuditColumn(connection, firstTable, firstTable.createdColumn(), false);
+                addAuditColumn(connection, firstTable, firstTable.updatedColumn(), true);
+                addAuditColumn(connection, secondTable, secondTable.createdColumn(), false);
+                addAuditColumn(connection, thirdTable, thirdTable.updatedColumn(), true);
+                renameTable(connection, lastTable.table(), RENAMED_LAST_TABLE);
+
+                for (AuditTable table : AUDIT_TABLES) {
+                    String actualTable = table.equals(lastTable) ? RENAMED_LAST_TABLE : table.table();
+                    columnsBeforeFailedMigration.put(actualTable,
+                        auditColumnCount(connection, actualTable, table));
+                }
+            }
+
+            assertThrows(FlywayException.class, () -> migrate(database, "64"),
+                "缺少任一目标表时 V64 必须在任何 ALTER 前失败");
+
+            try (Connection connection = connection(database)) {
+                assertFalse(tableExists(connection, lastTable.table()), "被临时改名的目标表应保持缺失");
+                for (AuditTable table : AUDIT_TABLES) {
+                    String actualTable = table.equals(lastTable) ? RENAMED_LAST_TABLE : table.table();
+                    assertEquals(columnsBeforeFailedMigration.get(actualTable),
+                        auditColumnCount(connection, actualTable, table),
+                        table.table() + " 预检失败后不得发生额外 DDL");
+                }
+                assertEquals(0, queryInt(connection,
+                    "SELECT COUNT(*) FROM `flyway_schema_history` "
+                        + "WHERE `version` = '64' AND `success` = 1"));
+                renameTable(connection, RENAMED_LAST_TABLE, lastTable.table());
+            }
+
+            repair(database);
+            migrate(database, "64");
+
+            try (Connection connection = connection(database)) {
+                for (AuditTable table : AUDIT_TABLES) {
+                    assertColumnDefinition(connection, table, table.createdColumn(), false);
+                    assertColumnDefinition(connection, table, table.updatedColumn(), true);
+                }
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM `flyway_schema_history` WHERE `version` = '64'"),
+                    "repair 后 V64 只能保留一条历史记录");
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM `flyway_schema_history` "
+                        + "WHERE `version` = '64' AND `success` = 1"),
+                    "repair 重试后的 V64 必须成功");
+            }
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    private void assertSqlDefinition(String sql, AuditTable table) {
+        Pattern pattern = Pattern.compile("(?s)-- target: " + Pattern.quote(table.table())
+            + "\\R(.*?)DEALLOCATE PREPARE v64_stmt;");
+        Matcher matcher = pattern.matcher(sql);
+        assertTrue(matcher.find(), table.table() + " 缺少动态 ALTER TABLE");
+        String statement = matcher.group().replaceAll("\\s+", " ");
+        String precision = table.precision() == 0 ? "" : "(" + table.precision() + ")";
+        assertTrue(statement.contains("ADD COLUMN `" + table.createdColumn() + "` DATETIME"
+            + precision + " NOT NULL DEFAULT CURRENT_TIMESTAMP" + precision + " COMMENT ''创建时间''"),
+            table.table() + " 创建时间定义不完整");
+        assertTrue(statement.contains("ADD COLUMN `" + table.updatedColumn() + "` DATETIME"
+            + precision + " NOT NULL DEFAULT CURRENT_TIMESTAMP" + precision
+            + " ON UPDATE CURRENT_TIMESTAMP" + precision + " COMMENT ''修改时间''"),
+            table.table() + " 修改时间定义不完整");
+        assertTrue(statement.contains("table_name = '" + table.table() + "'"),
+            table.table() + " 必须按 information_schema 实际列状态生成 ALTER");
+    }
+
+    private void assertColumnDefinition(Connection connection, AuditTable table,
+                                        String column, boolean updatedColumn) throws Exception {
+        String sql = "SELECT `data_type`, `datetime_precision`, `is_nullable`, `column_default`, "
+            + "`extra`, `column_comment` FROM information_schema.columns "
+            + "WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table.table());
+            statement.setString(2, column);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertTrue(resultSet.next(), table.table() + "." + column + " 必须存在");
+                assertEquals("datetime", resultSet.getString("data_type"));
+                assertEquals(table.precision(), resultSet.getInt("datetime_precision"));
+                assertEquals("NO", resultSet.getString("is_nullable"));
+                assertTrue(resultSet.getString("column_default").toLowerCase(Locale.ROOT)
+                    .startsWith("current_timestamp"), table.table() + "." + column + " 必须有数据库默认值");
+                String extra = resultSet.getString("extra").toLowerCase(Locale.ROOT);
+                if (updatedColumn) {
+                    assertTrue(extra.contains("on update current_timestamp"),
+                        table.table() + "." + column + " 必须由数据库自动更新");
+                    assertEquals("修改时间", resultSet.getString("column_comment"));
+                } else {
+                    assertFalse(extra.contains("on update current_timestamp"),
+                        table.table() + "." + column + " 不得随更新改变");
+                    assertEquals("创建时间", resultSet.getString("column_comment"));
+                }
+                assertFalse(resultSet.next(), table.table() + "." + column + " 不得重复");
+            }
+        }
+    }
+
+    private void insertRow(Connection connection, String table, long id) throws Exception {
+        String sql = switch (table) {
+            case "sys_user_role" -> "INSERT INTO `sys_user_role` "
+                + "(`id`, `user_id`, `role_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "sys_role_permission" -> "INSERT INTO `sys_role_permission` "
+                + "(`id`, `role_id`, `permission_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "ai_agent_mcp" -> "INSERT INTO `ai_agent_mcp` "
+                + "(`id`, `agent_id`, `mcp_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "ai_agent_skill" -> "INSERT INTO `ai_agent_skill` "
+                + "(`id`, `agent_id`, `skill_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "ai_agent_sub_agent" -> "INSERT INTO `ai_agent_sub_agent` "
+                + "(`id`, `agent_id`, `sub_agent_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "ai_agent_system_tool" -> "INSERT INTO `ai_agent_system_tool` "
+                + "(`id`, `agent_id`, `system_tool_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "ai_agent_knowledge_base" -> "INSERT INTO `ai_agent_knowledge_base` "
+                + "(`id`, `agent_id`, `knowledge_base_id`, `tenant_id`) VALUES (" + id + ", " + id
+                + ", " + (id + 1) + ", 'default')";
+            case "ai_scheduled_task_run" -> "INSERT INTO `ai_scheduled_task_run` "
+                + "(`id`, `task_id`, `task_code`, `trigger_type`, `start_time`, `status`, `tenant_id`) "
+                + "VALUES (" + id + ", " + id + ", 'audit-" + id
+                + "', 'MANUAL', '2026-01-01 00:00:00', 'SUCCESS', 'default')";
+            case "cw_agent_call_segment" -> "INSERT INTO `cw_agent_call_segment` "
+                + "(`id`, `call_log_id`, `seq`, `kind`, `name`, `start_time`, `tenant_id`) "
+                + "VALUES (" + id + ", " + id + ", 1, 'MODEL', 'audit', 1, 'default')";
+            default -> throw new IllegalArgumentException("unsupported audit table: " + table);
+        };
+        execute(connection, sql);
+    }
+
+    private AuditTimes auditTimes(Connection connection, AuditTable table, long id) throws Exception {
+        String sql = "SELECT " + quoted(table.createdColumn()) + ", " + quoted(table.updatedColumn())
+            + " FROM " + quoted(table.table()) + " WHERE `id` = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, id);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertTrue(resultSet.next(), table.table() + " 测试行必须存在");
+                Timestamp createdAt = resultSet.getTimestamp(1);
+                Timestamp updatedAt = resultSet.getTimestamp(2);
+                return new AuditTimes(
+                    createdAt == null ? null : createdAt.toLocalDateTime(),
+                    updatedAt == null ? null : updatedAt.toLocalDateTime());
+            }
+        }
+    }
+
+    private void updateTenant(Connection connection, String table, long id) throws Exception {
+        String sql = "UPDATE " + quoted(table) + " SET `tenant_id` = 'audit-updated' WHERE `id` = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, id);
+            assertEquals(1, statement.executeUpdate(), table + " 必须真实更新一行");
+        }
+    }
+
+    private void setBaselineUpdateTime(Connection connection, AuditTable table, long id) throws Exception {
+        String sql = "UPDATE " + quoted(table.table()) + " SET " + quoted(table.updatedColumn())
+            + " = ? WHERE `id` = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setTimestamp(1, Timestamp.valueOf(BASELINE_UPDATE_TIME));
+            statement.setLong(2, id);
+            assertEquals(1, statement.executeUpdate(), table.table() + " 必须设置一行修改时间基线");
+        }
+    }
+
+    private void addAuditColumn(Connection connection, AuditTable table,
+                                String column, boolean updatedColumn) throws Exception {
+        String precision = table.precision() == 0 ? "" : "(" + table.precision() + ")";
+        String onUpdate = updatedColumn
+            ? " ON UPDATE CURRENT_TIMESTAMP" + precision + " COMMENT '修改时间'"
+            : " COMMENT '创建时间'";
+        execute(connection, "ALTER TABLE " + quoted(table.table()) + " ADD COLUMN " + quoted(column)
+            + " DATETIME" + precision + " NOT NULL DEFAULT CURRENT_TIMESTAMP" + precision + onUpdate);
+    }
+
+    private int auditColumnCount(Connection connection, String actualTable,
+                                 AuditTable auditTable) throws Exception {
+        String sql = "SELECT COUNT(*) FROM information_schema.columns "
+            + "WHERE table_schema = DATABASE() AND table_name = ? AND column_name IN (?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, actualTable);
+            statement.setString(2, auditTable.createdColumn());
+            statement.setString(3, auditTable.updatedColumn());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
+    private boolean tableExists(Connection connection, String table) throws Exception {
+        String sql = "SELECT 1 FROM information_schema.tables "
+            + "WHERE table_schema = DATABASE() AND table_name = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private Set<String> tablesMissingBothAuditTimestamps(Connection connection) throws Exception {
+        String sql = "SELECT t.`table_name` FROM information_schema.tables t "
+            + "WHERE t.table_schema = DATABASE() AND t.table_type = 'BASE TABLE' "
+            + "AND t.table_name <> 'flyway_schema_history' "
+            + "AND NOT EXISTS (SELECT 1 FROM information_schema.columns c "
+            + "WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name "
+            + "AND c.column_name IN ('create_time', 'created_at', 'created_at_ms')) "
+            + "AND NOT EXISTS (SELECT 1 FROM information_schema.columns c "
+            + "WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name "
+            + "AND c.column_name IN ('update_time', 'updated_at', 'updated_at_ms'))";
+        Set<String> tables = new HashSet<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                tables.add(resultSet.getString(1));
+            }
+        }
+        return tables;
+    }
+
+    private void renameTable(Connection connection, String source, String target) throws Exception {
+        execute(connection, "RENAME TABLE " + quoted(source) + " TO " + quoted(target));
+    }
+
+    private void migrate(String database, String target) {
+        flyway(database, target).migrate();
+    }
+
+    private void repair(String database) {
+        flyway(database, "64").repair();
+    }
+
+    private Flyway flyway(String database, String target) {
+        FluentConfiguration configuration = Flyway.configure()
+            .dataSource(jdbcUrl(database), USERNAME, PASSWORD)
+            .locations("classpath:db/migration")
+            .placeholderReplacement(false)
+            .target(target);
+        return configuration.load();
+    }
+
+    private boolean columnExists(Connection connection, String table, String column) throws Exception {
+        String sql = "SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() "
+            + "AND table_name = ? AND column_name = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            statement.setString(2, column);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private int queryInt(Connection connection, String sql) throws Exception {
+        try (PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private void execute(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+
+    private boolean createDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE " + quoted(database)
+                + " DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci");
+            return true;
+        } catch (Exception e) {
+            dropDatabase(database);
+            return false;
+        }
+    }
+
+    private void dropDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DROP DATABASE IF EXISTS " + quoted(database));
+        } catch (Exception ignored) {
+            // 清理失败不覆盖原始断言；随机库名不会影响业务库，残留可按 admin_v64_* 识别。
+        }
+    }
+
+    private Connection adminConnection() throws Exception {
+        return DriverManager.getConnection(jdbcUrl(""), USERNAME, PASSWORD);
+    }
+
+    private Connection connection(String database) throws Exception {
+        return DriverManager.getConnection(jdbcUrl(database), USERNAME, PASSWORD);
+    }
+
+    private String jdbcUrl(String database) {
+        return "jdbc:mysql://" + HOST + ":" + PORT + "/" + database
+            + "?useUnicode=true&characterEncoding=utf8&useSSL=false"
+            + "&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true";
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), 1_500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Path repositoryRoot() {
+        Path workingDirectory = Path.of("").toAbsolutePath();
+        return Files.isDirectory(workingDirectory.resolve("mysql"))
+            ? workingDirectory : workingDirectory.getParent();
+    }
+
+    private static String randomSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+
+    private String quoted(String identifier) {
+        if (!identifier.matches("[a-z0-9_]+")) {
+            throw new IllegalArgumentException("illegal database identifier: " + identifier);
+        }
+        return "`" + identifier + "`";
+    }
+
+    private static String env(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private record AuditTable(String table, String createdColumn, String updatedColumn, int precision) {
+    }
+
+    private record AuditTimes(LocalDateTime createdAt, LocalDateTime updatedAt) {
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrator.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrator.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.infra.config;
 
 import com.richard.fyoung.customerwork.infra.migration.V2__ReconcileLegacySchema;
+import com.richard.fyoung.customerwork.infra.migration.V9__AddAuditTimestamps;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.slf4j.Logger;
@@ -54,7 +55,7 @@ public class CustomerWorkSchemaMigrator implements InitializingBean {
                 .baselineVersion(MigrationVersion.fromVersion(baselineVersion))
                 .validateMigrationNaming(true)
                 .cleanDisabled(true)
-                .javaMigrations(new V2__ReconcileLegacySchema())
+                .javaMigrations(new V2__ReconcileLegacySchema(), new V9__AddAuditTimestamps())
                 .load();
             int migrations = flyway.migrate().migrationsExecuted;
             log.info("customer-work schema migration completed, migrations={}", migrations);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/migration/V9__AddAuditTimestamps.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/migration/V9__AddAuditTimestamps.java
@@ -1,0 +1,138 @@
+package com.richard.fyoung.customerwork.infra.migration;
+
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * V9：为缺少标准审计时间的客服端业务表补齐创建时间和修改时间。
+ *
+ * <p>MySQL DDL 会隐式提交，无法依赖迁移事务回滚。因此先校验全部目标表都存在，再按表查询
+ * information_schema，并把同一张表缺失的列合并到一条 ALTER TABLE 中。迁移中途失败并完成
+ * Flyway repair 后重试时，已完成的表会因列已存在而跳过。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class V9__AddAuditTimestamps extends BaseJavaMigration {
+
+    private static final List<String> AUDIT_TABLES = Arrays.asList(
+        "cw_slot_filling_progress",
+        "cw_dialog_stage",
+        "cw_agent_call_segment",
+        "cw_product",
+        "cw_member",
+        "cw_knowledge",
+        "cw_fact_log",
+        "cw_prompt_version",
+        "cw_csat_survey",
+        "cw_knowledge_gap"
+    );
+
+    private static final String CREATED_AT_DEFINITION =
+        "DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间'";
+    private static final String UPDATED_AT_DEFINITION =
+        "DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) "
+            + "COMMENT '记录最后修改时间'";
+
+    @Override
+    public MigrationVersion getVersion() {
+        return MigrationVersion.fromVersion("9");
+    }
+
+    @Override
+    public String getDescription() {
+        return "add customer-work audit timestamps";
+    }
+
+    @Override
+    public Integer getChecksum() {
+        return 1;
+    }
+
+    @Override
+    public boolean canExecuteInTransaction() {
+        // MySQL DDL 会隐式提交，显式声明避免产生“整批可回滚”的错误预期。
+        return false;
+    }
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        verifyTablesExist(connection);
+        for (String table : AUDIT_TABLES) {
+            addMissingAuditColumns(connection, table);
+        }
+    }
+
+    private void verifyTablesExist(Connection connection) throws SQLException {
+        for (String table : AUDIT_TABLES) {
+            if (!tableExists(connection, table)) {
+                throw new SQLException("required customer-work table does not exist: " + table);
+            }
+        }
+    }
+
+    private void addMissingAuditColumns(Connection connection, String table) throws SQLException {
+        boolean createdAtExists = columnExists(connection, table, "created_at");
+        boolean updatedAtExists = columnExists(connection, table, "updated_at");
+        if (createdAtExists && updatedAtExists) {
+            return;
+        }
+
+        StringBuilder ddl = new StringBuilder("ALTER TABLE ").append(quoted(table));
+        if (!createdAtExists) {
+            ddl.append(" ADD COLUMN `created_at` ").append(CREATED_AT_DEFINITION);
+        }
+        if (!updatedAtExists) {
+            if (!createdAtExists) {
+                ddl.append(',');
+            }
+            ddl.append(" ADD COLUMN `updated_at` ").append(UPDATED_AT_DEFINITION);
+        }
+        executeDdl(connection, ddl.toString());
+    }
+
+    private boolean tableExists(Connection connection, String table) throws SQLException {
+        String sql = "SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() "
+            + "AND table_name = ? AND table_type = 'BASE TABLE'";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private boolean columnExists(Connection connection, String table, String column) throws SQLException {
+        String sql = "SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() "
+            + "AND table_name = ? AND column_name = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            statement.setString(2, column);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private void executeDdl(Connection connection, String ddl) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(ddl);
+        }
+    }
+
+    private String quoted(String identifier) {
+        if (!identifier.matches("[a-z0-9_]+")) {
+            throw new IllegalArgumentException("illegal database identifier: " + identifier);
+        }
+        return "`" + identifier + "`";
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrationIntegrationTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/CustomerWorkSchemaMigrationIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.infra.config;
 
 import com.richard.fyoung.customerwork.infra.migration.V2__ReconcileLegacySchema;
+import com.richard.fyoung.customerwork.infra.migration.V9__AddAuditTimestamps;
 import com.zaxxer.hikari.HikariDataSource;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.Test;
@@ -19,8 +20,11 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -47,6 +51,10 @@ class CustomerWorkSchemaMigrationIntegrationTest {
     private static final String USERNAME = System.getenv().getOrDefault("MYSQL_USERNAME", "root");
     private static final String PASSWORD = System.getenv().getOrDefault("MYSQL_PASSWORD", "root");
     private static final String DEFAULT_TENANT = "default";
+    private static final List<String> AUDIT_TIMESTAMP_TABLES = List.of(
+        "cw_slot_filling_progress", "cw_dialog_stage", "cw_agent_call_segment", "cw_product",
+        "cw_member", "cw_knowledge", "cw_fact_log", "cw_prompt_version", "cw_csat_survey",
+        "cw_knowledge_gap");
 
     private static final Set<String> TENANT_TABLES = Set.of(
         "cw_agent_call_log", "cw_agent_call_segment", "cw_approval", "cw_audit_log",
@@ -206,6 +214,49 @@ class CustomerWorkSchemaMigrationIntegrationTest {
         }
     }
 
+    @Test
+    void v9ShouldFailFastAndRecoverAfterRepair() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过客服端 Flyway 门控测试");
+        String database = "cw_flyway_audit_missing_"
+            + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        assumeTrue(canCreateDatabases(database), "MySQL 测试账号无建库权限，跳过");
+
+        try (HikariDataSource dataSource = dataSource(database, "flyway-audit-missing-test")) {
+            migrateTo(dataSource, "8");
+            assertEquals(new HashSet<>(AUDIT_TIMESTAMP_TABLES), tablesMissingBothAuditTimestamps(dataSource),
+                "V8 快照中同时缺少两类审计时间的表必须与扫描清单一致");
+
+            execute(dataSource, "ALTER TABLE `cw_slot_filling_progress` "
+                + "ADD COLUMN `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) "
+                + "COMMENT '记录创建时间'");
+            execute(dataSource, "ALTER TABLE `cw_dialog_stage` "
+                + "ADD COLUMN `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) "
+                + "ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间'");
+            execute(dataSource, "RENAME TABLE `cw_knowledge_gap` TO `cw_knowledge_gap_v9_missing`");
+
+            assertThrows(IllegalStateException.class, () -> migrate(dataSource, database),
+                "任一目标表缺失时 V9 必须中止迁移");
+            assertFalse(columnExists(dataSource, "cw_slot_filling_progress", "updated_at"),
+                "缺表预检不得补齐仅有创建时间的表");
+            assertFalse(columnExists(dataSource, "cw_dialog_stage", "created_at"),
+                "缺表预检不得补齐仅有修改时间的表");
+            assertFalse(columnExists(dataSource, "cw_product", "created_at"),
+                "缺表预检必须早于第一张表的 DDL，避免不可回滚的部分迁移");
+
+            execute(dataSource, "RENAME TABLE `cw_knowledge_gap_v9_missing` TO `cw_knowledge_gap`");
+            repair(dataSource);
+            migrate(dataSource, database);
+
+            assertAuditTimestampColumns(dataSource);
+            assertTrue(tablesMissingBothAuditTimestamps(dataSource).isEmpty(),
+                "V9 完成后不得残留同时缺少两类审计时间的客服端业务表");
+            assertEquals(1, countHistoryVersion(dataSource, "9"), "repair 后重试只应登记一条成功的 V9");
+            assertEquals("9", latestHistoryVersion(dataSource));
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
     private void verifyCompleteMirrorAdoption(String database) throws Exception {
         try (HikariDataSource dataSource = dataSource(database, "flyway-mirror-test")) {
             Path workingDirectory = Path.of("").toAbsolutePath();
@@ -226,15 +277,18 @@ class CustomerWorkSchemaMigrationIntegrationTest {
             assertEquals(44, countBusinessTables(dataSource));
             assertTrue(columnExists(dataSource, "cw_dead_letter", "lease_owner"));
             assertTrue(columnExists(dataSource, "cw_outbox_message", "lease_owner"));
-            // 接管基线 1 行 + 重跑的 V6/V7/V8 各 1 行。三者都是幂等迁移，
+            assertAuditTimestampColumns(dataSource);
+            // 接管基线 1 行 + 重跑的 V6/V7/V8/V9 各 1 行。四者都是幂等迁移，
             // 故刻意不给它们加镜像判定——为省历史行去写脆弱的数据猜测得不偿失
-            assertEquals(4, countHistoryRows(dataSource), "完整镜像只应登记一次接管基线");
+            assertEquals(5, countHistoryRows(dataSource), "完整镜像只应登记一次接管基线");
             // V5 是纯种子迁移，镜像里已带那两档，故接管版本要跟到 5——
             // 停在 4 的话 Flyway 会重跑 V5，撞唯一键直接失败（判定见 resolveBaselineVersion）
             assertEquals(1, countHistoryVersion(dataSource, "5"), "完整镜像应从当前版本接管");
             assertEquals(1, countHistoryVersion(dataSource, "6"), "幂等迁移重跑一次，两次 migrate 也只记一条");
             assertEquals(1, countHistoryVersion(dataSource, "7"), "平台租户归一迁移应登记一次");
             assertEquals(1, countHistoryVersion(dataSource, "8"), "遗留平台 scope 归一迁移应登记一次");
+            assertEquals(1, countHistoryVersion(dataSource, "9"), "审计时间迁移应登记一次");
+            assertEquals("9", latestHistoryVersion(dataSource));
         }
     }
 
@@ -242,11 +296,14 @@ class CustomerWorkSchemaMigrationIntegrationTest {
         try (HikariDataSource dataSource = dataSource(database, "flyway-empty-test")) {
             migrate(dataSource, database);
             assertEquals(44, countBusinessTables(dataSource));
-            // V5（ADMIN_USER 档种子）、V6（运营分区归一）、V7/V8（平台租户与 scope 归一）都不建表
-            assertEquals(8, countHistoryRows(dataSource));
+            // V5（ADMIN_USER 档种子）、V6（运营分区归一）、V7/V8（平台租户与 scope 归一）、V9（审计列）都不建表
+            assertEquals(9, countHistoryRows(dataSource));
             assertTrue(columnExists(dataSource, "cw_dead_letter", "lease_owner"));
+            assertAuditTimestampColumns(dataSource);
+            verifyUpdatedAtAutoAdvance(dataSource);
             assertEquals(0, countHistoryVersion(dataSource, "0"), "空库不应写 baseline 记录");
-            assertEquals(1, countHistoryVersion(dataSource, "8"));
+            assertEquals(1, countHistoryVersion(dataSource, "9"));
+            assertEquals("9", latestHistoryVersion(dataSource));
         }
     }
 
@@ -265,10 +322,12 @@ class CustomerWorkSchemaMigrationIntegrationTest {
             // V4 给存量 cw_user 加的配额等级列：这张表是 V1 就建好的，加列只能靠迁移补
             assertTrue(columnExists(dataSource, "cw_user", "level_code"));
             assertEquals(44, countBusinessTables(dataSource));
-            // baseline 0 + V1~V8
-            assertEquals(9, countHistoryRows(dataSource));
+            assertAuditTimestampColumns(dataSource);
+            // baseline 0 + V1~V9
+            assertEquals(10, countHistoryRows(dataSource));
             assertEquals(1, countHistoryVersion(dataSource, "0"), "非空存量库必须先登记 baseline 0");
-            assertEquals(1, countHistoryVersion(dataSource, "8"));
+            assertEquals(1, countHistoryVersion(dataSource, "9"));
+            assertEquals("9", latestHistoryVersion(dataSource));
         }
     }
 
@@ -369,10 +428,21 @@ class CustomerWorkSchemaMigrationIntegrationTest {
             .locations("classpath:db/customerwork/migration")
             .validateMigrationNaming(true)
             .cleanDisabled(true)
-            .javaMigrations(new V2__ReconcileLegacySchema())
+            .javaMigrations(new V2__ReconcileLegacySchema(), new V9__AddAuditTimestamps())
             .target(target)
             .load()
             .migrate();
+    }
+
+    private void repair(HikariDataSource dataSource) {
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/customerwork/migration")
+            .validateMigrationNaming(true)
+            .cleanDisabled(true)
+            .javaMigrations(new V2__ReconcileLegacySchema(), new V9__AddAuditTimestamps())
+            .load()
+            .repair();
     }
 
     private boolean canCreateDatabases(String... databases) {
@@ -429,6 +499,27 @@ class CustomerWorkSchemaMigrationIntegrationTest {
         return tables;
     }
 
+    private Set<String> tablesMissingBothAuditTimestamps(HikariDataSource dataSource) throws Exception {
+        String sql = "SELECT `table_name` FROM information_schema.tables t "
+            + "WHERE t.table_schema = DATABASE() AND t.table_type = 'BASE TABLE' "
+            + "AND t.table_name LIKE 'cw\\_%' "
+            + "AND NOT EXISTS (SELECT 1 FROM information_schema.columns c "
+            + "WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name "
+            + "AND c.column_name IN ('created_at', 'created_at_ms')) "
+            + "AND NOT EXISTS (SELECT 1 FROM information_schema.columns c "
+            + "WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name "
+            + "AND c.column_name IN ('updated_at', 'updated_at_ms'))";
+        Set<String> tables = new HashSet<>();
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                tables.add(resultSet.getString(1));
+            }
+        }
+        return tables;
+    }
+
     private int countPlatformRows(HikariDataSource dataSource) throws Exception {
         int count = 0;
         for (String table : tenantTables(dataSource)) {
@@ -460,6 +551,68 @@ class CustomerWorkSchemaMigrationIntegrationTest {
         }
     }
 
+    private String latestHistoryVersion(HikariDataSource dataSource) throws Exception {
+        return queryString(dataSource, "SELECT `version` FROM `flyway_schema_history` "
+            + "WHERE `success` = 1 AND `version` IS NOT NULL ORDER BY `installed_rank` DESC LIMIT 1");
+    }
+
+    private void assertAuditTimestampColumns(HikariDataSource dataSource) throws Exception {
+        for (String table : AUDIT_TIMESTAMP_TABLES) {
+            assertAuditTimestampColumn(dataSource, table, "created_at", "记录创建时间", false);
+            assertAuditTimestampColumn(dataSource, table, "updated_at", "记录最后修改时间", true);
+        }
+    }
+
+    private void assertAuditTimestampColumn(HikariDataSource dataSource, String table, String column,
+                                            String expectedComment, boolean autoUpdate) throws Exception {
+        String sql = "SELECT `data_type`, `datetime_precision`, `is_nullable`, `column_default`, "
+            + "`extra`, `column_comment` FROM information_schema.columns "
+            + "WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            statement.setString(2, column);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                String label = table + "." + column;
+                assertTrue(resultSet.next(), label + " 应存在");
+                assertEquals("datetime", resultSet.getString("data_type"), label + " 类型");
+                assertEquals(3, resultSet.getInt("datetime_precision"), label + " 毫秒精度");
+                assertEquals("NO", resultSet.getString("is_nullable"), label + " 非空约束");
+                assertEquals("current_timestamp(3)",
+                    normalizeMetadataExpression(resultSet.getString("column_default")), label + " 默认值");
+                String extra = normalizeMetadataExpression(resultSet.getString("extra"));
+                if (autoUpdate) {
+                    assertTrue(extra.contains("onupdatecurrent_timestamp(3)"), label + " 自动更新时间");
+                } else {
+                    assertFalse(extra.contains("onupdate"), label + " 不应随更新变化");
+                }
+                assertEquals(expectedComment, resultSet.getString("column_comment"), label + " 注释");
+            }
+        }
+    }
+
+    private String normalizeMetadataExpression(String value) {
+        return value == null ? "" : value.toLowerCase(Locale.ROOT).replaceAll("\\s+", "");
+    }
+
+    private void verifyUpdatedAtAutoAdvance(HikariDataSource dataSource) throws Exception {
+        execute(dataSource, "UPDATE `cw_product` SET `updated_at` = '2000-01-01 00:00:00.000' "
+            + "WHERE `product_id` = 'P001'");
+        Timestamp createdAtBefore = queryTimestamp(dataSource,
+            "SELECT `created_at` FROM `cw_product` WHERE `product_id` = 'P001'");
+        Timestamp updatedAtBefore = queryTimestamp(dataSource,
+            "SELECT `updated_at` FROM `cw_product` WHERE `product_id` = 'P001'");
+
+        execute(dataSource, "UPDATE `cw_product` SET `stock` = `stock` + 1 WHERE `product_id` = 'P001'");
+
+        assertTrue(queryTimestamp(dataSource,
+            "SELECT `updated_at` FROM `cw_product` WHERE `product_id` = 'P001'").after(updatedAtBefore),
+            "真实业务字段 UPDATE 后 updated_at 应由数据库推进");
+        assertEquals(createdAtBefore, queryTimestamp(dataSource,
+            "SELECT `created_at` FROM `cw_product` WHERE `product_id` = 'P001'"),
+            "业务字段 UPDATE 不应改写 created_at");
+    }
+
     private boolean columnExists(HikariDataSource dataSource, String table, String column) throws Exception {
         String sql = "SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() "
             + "AND table_name = ? AND column_name = ?";
@@ -488,6 +641,15 @@ class CustomerWorkSchemaMigrationIntegrationTest {
              ResultSet resultSet = statement.executeQuery()) {
             resultSet.next();
             return resultSet.getString(1);
+        }
+    }
+
+    private Timestamp queryTimestamp(HikariDataSource dataSource, String sql) throws Exception {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            resultSet.next();
+            return resultSet.getTimestamp(1);
         }
     }
 

--- a/mysql/01-agent-scope-customer-work/customer-work-schema.sql
+++ b/mysql/01-agent-scope-customer-work/customer-work-schema.sql
@@ -91,6 +91,8 @@ CREATE TABLE IF NOT EXISTS `cw_slot_filling_progress` (
     `progress_key`    VARCHAR(191) PRIMARY KEY COMMENT '收集进度键：sessionId:formName',
     `asking`          VARCHAR(64) COMMENT '当前追问的槽位名',
     `collected_json`  TEXT COMMENT '已收集槽位值（JSON）',
+    `created_at`      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_slot_filling_progress_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
@@ -105,6 +107,8 @@ CREATE TABLE IF NOT EXISTS `cw_dialog_stage` (
     `tenant_id`     VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
     `session_id`  VARCHAR(191) PRIMARY KEY COMMENT '会话 ID',
     `stage`       VARCHAR(24) NOT NULL COMMENT '当前对话阶段：GREETING/COLLECTING/PROCESSING/CONFIRMING/ESCALATED',
+    `created_at`  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_dialog_stage_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
@@ -299,6 +303,8 @@ CREATE TABLE IF NOT EXISTS `cw_agent_call_segment` (
     `model_reported_ms` BIGINT DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
     `success`        TINYINT(1) NOT NULL DEFAULT 1 COMMENT '分段是否成功',
     `error_msg`      VARCHAR(1024) COMMENT '失败原因',
+    `created_at`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_segment_call_log` (`call_log_id`, `seq`),
     INDEX `idx_agent_call_segment_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -346,6 +352,8 @@ CREATE TABLE IF NOT EXISTS `cw_product` (
     `description`  VARCHAR(500) COMMENT '商品描述',
     `promotion`    VARCHAR(255) COMMENT '优惠活动',
     `status`       VARCHAR(16) NOT NULL DEFAULT 'ON_SALE' COMMENT 'ON_SALE/OFF_SALE',
+    `created_at`   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_product_category` (`category`),
     INDEX `idx_product_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -418,6 +426,8 @@ CREATE TABLE IF NOT EXISTS `cw_member` (
     `next_level`       VARCHAR(32) COMMENT '下一等级',
     `upgrade_gap`      DECIMAL(10,2) DEFAULT 0 COMMENT '升级所需再消费金额',
     `phone`            VARCHAR(32) COMMENT '注册手机号',
+    `created_at`       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_member_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
@@ -459,6 +469,8 @@ CREATE TABLE IF NOT EXISTS `cw_knowledge` (
     `title`      VARCHAR(255) NOT NULL COMMENT '条目标题',
     `content`    TEXT NOT NULL COMMENT '条目内容',
     `source`     VARCHAR(255) COMMENT '来源标注',
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     UNIQUE KEY `uk_knowledge_title` (`tenant_id`, `title`),
     INDEX `idx_knowledge_tenant` (`tenant_id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -652,6 +664,8 @@ CREATE TABLE IF NOT EXISTS `cw_fact_log` (
     `scope_id`       VARCHAR(128) NOT NULL DEFAULT 'default' COMMENT '记忆分区键（TenantResolver 由 sessionId 解析）',
     `fact`           TEXT NOT NULL COMMENT '事实内容',
     `ts`             BIGINT NOT NULL COMMENT '事实时间戳（毫秒）',
+    `created_at`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_fact_log_scope` (`tenant_id`, `scope_id`, `id`),
     INDEX `idx_fact_log_ts` (`tenant_id`, `scope_id`, `ts`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT='事实日志（L3，append-only 审计流水，永不改写）';
@@ -827,6 +841,8 @@ CREATE TABLE IF NOT EXISTS `cw_prompt_version` (
     -- 同一版会被反复观测到（重启、多副本），写入用 INSERT IGNORE 保留最早那次，
     -- 那才是"这版什么时候上线的"
     `captured_at_ms` BIGINT NOT NULL COMMENT '首次观测到该版本的时间戳（毫秒）',
+    `created_at`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     INDEX `idx_prompt_version_time` (`tenant_id`, `captured_at_ms`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT='提示词版本（运行时实际生效的那份）';
 
@@ -845,6 +861,8 @@ CREATE TABLE IF NOT EXISTS `cw_csat_survey` (
     `comment`         TEXT COMMENT '文字说明',
     `invited_at_ms`   BIGINT NOT NULL COMMENT '发出邀请时间戳（毫秒）——统计窗口以它为准',
     `submitted_at_ms` BIGINT NOT NULL DEFAULT 0 COMMENT '提交评分时间戳（毫秒）；未评价为 0',
+    `created_at`      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     -- 统计按 (scope_id, invited_at_ms) 的窗口扫描：分子分母必须同一口径，
     -- 按提交时间筛会把"这周邀请、下周才评"的算进下周，两头都不对
     INDEX `idx_csat_window` (`tenant_id`, `scope_id`, `invited_at_ms`),
@@ -867,6 +885,8 @@ CREATE TABLE IF NOT EXISTS `cw_knowledge_gap` (
     `miss_count`        BIGINT NOT NULL DEFAULT 1 COMMENT '累计未命中次数：排行依据，越大越该优先补',
     `first_seen_at_ms`  BIGINT NOT NULL COMMENT '首次出现时间戳（毫秒）——这个问题何时开始查不到',
     `last_seen_at_ms`   BIGINT NOT NULL COMMENT '最近出现时间戳（毫秒）',
+    `created_at`        DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    `updated_at`        DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
     UNIQUE KEY `uk_knowledge_gap` (`tenant_id`, `scope_id`, `question_hash`),
     -- 排行查询是 (scope_id, miss_count DESC) 的限额扫描
     INDEX `idx_knowledge_gap_rank` (`tenant_id`, `scope_id`, `miss_count`)

--- a/mysql/02-customer-admin/64-V64__add_audit_timestamps.sql
+++ b/mysql/02-customer-admin/64-V64__add_audit_timestamps.sql
@@ -1,0 +1,111 @@
+SET NAMES utf8mb4;
+
+-- 为同时缺少创建时间与修改时间的存量表补齐数据库级审计时间。
+-- MySQL DDL 不可事务回滚：先确认九张目标表全部存在，再按实际缺列生成 ALTER，确保 repair 后可安全重试。
+
+SET @v64_table_count = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_type = 'BASE TABLE'
+      AND table_name IN (
+          'sys_user_role',
+          'sys_role_permission',
+          'ai_agent_mcp',
+          'ai_agent_skill',
+          'ai_agent_sub_agent',
+          'ai_agent_system_tool',
+          'ai_agent_knowledge_base',
+          'ai_scheduled_task_run',
+          'cw_agent_call_segment'
+      )
+);
+SET @v64_preflight_sql = IF(
+    @v64_table_count = 9,
+    'SELECT 1',
+    'SELECT * FROM `__customer_admin_v64_required_table_preflight_failed__`'
+);
+PREPARE v64_preflight_stmt FROM @v64_preflight_sql;
+EXECUTE v64_preflight_stmt;
+DEALLOCATE PREPARE v64_preflight_stmt;
+
+-- target: sys_user_role
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_user_role' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_user_role' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `sys_user_role` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: sys_role_permission
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_role_permission' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'sys_role_permission' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `sys_role_permission` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_mcp
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_mcp' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_mcp' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_mcp` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_skill
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_skill' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_skill' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_skill` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_sub_agent
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_sub_agent' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_sub_agent' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_sub_agent` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_system_tool
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_system_tool' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_system_tool' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_system_tool` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_agent_knowledge_base
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_knowledge_base' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_agent_knowledge_base' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_agent_knowledge_base` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: ai_scheduled_task_run
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_scheduled_task_run' AND column_name = 'create_time'), '', 'ADD COLUMN `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ai_scheduled_task_run' AND column_name = 'update_time'), '', 'ADD COLUMN `update_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `ai_scheduled_task_run` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;
+
+-- target: cw_agent_call_segment
+SET @v64_created_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'cw_agent_call_segment' AND column_name = 'created_at'), '', 'ADD COLUMN `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT ''创建时间''');
+SET @v64_updated_clause = IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'cw_agent_call_segment' AND column_name = 'updated_at'), '', 'ADD COLUMN `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT ''修改时间''');
+SET @v64_columns = CONCAT_WS(', ', NULLIF(@v64_created_clause, ''), NULLIF(@v64_updated_clause, ''));
+SET @v64_ddl = IF(@v64_columns = '', 'SELECT 1', CONCAT('ALTER TABLE `cw_agent_call_segment` ', @v64_columns));
+PREPARE v64_stmt FROM @v64_ddl;
+EXECUTE v64_stmt;
+DEALLOCATE PREPARE v64_stmt;


### PR DESCRIPTION
## 变更说明

- 扫描 96 张项目自有业务表，为同时缺少创建时间和修改时间的 19 张表补齐审计时间字段。
- 新增客服库 Flyway V9 Java 迁移与完整初始化镜像，统一使用 `created_at` / `updated_at`。
- 新增后台库 Flyway V64 SQL 迁移与 DBA 镜像；后台关系表沿用 `create_time` / `update_time`，`cw_agent_call_segment` 与客服库保持一致。
- 通过数据库默认值和 `ON UPDATE CURRENT_TIMESTAMP` 覆盖现有 BaseMapper、XML upsert 与跨库写入链路。
- 增加目标表预检、半迁移状态识别以及 Flyway repair 后安全重试能力。

## 验证

- 六模块全量测试：2618 tests，0 failures，0 errors，6 skipped，BUILD SUCCESS。
- 客服库迁移真库测试：5/5 通过。
- 后台库迁移真库测试：3/3 通过。
- `git diff --check` 通过，两份 V64 SQL 镜像逐字一致。

## 审计边界

- 存量行只能回填迁移执行时间，无法恢复真实历史创建时间。
- 本次补充的是行级创建/修改时间，不替代不可变操作日志或历史表。
- 本次口径为两个审计字段同时缺失；仅缺其中一个字段的表未纳入。
