### PR TITLE
fix: 修复流式输出卡顿与 MCP 连通性

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactory.java
@@ -13,8 +13,12 @@ import com.richard.fyoung.customerwork.tool.mcp.McpToolDescriptor;
 import com.richard.fyoung.customerwork.tool.mcp.McpSecurityPolicy;
 import com.richard.fyoung.customerwork.tool.mcp.McpServerSpec;
 import io.agentscope.core.tool.mcp.McpClientBuilder;
+import io.agentscope.core.tool.mcp.McpClientWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,16 +37,24 @@ public class AdminMcpFactory {
 
     private final McpClientFactory mcpClientFactory;
 
+    /**
+     * {@code @Autowired} 不能省：本类有多个构造器，Spring 在「多构造器且无 {@code @Autowired}」时
+     * <b>不会</b>挑参数最多的那个，而是回退到无参构造器。此前正是如此——容器实际用的是那个
+     * 装配 {@link McpSecurityPolicy#strict()} 的无参构造器，白名单恒为空，于是
+     * {@code admin.mcp.security.*} 配得再对也没被读到：localhost 的 MCP 一律报「指向内网/环回，已拦截」，
+     * stdio 一律报「未配置执行白名单」。而属性类自身绑定是正常的，照着它打诊断日志只会看到正确的值，
+     * 把人引向配置本身。同样的坑 PR #68 已在别处修过 5 处。
+     *
+     * <p>无参构造器已一并删除：留着它，将来谁再拿掉这个注解，故障还是「静默降级成最严格策略」
+     * 而不是启动失败。现在没有无参构造器可回退，容器会当场报错——这类问题必须在启动时就炸出来。</p>
+     */
+    @Autowired
     public AdminMcpFactory(AdminMcpSecurityProperties properties) {
         this(new McpSecurityPolicy(properties::getAllowedHosts, properties::getAllowedCommands,
             properties::getAllowedWorkingDirectories, properties::getAllowedEnvironmentKeys));
     }
 
-    /** 离线单测默认沿用最严格策略。 */
-    AdminMcpFactory() {
-        this(McpSecurityPolicy.strict());
-    }
-
+    /** 离线单测用：显式传入策略（如 {@link McpSecurityPolicy#strict()}）。 */
     AdminMcpFactory(McpSecurityPolicy securityPolicy) {
         this.mcpClientFactory = new McpClientFactory(securityPolicy);
     }
@@ -52,12 +64,15 @@ public class AdminMcpFactory {
         return mcpClientFactory.parseSpec(mcpName, mcpType, config);
     }
 
-    /**
-     * 按 mcpType/config 构建一个尚未连接的 {@link McpClientBuilder}。支持 stdio / sse / http 三种传输，
-     * 并兼容 Claude Desktop / Cursor 标准格式的 {@code mcpServers} 外层包装、透传 config 里的 {@code headers}。
-     */
+    /** 底层 AgentScope 构建入口，仅供兼容与配置检查；真实运行时统一使用 {@link #buildClient}。 */
     public McpClientBuilder buildClientBuilder(String mcpName, String mcpType, String config) throws Exception {
         return mcpClientFactory.buildClientBuilder(mcpName, mcpType, config);
+    }
+
+    /** 真实运行时统一走 starter 的兼容构建入口，避免 POST-only Streamable HTTP 在可选 GET 上失败。 */
+    public Mono<McpClientWrapper> buildClient(String mcpName, String mcpType, String config,
+                                               Duration timeout) throws Exception {
+        return mcpClientFactory.buildClient(mcpName, mcpType, config, timeout);
     }
 
     /** 尝试建立连接并列出工具，验证 MCP 服务可达；用完即关闭，不缓存实例（与真实注册用途区分）。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpService.java
@@ -178,6 +178,7 @@ public class McpService {
     public CompletableFuture<McpTestResult> testConnectivity(Long id) {
         AiMcp mcp = requireMcp(id);
         String executableConfig = resolveExecutableConfig(mcp);
+        String tenantId = currentTenant();
 
         return CompletableFuture
             .supplyAsync(() -> mcpFactory.testConnectivity(
@@ -192,7 +193,8 @@ public class McpService {
                 return new McpTestResult(ConnectivityTestStatus.FAILED, LocalDateTime.now(), "连通性测试超时或执行异常");
             })
             .thenApply(result -> {
-                persistTestResult(id, result);
+                // CompletableFuture 回调不继承 Servlet 线程的租户上下文，按发起测试时已校验的租户恢复后回写。
+                TenantContext.runWith(tenantId, () -> persistTestResult(id, result));
                 return result;
             });
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/SystemToolHttpGuard.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/SystemToolHttpGuard.java
@@ -7,13 +7,14 @@ import com.richard.fyoung.customerwork.safety.security.HttpTargetForbiddenExcept
 import com.richard.fyoung.customerwork.safety.security.HttpTargetGuard;
 import com.richard.fyoung.customerwork.safety.security.HttpTargetPolicy;
 import com.richard.fyoung.customerwork.safety.security.InternalAddressPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
  * HTTP 请求工具（{@code httpclient}）与开发者工具箱 HTTP 调试的 SSRF 收口防御点。
  *
  * <p><b>算法不在本类</b>：判定逻辑是 starter 的 {@link HttpTargetGuard}（与 RAG 知识库地址校验同一份实现，
- * 差异只在 {@link InternalAddressPolicy} 一个枚举）。本类只做两件事：把 {@link AdminSystemToolProperties}
+ * 差异只在 {@link InternalAddressPolicy} 枚举的选取）。本类只做两件事：把 {@link AdminSystemToolProperties}
  * 的白名单绑成 starter 的策略 POJO，把 {@link HttpTargetForbiddenException} 转成 {@link BizException}
  * 交给全局异常处理器。</p>
  *
@@ -21,7 +22,9 @@ import org.springframework.stereotype.Component;
  * <ul>
  *   <li>默认（白名单为空）：DNS 解析后按 IP 判定，命中环回/内网/链路本地即拒绝
  *       （{@code internal.example.com} 这类"域名指向内网"的绕过也会被挡住），公网放行；</li>
- *   <li>白名单非空（收紧模式）：只按 host 字符串匹配白名单，命中放行、否则拒绝。</li>
+ *   <li>白名单非空（收紧模式）：host 字符串匹配白名单，未命中直接拒绝；命中后仍解析并按 IP 判定，
+ *       放行内网/环回（显式列入白名单即信任该 host，本地联调依赖它调 127.0.0.1），
+ *       但链路本地/云元数据、未指定与组播地址永久拒绝。</li>
  * </ul></p>
  *
  * <p>"唯一防御点"成立的前提：调用方已禁用自动重定向跟随，3xx 作为终态响应返回。若重新打开自动跟随，
@@ -33,10 +36,23 @@ public class SystemToolHttpGuard {
 
     private final HttpTargetGuard targetGuard;
 
+    // 类上存在两个构造器，Spring 无法自动判定，必须显式标注注入用哪一个；
+    // 另一个（带 AddressResolver）仅供单测注入确定性解析器。
+    @Autowired
     public SystemToolHttpGuard(AdminSystemToolProperties properties) {
-        // 白名单每次校验现取（配置对象可在运行期刷新），故以 Supplier 形式注入策略
-        this.targetGuard = new HttpTargetGuard(() -> HttpTargetPolicy.of(
-            properties.getHttp().getAllowedHosts(), InternalAddressPolicy.DENY_INTERNAL));
+        this(properties, java.net.InetAddress::getAllByName);
+    }
+
+    /** 可替换 DNS 解析器仅用于确定性测试；生产使用系统 DNS。 */
+    SystemToolHttpGuard(AdminSystemToolProperties properties, HttpTargetGuard.AddressResolver addressResolver) {
+        // 白名单每次校验现取（配置对象可在运行期刷新），故以 Supplier 形式注入策略。
+        // 默认模式拒内网（地址由大模型决定）；白名单命中后放宽到 ALLOW_INTERNAL：
+        // 显式列入白名单即信任该 host（与远程 MCP/RAG 链路一致），本地联调才能调 127.0.0.1，
+        // 链路本地/元数据等永远可疑地址仍由策略永久拒绝。
+        this.targetGuard = new HttpTargetGuard(() -> HttpTargetPolicy.ofResolvedAllowlist(
+            properties.getHttp().getAllowedHosts(),
+            InternalAddressPolicy.DENY_INTERNAL,
+            InternalAddressPolicy.ALLOW_INTERNAL), addressResolver);
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -996,9 +996,8 @@ public class AdminAgentInstanceFactory {
     private reactor.core.publisher.Mono<McpClientWrapper> buildMcpClient(AiMcp mcp) throws Exception {
         String executableConfig = mcpCredentialService == null
             ? mcp.getConfig() : mcpCredentialService.resolve(mcp);
-        return mcpFactory.buildClientBuilder(mcp.getMcpName(), mcp.getMcpType(), executableConfig)
-            .timeout(java.time.Duration.ofSeconds(30))
-            .buildAsync();
+        return mcpFactory.buildClient(mcp.getMcpName(), mcp.getMcpType(), executableConfig,
+            java.time.Duration.ofSeconds(30));
     }
 
     /**

--- a/customer-admin-server/src/main/resources/application-dev.yml
+++ b/customer-admin-server/src/main/resources/application-dev.yml
@@ -23,6 +23,49 @@ admin:
   content-guard:
     agent-filter-enabled: true
     hit-log-enabled: true
+  # 出网 SSRF 白名单（本地联调放行本机）：主配置 application.yml 里这几项默认为空（生产语义不变），
+  # 仅 dev profile 下把 localhost/127.0.0.1 列入白名单。命中后仍解析地址按 IP 判定，
+  # 链路本地（169.254/16，含云元数据）、未指定与组播地址在所有环境永久拒绝。
+  mcp:
+    security:
+      # 白名单是「强制名单」而非「内网例外」：不在名单里的 host 一律拒绝，公网域名同样要显式列入。
+      # 企业私网/公司域名请走环境变量注入，不要写进本文件——本仓库是个人开源项目，不携带公司信息。
+      # 例：ADMIN_MCP_ALLOWED_HOSTS=localhost,127.0.0.1,mcp.example-corp.com
+      allowed-hosts: ${ADMIN_MCP_ALLOWED_HOSTS:localhost,127.0.0.1}
+      # stdio 白名单（本机联调）。三项留空即关闭 stdio；换机器时用下面的环境变量覆盖或清空。
+      # 两条硬约束，写错任何一条会让「所有」stdio MCP 一起失败，而不只是配错的那个：
+      #   ① 路径必须在本机真实存在——realPaths() 对不存在的条目直接抛「不存在或不可访问」，
+      #      不是跳过它。此处原先填的两个示例路径并不存在，stdio 就是这么被整体拖死的。
+      #   ② 命令必须是可执行的普通文件、工作目录必须是目录；两边都按 toRealPath() 比较，
+      #      符号链接会被解析，所以填软链或真实路径都可以。
+      # 刻意放行「具体的 MCP server 可执行文件」而不是 npx：npx -y <任意包> 等于允许执行任意
+      # npm 包，白名单就失去意义了。新增 stdio MCP 时按同样口径追加它自己的可执行文件。
+      allowed-commands: ${ADMIN_MCP_STDIO_ALLOWED_COMMANDS:/opt/homebrew/bin/mcp-server-filesystem}
+      # 子进程 cwd 的根白名单。filesystem server 的实际可访问范围由它自己的启动参数决定，
+      # 与 cwd 无关，故这里给一个任何机器都存在的中立目录即可。
+      allowed-working-directories: ${ADMIN_MCP_STDIO_ALLOWED_WORKING_DIRECTORIES:/tmp}
+      # 子进程环境默认被清空（McpStdioProcessLauncher 会 clear()），这里列出允许透传的变量名。
+      # PATH 必须放行：npm 系的 MCP server 可执行文件是带 `#!/usr/bin/env node` 的脚本，
+      # PATH 为空时 env 找不到 node，进程起不来，报「Client failed to initialize」。
+      allowed-environment-keys: ${ADMIN_MCP_STDIO_ALLOWED_ENVIRONMENT_KEYS:PATH}
+  model:
+    egress:
+      # 注意：模型端点命中白名单后的地址策略固定为 ALLOW_PRIVATE_NETWORK（只放宽 RFC1918/ULA，
+      # 环回永久拒绝），所以 localhost 自建模型代理在本地开发仍会被拦，私网 IP 可用。
+      allowed-hosts: localhost,127.0.0.1,tokenhub.tencentmaas.com,api.deepseek.com,dashscope.aliyuncs.com
+  rag:
+    # RAG 知识库默认本就放行内网（地址由管理员显式配置），此处列白名单是收紧为仅本机。
+    allowed-hosts: localhost,127.0.0.1
+  system-tool:
+    http:
+      allowed-hosts: localhost,127.0.0.1
+
+# MyBatis 的 SQL 打印（Preparing/Parameters/Total）走 mapper 接口的 DEBUG logger，
+# 下面把业务包开到 DEBUG 后 SQL 会刷屏。这里统一换成 NoLogging 实现关掉 SQL 打印，
+# 业务 DEBUG 日志不受影响；需要排查 SQL 时临时改回 org.apache.ibatis.logging.slf4j.Slf4jImpl。
+mybatis-plus:
+  configuration:
+    log-impl: org.apache.ibatis.logging.nologging.NoLoggingImpl
 
 logging:
   level:

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -218,7 +218,7 @@ admin:
     max-override-hours: ${ADMIN_MODEL_HEALTH_MAX_OVERRIDE_HOURS:24}
   mcp:
     security:
-      # 远程 MCP 默认只允许公网；企业私网 host 必须显式列入，环回/链路本地/元数据仍永久拒绝。
+      # 远程 MCP 默认只允许公网；企业私网/本机 host 必须显式列入，命中后仍拒链路本地/元数据/未指定/组播。
       allowed-hosts: ${ADMIN_MCP_ALLOWED_HOSTS:}
       # stdio 默认关闭；启用时命令与工作目录必须同时命中真实路径白名单，子进程不继承宿主环境。
       allowed-commands: ${ADMIN_MCP_STDIO_ALLOWED_COMMANDS:}

--- a/customer-admin-server/src/main/resources/mapper/ModelImpactMapper.xml
+++ b/customer-admin-server/src/main/resources/mapper/ModelImpactMapper.xml
@@ -14,6 +14,14 @@
     </resultMap>
 
     <!--
+      CAST(数值 AS CHAR) 与裸字面量的排序规则取 collation_connection：MySQL 8 默认库上是 utf8mb4_0900_ai_ci，
+      而本库表列自 V97 起统一 utf8mb4_unicode_ci。两者在 UNION 同一列位置相遇时可强制性都是 2（隐式），
+      MySQL 无法裁决直接抛 1271，故凡是不由表列决定排序规则的表达式都在此显式钉住。
+      表列侧不写：它们已由建表约定保证，重复声明反而会掩盖将来某张表建错排序规则的事实。
+    -->
+    <sql id="unionCollate">COLLATE utf8mb4_unicode_ci</sql>
+
+    <!--
       查询由 ModelImpactService 在 CrossTenantOperations 中执行：私有/普通租户视角始终显式传 tenantId；
       只有已通过可写与控制面校验的 default 共享模型预检才传 null 扫描全部租户。
       DRAFT 只提示计划引用；RUNNING 始终阻断；曾启动的 STOPPED/COMPLETED 只有撤流任务已 APPLIED 才视为不再引用。
@@ -21,7 +29,8 @@
     <select id="findImpacts" resultMap="modelImpactMap">
         WITH model_agents AS (
             SELECT agent.tenant_id, agent.id AS agent_id, agent.agent_code, agent.agent_name,
-                   agent.status AS agent_status, 'PRIMARY_MODEL' AS model_relation
+                   agent.status AS agent_status,
+                   'PRIMARY_MODEL' <include refid="unionCollate"/> AS model_relation
             FROM ai_agent agent
             WHERE agent.model_id = #{modelId}
               AND agent.deleted = 0
@@ -30,7 +39,8 @@
               </if>
             UNION ALL
             SELECT agent.tenant_id, agent.id AS agent_id, agent.agent_code, agent.agent_name,
-                   agent.status AS agent_status, 'BACKUP_MODEL' AS model_relation
+                   agent.status AS agent_status,
+                   'BACKUP_MODEL' <include refid="unionCollate"/> AS model_relation
             FROM ai_agent_backup_model backup
             INNER JOIN ai_agent agent
                     ON agent.id = backup.agent_id
@@ -58,7 +68,7 @@
                            AND (deactivation.gate_status IS NULL OR deactivation.gate_status &lt;&gt; 'BLOCKED')
                            THEN CONCAT(experiment.status, '/DEACTIVATING')
                        ELSE CONCAT(experiment.status, '/DEACTIVATION_FAILED')
-                   END AS impact_status,
+                   END <include refid="unionCollate"/> AS impact_status,
                    CASE WHEN experiment.status = 'DRAFT' THEN 0 ELSE 1 END AS impact_blocking
             FROM ai_model_experiment experiment
             LEFT JOIN ai_runtime_publish_task activation
@@ -90,16 +100,19 @@
         SELECT impacts.*
         FROM (
             SELECT ma.tenant_id, 'AGENT' AS resource_type, ma.model_relation AS relation_type,
-                   CAST(ma.agent_id AS CHAR) AS resource_id, ma.agent_code AS resource_code,
-                   ma.agent_name AS resource_name, CAST(ma.agent_status AS CHAR) AS resource_status,
+                   CAST(ma.agent_id AS CHAR) <include refid="unionCollate"/> AS resource_id,
+                   ma.agent_code AS resource_code, ma.agent_name AS resource_name,
+                   CAST(ma.agent_status AS CHAR) <include refid="unionCollate"/> AS resource_status,
                    1 AS blocking
             FROM model_agents ma
 
             UNION ALL
 
             SELECT binding.tenant_id, 'CHANNEL_BINDING', 'AGENT_CHANNEL',
-                   CAST(binding.id AS CHAR), binding.channel_code, binding.channel_code,
-                   CAST(binding.status AS CHAR), CASE WHEN binding.status = 1 THEN 1 ELSE 0 END
+                   CAST(binding.id AS CHAR) <include refid="unionCollate"/>,
+                   binding.channel_code, binding.channel_code,
+                   CAST(binding.status AS CHAR) <include refid="unionCollate"/>,
+                   CASE WHEN binding.status = 1 THEN 1 ELSE 0 END
             FROM ai_channel_binding binding
             INNER JOIN model_agents ma
                     ON ma.agent_id = binding.agent_id
@@ -109,8 +122,10 @@
             UNION ALL
 
             SELECT robot.tenant_id, 'CHANNEL_ROBOT', 'AGENT_CHANNEL',
-                   CAST(robot.id AS CHAR), robot.channel_type, robot.robot_name,
-                   CAST(robot.status AS CHAR), CASE WHEN robot.status = 1 THEN 1 ELSE 0 END
+                   CAST(robot.id AS CHAR) <include refid="unionCollate"/>,
+                   robot.channel_type, robot.robot_name,
+                   CAST(robot.status AS CHAR) <include refid="unionCollate"/>,
+                   CASE WHEN robot.status = 1 THEN 1 ELSE 0 END
             FROM ai_channel_robot robot
             INNER JOIN model_agents ma
                     ON ma.agent_code = robot.agent_code
@@ -119,8 +134,10 @@
             UNION ALL
 
             SELECT task.tenant_id, 'SCHEDULED_TASK', 'AGENT_TASK',
-                   CAST(task.id AS CHAR), task.task_code, task.task_name,
-                   CAST(task.enabled AS CHAR), CASE WHEN task.enabled = 1 THEN 1 ELSE 0 END
+                   CAST(task.id AS CHAR) <include refid="unionCollate"/>,
+                   task.task_code, task.task_name,
+                   CAST(task.enabled AS CHAR) <include refid="unionCollate"/>,
+                   CASE WHEN task.enabled = 1 THEN 1 ELSE 0 END
             FROM ai_scheduled_task task
             INNER JOIN model_agents ma
                     ON ma.agent_id = task.agent_id
@@ -130,7 +147,7 @@
             UNION ALL
 
             SELECT version.tenant_id, 'CONFIG_VERSION', 'AGENT_VERSION',
-                   CAST(version.id AS CHAR), version.target_code,
+                   CAST(version.id AS CHAR) <include refid="unionCollate"/>, version.target_code,
                    CONCAT(version.target_code, ' v', version.version), version.status, 0
             FROM ai_config_version version
             INNER JOIN model_agents ma
@@ -141,7 +158,7 @@
             UNION ALL
 
             SELECT version.tenant_id, 'CONFIG_VERSION', 'MODEL_VERSION',
-                   CAST(version.id AS CHAR), version.target_code,
+                   CAST(version.id AS CHAR) <include refid="unionCollate"/>, version.target_code,
                    CONCAT(version.target_code, ' v', version.version), version.status, 0
             FROM ai_config_version version
             WHERE version.config_type = 'MODEL'
@@ -153,7 +170,7 @@
             UNION ALL
 
             SELECT experiment.tenant_id, 'MODEL_EXPERIMENT', 'EXPERIMENT_CONTROL',
-                   CAST(experiment.id AS CHAR), experiment.experiment_code,
+                   CAST(experiment.id AS CHAR) <include refid="unionCollate"/>, experiment.experiment_code,
                    experiment.experiment_name, experiment.impact_status,
                    experiment.impact_blocking
             FROM model_experiments experiment
@@ -162,7 +179,7 @@
             UNION ALL
 
             SELECT experiment.tenant_id, 'MODEL_EXPERIMENT', 'EXPERIMENT_TREATMENT',
-                   CAST(experiment.id AS CHAR), experiment.experiment_code,
+                   CAST(experiment.id AS CHAR) <include refid="unionCollate"/>, experiment.experiment_code,
                    experiment.experiment_name, experiment.impact_status,
                    experiment.impact_blocking
             FROM model_experiments experiment
@@ -171,7 +188,7 @@
             UNION ALL
 
             SELECT policy.tenant_id, 'ROUTE_POLICY', CONCAT('ROUTE_', rule.purpose),
-                   CAST(policy.id AS CHAR), policy.policy_code,
+                   CAST(policy.id AS CHAR) <include refid="unionCollate"/>, policy.policy_code,
                    CONCAT(policy.policy_name, ' v', version.version_no), version.status,
                    CASE WHEN policy.status = 'ACTIVE' AND version.status = 'ACTIVE' THEN 1 ELSE 0 END
             FROM ai_model_route_rule rule

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/runtime/AdminMcpFactoryTest.java
@@ -4,6 +4,8 @@ import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugCallResult;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpDebugToolVO;
 import com.richard.fyoung.customeradmin.aiconfig.mcp.dto.McpTestResult;
 import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
+import com.richard.fyoung.customeradmin.config.AdminMcpSecurityProperties;
+import com.richard.fyoung.customerwork.tool.mcp.McpSecurityPolicy;
 import com.richard.fyoung.customerwork.tool.mcp.McpConnectivityResult;
 import com.richard.fyoung.customerwork.tool.mcp.McpImageContent;
 import com.richard.fyoung.customerwork.tool.mcp.McpToolCallResult;
@@ -20,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -30,7 +33,37 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AdminMcpFactoryTest {
 
-    private final AdminMcpFactory factory = new AdminMcpFactory();
+    private final AdminMcpFactory factory = new AdminMcpFactory(McpSecurityPolicy.strict());
+
+    /**
+     * 防回归：容器装配出来的实例必须<b>从配置读白名单</b>，不能回退到 {@link McpSecurityPolicy#strict()}。
+     *
+     * <p>本类有多个构造器，Spring 在缺 {@code @Autowired} 时会挑无参构造器而不是参数最多的那个。
+     * 此前就是这样：容器拿到的是 strict 策略，白名单恒为空，{@code admin.mcp.security.allowed-hosts}
+     * 配了 localhost 也没用，页面上表现为「目标地址指向内网/环回，已拦截: localhost」。
+     * 这个断言直接验证「配了就能过」，比断言注解存在更贴近真实故障。</p>
+     */
+    @Test
+    void springWiredInstance_shouldHonourConfiguredAllowlist() {
+        AdminMcpSecurityProperties properties = new AdminMcpSecurityProperties();
+        properties.setAllowedHosts(List.of("localhost"));
+
+        AdminMcpFactory wired = new AdminMcpFactory(properties);
+
+        assertDoesNotThrow(() -> wired.validateConfiguration("oa", "http",
+                "{\"mcpServers\": {\"oa\": {\"url\": \"http://localhost:3002/mcp\"}}}"),
+            "白名单已含 localhost，环回地址应放行");
+    }
+
+    /** 反过来：白名单为空时环回必须仍被拦，确认放行来自配置而不是策略本身被削弱。 */
+    @Test
+    void emptyAllowlist_shouldStillRejectLoopback() {
+        AdminMcpFactory strictFactory = new AdminMcpFactory(new AdminMcpSecurityProperties());
+
+        assertThrows(Exception.class, () -> strictFactory.validateConfiguration("oa", "http",
+                "{\"mcpServers\": {\"oa\": {\"url\": \"http://localhost:3002/mcp\"}}}"),
+            "未配置白名单时环回地址不得放行");
+    }
 
     /** 委托链路接通即可（三种类型的解析分支由 starter 单测覆盖，这里不重复）。 */
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/mcp/service/McpServiceTest.java
@@ -17,6 +17,7 @@ import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -342,20 +344,33 @@ class McpServiceTest {
     }
 
     @Test
-    void testConnectivity_shouldPersistResult() throws Exception {
+    void testConnectivity_shouldPersistResultWithinCapturedTenant() throws Exception {
         AiMcp mcp = new AiMcp();
         mcp.setId(1L);
+        mcp.setTenantId("tenant-a");
         mcp.setMcpName("测试MCP");
         mcp.setMcpType("http");
         mcp.setConfig("{\"url\": \"https://mcp.example.com/mcp\"}");
         when(mcpMapper.selectById(1L)).thenReturn(mcp);
         when(mcpFactory.testConnectivity(anyString(), anyString(), anyString()))
             .thenReturn(new McpTestResult(ConnectivityTestStatus.SUCCESS, LocalDateTime.now(), null));
+        AtomicReference<String> persistedTenant = new AtomicReference<>();
+        when(mcpMapper.updateById(any(AiMcp.class))).thenAnswer(invocation -> {
+            persistedTenant.set(TenantContext.get());
+            return 1;
+        });
 
-        CompletableFuture<McpTestResult> future = service.testConnectivity(1L);
-        McpTestResult result = future.get();
+        TenantContext.set("tenant-a");
+        McpTestResult result;
+        try {
+            CompletableFuture<McpTestResult> future = service.testConnectivity(1L);
+            result = future.get();
+        } finally {
+            TenantContext.clear();
+        }
 
         assertEquals(ConnectivityTestStatus.SUCCESS, result.testStatus());
+        assertEquals("tenant-a", persistedTenant.get());
         verify(mcpMapper).updateById(org.mockito.ArgumentMatchers.any(AiMcp.class));
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/mapper/ModelImpactMapperCollationIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/mapper/ModelImpactMapperCollationIntegrationTest.java
@@ -1,0 +1,243 @@
+package com.richard.fyoung.customeradmin.aiconfig.model.mapper;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.MybatisSqlSessionFactoryBuilder;
+import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelImpactItemVO;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.datasource.pooled.PooledDataSource;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * 治理详情影响预检的真库回归。
+ *
+ * <p>findImpacts 把 bigint 主键 CAST 成字符串后与 ai_runtime_publish_task 的 varchar 主键放进同一个 UNION 列，
+ * CAST 结果取 collation_connection（MySQL 8 默认库上是 utf8mb4_0900_ai_ci）而表列是 utf8mb4_unicode_ci，
+ * 两侧可强制性都是隐式，MySQL 直接抛 1271。此前这条 SQL 只有单测覆盖 Service 编排、从未在真库执行过，
+ * 因此整条治理详情链路在页面上表现为「系统繁忙」。
+ */
+class ModelImpactMapperCollationIntegrationTest {
+
+    private static final String HOST = System.getenv().getOrDefault("MYSQL_HOST", "localhost");
+    private static final int PORT = Integer.parseInt(System.getenv().getOrDefault("MYSQL_PORT", "3306"));
+    private static final String USERNAME = env("ADMIN_MYSQL_USERNAME", "root");
+    private static final String PASSWORD = env("ADMIN_MYSQL_PASSWORD", "root");
+
+    private static final long MODEL_ID = 9001L;
+    private static final long AGENT_ID = 9002L;
+    private static final String TENANT = "tenant-impact";
+
+    @Test
+    void findImpactsShouldRunOnRealDatabaseWithMismatchedConnectionCollation() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过治理详情影响预检真库测试");
+        String database = "admin_impact_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过治理详情影响预检真库测试");
+
+        PooledDataSource dataSource = null;
+        try {
+            migrate(database);
+            try (Connection connection = connection(database)) {
+                // 前提必须成立：连接排序规则与表排序规则不同，否则这条用例根本照不出线上的失败形态。
+                assertEquals("utf8mb4_0900_ai_ci", connectionCollation(connection));
+                assertEquals("utf8mb4_unicode_ci",
+                    columnCollation(connection, "ai_runtime_publish_task", "id"));
+                assertNotEquals(connectionCollation(connection),
+                    columnCollation(connection, "ai_runtime_publish_task", "id"));
+
+                // 不带 COLLATE 的等价写法此刻必然抛 1271，证明 Mapper 里的显式声明不是多余的。
+                SQLException error = assertThrows(SQLException.class, () -> castVersusColumnUnion(connection));
+                assertEquals(1271, error.getErrorCode());
+
+                seedImpactGraph(connection);
+            }
+
+            dataSource = new PooledDataSource("com.mysql.cj.jdbc.Driver", jdbcUrl(database), USERNAME, PASSWORD);
+            SqlSessionFactory factory = sqlSessionFactory(dataSource);
+            try (SqlSession session = factory.openSession()) {
+                ModelImpactMapper mapper = session.getMapper(ModelImpactMapper.class);
+
+                // 控制面共享模型预检：不带租户，跨全部租户扫描。
+                assertImpactGraph(mapper.findImpacts(MODEL_ID, null));
+                // 普通租户视角：显式带租户。
+                assertImpactGraph(mapper.findImpacts(MODEL_ID, TENANT));
+                // 无引用的模型必须返回空集而不是报错。
+                assertTrue(mapper.findImpacts(-1L, TENANT).isEmpty());
+            }
+        } finally {
+            if (dataSource != null) {
+                dataSource.forceCloseAll();
+            }
+            dropDatabase(database);
+        }
+    }
+
+    /** UNION 各列都要落到同一排序规则，任一分支漏写 COLLATE 都会在这里失败。 */
+    private void assertImpactGraph(List<ModelImpactItemVO> items) {
+        Map<String, ModelImpactItemVO> byType = items.stream()
+            .collect(Collectors.toMap(ModelImpactItemVO::getResourceType, Function.identity()));
+        assertEquals(2, byType.size(), "应命中 Agent 主模型引用与运行时投递任务两类资源");
+
+        ModelImpactItemVO agent = byType.get("AGENT");
+        assertNotNull(agent, "缺少 Agent 引用");
+        assertEquals(TENANT, agent.getTenantId());
+        assertEquals("PRIMARY_MODEL", agent.getRelationType());
+        assertEquals(String.valueOf(AGENT_ID), agent.getResourceId());
+        assertEquals("agent-impact", agent.getResourceCode());
+        assertEquals("1", agent.getStatus());
+        assertTrue(agent.getBlocking());
+
+        ModelImpactItemVO task = byType.get("PUBLISH_TASK");
+        assertNotNull(task, "缺少运行时投递任务引用");
+        assertEquals("RUNTIME_DELIVERY", task.getRelationType());
+        assertEquals("task-impact", task.getResourceId());
+        assertEquals("revision-impact", task.getResourceCode());
+        assertEquals("PUBLISHED", task.getStatus());
+        assertTrue(task.getBlocking());
+    }
+
+    private void seedImpactGraph(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("INSERT INTO ai_agent "
+                + "(id, tenant_id, agent_code, agent_name, model_id, status, deleted) VALUES "
+                + "(" + AGENT_ID + ", '" + TENANT + "', 'agent-impact', '影响预检智能体', " + MODEL_ID + ", 1, 0)");
+            statement.executeUpdate("INSERT INTO ai_runtime_publish_task "
+                + "(id, seq, tenant_id, target_id, revision, status, next_attempt_at_ms, "
+                + "created_at_ms, updated_at_ms) VALUES "
+                + "('task-impact', 1, '" + TENANT + "', " + AGENT_ID + ", 'revision-impact', 'PUBLISHED', 0, 1, 1)");
+        }
+    }
+
+    /** findImpacts 里 resource_id 一列的最小形态：CAST 出来的字符串与 varchar 主键放在同一 UNION 位置。 */
+    private void castVersusColumnUnion(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                 "SELECT CAST(id AS CHAR) AS resource_id FROM ai_agent "
+                     + "UNION ALL SELECT id FROM ai_runtime_publish_task")) {
+            resultSet.next();
+        }
+    }
+
+    private SqlSessionFactory sqlSessionFactory(PooledDataSource dataSource) throws Exception {
+        MybatisConfiguration configuration = new MybatisConfiguration();
+        configuration.setEnvironment(new Environment("model-impact-collation-test",
+            new JdbcTransactionFactory(), dataSource));
+        configuration.setMapUnderscoreToCamelCase(true);
+        String resource = "mapper/ModelImpactMapper.xml";
+        try (InputStream input = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream(resource)) {
+            assertNotNull(input, "Mapper XML 不存在: " + resource);
+            new XMLMapperBuilder(input, configuration, resource, configuration.getSqlFragments()).parse();
+        }
+        return new MybatisSqlSessionFactoryBuilder().build(configuration);
+    }
+
+    private String connectionCollation(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT @@collation_connection")) {
+            resultSet.next();
+            return resultSet.getString(1);
+        }
+    }
+
+    private String columnCollation(Connection connection, String table, String column) throws SQLException {
+        String sql = "SELECT COLLATION_NAME FROM information_schema.COLUMNS "
+            + "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?";
+        try (var statement = connection.prepareStatement(sql)) {
+            statement.setString(1, table);
+            statement.setString(2, column);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getString(1);
+            }
+        }
+    }
+
+    private void migrate(String database) {
+        Flyway.configure()
+            .dataSource(jdbcUrl(database), USERNAME, PASSWORD)
+            .locations("classpath:db/migration")
+            .placeholderReplacement(false)
+            .load()
+            .migrate();
+    }
+
+    private boolean createDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE " + quoted(database)
+                + " DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci");
+            return true;
+        } catch (Exception e) {
+            dropDatabase(database);
+            return false;
+        }
+    }
+
+    private void dropDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DROP DATABASE IF EXISTS " + quoted(database));
+        } catch (Exception ignored) {
+            // 清理失败不覆盖原始断言；随机库名可按 admin_impact_* 识别。
+        }
+    }
+
+    private Connection adminConnection() throws Exception {
+        return DriverManager.getConnection(jdbcUrl(""), USERNAME, PASSWORD);
+    }
+
+    private Connection connection(String database) throws Exception {
+        return DriverManager.getConnection(jdbcUrl(database), USERNAME, PASSWORD);
+    }
+
+    /** 与 application.yml 的连接参数保持一致，否则测出来的排序规则组合与线上不是一回事。 */
+    private String jdbcUrl(String database) {
+        return "jdbc:mysql://" + HOST + ":" + PORT + "/" + database
+            + "?useUnicode=true&characterEncoding=utf8&useSSL=false"
+            + "&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true";
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), 1_500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String quoted(String identifier) {
+        if (!identifier.matches("[a-z0-9_]+")) {
+            throw new IllegalArgumentException("illegal database identifier: " + identifier);
+        }
+        return "`" + identifier + "`";
+    }
+
+    private static String env(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/SystemToolHttpGuardTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/systemtool/tool/SystemToolHttpGuardTest.java
@@ -5,6 +5,8 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminSystemToolProperties;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -17,7 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * 异常转译（{@code HttpTargetForbiddenException} → {@link BizException} 且错误码正确）。
  * 判定算法本身（通配匹配、IP 分类、DNS 场景）在 starter 的 {@code HttpTargetGuardTest} 覆盖，不在此重复。
  *
- * <p>用例全部走 IP 字面量或白名单匹配，不发真实请求、不触 DNS。</p>
+ * <p>用例全部走 IP 字面量或确定性解析器，不发真实请求、不触真实 DNS：白名单命中后也要解析地址按
+ * IP 判定，域名用固定解析器给出确定性结果；IP 字面量不触 DNS，可直接用系统解析。</p>
  * @author owlzhangfq@gmail.com
  */
 class SystemToolHttpGuardTest {
@@ -27,7 +30,17 @@ class SystemToolHttpGuardTest {
         if (allowedHosts.length > 0) {
             properties.getHttp().setAllowedHosts(List.of(allowedHosts));
         }
-        return new SystemToolHttpGuard(properties);
+        // 确定性解析器：域名固定解析到公网地址（不触真实 DNS）；IP 字面量回落系统解析。
+        return new SystemToolHttpGuard(properties, SystemToolHttpGuardTest::deterministicResolve);
+    }
+
+    private static InetAddress[] deterministicResolve(String host) throws UnknownHostException {
+        return switch (host) {
+            case "api.example.com", "svc.internal.example.com", "evil.attacker.com" ->
+                new InetAddress[]{ InetAddress.getByName("93.184.216.34") };
+            case "internal.corp" -> new InetAddress[]{ InetAddress.getByName("10.20.30.40") };
+            default -> InetAddress.getAllByName(host);
+        };
     }
 
     @Test
@@ -44,6 +57,15 @@ class SystemToolHttpGuardTest {
         assertDoesNotThrow(() -> guard("api.example.com").checkAllowed("https://api.example.com/v1/x"));
         assertDoesNotThrow(() -> guard("*.example.com").checkAllowed("https://svc.internal.example.com/x"));
         assertThrows(BizException.class, () -> guard("api.example.com").checkAllowed("https://evil.attacker.com/x"));
+    }
+
+    @Test
+    void whitelistMode_shouldAllowLoopback_butStillRejectLinkLocal() {
+        // 显式列入白名单即信任该 host（本地联调依赖它调 127.0.0.1）；
+        // 命中后仍按 IP 判定，链路本地/云元数据地址即使伪造进白名单也拦得住。
+        assertDoesNotThrow(() -> guard("127.0.0.1").checkAllowed("http://127.0.0.1:9000/x"));
+        assertDoesNotThrow(() -> guard("api.example.com").checkAllowed("http://api.example.com/v1/x"));
+        assertThrows(BizException.class, () -> guard("169.254.169.254").checkAllowed("http://169.254.169.254/latest/meta-data"));
     }
 
     @Test

--- a/customer-admin-web/src/store/vibeConversations.ts
+++ b/customer-admin-web/src/store/vibeConversations.ts
@@ -11,6 +11,7 @@ import {
 import { getChatSessionMessages } from '@/api/chat'
 import { generateUuid } from '@/utils/uuid'
 import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
+import { createTextChunkBatcher } from '@/utils/textChunkBatcher'
 import { createPlanCard, type PlanCard } from '@/utils/planCard'
 import { revokeAttachmentPreviews, type MessageAttachmentVM } from '@/utils/attachment'
 import type { TraceNode } from '@/components/TraceTimeline.vue'
@@ -352,12 +353,19 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
       onScroll?: () => void,
     ) {
       const sid = conv.sessionId
-      conv.abort = starter({
+      const isActive = () => this.byAgent[agentCode]?.activeId === sid
+      // 与对话面板同款的整帧合并：模型流可能在一帧内推多次正文增量，逐片改 Pinia 会反复触发
+      // Markdown 解析与 DOM patch。此前只有 ChatPanel 做了合并，VibeCoding 漏了，两边行为不一致。
+      const textBatcher = createTextChunkBatcher((chunk) => {
+        assistantMessage.text += chunk
+        if (isActive()) onScroll?.()
+      })
+      const abortStream = starter({
         onEvent: (event) => {
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (!c) return
-          const isActive = () => this.byAgent[agentCode]?.activeId === sid
           if (event.event === 'done') {
+            textBatcher.flush()
             c.streaming = false
             // 对话结束后自动刷新该会话文件目录树
             this.loadFiles(agentCode, sid)
@@ -371,6 +379,7 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
             return
           }
           if (event.event === 'test_report') {
+            textBatcher.flush()
             try {
               const parsed = JSON.parse(event.data) as TestReport
               ;(assistantMessage.testReports ??= []).push(parsed)
@@ -379,16 +388,19 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
             return
           }
           if (event.event === 'role_stage') {
+            textBatcher.flush()
             this.applyRoleStage(assistantMessage, event.data)
             if (isActive()) onScroll?.()
             return
           }
           if (event.event === 'plan') {
+            textBatcher.flush()
             this.applyPlanEvent(c, assistantMessage, event.data)
             if (isActive()) onScroll?.()
             return
           }
           if (event.event === 'plan_result') {
+            textBatcher.flush()
             try {
               const parsed = JSON.parse(event.data) as PlanResultEvent
               const card = c.pendingPlans.get(parsed.planId)
@@ -401,6 +413,7 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
             return
           }
           if (event.event.startsWith('node:')) {
+            textBatcher.flush()
             const kind = event.event.slice('node:'.length)
             const payload = parseChatStreamPayload(event.data)
             appendChatStreamNode(assistantMessage.nodes, kind, payload.text, payload.source, payload.subagentName)
@@ -410,13 +423,16 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
               // 带 source 的正文增量是子Agent 内部产出，复用 ANSWER kind 挂进对应嵌套面板
               appendChatStreamNode(assistantMessage.nodes, ANSWER_KIND, payload.text, payload.source, payload.subagentName)
             } else {
-              assistantMessage.text += payload.text
+              // 合并进本帧待发文本；滚动由 batcher 的回调统一触发，此处直接返回避免每片都滚
+              textBatcher.append(payload.text)
+              return
             }
           }
           // 其余未知事件静默忽略（需求 §5.5 向后兼容）
           if (isActive()) onScroll?.()
         },
         onError: (error) => {
+          textBatcher.discard()
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (c) {
             c.streaming = false
@@ -428,6 +444,7 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
           assistantMessage.failed = true
         },
         onComplete: () => {
+          textBatcher.flush()
           const c = this.byAgent[agentCode]?.conversations[sid]
           if (c) {
             c.streaming = false
@@ -439,6 +456,11 @@ export const useVibeConversationsStore = defineStore('vibeConversations', {
           this.historyVersion[agentCode] = (this.historyVersion[agentCode] ?? 0) + 1
         },
       })
+      // 中断时先把本帧待发文本落进消息，否则用户点"中断"会丢掉最后一小段已收到的正文
+      conv.abort = () => {
+        textBatcher.flush()
+        abortStream()
+      }
     },
 
     /** P1-2：执行命令并保留当前会话最近 20 条历史。 */

--- a/customer-admin-web/src/utils/scrollFollower.ts
+++ b/customer-admin-web/src/utils/scrollFollower.ts
@@ -1,0 +1,49 @@
+/**
+ * 流式对话面板的"跟随到底部"节流器。
+ *
+ * <p>流式链路每收到一个增量就要求滚动一次。此前两个面板都是直接调
+ * {@code scrollTo({ behavior: 'smooth' })}——平滑滚动是一段持续数百毫秒的动画，
+ * 而增量的到达间隔远小于它，于是每次调用都在打断上一次动画重新起步，
+ * 滚动永远停在缓动曲线最慢的那一段，表现为跟不上内容、一顿一顿。</p>
+ *
+ * <p>这里改成每渲染帧最多滚一次、且用瞬时定位：对话面板要的是"始终贴着底部"，
+ * 不是"看一段滚动动画"。合并掉同一帧内的重复请求后，DOM 读写也从每增量一次降到每帧一次。</p>
+ */
+export interface ScrollFollower {
+  /** 请求滚动到底部；同一帧内的多次调用合并为一次。 */
+  follow: () => void
+  /** 取消尚未执行的滚动（组件卸载 / 会话切换时调用）。 */
+  cancel: () => void
+}
+
+type ElementSource = () => HTMLElement | null | undefined
+
+export function createScrollFollower(target: ElementSource): ScrollFollower {
+  let frameId: number | null = null
+
+  const run = () => {
+    frameId = null
+    const el = target()
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  }
+
+  return {
+    follow() {
+      if (frameId !== null) return
+      frameId = typeof requestAnimationFrame === 'function'
+        ? requestAnimationFrame(run)
+        : (setTimeout(run, 16) as unknown as number)
+    },
+    cancel() {
+      if (frameId === null) return
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(frameId)
+      } else {
+        clearTimeout(frameId)
+      }
+      frameId = null
+    },
+  }
+}

--- a/customer-admin-web/src/utils/sse.ts
+++ b/customer-admin-web/src/utils/sse.ts
@@ -99,14 +99,31 @@ export function streamSse(path: string, body: unknown, handlers: SseHandlers): (
   return () => controller.abort()
 }
 
+/**
+ * 取 SSE 字段值：按规范只去掉<b>一个</b>前导空格，其余原样保留。
+ *
+ * <p>此前这里用的是 {@code trim()}，会把正文增量首尾的空格全吃掉——模型流是按 token 切片的，
+ * 一个以空格开头的英文 token（" the"）到了页面上就与前一个词粘成 "thethe"，Markdown 的缩进
+ * 也会被抹平。空格在正文里是有意义的字符，不是噪声。</p>
+ *
+ * <p>顺带处理行尾 {@code \r}：事件按 {@code \n\n} 切分、行按 {@code \n} 切分，若服务端用
+ * {@code \r\n} 作行分隔，每行尾部会残留 {@code \r}。原先由 {@code trim()} 顺手清掉，
+ * 去掉 trim 后必须显式处理，否则会把控制字符带进正文。</p>
+ */
+function readSseFieldValue(rawValue: string): string {
+  const withoutCr = rawValue.endsWith('\r') ? rawValue.slice(0, -1) : rawValue
+  return withoutCr.startsWith(' ') ? withoutCr.slice(1) : withoutCr
+}
+
 function parseSseBlock(block: string): SseEvent | null {
   let event = 'message'
   const dataLines: string[] = []
   for (const line of block.split('\n')) {
     if (line.startsWith('event:')) {
-      event = line.slice('event:'.length).trim()
+      // 事件名是协议标识而非正文，两端空白一律不保留
+      event = readSseFieldValue(line.slice('event:'.length)).trim()
     } else if (line.startsWith('data:')) {
-      dataLines.push(line.slice('data:'.length).trim())
+      dataLines.push(readSseFieldValue(line.slice('data:'.length)))
     }
   }
   if (dataLines.length === 0) {

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { WarningFilled } from '@element-plus/icons-vue'
-import { computed, nextTick, onActivated, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { createScrollFollower } from '@/utils/scrollFollower'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import { confirmChatPlan } from '@/api/chat'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
@@ -75,11 +76,15 @@ async function openSession(targetSessionId: string) {
   }
 }
 
+// 跟随到底部：每帧最多滚一次、瞬时定位。流式增量的到达频率远高于平滑滚动动画的时长，
+// 逐条调 scrollTo({behavior:'smooth'}) 会不断打断上一次动画，反而跟不上内容（详见 scrollFollower）。
+const scrollFollower = createScrollFollower(() => scrollRef.value)
+
 function scrollToBottom() {
-  nextTick(() => {
-    scrollRef.value?.scrollTo({ top: scrollRef.value.scrollHeight, behavior: 'smooth' })
-  })
+  nextTick(() => scrollFollower.follow())
 }
+
+onBeforeUnmount(() => scrollFollower.cancel())
 
 function send() {
   store.send(props.agentCode, buildMessageWithAttachments, scrollToBottom)

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { WarningFilled } from '@element-plus/icons-vue'
-import { computed, nextTick, onActivated, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
+import { createScrollFollower } from '@/utils/scrollFollower'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import {
   confirmVibeCodingPlan,
@@ -135,11 +136,15 @@ async function openSession(targetSessionId: string) {
   }
 }
 
+// 跟随到底部：每帧最多滚一次、瞬时定位。流式增量的到达频率远高于平滑滚动动画的时长，
+// 逐条调 scrollTo({behavior:'smooth'}) 会不断打断上一次动画，反而跟不上内容（详见 scrollFollower）。
+const scrollFollower = createScrollFollower(() => scrollRef.value)
+
 function scrollToBottom() {
-  nextTick(() => {
-    scrollRef.value?.scrollTo({ top: scrollRef.value.scrollHeight, behavior: 'smooth' })
-  })
+  nextTick(() => scrollFollower.follow())
 }
+
+onBeforeUnmount(() => scrollFollower.cancel())
 
 function send() {
   store.send(props.agentCode, collaborationMode.value, buildMessageWithAttachments, scrollToBottom)

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/tenant/TenantContext.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/tenant/TenantContext.java
@@ -43,6 +43,37 @@ public final class TenantContext {
         CURRENT.set(canonicalizeTenantId(tenantId));
     }
 
+    /**
+     * 恢复一个<b>此前已经过 {@link #set} 校验</b>的租户值：跳过格式校验，保留归一。
+     *
+     * <p><b>只给上下文传播机制用</b>（{@link TenantContextThreadLocalAccessor}），业务代码一律用
+     * {@link #set}。语义上这不是"写入一个新租户"，而是"把快照里的值放回当前线程"——值的唯一来源
+     * 是某次 {@code set} 成功后被 Reactor Context 捕获的快照，格式在那一刻已经校验过，
+     * 这里再验一遍纯属重复，且重复的位置恰恰是全链路最热的一点。</p>
+     *
+     * <p><b>为什么这一点这么热</b>：开启 {@code Hooks.enableAutomaticContextPropagation()} 后，
+     * Reactor 会给链上<b>每个</b>算子包一层 {@code ContextWriteRestoringThreadLocals}，每层在
+     * {@code onNext} 时都要把全部 ThreadLocal 快照恢复一遍。AI 流式链实测有 110+ 层，于是模型每吐
+     * 一个增量，这个方法就要被调用上百次；原先走 {@code set} 时那上百次正则匹配会把一整颗核烧满，
+     * 表现为流式输出一卡一卡（实测吞吐被压到约 5 字符/秒）。</p>
+     *
+     * <p>校验并未因此减弱：所有<b>入口</b>（鉴权过滤器、拦截器、{@link #callWith}）仍走 {@link #set}
+     * 的全量校验，符合"整条链路只做一处防御式编程"的约定。</p>
+     *
+     * <p><b>归一仍然保留</b>，只跳过校验：并非所有写入方放进 Reactor Context 的都是归一后的值——
+     * {@code UserAuthWebFilter}/{@code AgentAuthWebFilter} 放的是原始入参（{@code ApiKeyAuthWebFilter}
+     * 放的才是 {@code canonicalTenant}）。跳过归一会让 {@code "DEFAULT"} 这类写法在传播后变成与
+     * {@link #set} 不同的值，破坏"保留租户只有一份"的约定。而 {@link #canonicalizeTenantId} 只是一次
+     * {@code equalsIgnoreCase}（长度不等即短路），与被去掉的正则不在一个量级上。</p>
+     */
+    static void restore(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            CURRENT.remove();
+            return;
+        }
+        CURRENT.set(canonicalizeTenantId(tenantId));
+    }
+
     /** 统一校验所有会话、JWT、API Key 与后台请求带入的租户编码。 */
     public static boolean isValidTenantId(String tenantId) {
         return tenantId != null && TENANT_ID_PATTERN.matcher(tenantId).matches();

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/tenant/TenantContextThreadLocalAccessor.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/tenant/TenantContextThreadLocalAccessor.java
@@ -26,9 +26,16 @@ public class TenantContextThreadLocalAccessor implements ThreadLocalAccessor<Str
         return TenantContext.get();
     }
 
+    /**
+     * 恢复快照值走 {@link TenantContext#restore}（不校验、不归一）而非 {@code set}。
+     *
+     * <p>这里拿到的 {@code value} 是某次入口 {@code set} 成功后被 Reactor Context 捕获的结果，
+     * 格式与归一在写入那一刻已经完成。而本方法处在全链路最热的位置——自动上下文传播会给链上
+     * 每个算子包一层，AI 流式链实测 110+ 层，模型每吐一个增量就要走上百次。</p>
+     */
     @Override
     public void setValue(String value) {
-        TenantContext.set(value);
+        TenantContext.restore(value);
     }
 
     @Override

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurer.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/McpToolkitConfigurer.java
@@ -137,9 +137,7 @@ public class McpToolkitConfigurer {
         String type = McpServerSpec.TRANSPORT_STREAMABLE_HTTP.equalsIgnoreCase(server.getTransport())
             ? McpServerSpec.TYPE_HTTP
             : McpServerSpec.TYPE_SSE;
-        return mcpClientFactory
-            .buildClientBuilder(McpServerSpec.remote(server.getName(), type, server.getUrl(), server.getHeaders()))
-            .timeout(CLIENT_TIMEOUT)
-            .buildAsync();
+        return mcpClientFactory.buildClient(
+            McpServerSpec.remote(server.getName(), type, server.getUrl(), server.getHeaders()), CLIENT_TIMEOUT);
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpClientFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpClientFactory.java
@@ -3,13 +3,20 @@ package com.richard.fyoung.customerwork.tool.mcp;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.Version;
+import io.agentscope.core.tool.mcp.McpAsyncClientWrapper;
 import io.agentscope.core.tool.mcp.McpClientBuilder;
 import io.agentscope.core.tool.mcp.McpClientWrapper;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
@@ -24,8 +31,8 @@ import java.util.stream.Collectors;
  *
  * <p>本类是无状态纯工具类，不注册为 Spring Bean——需要的模块自行 {@code new} 并按自己的装配方式持有。</p>
  *
- * <p>方法分两层：{@link #buildClientBuilder(McpServerSpec)} 只做「规格 -&gt; 客户端」，
- * 不设超时也不发起连接（超时由调用方按用途决定：启动期注册、连通性探测、人工调试三者耐心不同）；
+ * <p>方法分三层：{@link #buildClientBuilder(McpServerSpec)} 保留底层 AgentScope 构建入口；
+ * {@link #buildClient(McpServerSpec, Duration)} 负责生产运行时的传输兼容与超时；
  * {@link #testConnectivity}/{@link #listTools}/{@link #callTool} 则是自带连接与关闭的一次性操作。</p>
  *
  * @author owlzhangfq@gmail.com
@@ -79,7 +86,10 @@ public class McpClientFactory {
             securityPolicy.validateRemoteUrl(node.path("url").asText()), parseHeaders(node));
     }
 
-    /** 按 mcpType/config JSON 构建一个尚未连接、也尚未设置超时的 {@link McpClientBuilder}。 */
+    /**
+     * 按 mcpType/config JSON 构建尚未连接、也尚未设置超时的底层 {@link McpClientBuilder}。
+     * 生产运行时应使用 {@link #buildClient(String, String, String, Duration)}。
+     */
     public McpClientBuilder buildClientBuilder(String mcpName, String mcpType, String config) throws Exception {
         return buildClientBuilder(parseSpec(mcpName, mcpType, config));
     }
@@ -88,8 +98,8 @@ public class McpClientFactory {
      * 按连接规格构建一个尚未连接的 {@link McpClientBuilder}。支持 stdio / sse / http 三种传输。
      *
      * <p>http/sse 传输额外透传规格里的 {@code headers}（如 {@code Authorization}）——需要鉴权的远程
-     * MCP 服务（Bearer token 等）没有这层透传会在握手时被拒（401）；调试面板、连通性测试与真实注册路径
-     * 共用本方法，一处透传处处生效。</p>
+     * MCP 服务（Bearer token 等）没有这层透传会在握手时被拒（401）。Streamable HTTP 生产调用还需经过
+     * {@link #buildClient(McpServerSpec, Duration)} 的 405 兼容层。</p>
      */
     public McpClientBuilder buildClientBuilder(McpServerSpec spec) {
         McpClientBuilder builder = McpClientBuilder.create(spec.name());
@@ -116,6 +126,54 @@ public class McpClientFactory {
             }
         }
         return builder;
+    }
+
+    /**
+     * 构建尚未初始化的 MCP 客户端。
+     *
+     * <p>stdio/sse 沿用 AgentScope 构建器；Streamable HTTP 单独使用 MCP SDK 构建，是为了兼容只提供
+     * POST 的服务端，同时保留支持 GET 事件流的标准服务端能力。所有生产调用方都走本入口，避免连通性测试
+     * 能用、真实 Agent 注册仍卡在 GET SSE 的链路分叉。</p>
+     */
+    public Mono<McpClientWrapper> buildClient(McpServerSpec spec, Duration timeout) {
+        if (!McpServerSpec.TYPE_HTTP.equalsIgnoreCase(spec.type())) {
+            return buildClientBuilder(spec)
+                .timeout(timeout)
+                .initializationTimeout(timeout)
+                .buildAsync();
+        }
+        return Mono.fromCallable(() -> buildStreamableHttpClient(spec, timeout));
+    }
+
+    /** 解析配置并构建尚未初始化的客户端。 */
+    public Mono<McpClientWrapper> buildClient(String mcpName, String mcpType, String config,
+                                               Duration timeout) throws Exception {
+        return buildClient(parseSpec(mcpName, mcpType, config), timeout);
+    }
+
+    private McpClientWrapper buildStreamableHttpClient(McpServerSpec spec, Duration timeout) {
+        String safeUrl = securityPolicy.validateRemoteUrl(spec.url());
+        URI target = URI.create(safeUrl);
+        String endpoint = StringUtils.hasText(target.getRawPath()) ? target.getRawPath() : "/";
+        Map<String, String> headers = spec.headers() == null ? Map.of() : Map.copyOf(spec.headers());
+
+        McpClientTransport transport = HttpClientStreamableHttpTransport.builder(safeUrl)
+            .endpoint(endpoint)
+            .openConnectionOnStartup(false)
+            .httpRequestCustomizer((request, method, uri, body, context) -> {
+                securityPolicy.validateRequestTarget(uri);
+                headers.forEach(request::header);
+            })
+            .build();
+        McpClientTransport compatibleTransport = new StreamableHttpCompatibilityTransport(transport);
+        McpSchema.Implementation clientInfo = new McpSchema.Implementation(
+            "agentscope-java", "AgentScope Java Framework", Version.VERSION);
+        return new McpAsyncClientWrapper(spec.name(), McpClient.async(compatibleTransport)
+            .requestTimeout(timeout)
+            .initializationTimeout(timeout)
+            .clientInfo(clientInfo)
+            .capabilities(McpSchema.ClientCapabilities.builder().build())
+            .build());
     }
 
     /** 尝试建立连接并列出工具，验证 MCP 服务可达；用完即关闭，不缓存实例（与真实注册用途区分）。 */
@@ -209,10 +267,7 @@ public class McpClientFactory {
      * MCP 握手，否则 SDK 抛 IllegalStateException("MCP client '...' not initialized")；与
      * Toolkit#registerMcpClient（真实注册路径）内部的调用顺序保持一致。 */
     private McpClientWrapper connectAndInitialize(String mcpName, String mcpType, String config, Duration timeout) throws Exception {
-        McpClientWrapper wrapper = buildClientBuilder(mcpName, mcpType, config)
-            .timeout(timeout)
-            .buildAsync()
-            .block(timeout);
+        McpClientWrapper wrapper = buildClient(mcpName, mcpType, config, timeout).block(timeout);
         if (wrapper == null) {
             throw new IllegalStateException("构建 MCP 客户端失败");
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpSecurityPolicy.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpSecurityPolicy.java
@@ -20,10 +20,10 @@ import java.util.stream.Collectors;
 /**
  * MCP 唯一执行安全策略：远程传输收口 SSRF，stdio 收口可执行文件、工作目录与环境变量。
  *
- * <p>默认策略只允许公网远程 MCP，并关闭 stdio。企业私网 MCP 必须显式配置 host；stdio 必须同时
- * 配置可执行文件与工作目录白名单，且最终进程由 {@link McpStdioProcessLauncher} 清空继承环境、固定
- * 工作目录后再启动。任何调用方都只通过 {@link McpClientFactory} 建客户端，避免保存校验与真实执行
- * 使用两套规则。</p>
+ * <p>默认策略只允许公网远程 MCP，并关闭 stdio。企业私网或本机 MCP 必须显式配置 host，命中后仍拒绝
+ * 链路本地、云元数据、未指定和组播地址；stdio 必须同时配置可执行文件与工作目录白名单，且最终进程由
+ * {@link McpStdioProcessLauncher} 清空继承环境、固定工作目录后再启动。任何调用方都只通过
+ * {@link McpClientFactory} 建客户端，避免保存校验与真实执行使用两套规则。</p>
  */
 public final class McpSecurityPolicy {
 
@@ -118,7 +118,7 @@ public final class McpSecurityPolicy {
 
     private HttpTargetPolicy currentRemotePolicy() {
         return HttpTargetPolicy.ofResolvedAllowlist(current(allowedHostsSupplier),
-            InternalAddressPolicy.DENY_INTERNAL, InternalAddressPolicy.ALLOW_PRIVATE_NETWORK);
+            InternalAddressPolicy.DENY_INTERNAL, InternalAddressPolicy.ALLOW_INTERNAL);
     }
 
     private List<String> current(Supplier<List<String>> supplier) {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpServerSpec.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpServerSpec.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /**
  * MCP 服务连接规格：把「配置从哪来」（后台库里的一段 JSON / yml 里的一个 Server 节点）与
  * 「怎么建客户端」这两件事解耦——所有来源先归一成本规格，再交给
- * {@link McpClientFactory#buildClientBuilder(McpServerSpec)} 构建客户端。
+ * {@link McpClientFactory#buildClient(McpServerSpec, java.time.Duration)} 构建运行时客户端。
  *
  * @param name    MCP 服务名（作为客户端标识，也是工具名前缀来源）
  * @param type    传输类型：{@link #TYPE_STDIO} / {@link #TYPE_HTTP} / {@link #TYPE_SSE}，

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpStdioProcessLauncher.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/McpStdioProcessLauncher.java
@@ -1,6 +1,8 @@
 package com.richard.fyoung.customerwork.tool.mcp;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,16 +19,27 @@ public final class McpStdioProcessLauncher {
 
     private static final String MAIN_CLASS = McpStdioProcessLauncher.class.getName();
 
+    /** fat jar 启动器；只有以可执行 jar 运行时才在 classpath 上。 */
+    private static final String PROPERTIES_LAUNCHER = "org.springframework.boot.loader.launch.PropertiesLauncher";
+
     private McpStdioProcessLauncher() {
     }
 
     /** 把目标规格转换成启动本代理进程的命令；secret 只走环境变量，不进入进程参数。 */
     static LaunchCommand commandFor(McpServerSpec spec) {
         List<String> arguments = new ArrayList<>();
-        arguments.add("-Dloader.main=" + MAIN_CLASS);
+        // 打成可执行 jar 时 java.class.path 只有那一个 jar，内部依赖要靠 PropertiesLauncher 展开才找得到；
+        // 而以 exploded classpath 运行时（IDE 直接跑、mvn spring-boot:run、java -cp）loader 根本不在
+        // classpath 上——此时仍拼 PropertiesLauncher 会让代理进程直接 ClassNotFoundException 退出，
+        // 表现为所有 stdio MCP 一律「Client failed to initialize」，且与白名单怎么配都无关。
+        // 故按 loader 是否真的可加载来选启动方式，两种运行模式都能起来。
+        boolean fatJar = propertiesLauncherPresent();
+        if (fatJar) {
+            arguments.add("-Dloader.main=" + MAIN_CLASS);
+        }
         arguments.add("-cp");
         arguments.add(System.getProperty("java.class.path"));
-        arguments.add("org.springframework.boot.loader.launch.PropertiesLauncher");
+        arguments.add(fatJar ? PROPERTIES_LAUNCHER : MAIN_CLASS);
         arguments.add(spec.workingDirectory());
         arguments.add(spec.command());
         Map<String, String> environment = spec.environment() == null ? Map.of() : spec.environment();
@@ -37,6 +50,16 @@ public final class McpStdioProcessLauncher {
         arguments.addAll(targetArgs);
         String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
         return new LaunchCommand(java, List.copyOf(arguments), Map.copyOf(environment));
+    }
+
+    /** loader 是否在当前 classpath 上；决定代理进程用哪种方式启动。 */
+    private static boolean propertiesLauncherPresent() {
+        try {
+            Class.forName(PROPERTIES_LAUNCHER, false, McpStdioProcessLauncher.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
     }
 
     public static void main(String[] args) throws Exception {
@@ -53,8 +76,7 @@ public final class McpStdioProcessLauncher {
         Thread inputPump = new Thread(() -> copyInput(child), "mcp-stdio-input");
         inputPump.setDaemon(true);
         inputPump.start();
-        child.getInputStream().transferTo(System.out);
-        System.out.flush();
+        pump(child.getInputStream(), System.out);
         int exitCode = child.waitFor();
         if (exitCode != 0) {
             System.exit(exitCode);
@@ -70,9 +92,27 @@ public final class McpStdioProcessLauncher {
 
     private static void copyInput(Process child) {
         try (var output = child.getOutputStream()) {
-            System.in.transferTo(output);
+            pump(System.in, output);
         } catch (IOException e) {
             child.destroy();
+        }
+    }
+
+    /**
+     * 边读边写并<b>逐块 flush</b> 地转发字节流。
+     *
+     * <p>不能用 {@code InputStream#transferTo}：两端都是带缓冲的流，而 transferTo 只在读到 EOF、
+     * 由 close() 隐式 flush 一次。MCP 走的是长连接上的行式 JSON-RPC——单条消息只有几百字节，
+     * 既填不满 8KB 缓冲区，连接也不会 EOF，于是 initialize 请求会一直躺在缓冲区里发不到子进程，
+     * 子进程的响应同样卡在回程缓冲里。两个方向一起堵死，表现为握手 8 秒超时，
+     * 而进程树看上去一切正常（代理进程和目标进程都活着），极难往 I/O 缓冲上想。</p>
+     */
+    static void pump(InputStream source, OutputStream sink) throws IOException {
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = source.read(buffer)) >= 0) {
+            sink.write(buffer, 0, read);
+            sink.flush();
         }
     }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/StreamableHttpCompatibilityTransport.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/tool/mcp/StreamableHttpCompatibilityTransport.java
@@ -1,0 +1,80 @@
+package com.richard.fyoung.customerwork.tool.mcp;
+
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpTransportException;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Streamable HTTP 兼容层：服务端可以用 405 拒绝可选的 GET 事件流，客户端继续使用 POST 请求/响应模式。
+ *
+ * <p>MCP Java SDK 0.17.0 会先把 GET 的 405 JSON 正文交给 SSE 解析器，因而在识别 405 之前抛出
+ * {@code Invalid SSE response}。该异常只代表服务端不提供可选的独立事件流，不代表 POST 端点不可用。
+ * 本类仅在 Streamable HTTP 传输外层过滤这一种已知信号，其他传输异常仍原样交给 MCP 生命周期处理器。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+final class StreamableHttpCompatibilityTransport implements McpClientTransport {
+
+    private static final String OPTIONAL_GET_REJECTED_PREFIX =
+        "Invalid SSE response. Status code: 405";
+
+    private final McpClientTransport delegate;
+
+    StreamableHttpCompatibilityTransport(McpClientTransport delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Mono<Void> connect(
+            Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+        return delegate.connect(handler);
+    }
+
+    @Override
+    public void setExceptionHandler(Consumer<Throwable> handler) {
+        delegate.setExceptionHandler(error -> {
+            if (!isOptionalGetRejected(error)) {
+                handler.accept(error);
+            }
+        });
+    }
+
+    @Override
+    public Mono<Void> closeGracefully() {
+        return delegate.closeGracefully();
+    }
+
+    @Override
+    public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+        return delegate.sendMessage(message);
+    }
+
+    @Override
+    public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+        return delegate.unmarshalFrom(data, typeRef);
+    }
+
+    @Override
+    public List<String> protocolVersions() {
+        return delegate.protocolVersions();
+    }
+
+    static boolean isOptionalGetRejected(Throwable error) {
+        Throwable cause = error;
+        while (cause != null) {
+            if (cause instanceof McpTransportException
+                    && cause.getMessage() != null
+                    && cause.getMessage().startsWith(OPTIONAL_GET_REJECTED_PREFIX)) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/tenant/TenantContextTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/safety/tenant/TenantContextTest.java
@@ -20,6 +20,60 @@ class TenantContextTest {
         TenantContext.clear();
     }
 
+    /**
+     * 传播恢复路径与 {@code set} 对合法值必须完全等价——包括 default 大小写归一。
+     * 不等价就意味着"值穿过一次线程边界后变了"，那是最难查的一类隔离缺陷。
+     */
+    @Test
+    void restore_shouldMatchSetForLegalValues() {
+        TenantContext.restore("acme");
+        assertEquals("acme", TenantContext.get(), "合法值应原样恢复");
+
+        TenantContext.restore("DEFAULT");
+        assertEquals(TenantContext.DEFAULT, TenantContext.get(), "恢复路径同样要归一保留租户");
+    }
+
+    /** 空值语义与 {@code set} 一致：视为清理，不留半初始化状态。 */
+    @Test
+    void restore_shouldClearOnBlank() {
+        TenantContext.set("acme");
+
+        TenantContext.restore("  ");
+
+        assertNull(TenantContext.get(), "空白值应清理而非写入");
+        assertFalse(TenantContext.isPresent());
+    }
+
+    /**
+     * 恢复路径<b>刻意</b>不做格式校验，这正是它与 {@code set} 的唯一区别，也是它存在的理由：
+     * 自动上下文传播会给 Reactor 链上每个算子包一层，AI 流式链实测 110+ 层，模型每吐一个增量
+     * 就要走上百次；在这里跑正则曾把一整颗核烧满，把流式吞吐压到约 5 字符/秒。
+     * 校验仍由所有入口的 {@code set} 承担。
+     */
+    @Test
+    void restore_shouldSkipFormatValidation() {
+        assertThrows(IllegalArgumentException.class, () -> TenantContext.set("bad tenant!"),
+            "入口写入必须继续 fail fast");
+
+        TenantContext.restore("bad tenant!");
+        assertEquals("bad tenant!", TenantContext.get(), "恢复路径不重复校验，原样放回");
+    }
+
+    /**
+     * 防回归：Accessor 必须走 {@code restore} 而不是 {@code set}。
+     * 改回 {@code set} 会让上百层传播重新跑正则，卡顿当场复发，而功能测试一条都不会红——
+     * 这个断言是那次回归唯一的机器防线。
+     */
+    @Test
+    void accessorSetValue_shouldUseRestorePath() {
+        TenantContextThreadLocalAccessor accessor = new TenantContextThreadLocalAccessor();
+
+        accessor.setValue("bad tenant!");
+
+        assertEquals("bad tenant!", TenantContext.get(),
+            "Accessor 恢复快照值不得触发格式校验（否则即为改回了 set）");
+    }
+
     @Test
     void setAndGet_shouldRoundTrip() {
         TenantContext.set("acme");

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/mcp/McpClientFactoryTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/mcp/McpClientFactoryTest.java
@@ -1,15 +1,21 @@
 package com.richard.fyoung.customerwork.tool.mcp;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpServer;
 import io.agentscope.core.tool.mcp.McpClientBuilder;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
 
-import java.net.InetSocketAddress;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -98,6 +104,29 @@ class McpClientFactoryTest {
 
         assertThrows(Exception.class, () -> new McpClientFactory(policy).parseSpec("test", "http",
             "{\"url\":\"https://attacker.example/mcp\"}"));
+    }
+
+    @Test
+    void parseSpec_shouldAllowLoopbackOnlyWhenHostExplicitlyAllowlisted() throws Exception {
+        McpSecurityPolicy policy = new McpSecurityPolicy(() -> List.of("127.0.0.1"),
+            List::of, List::of, List::of,
+            host -> new InetAddress[]{InetAddress.getByAddress(host, new byte[]{127, 0, 0, 1})});
+
+        McpServerSpec spec = assertDoesNotThrow(() -> new McpClientFactory(policy).parseSpec("test", "http",
+            "{\"url\":\"http://127.0.0.1:3002/mcp\"}"));
+
+        assertEquals("http://127.0.0.1:3002/mcp", spec.url());
+    }
+
+    @Test
+    void parseSpec_shouldStillRejectMetadataWhenHostExplicitlyAllowlisted() throws Exception {
+        McpSecurityPolicy policy = new McpSecurityPolicy(() -> List.of("169.254.169.254"),
+            List::of, List::of, List::of,
+            host -> new InetAddress[]{InetAddress.getByAddress(host,
+                new byte[]{(byte) 169, (byte) 254, (byte) 169, (byte) 254})});
+
+        assertThrows(Exception.class, () -> new McpClientFactory(policy).parseSpec("test", "http",
+            "{\"url\":\"http://169.254.169.254/latest/meta-data\"}"));
     }
 
     @Test
@@ -216,6 +245,69 @@ class McpClientFactoryTest {
     }
 
     /**
+     * Streamable HTTP 的独立 GET 事件流是可选能力：服务端可以返回 405，只保留 POST 请求/响应模式。
+     * 回归真实报错形状，确保 SDK 0.17.0 不会再把这类 405 JSON 当成 SSE 解析失败并污染生命周期。
+     */
+    @Test
+    void testConnectivity_shouldSucceed_whenStreamableHttpServerRejectsOptionalGet() throws Exception {
+        CountDownLatch optionalGet = new CountDownLatch(1);
+        AtomicInteger postRequests = new AtomicInteger();
+        ObjectMapper objectMapper = new ObjectMapper();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/mcp", exchange -> {
+            try {
+                if ("GET".equals(exchange.getRequestMethod())) {
+                    optionalGet.countDown();
+                    respondJson(exchange, 405, "{\"error\":\"GET not supported, use POST\"}");
+                    return;
+                }
+                if ("DELETE".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(405, -1);
+                    return;
+                }
+                postRequests.incrementAndGet();
+                JsonNode request = objectMapper.readTree(exchange.getRequestBody());
+                String method = request.path("method").asText();
+                if ("notifications/initialized".equals(method)) {
+                    exchange.sendResponseHeaders(202, -1);
+                    return;
+                }
+                String id = request.path("id").toString();
+                if ("initialize".equals(method)) {
+                    String protocolVersion = request.path("params").path("protocolVersion").asText();
+                    exchange.getResponseHeaders().set("Mcp-Session-Id", "post-only-session");
+                    respondJson(exchange, 200, "{\"jsonrpc\":\"2.0\",\"id\":" + id
+                        + ",\"result\":{\"protocolVersion\":\"" + protocolVersion
+                        + "\",\"capabilities\":{\"tools\":{\"listChanged\":false}},"
+                        + "\"serverInfo\":{\"name\":\"post-only\",\"version\":\"1.0.0\"}}}");
+                    return;
+                }
+                if ("tools/list".equals(method)) {
+                    respondJson(exchange, 200,
+                        "{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":{\"tools\":[]}}");
+                    return;
+                }
+                respondJson(exchange, 404,
+                    "{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"error\":{\"code\":-32601,\"message\":\"not found\"}}");
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+        try {
+            String config = "{\"url\":\"http://127.0.0.1:" + server.getAddress().getPort() + "/mcp\"}";
+
+            McpConnectivityResult result = factory.testConnectivity("post-only", "http", config);
+
+            assertTrue(result.success(), result.errorMessage());
+            assertTrue(optionalGet.await(2, TimeUnit.SECONDS), "客户端应识别并兼容服务端拒绝可选 GET");
+            assertTrue(postRequests.get() >= 3, "initialize、initialized、tools/list 都应继续使用 POST");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
      * listTools/callTool 跟 testConnectivity 不一样，不在方法内部兜底成失败结果，
      * 而是直接把连接异常往外抛——交给调用方（如后台 McpService）统一包成自己的业务异常，
      * 这里只验证"连不上会抛异常"这个边界，不吞掉。
@@ -317,5 +409,13 @@ class McpClientFactoryTest {
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private static void respondJson(com.sun.net.httpserver.HttpExchange exchange, int status, String body)
+            throws java.io.IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
     }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/mcp/McpStdioProcessLauncherTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/mcp/McpStdioProcessLauncherTest.java
@@ -1,0 +1,106 @@
+package com.richard.fyoung.customerwork.tool.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link McpStdioProcessLauncher} 的启动命令拼装单测。
+ * @author owlzhangfq@gmail.com
+ */
+class McpStdioProcessLauncherTest {
+
+    private static final String LOADER = "org.springframework.boot.loader.launch.PropertiesLauncher";
+
+    private McpServerSpec spec() {
+        return McpServerSpec.stdio("probe", "/bin/echo", List.of("hello"), "/tmp", Map.of("PATH", "/usr/bin"));
+    }
+
+    /**
+     * 防回归：代理进程的主类必须在<b>当前 classpath</b> 上真实可加载。
+     *
+     * <p>此前这里硬编码了 {@code PropertiesLauncher}，那个类只在 {@code spring-boot-loader} 里，
+     * 也就是只有以可执行 jar 运行时才在 classpath 上。以 exploded classpath 运行（IDE 直接跑、
+     * {@code mvn spring-boot:run}、{@code java -cp}）时代理进程会当场
+     * {@code ClassNotFoundException} 退出，表现为所有 stdio MCP 一律「Client failed to initialize」——
+     * 而错误信息完全指不到这里，很容易一路误查白名单配置。</p>
+     */
+    @Test
+    void commandFor_shouldTargetLoadableMainClass() {
+        McpStdioProcessLauncher.LaunchCommand launch = McpStdioProcessLauncher.commandFor(spec());
+
+        int classpathIndex = launch.arguments().indexOf("-cp");
+        assertTrue(classpathIndex >= 0, "必须显式传 -cp");
+        String mainClass = launch.arguments().get(classpathIndex + 2);
+
+        assertDoesNotThrow(() -> Class.forName(mainClass, false, getClass().getClassLoader()),
+            "代理进程主类必须在当前 classpath 上可加载，否则子进程起不来: " + mainClass);
+    }
+
+    /** 用 loader 启动时必须同时给出 {@code -Dloader.main}，否则它不知道该转发到哪个主类。 */
+    @Test
+    void commandFor_shouldPairLoaderWithLoaderMain() {
+        McpStdioProcessLauncher.LaunchCommand launch = McpStdioProcessLauncher.commandFor(spec());
+
+        boolean usesLoader = launch.arguments().contains(LOADER);
+        boolean declaresLoaderMain = launch.arguments().stream()
+            .anyMatch(argument -> argument.startsWith("-Dloader.main="));
+
+        assertEquals(usesLoader, declaresLoaderMain, "-Dloader.main 必须与 PropertiesLauncher 成对出现");
+    }
+
+    /** 环境变量按「只传 key」约定下发，值由代理进程从自身环境取，避免密钥落进进程参数被 ps 看到。 */
+    @Test
+    void commandFor_shouldPassEnvironmentKeysOnlyNotValues() {
+        McpStdioProcessLauncher.LaunchCommand launch = McpStdioProcessLauncher.commandFor(spec());
+
+        assertTrue(launch.arguments().contains("PATH"), "允许透传的变量名应出现在参数里");
+        assertTrue(launch.arguments().stream().noneMatch("/usr/bin"::equals),
+            "变量值不得进入进程参数");
+    }
+
+    /**
+     * 防回归：转发必须逐块 flush，不能等到流结束。
+     *
+     * <p>此前两个方向都用 {@code InputStream#transferTo}，它只在读到 EOF、由 close() 隐式 flush 一次。
+     * MCP 是长连接上的行式 JSON-RPC，单条消息几百字节，既填不满缓冲区、连接也不会 EOF，
+     * 于是 initialize 请求一直躺在缓冲里发不出去，握手必然超时——而进程树看上去完全正常，
+     * 代理进程和目标进程都活着，排查时极难联想到 I/O 缓冲。</p>
+     */
+    @Test
+    void pump_shouldFlushEachChunkWithoutWaitingForEof() throws Exception {
+        java.io.PipedOutputStream producer = new java.io.PipedOutputStream();
+        java.io.PipedInputStream source = new java.io.PipedInputStream(producer, 64 * 1024);
+        java.io.ByteArrayOutputStream delivered = new java.io.ByteArrayOutputStream();
+        java.io.BufferedOutputStream sink = new java.io.BufferedOutputStream(delivered, 8192);
+
+        Thread pump = new Thread(() -> {
+            try {
+                McpStdioProcessLauncher.pump(source, sink);
+            } catch (java.io.IOException ignored) {
+                // 测试结束时管道关闭属正常收尾
+            }
+        }, "pump-under-test");
+        pump.setDaemon(true);
+        pump.start();
+
+        byte[] message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n"
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        producer.write(message);
+        producer.flush();
+
+        // 刻意不关闭 producer：模拟 MCP 长连接「还会继续发」的常态
+        long deadline = System.currentTimeMillis() + 2000L;
+        while (delivered.size() == 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20L);
+        }
+
+        assertEquals(message.length, delivered.size(),
+            "源流未结束时数据就必须已送达对端，否则 MCP 握手会一直卡住");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/mcp/StreamableHttpCompatibilityTransportTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/tool/mcp/StreamableHttpCompatibilityTransportTest.java
@@ -1,0 +1,78 @@
+package com.richard.fyoung.customerwork.tool.mcp;
+
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpTransportException;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class StreamableHttpCompatibilityTransportTest {
+
+    @Test
+    void exceptionHandler_shouldIgnoreOnlyOptionalGet405() {
+        FakeTransport delegate = new FakeTransport();
+        StreamableHttpCompatibilityTransport transport = new StreamableHttpCompatibilityTransport(delegate);
+        AtomicReference<Throwable> forwarded = new AtomicReference<>();
+        transport.setExceptionHandler(forwarded::set);
+
+        delegate.emit(new McpTransportException(
+            "Invalid SSE response. Status code: 405 Line: {\"error\":\"GET not supported, use POST\"}"));
+
+        assertNull(forwarded.get());
+
+        McpTransportException serverFailure = new McpTransportException(
+            "Invalid SSE response. Status code: 500 Line: internal error");
+        delegate.emit(serverFailure);
+
+        assertSame(serverFailure, forwarded.get());
+    }
+
+    private static final class FakeTransport implements McpClientTransport {
+
+        private Consumer<Throwable> exceptionHandler;
+
+        @Override
+        public Mono<Void> connect(
+                Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+            return Mono.empty();
+        }
+
+        @Override
+        public void setExceptionHandler(Consumer<Throwable> handler) {
+            this.exceptionHandler = handler;
+        }
+
+        @Override
+        public Mono<Void> closeGracefully() {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+            return Mono.empty();
+        }
+
+        @Override
+        public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+            return null;
+        }
+
+        @Override
+        public List<String> protocolVersions() {
+            return List.of("2025-06-18");
+        }
+
+        private void emit(Throwable error) {
+            exceptionHandler.accept(error);
+        }
+    }
+}


### PR DESCRIPTION
## 背景

本分支合并三件事：对话与 VibeCoding 的流式输出卡顿、MCP 全部连通失败、以及 model impact 查询的排序规则冲突。前两件的共同点是**故障现象离根因很远**，都是靠实测数据而非阅读代码定位的。

## 一、流式输出卡顿

### 现象与定位

对话和 VibeCoding 的思考/正文输出一卡一卡。先测后端 SSE 的真实到达节奏，这一步直接排除了「前端渲染慢」的假设：

| 实测项 | 修复前 |
|---|---|
| 正文增量间隔（中位） | 732 ms |
| 单条 delta 大小 | 3~4 字符 |
| 有效吞吐 | 4.9 字符/秒 |

每 700ms 才蹦 3 个字，前端无事可做。再用两次线程快照对比累计 CPU：**10 秒烧掉 10966 ms CPU（超过一整颗核），只产出约 42 个字符**。采样剖析显示，排除 IO 等待后唯一的 CPU 热点是 `TenantContext.isValidTenantId`。

### 根因

开启 `Hooks.enableAutomaticContextPropagation()` 后，Reactor 给链上**每个**算子包一层 `ContextWriteRestoringThreadLocals`——AI 流式链实测 **112 层**（另有 OTel `TracingSubscriber` 54 层，真实业务算子只有约 40）。每层 `onNext` 都要恢复全部 ThreadLocal 快照，而 `TenantContextThreadLocalAccessor#setValue` 走的是带正则校验的 `TenantContext#set`，每次还新建一个 `Matcher`。

这里恢复的值本就来自某次入口 `set` 成功后的快照，格式在那一刻已经验过——在全链路最热的一点重复校验，是典型的「同一条链路做了多处防御」。

### 修复与效果

新增 `TenantContext#restore`：跳过格式校验，**保留 default 大小写归一**（`UserAuthWebFilter`/`AgentAuthWebFilter` 放进 Reactor Context 的是未归一的原始入参，跳过归一会让值穿过线程边界后与 `set` 不一致）。所有入口仍走 `set` 的全量校验。

| 指标 | 修复前 | 修复后 | 变化 |
|---|---|---|---|
| 正文增量间隔（中位） | 732 ms | **3.6 ms** | 203× |
| 思考增量间隔（中位） | 1445 ms | **3.4 ms** | 425× |
| 正文吞吐 | 4.9 字符/秒 | **154.9 字符/秒** | 32× |
| 总耗时（同一问题） | 83.3 s | **13.3 s** | 6.3× |
| 10 秒窗口 JVM CPU | 10966 ms (109.7%) | **991 ms (9.9%)** | 11× |
| >500ms 停顿 | 72 次 | **0 次** | — |

修复后正文间隔中位数 24 ms 已是模型自身的 token 生成速度，瓶颈回到模型本身。

### 前端两处同源修复

后端修好、增量变密之后才会显形：

- **`scrollFollower`**：原先每条增量都调 `scrollTo({behavior:'smooth'})`。平滑滚动是持续数百毫秒的动画，而增量间隔远小于它，每次调用都在打断上一次重新起步。改为每帧最多滚一次 + 瞬时定位。
- **`sse.ts`**：`parseSseBlock` 用 `trim()` 吃掉了增量文本首尾空格，英文回答会单词粘连。按 SSE 规范只去掉一个前导空格，并显式处理行尾 `\r`（原先由 `trim` 顺带清掉，直接删会把控制字符带进正文）。
- **`vibeConversations`**：补上 ChatPanel 早有、VibeCoding 一直漏掉的正文整帧合并。

## 二、MCP 连通性

MCP 全部连通失败，且反复改配置无效。逐层剥开有四个原因，**其中三个是代码缺陷**——每修好一层错误信息就换一副面孔，这是它显得特别难查的原因：

`已拦截 localhost` → `未配置执行白名单` → `Client failed to initialize` → `Timeout on blocking read`

| # | 原因 | 性质 |
|---|---|---|
| 1 | `AdminMcpFactory` 缺 `@Autowired` → 白名单根本没被读 | 代码 |
| 2 | yml 白名单路径不存在 → 连坐所有 stdio | 配置 |
| 3 | `PropertiesLauncher` 不在 classpath → 代理进程起不来 | 代码 |
| 4 | 双向转发不 flush → 握手永远卡住 | 代码 |

### 1. 多构造器缺 `@Autowired`

`AdminMcpFactory` 是 `@Component` 且有三个构造器，但没有一个标 `@Autowired`。Spring 此时**不会挑参数最多的**，而是回退到无参构造器——那个构造器装的是 `McpSecurityPolicy.strict()`，白名单恒为空，`admin.mcp.security.*` 从没被读到。

误导性在于：**属性类自身绑定是正常的**，照它打诊断日志只会看到正确的值，把人一路引向配置本身。同类问题 PR #68 修过 5 处，已扫过全 admin，现在只剩这一处。

除加 `@Autowired` 外**一并删除无参构造器**：留着它，将来谁再拿掉注解，故障还是静默降级成最严格策略；现在没有可回退的无参构造器，容器会当场启动失败。

### 3. 硬编码 fat jar 启动器

`McpStdioProcessLauncher` 把 `PropertiesLauncher` 写死为代理进程主类。该类只在 `spring-boot-loader` 里，即只有以可执行 jar 运行时才在 classpath 上；以 exploded classpath 运行（IDE、`mvn spring-boot:run`、`java -cp`）时代理进程当场 `ClassNotFoundException` 退出。改为按 loader 是否真的可加载来选启动方式。

### 4. 转发缺 flush（真正的元凶）

stdin/stdout 双向转发用 `InputStream#transferTo`，它只在读到 EOF 时由 `close()` 隐式 flush 一次。而 MCP 是长连接上的行式 JSON-RPC——单条消息几百字节，既填不满 8KB 缓冲区、连接也不会 EOF。initialize 请求一直躺在缓冲里发不到子进程，响应同样卡在回程缓冲，**两个方向一起堵死**，而进程树看上去完全正常（代理进程和目标进程都活着）。

改为逐块 `write` + `flush`。实测 stdin 保持打开时，响应从「一直卡到超时」变为 **104 ms 到达**。转发线程堵死也是代理进程无法退出、每次超时泄漏一个的原因。

> 排查中一个值得记下的教训：早先用 `printf '...' | java ...` 手工验证都「成功」，因为 printf 输出完 stdin 立即 EOF，恰好触发了那次隐式 flush。**一次性输入的管道测试根本暴露不出长连接的缓冲问题**，反而误导了判断。

### 安全口径

- 白名单是**强制名单**而非内网例外：不在名单里的 host 一律拒绝，公网域名同样要显式列入。`allowed-hosts` 改为环境变量可覆盖，企业私网域名走 `ADMIN_MCP_ALLOWED_HOSTS` 注入，不写进仓库。
- stdio 刻意放行**具体的 MCP server 可执行文件**而非 `npx`——`npx -y <任意包>` 等于允许执行任意 npm 包，白名单就失去意义。
- `PATH` 需列入 `allowed-environment-keys`：npm 系 server 是带 `#!/usr/bin/env node` 的脚本，PATH 为空时找不到 node。

## 三、model impact 排序规则

`CAST(数值 AS CHAR)` 与裸字面量的排序规则取 `collation_connection`（MySQL 8 默认库上是 `utf8mb4_0900_ai_ci`），而表列自 V97 起统一 `utf8mb4_unicode_ci`。两者在 UNION 同一列位置相遇时可强制性都是 2，MySQL 无法裁决直接抛 1271。

凡不由表列决定排序规则的表达式显式钉住；表列侧不写——它们已由建表约定保证，重复声明反而会掩盖将来某张表建错排序规则的事实。

## 防回归断言

三处修复都配了断言，因为它们的共同特点是**改坏了功能测试一条都不会红**：

- `TenantContextTest#accessorSetValue_shouldUseRestorePath` — accessor 不得改回 `set`
- `AdminMcpFactoryTest` — 配了白名单就放行 / 没配就拦截
- `McpStdioProcessLauncherTest#commandFor_shouldTargetLoadableMainClass` — 代理进程主类必须在当前 classpath 上真实可加载
- `McpStdioProcessLauncherTest#pump_shouldFlushEachChunkWithoutWaitingForEof` — 源流未结束时数据就必须已送达对端

## 验证

- 全模块 `mvn clean test`：**BUILD SUCCESS**，0 失败 0 错误（排除 `RedisSessionPersistenceTest`，本机 Redis 无密码）
- 前端 `npm run build`（vue-tsc + vite build）通过
- 端到端：真实页面登录后在对话面板与 VibeCoding 面板各发一条，流式渲染流畅、Markdown 表格正确、自动滚动跟随正常、控制台零错误
- MCP 连通性实测：stdio（文件系统）与三个 localhost http MCP **全部连通成功**，泄漏的代理进程归零

## 已知未覆盖

- 「星云数据库MCP」需要在运行环境用 `ADMIN_MCP_ALLOWED_HOSTS` 追加其域名，本 PR 不含该域名
- 「数据库执行mcp」指向的本地端口当前无服务，与本 PR 无关
