### PR TITLE
fix(admin): reduce java assistant stream latency

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -49,6 +49,8 @@ import com.richard.fyoung.customeradmin.workspace.task.entity.AiAgentTask;
 import com.richard.fyoung.customeradmin.workspace.task.runtime.AgentTaskReplayCaptureMiddleware;
 import com.richard.fyoung.customeradmin.workspace.task.runtime.MybatisTaskRepository;
 import com.richard.fyoung.customerwork.core.agent.AgentResourceCloser;
+import com.richard.fyoung.customerwork.core.agent.HarnessMemoryPolicy;
+import com.richard.fyoung.customerwork.core.agent.HarnessOptInPolicy;
 import com.richard.fyoung.customerwork.infra.config.RuntimeWorkDir;
 import com.richard.fyoung.customerwork.infra.config.CustomerWorkRuntimeConfig;
 import com.richard.fyoung.customerwork.infra.config.RuntimeModelRouteMapper;
@@ -84,7 +86,6 @@ import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.spec.SandboxFilesystemSpec;
-import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerFilesystemSpec;
@@ -476,6 +477,9 @@ public class AdminAgentInstanceFactory {
         // 召回内容由 KnowledgeRetrievalMiddleware 自己包，工具结果由框架产出、只能在这里拦。
         // 两者的系统提示词规则走同一个幂等追加方法，不会写重复。
         builder.middleware(indirectInjectionGuardMiddleware);
+        // 当前时间作为瞬时系统上下文注入：模型可直接回答“今天/现在/星期”等确定性问题，避免先调用
+        // timestamp_convert 再进行第二轮推理；不拼进用户消息，因此不会污染会话历史。
+        builder.middleware(new CurrentTimeContextMiddleware());
         // 最内层采集最终模型输入：外层的 RAG/动态参数改写均已完成；只保存哈希和非密钥参数。
         builder.middleware(new ModelReplayCaptureMiddleware());
         if (capabilities.contains(AgentCapabilities.VIBECODING)) {
@@ -553,6 +557,17 @@ public class AdminAgentInstanceFactory {
             .taskRepository(taskRepository)
             .workspace(workspace);
 
+        boolean staticSubagentsEnabled = capabilities.contains(AgentCapabilities.SUBAGENT);
+        boolean dynamicSubagentsEnabled = capabilities.contains(AgentCapabilities.DYNAMIC_SUBAGENT);
+        boolean dynamicSkillsEnabled = capabilities.contains(AgentCapabilities.SKILL_LEARNING);
+        HarnessOptInPolicy.apply(harnessBuilder,
+            vibecoding,
+            agent.getCompressTriggerMsgs() != null,
+            false,
+            staticSubagentsEnabled,
+            dynamicSubagentsEnabled,
+            dynamicSkillsEnabled);
+
         if (vibecoding) {
             if (sandboxProperties.isDockerMode()) {
                 harnessBuilder.filesystem(buildDockerFilesystemSpec(sandboxProperties, agentCode));
@@ -566,20 +581,21 @@ public class AdminAgentInstanceFactory {
                 .allowShellInPlanMode(false)
                 .planFileDirectory(workspace.resolve(PLAN_DIR_NAME).toString());
         }
-        if (capabilities.contains(AgentCapabilities.SKILL_LEARNING)) {
+        if (dynamicSkillsEnabled) {
             // 互动学习新技能（Harness 半边）：技能管理工具 + SkillCurator 自动沉淀成功模式
             harnessBuilder.enableSkillManageTool(true)
                 .enableSkillCurator(SkillCuratorConfig.defaults());
         }
-        if (capabilities.contains(AgentCapabilities.MEMORY)) {
+        boolean memoryEnabled = capabilities.contains(AgentCapabilities.MEMORY);
+        if (memoryEnabled) {
             // 跨会话长期记忆（分层记忆）：对话事实自动 flush 到 workspace/MEMORY.md 并定期 consolidation，
             // 按 agentCode 隔离（一个智能体一份记忆，全部会话共享）。workspace 文件只是框架的工作副本，
             // 权威存储在 AgentMemoryStore（默认落库）：构建时水合到 workspace，对话轮次结束后由
             // ChatService 回写（见 AgentMemorySyncService）
             memorySyncService.hydrate(memoryScope.storageKey(), workspace);
-            harnessBuilder.memory(MemoryConfig.builder().model(model).build());
             log.info("[workspace] layered memory enabled: agentCode={}", agentCode);
         }
+        HarnessMemoryPolicy.apply(harnessBuilder, memoryEnabled, model);
         if (agent.getCompressTriggerMsgs() != null) {
             int keepMsgs = agent.getCompressKeepMsgs() != null
                 ? agent.getCompressKeepMsgs() : DEFAULT_COMPRESS_KEEP_MSGS;
@@ -589,19 +605,17 @@ public class AdminAgentInstanceFactory {
                 .model(model)
                 .build());
         }
-        if (capabilities.contains(AgentCapabilities.SUBAGENT)) {
+        if (staticSubagentsEnabled) {
             registerSubagents(harnessBuilder, agent, visited);
         }
-        if (capabilities.contains(AgentCapabilities.DYNAMIC_SUBAGENT)) {
+        if (dynamicSubagentsEnabled) {
             // 动态子Agent：框架在 HarnessAgent 上默认开启（DynamicSubagentsMiddleware），勾选时保留默认，
             // 主 Agent 可在运行时按任务临时声明子 Agent（SubagentSpecGenerator 现场生成规格，无需预注册）
             log.info("[workspace] dynamic subagents enabled: agentCode={}", agentCode);
-        } else {
-            // 未勾选则显式关闭，避免框架默认行为让所有 Harness 智能体都悄悄具备运行时造 Agent 的能力
-            harnessBuilder.disableDynamicSubagents();
         }
 
         HarnessAgent harnessAgent = harnessBuilder.build();
+        HarnessOptInPolicy.pruneBuiltInTools(harnessAgent, staticSubagentsEnabled, dynamicSubagentsEnabled);
         log.info("[workspace] harness agent built: agentCode={} capabilities={} sandboxMode={}",
             agentCode, capabilities, vibecoding ? sandboxProperties.getMode() : "none");
         return harnessAgent;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/CurrentTimeContextMiddleware.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/CurrentTimeContextMiddleware.java
@@ -1,0 +1,46 @@
+package com.richard.fyoung.customeradmin.workspace.runtime;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.middleware.MiddlewareBase;
+import reactor.core.publisher.Mono;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * 为模型提供本轮请求的当前时间，避免“今天星期几”等确定性问题先调用工具、再进行第二轮推理。
+ *
+ * <p>时间只在 {@code onSystemPrompt} 阶段瞬时注入，不写入用户消息和会话历史；格式中同时包含偏移量与
+ * ZoneId，部署在不同时区时也不会把服务器本地时间误称为北京时间。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+final class CurrentTimeContextMiddleware implements MiddlewareBase {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(
+        "yyyy-MM-dd HH:mm:ss EEEE XXX '['VV']'", Locale.SIMPLIFIED_CHINESE);
+
+    private final Clock clock;
+
+    CurrentTimeContextMiddleware() {
+        this(Clock.systemDefaultZone());
+    }
+
+    CurrentTimeContextMiddleware(Clock clock) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    @Override
+    public Mono<String> onSystemPrompt(Agent agent, RuntimeContext ctx, String currentPrompt) {
+        String now = ZonedDateTime.now(clock).format(FORMATTER);
+        String runtimeNote = String.format(
+            "%n%n[运行时上下文] 当前服务器时间=%s。询问当前日期、星期或时间时直接使用该事实；"
+                + "除非用户明确要求时区换算，否则不要调用时间工具。",
+            now);
+        return Mono.just((currentPrompt == null ? "" : currentPrompt) + runtimeNote);
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/CurrentTimeContextMiddlewareTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/CurrentTimeContextMiddlewareTest.java
@@ -1,0 +1,24 @@
+package com.richard.fyoung.customeradmin.workspace.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CurrentTimeContextMiddlewareTest {
+
+    @Test
+    void onSystemPrompt_shouldAppendStableZonedTime_withoutChangingUserHistory() {
+        Clock clock = Clock.fixed(Instant.parse("2026-08-24T13:15:30Z"), ZoneId.of("Asia/Shanghai"));
+        CurrentTimeContextMiddleware middleware = new CurrentTimeContextMiddleware(clock);
+
+        String prompt = middleware.onSystemPrompt(null, null, "你是 Java 助手。").block();
+
+        assertTrue(prompt.startsWith("你是 Java 助手。"));
+        assertTrue(prompt.contains("2026-08-24 21:15:30 星期一 +08:00 [Asia/Shanghai]"));
+        assertTrue(prompt.contains("不要调用时间工具"));
+    }
+}

--- a/customer-admin-web/src/store/chatConversations.ts
+++ b/customer-admin-web/src/store/chatConversations.ts
@@ -4,6 +4,7 @@ import { generateUuid } from '@/utils/uuid'
 import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
 import { createPlanCard, type PlanCard } from '@/utils/planCard'
 import { revokeAttachmentPreviews, type MessageAttachmentVM } from '@/utils/attachment'
+import { createTextChunkBatcher } from '@/utils/textChunkBatcher'
 import type { TraceNode } from '@/components/TraceTimeline.vue'
 import type { ExecutionMode, LiveSession, PlanEvent, PlanResultEvent } from '@/types/api'
 
@@ -230,22 +231,29 @@ export const useChatConversationsStore = defineStore('chatConversations', {
       conv.attachments = []
       conv.streaming = true
       const sid = conv.sessionId
+      const isActive = () => this.byAgent[agentCode]?.activeId === sid
+      const textBatcher = createTextChunkBatcher((chunk) => {
+        assistantMessage.text += chunk
+        if (isActive()) onScroll?.()
+      })
 
-      conv.abort = streamChat(agentCode, { sessionId: sid, message: messageToSend, mode: conv.mode, attachmentIds }, {
+      const abortStream = streamChat(agentCode, { sessionId: sid, message: messageToSend, mode: conv.mode, attachmentIds }, {
         onEvent: (event) => {
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (!c) return
-          const isActive = () => this.byAgent[agentCode]?.activeId === sid
           if (event.event === 'done') {
+            textBatcher.flush()
             c.streaming = false
             return
           }
           if (event.event === 'plan') {
+            textBatcher.flush()
             this.applyPlanEvent(c, assistantMessage, event.data)
             if (isActive()) onScroll?.()
             return
           }
           if (event.event === 'plan_result') {
+            textBatcher.flush()
             try {
               const parsed = JSON.parse(event.data) as PlanResultEvent
               const card = c.pendingPlans.get(parsed.planId)
@@ -258,6 +266,7 @@ export const useChatConversationsStore = defineStore('chatConversations', {
             return
           }
           if (event.event.startsWith('node:')) {
+            textBatcher.flush()
             const kind = event.event.slice('node:'.length)
             const payload = parseChatStreamPayload(event.data)
             appendChatStreamNode(assistantMessage.nodes, kind, payload.text, payload.source, payload.subagentName)
@@ -267,13 +276,15 @@ export const useChatConversationsStore = defineStore('chatConversations', {
               // 带 source 的正文增量是子Agent 内部产出，复用 ANSWER kind 挂进对应嵌套面板
               appendChatStreamNode(assistantMessage.nodes, ANSWER_KIND, payload.text, payload.source, payload.subagentName)
             } else {
-              assistantMessage.text += payload.text
+              textBatcher.append(payload.text)
+              return
             }
           }
           // 其余未知事件静默忽略：后端新增 SSE 事件类型时旧前端不受影响（需求 §5.5 向后兼容）
           if (isActive()) onScroll?.()
         },
         onError: (error) => {
+          textBatcher.discard()
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (c) {
             c.streaming = false
@@ -286,6 +297,7 @@ export const useChatConversationsStore = defineStore('chatConversations', {
           assistantMessage.failed = true
         },
         onComplete: () => {
+          textBatcher.flush()
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (c) {
             c.streaming = false
@@ -298,6 +310,10 @@ export const useChatConversationsStore = defineStore('chatConversations', {
           this.historyVersion[agentCode] = (this.historyVersion[agentCode] ?? 0) + 1
         },
       })
+      conv.abort = () => {
+        textBatcher.flush()
+        abortStream()
+      }
       onScroll?.()
     },
 

--- a/customer-admin-web/src/utils/textChunkBatcher.ts
+++ b/customer-admin-web/src/utils/textChunkBatcher.ts
@@ -1,0 +1,56 @@
+/**
+ * 把同一渲染帧内到达的文本增量合并后再写入响应式状态。
+ *
+ * 模型流可能在一帧内推送多次；若每片都改 Pinia，会反复触发 Markdown 解析、DOM patch 与滚动。
+ * 这里最多增加一帧延迟，同时保留 flush/discard 两种显式收尾语义。
+ */
+export interface TextChunkBatcher {
+  append: (chunk: string) => void
+  flush: () => void
+  discard: () => void
+}
+
+type CancelScheduledFrame = () => void
+
+function scheduleRenderFrame(callback: () => void): CancelScheduledFrame {
+  if (typeof requestAnimationFrame === 'function') {
+    const frameId = requestAnimationFrame(callback)
+    return () => cancelAnimationFrame(frameId)
+  }
+  // 测试或非浏览器环境兜底；生产浏览器始终走 requestAnimationFrame。
+  const timeoutId = setTimeout(callback, 16)
+  return () => clearTimeout(timeoutId)
+}
+
+export function createTextChunkBatcher(onFlush: (text: string) => void): TextChunkBatcher {
+  let pending = ''
+  let cancelScheduledFrame: CancelScheduledFrame | null = null
+
+  const emitPending = () => {
+    cancelScheduledFrame = null
+    if (!pending) return
+    const text = pending
+    pending = ''
+    onFlush(text)
+  }
+
+  return {
+    append(chunk: string) {
+      if (!chunk) return
+      pending += chunk
+      if (!cancelScheduledFrame) {
+        cancelScheduledFrame = scheduleRenderFrame(emitPending)
+      }
+    },
+    flush() {
+      cancelScheduledFrame?.()
+      cancelScheduledFrame = null
+      emitPending()
+    },
+    discard() {
+      cancelScheduledFrame?.()
+      cancelScheduledFrame = null
+      pending = ''
+    },
+  }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentFactory.java
@@ -14,7 +14,6 @@ import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.spec.SandboxFilesystemSpec;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerFilesystemSpec;
-import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
 import io.agentscope.harness.agent.skill.curator.SkillCuratorConfig;
@@ -98,6 +97,14 @@ public class HarnessAgentFactory {
 
         // 上下文压缩（长对话有界）
         CompactionConfig compaction = contextMemoryFactory.createCompaction();
+        boolean filesystemEnabled = !"none".equalsIgnoreCase(cfg.getSandbox().getMode());
+        HarnessOptInPolicy.apply(builder,
+            filesystemEnabled,
+            compaction != null,
+            cfg.isToolResultEvictionEnabled(),
+            cfg.getSubagent().isEnabled(),
+            false,
+            cfg.isSkillCuratorEnabled());
         if (compaction != null) {
             builder.compaction(compaction);
         }
@@ -105,11 +112,12 @@ public class HarnessAgentFactory {
         // 分层记忆：MEMORY.md 持久画像 + 会话沉淀 + 自动 consolidation
         // 框架只从 workspace 文件读记忆，故构建前先把 MySQL 里的权威副本水合下来——
         // 否则换机 / 重启 / 清理 workspace 之后，历史记忆对框架就等于不存在。
-        if (cfg.isMemoryEnabled()) {
+        boolean memoryEnabled = cfg.isMemoryEnabled();
+        if (memoryEnabled) {
             memorySyncService.hydrate(resolveWorkspace(cfg.getWorkspaceDir()));
-            builder.memory(MemoryConfig.builder().model(model).build());
             log.info("[Harness] layered memory enabled (MEMORY.md + consolidation)");
         }
+        HarnessMemoryPolicy.apply(builder, memoryEnabled, model);
 
         // 环境级记忆：跨会话共享的环境记忆
         if (StringUtils.hasText(cfg.getEnvironmentMemory())) {
@@ -156,8 +164,10 @@ public class HarnessAgentFactory {
             log.info("[Harness] subagents registered: order/after-sales/knowledge experts");
         }
 
+        HarnessAgent harnessAgent = builder.build();
+        HarnessOptInPolicy.pruneBuiltInTools(harnessAgent, cfg.getSubagent().isEnabled(), false);
         log.info("[Harness] HarnessAgent built for session {}", sessionId);
-        return builder.build();
+        return harnessAgent;
     }
 
     /**

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/HarnessMemoryPolicy.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/HarnessMemoryPolicy.java
@@ -1,0 +1,41 @@
+package com.richard.fyoung.customerwork.core.agent;
+
+import io.agentscope.core.model.Model;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.memory.MemoryConfig;
+
+import java.util.Objects;
+
+/**
+ * Harness 长期记忆能力策略。
+ *
+ * <p>AgentScope Harness 2.0 默认注册记忆工具，并在每轮调用后执行 memory flush / consolidation。
+ * 项目侧的记忆能力是显式开启语义，因此不能只在开启时设置 {@link MemoryConfig}，关闭时也必须覆盖
+ * 框架默认值，避免未声明 memory 能力的 Agent 产生隐藏模型调用和记忆文件。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class HarnessMemoryPolicy {
+
+    private HarnessMemoryPolicy() {
+    }
+
+    /**
+     * 让 Harness 的实际记忆行为与项目配置保持一致。
+     *
+     * @param builder Harness 构建器
+     * @param enabled 是否显式启用长期记忆
+     * @param model   记忆提取与整理使用的模型；仅在启用时要求非空
+     */
+    public static void apply(HarnessAgent.Builder builder, boolean enabled, Model model) {
+        Objects.requireNonNull(builder, "builder");
+        if (enabled) {
+            builder.memory(MemoryConfig.builder()
+                .model(Objects.requireNonNull(model, "model"))
+                .build());
+            return;
+        }
+        builder.disableMemoryHooks();
+        builder.disableMemoryTools();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/HarnessOptInPolicy.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/agent/HarnessOptInPolicy.java
@@ -1,0 +1,65 @@
+package com.richard.fyoung.customerwork.core.agent;
+
+import io.agentscope.harness.agent.HarnessAgent;
+
+import java.util.Objects;
+
+/**
+ * 把 Harness 默认开启的可选能力收敛为项目侧显式开启语义。
+ *
+ * <p>AgentScope Harness 2.0 默认带文件、Shell、上下文压缩、工具结果落盘、子智能体和动态技能能力。
+ * 项目配置与智能体 capabilities 均采用 opt-in 语义；未配置时若不显式关闭，不仅会扩大工具 Schema，
+ * 还可能触发未声明的模型调用或写操作。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class HarnessOptInPolicy {
+
+    private static final String WAIT_ASYNC_RESULTS_TOOL = "wait_async_results";
+
+    private HarnessOptInPolicy() {
+    }
+
+    /** 根据项目侧能力开关覆盖 Harness 默认值。 */
+    public static void apply(HarnessAgent.Builder builder,
+                             boolean filesystemEnabled,
+                             boolean compactionEnabled,
+                             boolean toolResultEvictionEnabled,
+                             boolean subagentsEnabled,
+                             boolean dynamicSubagentsEnabled,
+                             boolean dynamicSkillsEnabled) {
+        Objects.requireNonNull(builder, "builder");
+        if (!filesystemEnabled) {
+            builder.disableFilesystemTools();
+            builder.disableShellTool();
+        }
+        if (!compactionEnabled) {
+            builder.disableCompaction();
+        }
+        if (!toolResultEvictionEnabled) {
+            builder.disableToolResultEviction();
+        }
+        if (!subagentsEnabled && !dynamicSubagentsEnabled) {
+            builder.disableSubagents();
+        } else if (!dynamicSubagentsEnabled) {
+            builder.disableDynamicSubagents();
+        }
+        if (!dynamicSkillsEnabled) {
+            builder.disableDynamicSkills();
+        }
+    }
+
+    /**
+     * 清理 Builder 关闭能力后仍被框架无条件注册的工具。
+     *
+     * <p>Harness 2.0 即使 {@code disableSubagents()} 仍会留下 {@code wait_async_results}；没有任何
+     * 静态或动态子 Agent 时该工具既不可产生结果，也不应继续占用模型上下文。</p>
+     */
+    public static void pruneBuiltInTools(HarnessAgent agent, boolean subagentsEnabled,
+                                         boolean dynamicSubagentsEnabled) {
+        Objects.requireNonNull(agent, "agent");
+        if (!subagentsEnabled && !dynamicSubagentsEnabled) {
+            agent.getToolkit().removeTool(WAIT_ASYNC_RESULTS_TOOL);
+        }
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/middleware/SensitiveWordMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/middleware/SensitiveWordMiddleware.java
@@ -219,7 +219,7 @@ public class SensitiveWordMiddleware implements MiddlewareBase {
      * 流式正文增量的滑动缓冲过滤。
      *
      * <p>每片到达后与缓冲区拼接整体过滤，只放行"确定不可能再是某个词前缀"的前半段，
-     * 尾部留 {@link SensitiveWordFilter#streamRetainLength()} 个字符等下一片——
+     * 尾部只保留仍可扩展成敏感词的真实歧义前缀等下一片——
      * 否则 {@code 阿根廷} 被拆成三片推送时永远匹配不上。</p>
      *
      * <p><b>BLOCK 在流式下的固有限制</b>：命中时前面的片段已经在用户屏幕上，收不回来。

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/service/CustomerServiceService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/service/CustomerServiceService.java
@@ -258,7 +258,7 @@ public class CustomerServiceService {
     /**
      * 把 guard 挂到文本流上：逐片过滤（可能整片被缓冲而不发），流末尾 flush 出留住的尾巴。
      *
-     * <p>不 flush 会吞掉正文最后几个字——尾部那 {@code 最长词长-1} 个字符正是被刻意留住等下一片的。</p>
+     * <p>不 flush 会吞掉正文末尾仍可能扩展成敏感词的歧义前缀——它们被刻意留住等待下一片。</p>
      */
     private Flux<String> applyOutboundGuard(Flux<String> source, SensitiveWordStreamGuard guard) {
         if (guard == null) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/AhoCorasickMatcher.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/AhoCorasickMatcher.java
@@ -28,6 +28,8 @@ public final class AhoCorasickMatcher {
     private final List<Map<Character, Integer>> gotoTable = new ArrayList<>();
     /** 失败指针。 */
     private final List<Integer> fail = new ArrayList<>();
+    /** Trie 深度：节点对应的模式前缀长度。 */
+    private final List<Integer> depth = new ArrayList<>();
     /** 每个节点的输出（以该节点结尾的模式，含经失败链继承的），元素为词表下标。 */
     private final List<List<Integer>> output = new ArrayList<>();
     /** 词表（下标与 output 元素对应）。 */
@@ -67,8 +69,8 @@ public final class AhoCorasickMatcher {
     /**
      * 最长模式串长度（归一化后）。
      *
-     * <p>流式过滤要用它决定"尾部留多少字符不放行"：一个词可能被拆进相邻两个增量片段，
-     * 只有留住 {@code maxPatternLength - 1} 个字符等下一片拼上来再匹配，才不会漏。</p>
+     * <p>保留给旧版固定窗口 API 计算安全上界；当前项目流式链路使用
+     * {@link #pendingPrefixLength(String)} 计算真实歧义后缀，避免长词让所有短回复都延迟到流结束。</p>
      */
     public int maxPatternLength() {
         int max = 0;
@@ -76,6 +78,27 @@ public final class AhoCorasickMatcher {
             max = Math.max(max, word.getMatchWord().length());
         }
         return max;
+    }
+
+    /**
+     * 返回文本尾部仍可能继续扩展成某个模式串的归一化字符数。
+     *
+     * <p>完整扫描后的 AC 状态就是“文本最长后缀且为 Trie 前缀”的节点；若该节点是叶子，说明它即使
+     * 已完整命中也不可能再向后扩展，此时沿 fail 链寻找下一个仍有子节点的后缀。与固定保留
+     * {@code maxPatternLength - 1} 相比，本方法只保留真实歧义前缀。</p>
+     */
+    int pendingPrefixLength(String normalizedText) {
+        if (normalizedText == null || normalizedText.isEmpty() || patterns.isEmpty()) {
+            return 0;
+        }
+        int node = 0;
+        for (int i = 0; i < normalizedText.length(); i++) {
+            node = step(node, normalizedText.charAt(i));
+        }
+        while (node != 0 && gotoTable.get(node).isEmpty()) {
+            node = fail.get(node);
+        }
+        return depth.get(node);
     }
 
     /**
@@ -122,6 +145,7 @@ public final class AhoCorasickMatcher {
                 Integer child = gotoTable.get(node).get(c);
                 if (child == null) {
                     child = newNode();
+                    depth.set(child, depth.get(node) + 1);
                     gotoTable.get(node).put(c, child);
                 }
                 node = child;
@@ -158,6 +182,7 @@ public final class AhoCorasickMatcher {
     private int newNode() {
         gotoTable.add(new HashMap<>());
         fail.add(0);
+        depth.add(0);
         output.add(new ArrayList<>());
         return gotoTable.size() - 1;
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordFilter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordFilter.java
@@ -102,12 +102,10 @@ public class SensitiveWordFilter {
     }
 
     /**
-     * 流式过滤的安全保留长度：{@code 最长词长 - 1}。
-     *
-     * <p>流式输出下一个词会被拆进相邻增量片段（"阿根廷" 可能来自三次推送），必须留住这么多字符
-     * 等下一片拼上来再匹配，否则跨片段的词永远命中不了。fail-closed 哨兵态返回 0——那时任何文本
-     * 都会被整体拦下，不存在"放行一部分"的问题。</p>
+     * 流式过滤的最大安全保留长度。保留该旧 API 供外部兼容；项目内流式链路使用
+     * {@link #checkStreamWindow(String)} 的动态歧义前缀长度。
      */
+    @Deprecated
     public int streamRetainLength() {
         if (failClosed) {
             return 0;
@@ -126,16 +124,33 @@ public class SensitiveWordFilter {
      * @param rawText 原始文本（null / 空返回放行结果）
      */
     public SensitiveWordFilterResult check(String rawText) {
+        return check(rawText, matcher, failClosed);
+    }
+
+    /**
+     * 在同一个词表快照上完成过滤与流式尾部判定，避免热重载恰好发生在两步之间时使用两份词表。
+     */
+    StreamWindow checkStreamWindow(String rawText) {
+        boolean failClosedSnapshot = failClosed;
+        AhoCorasickMatcher matcherSnapshot = matcher;
+        SensitiveWordFilterResult result = check(rawText, matcherSnapshot, failClosedSnapshot);
+        int retainLength = result.decision() == SensitiveWordAction.BLOCK
+            ? 0 : streamRetainLength(rawText, matcherSnapshot, failClosedSnapshot);
+        return new StreamWindow(result, retainLength);
+    }
+
+    private SensitiveWordFilterResult check(String rawText, AhoCorasickMatcher matcherSnapshot,
+                                             boolean failClosedSnapshot) {
         if (rawText == null || rawText.isEmpty()) {
             return SensitiveWordFilterResult.pass(rawText);
         }
-        if (failClosed) {
+        if (failClosedSnapshot) {
             // fail-closed 哨兵：词表从未成功加载，任何非空文本一律拦截（合成一个 BLOCK 命中）
             List<SensitiveWordHit> sentinelHits = List.of(new SensitiveWordHit(SENTINEL_BLOCK_WORD, 0, 0));
             return new SensitiveWordFilterResult(rawText, rawText, sentinelHits, SensitiveWordAction.BLOCK);
         }
         TextNormalizer.Normalized norm = TextNormalizer.normalizeTracked(rawText);
-        List<SensitiveWordHit> hits = matcher.match(norm.text());
+        List<SensitiveWordHit> hits = matcherSnapshot.match(norm.text());
         if (hits.isEmpty()) {
             return SensitiveWordFilterResult.pass(rawText);
         }
@@ -144,6 +159,26 @@ public class SensitiveWordFilter {
             ? rawText  // BLOCK 决策整体替换为兜底话术，无需逐词打码
             : maskHits(rawText, norm.originalIndex(), hits);
         return new SensitiveWordFilterResult(rawText, maskedText, hits, decision);
+    }
+
+    /** 把归一化歧义前缀映射回原文尾部长度，保留其中用于绕过的空白与插入符。 */
+    private int streamRetainLength(String rawText, AhoCorasickMatcher matcherSnapshot,
+                                   boolean failClosedSnapshot) {
+        if (failClosedSnapshot || rawText == null || rawText.isEmpty()) {
+            return 0;
+        }
+        TextNormalizer.Normalized normalized = TextNormalizer.normalizeTracked(rawText);
+        int normalizedRetain = matcherSnapshot.pendingPrefixLength(normalized.text());
+        if (normalizedRetain == 0) {
+            return 0;
+        }
+        int normalizedStart = normalized.text().length() - normalizedRetain;
+        int rawStart = normalized.originalIndex()[normalizedStart];
+        return rawText.length() - rawStart;
+    }
+
+    /** 一次流式窗口检查的不可变结果。 */
+    record StreamWindow(SensitiveWordFilterResult result, int retainLength) {
     }
 
     /** 命中词的动作（防御式：动作缺省时回退 {@link #defaultAction}）。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordStreamGuard.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordStreamGuard.java
@@ -23,9 +23,8 @@ import java.util.function.Consumer;
  * 非流式 {@code call()} 路径），不该夹带进迁移里，故两侧的流式出口各挂一道 guard 仍是当前做法。</p>
  *
  * <p><b>滑动缓冲</b>：一个词会被拆进相邻增量（"阿根廷" 可能来自三次推送），逐片匹配必漏。
- * 每片与缓冲区拼接后整体过滤，只放行"确定不再是任何词前缀"的前半段，尾部留
- * {@link SensitiveWordFilter#streamRetainLength()} 个字符等下一片；{@link #flush()} 时吐出剩余，
- * 一个字都不吞。</p>
+ * 每片与缓冲区拼接后整体过滤，只放行"确定不再是任何词前缀"的前半段；尾部只保留当前仍可扩展成
+ * 某个词的真实歧义前缀，而不是按全局最长词固定缓冲。{@link #flush()} 时吐出剩余，一个字都不吞。</p>
  *
  * <p><b>BLOCK 的固有限制</b>：命中时前面的片段已经发出去了，收不回。这里的处置是"立即停止后续
  * 输出 + 补一条安全话术"，把伤害面收敛到命中点之后。要一个字都不漏只能整段缓冲后再发，
@@ -84,7 +83,8 @@ public class SensitiveWordStreamGuard {
             return "";
         }
         buffer.append(delta);
-        SensitiveWordFilterResult result = filter.check(buffer.toString());
+        SensitiveWordFilter.StreamWindow window = filter.checkStreamWindow(buffer.toString());
+        SensitiveWordFilterResult result = window.result();
         if (result.decision() == SensitiveWordAction.BLOCK) {
             blocked = true;
             buffer.setLength(0);
@@ -97,10 +97,11 @@ public class SensitiveWordStreamGuard {
             notifyHit(result);
         }
         String masked = result.maskedText();
-        int retain = Math.min(filter.streamRetainLength(), masked.length());
+        int retain = Math.min(window.retainLength(), masked.length());
         String emit = masked.substring(0, masked.length() - retain);
-        buffer.setLength(0);
-        buffer.append(masked, masked.length() - retain, masked.length());
+        // 缓冲区必须保留原文而不是打码文本：若短词是长词前缀（短词 MASK、长词 BLOCK），提前把短词
+        // 改成 *** 会破坏下一片到来时的长词匹配。这里只删除已安全放行的原文前缀。
+        buffer.delete(0, buffer.length() - retain);
         return emit;
     }
 

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentFactoryTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentFactoryTest.java
@@ -13,6 +13,9 @@ import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.HarnessAgent;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -60,6 +63,18 @@ class HarnessAgentFactoryTest {
 
         assertNotNull(agent, "HarnessAgent 应成功构建");
         assertNotNull(agent.getStateStore(), "应挂载 StateStore");
+        assertFalse(agent.getDelegate().getMiddlewares().stream()
+            .anyMatch(middleware -> middleware.getClass().getSimpleName().contains("Memory")));
+        assertFalse(agent.getDelegate().getMiddlewares().stream()
+            .anyMatch(middleware -> middleware.getClass().getSimpleName().contains("Compaction")));
+        assertFalse(agent.getDelegate().getMiddlewares().stream()
+            .anyMatch(middleware -> middleware.getClass().getSimpleName().contains("ToolResultEviction")));
+        Set<String> toolNames = agent.getToolkit().getToolNames();
+        assertFalse(toolNames.stream().anyMatch(name -> name.startsWith("memory_") || name.startsWith("session_")));
+        assertFalse(toolNames.stream().anyMatch(name -> name.startsWith("agent_") || name.startsWith("task_")
+            || "wait_async_results".equals(name)));
+        assertFalse(toolNames.stream().anyMatch(name -> Set.of("list_files", "read_file", "write_file", "edit_file",
+            "grep_files", "glob_files", "execute").contains(name)));
     }
 
     @Test

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessMemoryPolicyTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessMemoryPolicyTest.java
@@ -1,0 +1,64 @@
+package com.richard.fyoung.customerwork.core.agent;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.middleware.MemoryFlushMiddleware;
+import io.agentscope.harness.agent.middleware.MemoryMaintenanceMiddleware;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class HarnessMemoryPolicyTest {
+
+    @TempDir
+    Path workspace;
+
+    @Test
+    void apply_shouldDisableDefaultMemoryHooksAndTools_whenMemoryIsNotEnabled() {
+        try (HarnessAgent agent = buildAgent(false)) {
+            List<MiddlewareBase> middlewares = agent.getDelegate().getMiddlewares();
+            Set<String> toolNames = agent.getToolkit().getToolNames();
+
+            assertFalse(middlewares.stream().anyMatch(MemoryFlushMiddleware.class::isInstance));
+            assertFalse(middlewares.stream().anyMatch(MemoryMaintenanceMiddleware.class::isInstance));
+            assertFalse(toolNames.stream().anyMatch(name -> name.startsWith("memory_")));
+        }
+    }
+
+    @Test
+    void apply_shouldKeepMemoryHooksAndTools_whenMemoryIsEnabled() {
+        try (HarnessAgent agent = buildAgent(true)) {
+            List<MiddlewareBase> middlewares = agent.getDelegate().getMiddlewares();
+            Set<String> toolNames = agent.getToolkit().getToolNames();
+
+            assertTrue(middlewares.stream().anyMatch(MemoryFlushMiddleware.class::isInstance));
+            assertTrue(middlewares.stream().anyMatch(MemoryMaintenanceMiddleware.class::isInstance));
+            assertTrue(toolNames.stream().anyMatch(name -> name.startsWith("memory_")));
+        }
+    }
+
+    private HarnessAgent buildAgent(boolean memoryEnabled) {
+        Model model = mock(Model.class);
+        ReActAgent inner = ReActAgent.builder()
+            .name("memory-policy-test")
+            .model(model)
+            .toolkit(new Toolkit())
+            .stateStore(new InMemoryAgentStateStore())
+            .build();
+        HarnessAgent.Builder builder = HarnessAgent.Builder.fromAgent(inner)
+            .workspace(workspace);
+        HarnessMemoryPolicy.apply(builder, memoryEnabled, model);
+        return builder.build();
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessOptInPolicyTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessOptInPolicyTest.java
@@ -1,0 +1,54 @@
+package com.richard.fyoung.customerwork.core.agent;
+
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.HarnessAgent;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HarnessOptInPolicyTest {
+
+    @Test
+    void apply_shouldDisableEveryUnconfiguredHarnessDefault() {
+        HarnessAgent.Builder builder = mock(HarnessAgent.Builder.class);
+
+        HarnessOptInPolicy.apply(builder, false, false, false, false, false, false);
+
+        verify(builder).disableFilesystemTools();
+        verify(builder).disableShellTool();
+        verify(builder).disableCompaction();
+        verify(builder).disableToolResultEviction();
+        verify(builder).disableSubagents();
+        verify(builder).disableDynamicSkills();
+        verify(builder, never()).disableDynamicSubagents();
+    }
+
+    @Test
+    void apply_shouldKeepConfiguredFeatures_andDisableOnlyDynamicSubagents() {
+        HarnessAgent.Builder builder = mock(HarnessAgent.Builder.class);
+
+        HarnessOptInPolicy.apply(builder, true, true, true, true, false, true);
+
+        verify(builder).disableDynamicSubagents();
+        verify(builder, never()).disableFilesystemTools();
+        verify(builder, never()).disableShellTool();
+        verify(builder, never()).disableCompaction();
+        verify(builder, never()).disableToolResultEviction();
+        verify(builder, never()).disableSubagents();
+        verify(builder, never()).disableDynamicSkills();
+    }
+
+    @Test
+    void pruneBuiltInTools_shouldRemoveWaitTool_onlyWhenSubagentsAreDisabled() {
+        HarnessAgent agent = mock(HarnessAgent.class);
+        Toolkit toolkit = mock(Toolkit.class);
+        when(agent.getToolkit()).thenReturn(toolkit);
+
+        HarnessOptInPolicy.pruneBuiltInTools(agent, false, false);
+
+        verify(toolkit).removeTool("wait_async_results");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/RedisSessionPersistenceTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/RedisSessionPersistenceTest.java
@@ -11,30 +11,39 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import com.richard.fyoung.customerwork.infra.config.properties.SessionProperties;
 
 /**
- * Redis 会话持久化测试（对接本机 Redis：localhost:6379，密码 123456）。
+ * Redis 会话持久化测试（默认对接 localhost:6379，密码 123456）。
  *
  * <p>当 Redis 不可达时<b>自动跳过</b>（assumeTrue），保证 {@code mvn test} 在无 Redis 的环境
- * 仍然通过；在 Redis 在线的机器上则真实执行存-取-删往返，验证 {@code RedisSession} 可用。</p>
+ * 仍然通过；在 Redis 在线的机器上则真实执行存-取-删往返，验证 {@code RedisSession} 可用。
+ * 地址与密码可由 {@code ADMIN_REDIS_HOST}/{@code ADMIN_REDIS_PORT}/
+ * {@code ADMIN_REDIS_PASSWORD} 覆盖，既与运行期配置同源，也允许本机无密码 Redis 参与真实门禁；
+ * CI 未覆盖时仍使用 123456。</p>
  * @author owlzhangfq@gmail.com
  */
 class RedisSessionPersistenceTest {
 
-    private static final String HOST = "localhost";
-    private static final int PORT = 6379;
-    private static final String PASSWORD = "123456";
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 6379;
+    private static final String DEFAULT_PASSWORD = "123456";
 
     private AgentStateStore store;
 
     @BeforeEach
     void setUp() {
-        assumeTrue(SessionPersistenceTestSupport.reachable(HOST, PORT),
-            "Redis 不可达（" + HOST + ":" + PORT + "），跳过该测试");
+        String host = envOrDefault("ADMIN_REDIS_HOST", DEFAULT_HOST);
+        int port = Integer.parseInt(envOrDefault("ADMIN_REDIS_PORT", String.valueOf(DEFAULT_PORT)));
+        String password = System.getenv("ADMIN_REDIS_PASSWORD");
+        if (password == null) {
+            password = DEFAULT_PASSWORD;
+        }
+        assumeTrue(SessionPersistenceTestSupport.reachable(host, port),
+            "Redis 不可达（" + host + ":" + port + "），跳过该测试");
 
         SessionProperties cfg = new CustomerWorkProperties().getSession();
         cfg.setMode("redis");
-        cfg.getRedis().setHost(HOST);
-        cfg.getRedis().setPort(PORT);
-        cfg.getRedis().setPassword(PASSWORD);
+        cfg.getRedis().setHost(host);
+        cfg.getRedis().setPort(port);
+        cfg.getRedis().setPassword(password);
         cfg.getRedis().setKeyPrefix("customer-work-it");
 
         store = new SessionConfig().buildStateStore(cfg);
@@ -50,5 +59,10 @@ class RedisSessionPersistenceTest {
     @Test
     void saveGetDelete_overRedis() {
         SessionPersistenceTestSupport.assertSaveGetDelete(store, "it-redis:" + UUID.randomUUID());
+    }
+
+    private String envOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
     }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/sensitiveword/AhoCorasickMatcherTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/sensitiveword/AhoCorasickMatcherTest.java
@@ -58,4 +58,16 @@ class AhoCorasickMatcherTest {
         AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("abc"), w(""), w("def")));
         assertEquals(2, m.patternCount());
     }
+
+    @Test
+    void pendingPrefixLength_shouldKeepOnlySuffixThatCanStillExtend() {
+        AhoCorasickMatcher m = AhoCorasickMatcher.build(List.of(w("abc"), w("abcdef"), w("bcde")));
+
+        assertEquals(0, m.pendingPrefixLength("普通文本"));
+        assertEquals(2, m.pendingPrefixLength("xxab"));
+        assertEquals(3, m.pendingPrefixLength("xxabc"), "abc 同时是更长词前缀，必须继续保留");
+        AhoCorasickMatcher leafWithExpandableSuffix = AhoCorasickMatcher.build(List.of(w("abc"), w("bcde")));
+        assertEquals(2, leafWithExpandableSuffix.pendingPrefixLength("xabc"),
+            "叶子命中后应沿 fail 链找到可扩展后缀");
+    }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordFilterTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordFilterTest.java
@@ -91,6 +91,17 @@ class SensitiveWordFilterTest {
     }
 
     @Test
+    void streamWindow_shouldRetainOnlyAmbiguousRawSuffixIncludingNoise() {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        store.save(SensitiveWord.of("敏感词", SensitiveWordCategory.CUSTOM, SensitiveWordAction.MASK));
+        SensitiveWordFilter f = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);
+
+        assertEquals(0, f.checkStreamWindow("完全普通").retainLength());
+        assertEquals(2, f.checkStreamWindow("普通敏*").retainLength(), "归一化前缀后的插入符也必须留在窗口内");
+        assertEquals(3, f.checkStreamWindow("普通敏*感").retainLength());
+    }
+
+    @Test
     void reload_shouldPickUpNewWord() {
         InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
         SensitiveWordFilter f = new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK);

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordStreamGuardTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/sensitiveword/SensitiveWordStreamGuardTest.java
@@ -25,6 +25,15 @@ class SensitiveWordStreamGuardTest {
             new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK), SAFE_REPLY);
     }
 
+    private SensitiveWordStreamGuard guard(SensitiveWord... words) {
+        InMemorySensitiveWordStore store = new InMemorySensitiveWordStore();
+        for (SensitiveWord word : words) {
+            store.save(word);
+        }
+        return new SensitiveWordStreamGuard(
+            new SensitiveWordFilter(store, '*', SensitiveWordAction.BLOCK), SAFE_REPLY);
+    }
+
     /** 按片喂入并拼接放行结果 + flush 尾巴，等价于用户最终看到的正文。 */
     private String feed(SensitiveWordStreamGuard guard, String... deltas) {
         StringBuilder sb = new StringBuilder();
@@ -39,6 +48,25 @@ class SensitiveWordStreamGuardTest {
     void mask_shouldCatchWordSplitAcrossDeltas() {
         // 逐片匹配必漏，只有滑动缓冲能命中——这条是整个流式过滤的立身之本
         assertEquals("冠军是***队", feed(guard(SensitiveWordAction.MASK, "阿根廷"), "冠军是阿", "根", "廷队"));
+    }
+
+    @Test
+    void cleanText_shouldEmitImmediately_insteadOfWaitingForLongestDictionaryWord() {
+        SensitiveWordStreamGuard g = guard(SensitiveWordAction.BLOCK,
+            "这是一个长度很长但与当前回复毫无前缀关系的敏感词条用于验证不应固定缓冲全部短回复");
+
+        assertEquals("好", g.accept("好"));
+        assertEquals("", g.flush());
+    }
+
+    @Test
+    void cleanText_shouldRetainOnlyActualAmbiguousSuffix() {
+        SensitiveWordStreamGuard g = guard(SensitiveWordAction.MASK, "阿根廷");
+
+        assertEquals("普通", g.accept("普通阿"));
+        assertEquals("", g.accept("根"));
+        assertEquals("***队", g.accept("廷队"));
+        assertEquals("", g.flush());
     }
 
     @Test
@@ -60,6 +88,24 @@ class SensitiveWordStreamGuardTest {
     @Test
     void mask_shouldHandleMultipleOccurrences() {
         assertEquals("***和***", feed(guard(SensitiveWordAction.MASK, "阿根廷"), "阿根", "廷和阿根廷"));
+    }
+
+    @Test
+    void mask_shouldCatchObfuscatedWordSplitAcrossDeltas() {
+        assertEquals("文本*****结束", feed(guard(SensitiveWordAction.MASK, "敏感词"),
+            "文本敏*", "感*词结束"));
+    }
+
+    @Test
+    void shorterMaskMustNotHideLongerBlockAcrossDeltas() {
+        SensitiveWordStreamGuard g = guard(
+            SensitiveWord.of("违禁", SensitiveWordCategory.CUSTOM, SensitiveWordAction.MASK),
+            SensitiveWord.of("违禁词", SensitiveWordCategory.CUSTOM, SensitiveWordAction.BLOCK));
+
+        assertEquals("出现", g.accept("出现违禁"), "短词虽已命中，也要保留原文等待可能的长词");
+        assertEquals(SAFE_REPLY, g.accept("词"));
+        assertTrue(g.isBlocked());
+        assertEquals("", g.flush());
     }
 
     @Test
@@ -85,9 +131,9 @@ class SensitiveWordStreamGuardTest {
     @Test
     void flush_shouldBeIdempotent() {
         SensitiveWordStreamGuard g = guard(SensitiveWordAction.MASK, "阿根廷");
-        g.accept("普通文本");
+        assertEquals("普通", g.accept("普通阿"));
 
-        assertEquals("普通文本", g.flush());
+        assertEquals("阿", g.flush());
         assertEquals("", g.flush(), "重复 flush 不应重复吐出内容");
     }
 


### PR DESCRIPTION
## 问题

`/workspace/java-assistant` 的卡顿不是单点问题：

- AgentScope Harness 2.0 默认挂载了项目未显式启用的记忆、压缩、子 Agent、文件与动态技能能力，扩大工具 Schema，并可能触发隐藏处理或额外模型调用。
- 当前日期/星期问题会先调用时间工具，再进入第二轮模型推理。
- 敏感词流式出口按全局最长词固定保留尾部，短而干净的回复也可能等到流结束才显示。
- 前端每个 SSE 文本片段都立即更新 Pinia、Markdown、DOM 和滚动，密集 token 下产生主线程抖动。

## 修复

1. 将 Harness 记忆及其他可选能力统一收敛为项目侧显式 opt-in，并清理能力关闭后残留的内置工具。
2. 在模型系统上下文中瞬时注入带时区的当前服务器时间，确定性日期/星期问题无需时间工具和第二轮推理。
3. 将敏感词固定窗口改为 AC 自动机真实歧义后缀窗口，继续覆盖跨 delta、混淆字符及短词 MASK/长词 BLOCK 场景。
4. 将前端正文增量按 `requestAnimationFrame` 合并，终止、完成、计划与节点边界显式 flush。
5. 让 Redis 持久化集成测试读取与运行期同源的 `ADMIN_REDIS_*` 环境变量，支持无密码本地 Redis 真实往返。

## 验证

- `mvn -B -gs settings-central-direct.xml -s settings-central-direct.xml clean test`
  - 6 个 Maven 模块全部 SUCCESS
  - 3267 tests，0 failures，0 errors，7 skipped
- `npm run build`：通过
- 浏览器批处理检查：1000 个同步文本增量合并为 1 次帧刷新，正文长度保持 1000，终态 flush 正常
- `git diff --check`：通过

## 运行态验证边界

隔离构建的 admin 可执行包曾在 `18082` 正常启动；通过浏览器临时路由验证新后端时，机器恢复阶段 Redis 短暂拒绝连接，认证链路在进入聊天前失败，因此这次未把端到端新后端对话列为通过项，也没有产生新的调用日志。原有 `5174/8082` 进程未被重启或替换；确定性行为由单元测试、全量测试和独立浏览器批处理检查覆盖。

外部模型本身的供应商延迟仍属于剩余风险，本次修复消除的是应用侧额外轮次、固定缓冲和逐 token 渲染开销。