### PR TITLE
fix(admin): 修复跨库只读池失守、门禁阻断死循环与错误码撞值

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/RuntimePublishStatus.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/RuntimePublishStatus.java
@@ -1,15 +1,76 @@
 package com.richard.fyoung.customeradmin.aiconfig.channel.publish;
 
-/** 运行时配置从本地任务到实例应用的状态。 */
+/**
+ * 运行时配置从本地任务到实例应用的状态。
+ *
+ * <p><b>"这个状态还会不会自行推进"只在本枚举回答一次</b>：消费方一律调
+ * {@link #isAdvancing()} / {@link #needsHumanAction()} / {@link #isSettled()}，
+ * 不要在各处再写 {@code == APPLIED || == FAILED} 这类分类
+ * （同 {@code TicketStatus#isEnded()} 立过的约定）。</p>
+ *
+ * <p><b>为什么立这条规矩</b>：这件事此前被三个消费方各判了一遍，在 {@link #BLOCKED} 上正面冲突——
+ * {@code RuntimePublishTaskMapper.findDueCandidates} 只捞 {@code PENDING} 与租约过期的
+ * {@code PROCESSING}（即调度器永远不会再碰 BLOCKED）、{@code ModelExperimentEffectiveStateResolver}
+ * 把它算作失败、而 {@code ImprovementCaseService#refreshPublish} 的 else 分支把它当"进行中"继续轮询。
+ * 于是门禁一旦阻断发布，改进闭环就每个扫描周期捞一次、判一次、再排下一次，
+ * 状态永远停在 {@code PUBLISHING}；又因为走的不是失败分支，{@code lastError} 恒为空、
+ * 面板上的错误提示不显示，运营只看到"发布中"挂着不动。同一行数据在模型实验页却显示"失败"。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
 public enum RuntimePublishStatus {
+
+    /** 待调度：Worker 会捞起。 */
     PENDING,
+    /** Worker 持租约处理中；租约过期后会被重新捞起。 */
     PROCESSING,
-    /** 评测门禁确定性阻断；不自动重试，等待重评或有审计的紧急豁免。 */
+    /**
+     * 评测门禁确定性阻断；不自动重试，等待重评或有审计的紧急豁免。
+     *
+     * <p>出口只有 {@code RuntimePublishTaskService#retryGateBlocked}（重评后放回 PENDING）
+     * 与 {@code #overrideGateBlocked}（紧急豁免），两者都要人介入——调度器的捞取条件里没有本状态。</p>
+     */
     BLOCKED,
+    /** 已投递 Nacos，等待实例 ACK 聚合。 */
     PUBLISHED,
+    /** 部分实例已生效：ACK 继续到齐会转 APPLIED，不是终态。 */
     PARTIAL,
+    /** 全部目标实例已生效。 */
     APPLIED,
     /** 任务固化快照已被同一 Nacos 键的更新发布意图取代。 */
     SUPERSEDED,
-    FAILED
+    /** 有实例拒绝且无一生效。 */
+    FAILED;
+
+    /**
+     * 还会自行往前走，不需要任何人介入。
+     *
+     * <p>前两个靠 Worker 轮询推进，后两个靠实例 ACK 聚合推进
+     * （{@code RuntimePublishTaskService#refreshAckStatus} 每收到一条 ACK 重算一次）。
+     * 调用方据此决定"要不要排下一次检查"。</p>
+     */
+    public boolean isAdvancing() {
+        return this == PENDING || this == PROCESSING || this == PUBLISHED || this == PARTIAL;
+    }
+
+    /**
+     * 卡住了，等人做决定——既不会自己往前走，也不该被当成失败草草收场。
+     *
+     * <p>只有 {@link #BLOCKED}。误判成"进行中"会导致无限轮询；
+     * 误判成"失败"则让重评后本可继续的发布被提前关掉。</p>
+     */
+    public boolean needsHumanAction() {
+        return this == BLOCKED;
+    }
+
+    /**
+     * 已成定局，不必再看。
+     *
+     * <p>{@link #FAILED} 归入本类是<b>产品语义</b>上的定局（有实例拒绝且无一生效，这一轮发布判定失败）。
+     * 底层 {@code updateAckStatus} 允许迟到的 ACK 把它翻成 PARTIAL/APPLIED，
+     * 那属于补报而不是"它会自己好起来"，消费方不应据此继续轮询。</p>
+     */
+    public boolean isSettled() {
+        return this == APPLIED || this == SUPERSEDED || this == FAILED;
+    }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/experiment/service/ModelExperimentEffectiveStateResolver.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/experiment/service/ModelExperimentEffectiveStateResolver.java
@@ -66,16 +66,35 @@ public final class ModelExperimentEffectiveStateResolver {
         if (EvalGateStatus.BLOCKED.name().equals(task.getGateStatus())) {
             return TaskOutcome.FAILED;
         }
-        if (RuntimePublishStatus.APPLIED.name().equals(task.getStatus())) {
-            return TaskOutcome.APPLIED;
+        RuntimePublishStatus status = parseStatus(task.getStatus());
+        if (status == null) {
+            // 库里出现枚举外的值：按最保守的方向判，绝不冒充生效
+            return TaskOutcome.FAILED;
         }
-        if (RuntimePublishStatus.PENDING.name().equals(task.getStatus())
-            || RuntimePublishStatus.PROCESSING.name().equals(task.getStatus())
-            || RuntimePublishStatus.PUBLISHED.name().equals(task.getStatus())) {
-            return TaskOutcome.IN_PROGRESS;
+        // 穷尽 switch 且不写 default：将来给 RuntimePublishStatus 加值时这里会编译不过，
+        // 强制新增者回答"它在'当前是否已生效'这个问题上算什么"。
+        // 此前是 if 链 + 兜底 return FAILED，新枚举值会被静默吞成"失败"而无人察觉。
+        return switch (status) {
+            case APPLIED -> TaskOutcome.APPLIED;
+            case PENDING, PROCESSING, PUBLISHED -> TaskOutcome.IN_PROGRESS;
+            // 本方法问的是"现在能不能宣布整体生效"，与 RuntimePublishStatus#isAdvancing()
+            // 问的"还会不会自行推进"是两个问题，刻意不复用那组判定：
+            // PARTIAL 会随 ACK 到齐继续推进（isAdvancing 为真），但此刻已有实例拒绝或尚未形成
+            // 一致生效事实，不能把局部成功冒充整体 ACTIVE/INACTIVE；
+            // BLOCKED 等人重评或豁免，在这个问题上同样只能答否。
+            case PARTIAL, BLOCKED, SUPERSEDED, FAILED -> TaskOutcome.FAILED;
+        };
+    }
+
+    private static RuntimePublishStatus parseStatus(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
         }
-        // PARTIAL 表示已有实例拒绝或尚未形成一致生效事实，不能把局部成功冒充整体 ACTIVE/INACTIVE。
-        return TaskOutcome.FAILED;
+        try {
+            return RuntimePublishStatus.valueOf(raw);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private enum TaskOutcome {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/config/AdminKnowledgeGapRecorder.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/config/AdminKnowledgeGapRecorder.java
@@ -44,6 +44,7 @@ public class AdminKnowledgeGapRecorder implements KnowledgeGapRecorder {
             .mapperClasses(KnowledgeGapGatewayFactory.MAPPER_CLASSES)
             .mapperXml(KnowledgeGapGatewayFactory.MAPPER_XML_LOCATIONS)
             .maxPoolSize(2)
+            .readOnly(false)
             .error("GAP-DS-UNAVAILABLE", "客服端库不可达（知识盲区计数存放于此）")
             .build(KnowledgeGapGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/badcase/config/BadcaseGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/badcase/config/BadcaseGatewayProvider.java
@@ -25,6 +25,7 @@ public class BadcaseGatewayProvider {
         this.facade = CustomerWorkFacade.builder("badcase-pool", properties, tenantPlugins)
             .mapperClasses(BadcaseGatewayFactory.MAPPER_CLASSES)
             .mapperXml(BadcaseGatewayFactory.MAPPER_XML_LOCATIONS)
+            .readOnly(false)
             .error("BADCASE-DS-UNAVAILABLE", "客服端库不可达（badcase 与回流目标存放于此）")
             .build(BadcaseGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/QuotaGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/config/QuotaGatewayProvider.java
@@ -26,6 +26,7 @@ public class QuotaGatewayProvider {
         this.facade = CustomerWorkFacade.builder("tenant-quota-pool", properties, tenantPlugins)
             .mapperClasses(QuotaGatewayFactory.MAPPER_CLASSES)
             .mapperXml(QuotaGatewayFactory.MAPPER_XML_LOCATIONS)
+            .readOnly(false)
             .error("QUOTA-DS-UNAVAILABLE", "客服端库不可达（租户配额存放于此）")
             .build(QuotaGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/gateway/CustomerUsageFactGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/billing/gateway/CustomerUsageFactGatewayProvider.java
@@ -22,6 +22,7 @@ public class CustomerUsageFactGatewayProvider {
         this.facade = CustomerWorkFacade.builder("billing-usage-fact-pool", properties, tenantPlugins)
             .mapperClasses(List.of(CustomerUsageFactMapper.class))
             .maxPoolSize(2)
+            .readOnly(false)
             .error("BILLING-USAGE-DS-UNAVAILABLE", "客服端库不可达（模型调用金额事实存放于此）")
             .build(gateway -> new CustomerUsageFactGateway(
                 gateway.getMapper(CustomerUsageFactMapper.class)));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/businessoutcome/gateway/BusinessOutcomeGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/businessoutcome/gateway/BusinessOutcomeGatewayProvider.java
@@ -19,6 +19,7 @@ public class BusinessOutcomeGatewayProvider {
         this.facade = CustomerWorkFacade.builder("business-outcome-pool", properties, tenantPlugins)
             .mapperClasses(BusinessOutcomeGatewayFactory.MAPPER_CLASSES)
             .maxPoolSize(4)
+            .readOnly(true)
             .error("BUSINESS-OUTCOME-DS-UNAVAILABLE", "客服端库不可达（业务结果事实存放于此）")
             .build(BusinessOutcomeGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/gateway/CustomerWorkFacade.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/gateway/CustomerWorkFacade.java
@@ -101,6 +101,7 @@ public final class CustomerWorkFacade<T> {
         private List<Class<?>> mapperClasses = List.of();
         private List<String> mapperXmlLocations = List.of();
         private int maxPoolSize = CrossDbConnectionSettings.DEFAULT_MAX_POOL_SIZE;
+        private boolean readOnly = false;
         private String driverClassName = CrossDbConnectionSettings.DEFAULT_DRIVER_CLASS;
         private String errorCode = "CUSTOMER-WORK-DS-UNAVAILABLE";
         private String errorHint = "客服端库不可达";
@@ -127,6 +128,20 @@ public final class CustomerWorkFacade<T> {
 
         public Builder maxPoolSize(int size) {
             this.maxPoolSize = size;
+            return this;
+        }
+
+        /**
+         * 只读门面开启后 Hikari 把连接置为只读，误写立即报错，而不是事后才发现客服端运行库被改。
+         *
+         * <p><b>凡是 javadoc 里自称"只读"的门面都必须调它</b>——这两件事一旦分家就没人能发现：
+         * {@code faa1c7bf} 把各域装配收敛进本类时，{@code maxPoolSize} 被逐个搬了过来，
+         * 而当时只有 callstats 一处用到的 {@code readOnly} 没有，注释却原样保留，
+         * 于是"只读"变成了一句无人执行的描述，后台删除按钮开始真删客服端库的行。
+         * {@code CustomerWorkFacadeReadOnlyAlignmentTest} 现在对此下断言。</p>
+         */
+        public Builder readOnly(boolean readOnly) {
+            this.readOnly = readOnly;
             return this;
         }
 
@@ -170,6 +185,7 @@ public final class CustomerWorkFacade<T> {
                     .credentials(properties.getUsername(), properties.getPassword())
                     .driverClassName(driverClassName)
                     .maximumPoolSize(maxPoolSize)
+                    .readOnly(readOnly)
                     .build(),
                 mapperClasses, mapperXmlLocations, tenantPlugins::create, schemaGuardedFactory);
             return new CustomerWorkFacade<>(properties, provider, errorCode, errorHint);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -84,11 +84,17 @@ public enum ResultCode {
     TENANT_RESERVED_PROTECTED(40040, "系统保留租户不允许该操作"),
     TENANT_SUSPENDED(40041, "租户已被冻结或已退租，请联系管理员"),
     TENANT_VIEW_FORBIDDEN(40042, "缺少跨租户控制面权限"),
-    AI_CODING_FEATURE_DISABLED(40043, "该 AI 编码能力未开启"),
     SANDBOX_COMMAND_BLOCKED(40044, "命令命中沙箱安全规则，已拒绝执行"),
     SANDBOX_COMMAND_RUNNING(40045, "该会话已有命令正在执行"),
     SANDBOX_RUNTIME_FAILED(40046, "沙箱运行失败，请检查运行时配置"),
     MODEL_ENDPOINT_FORBIDDEN(40047, "模型端点不在允许访问范围内，已被安全策略拦截"),
+    // 原为 40043，与下方 QUOTA_EXCEEDED 撞值：前端 sse.ts 按 40043 判定"额度用尽"，
+    // 于是"AI 编码能力未开启"会被当成额度用尽提示。改号到未占用的 40048，
+    // QUOTA_EXCEEDED 保持 40043 不动（前端已按它取值，改那边才是契约变更）
+    AI_CODING_FEATURE_DISABLED(40048, "该 AI 编码能力未开启"),
+    // 跨库只读门面上的写操作：既不是没权限也不是参数错，单独发码，
+    // 让调用方知道"这条数据的写入方不是后台"而不是去申请权限
+    CUSTOMER_WORK_READONLY(40049, "客服端运行库为只读接入，后台不支持写操作"),
 
     // 主体级速率配额（B7）：额度用尽不是权限问题也不是参数问题，单独发码，
     // 前端据此给"稍后再试"而不是"联系管理员开权限"

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/config/ContentGuardGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/contentguard/config/ContentGuardGatewayProvider.java
@@ -29,6 +29,7 @@ public class ContentGuardGatewayProvider {
         this.facade = CustomerWorkFacade.builder("content-guard-pool", properties, tenantPlugins)
             .mapperClasses(ContentGuardGatewayFactory.MAPPER_CLASSES)
             .mapperXml(ContentGuardGatewayFactory.MAPPER_XML_LOCATIONS)
+            .readOnly(false)
             .error("CONTENTGUARD-DS-UNAVAILABLE", "客服端库不可达（敏感词/限流规则存放于此）")
             .build(ContentGuardGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/dict/config/DictGatewayProvider.java
@@ -28,6 +28,7 @@ public class DictGatewayProvider {
             .mapperClasses(DictGatewayFactory.MAPPER_CLASSES)
             .mapperXml(DictGatewayFactory.MAPPER_XML_LOCATIONS)
             .maxPoolSize(2)
+            .readOnly(false)
             .error("DICT-DS-UNAVAILABLE", "客服端库不可达（字典数据存放于此）")
             .build(DictGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/eval/config/EvalGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/eval/config/EvalGatewayProvider.java
@@ -28,6 +28,7 @@ public class EvalGatewayProvider {
         this.facade = CustomerWorkFacade.builder("eval-run-pool", properties, tenantPlugins)
             .mapperClasses(EvalGatewayFactory.MAPPER_CLASSES)
             .mapperXml(EvalGatewayFactory.MAPPER_XML_LOCATIONS)
+            .readOnly(false)
             .error("EVAL-DS-UNAVAILABLE", "客服端库不可达（评测记录存放于此）")
             .build(EvalGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/improvement/config/ImprovementSignalGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/improvement/config/ImprovementSignalGatewayProvider.java
@@ -25,6 +25,7 @@ public class ImprovementSignalGatewayProvider {
             .mapperClasses(List.of(ImprovementSignalMapper.class))
             .mapperXml(List.of(StarterMapperXml.EVAL_CASE))
             .maxPoolSize(2)
+            .readOnly(false)
             .error("IMPROVEMENT-SIGNAL-DS-UNAVAILABLE", "客服端库不可达（改进信号与评测用例存放于此）")
             .build(gateway -> new ImprovementSignalGateway(
                 gateway.getMapper(ImprovementSignalMapper.class),

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseService.java
@@ -422,13 +422,25 @@ public class ImprovementCaseService {
             row.setEffectStatus(ImprovementEffectStatus.OBSERVING.name());
             row.setStatus(ImprovementCaseStatus.OBSERVING.name());
             row.setNextActionAtMs(now);
-        } else if (publishStatus == RuntimePublishStatus.FAILED
-            || publishStatus == RuntimePublishStatus.SUPERSEDED) {
+        } else if (publishStatus.isAdvancing()) {
+            // Worker 或实例 ACK 会把它继续往前推，排下一次扫描等它走完
+            row.setNextActionAtMs(now + Math.max(1000L, properties.getScanIntervalMs()));
+        } else {
+            // 剩下的只有 BLOCKED（门禁阻断，等重评或紧急豁免）与 FAILED / SUPERSEDED，
+            // 共同点是"不会自己往前走"，所以一律停掉轮询并把失败原因抬到面板上。
+            //
+            // BLOCKED 此前落在"继续轮询"那一支，是本方法真正的缺陷所在：调度器的
+            // findDueCandidates 只认 PENDING 与租约过期的 PROCESSING，永远不会再捞 BLOCKED，
+            // 于是这条 case 每个扫描周期被捞一次、判一次、再排下一次——状态永远停在 PUBLISHING，
+            // 又因为没走失败分支，lastError 恒为空、面板的错误提示条不显示，
+            // 运营只能看到"发布中"挂着不动，直到 SLA 逾期才冒出一个误导性的"责任人拖了"。
+            //
+            // 置为非终态的 PUBLISH_FAILED：重评（retryGateBlocked）或豁免（overrideGateBlocked）
+            // 之后会新建发布任务重新驱动本 case，面板上它也仍是可再次操作的状态。
+            // 门禁失败摘要由 recordGateDecision 写进 last_error，与发布失败共用同一个字段。
             row.setStatus(ImprovementCaseStatus.PUBLISH_FAILED.name());
             row.setNextActionAtMs(NO_ACTION_AT);
             row.setLastError(truncate(task.getLastError()));
-        } else {
-            row.setNextActionAtMs(now + Math.max(1000L, properties.getScanIntervalMs()));
         }
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/config/OpsGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/ops/config/OpsGatewayProvider.java
@@ -26,6 +26,7 @@ public class OpsGatewayProvider {
             .mapperClasses(OpsGatewayFactory.MAPPER_CLASSES)
             .mapperXml(OpsGatewayFactory.MAPPER_XML_LOCATIONS)
             .maxPoolSize(4)
+            .readOnly(false)
             .error("OPS-DS-UNAVAILABLE", "客服端库不可达（运营闭环数据存放于此）")
             .build(OpsGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/subjectquota/config/SubjectQuotaGatewayProvider.java
@@ -25,6 +25,7 @@ public class SubjectQuotaGatewayProvider {
         this.facade = CustomerWorkFacade.builder("subject-quota-pool", properties, tenantPlugins)
             .mapperClasses(SubjectQuotaGatewayFactory.MAPPER_CLASSES)
             .mapperXml(SubjectQuotaGatewayFactory.MAPPER_XML_LOCATIONS)
+            .readOnly(false)
             .error("SQUOTA-DS-UNAVAILABLE", "客服端库不可达（主体配额等级存放于此）")
             .build(SubjectQuotaGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AppAgentCallStatsGatewayProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/config/AppAgentCallStatsGatewayProvider.java
@@ -26,6 +26,7 @@ public class AppAgentCallStatsGatewayProvider {
         this.facade = CustomerWorkFacade.builder("agent-call-stats-app-pool", properties, tenantPlugins)
             .mapperClasses(AgentCallStatsGatewayFactory.MAPPER_CLASSES)
             .mapperXml(AgentCallStatsGatewayFactory.MAPPER_XML_LOCATIONS)
+            .readOnly(true)
             .error("CALLSTATS-APP-DS-UNAVAILABLE", "客服端调用日志库不可达")
             .build(AgentCallStatsGatewayFactory::build);
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/callstats/service/AgentCallStatsService.java
@@ -150,12 +150,21 @@ public class AgentCallStatsService {
         return result;
     }
 
-    /** 删除一条调用（主记录 + 分段级联，复用 starter Store）。 */
+    /**
+     * 删除一条调用（主记录 + 分段级联，复用 starter Store）。
+     *
+     * <p><b>只允许删 ADMIN 本库的记录</b>：APP 源是客服端运行库，写入方是 8080 那条链路，
+     * 后台只查不写。这道判定与 {@code AppAgentCallStatsGatewayProvider} 的只读连接池是
+     * 双保险——只读池会让误写在驱动层报 SQLException，那对使用者是一串看不懂的堆栈；
+     * 这里先 fast-fail，给出"这条数据的写入方不是后台"这个真正有用的信息。</p>
+     */
     public boolean delete(long id, String source) {
-        AgentCallStatsGateway gateway = gatewayOf(source);
-        boolean deleted = gateway.store().delete(id);
-        log.info("agent call stats deleted, source={}, id={}, deleted={}",
-            AgentCallStatsSource.parse(source), id, deleted);
+        AgentCallStatsSource parsed = AgentCallStatsSource.parse(source);
+        if (parsed == AgentCallStatsSource.APP) {
+            throw new BizException(ResultCode.CUSTOMER_WORK_READONLY, "客服端调用日志由客服端链路写入，后台不支持删除");
+        }
+        boolean deleted = gatewayOf(source).store().delete(id);
+        log.info("agent call stats deleted, source={}, id={}, deleted={}", parsed, id, deleted);
         return deleted;
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/RuntimePublishStatusTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/channel/publish/RuntimePublishStatusTest.java
@@ -1,0 +1,81 @@
+package com.richard.fyoung.customeradmin.aiconfig.channel.publish;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * {@link RuntimePublishStatus} 三分判定的门禁。
+ *
+ * <p>{@code isAdvancing()} / {@code needsHumanAction()} / {@code isSettled()} 必须<b>互斥且穷尽</b>：
+ * 每个枚举值恰好命中一个。这条断言的作用是让"新增枚举值忘了归类"当场变红——
+ * 那正是 {@code BLOCKED} 出问题的形状：它落在各消费方 if 链的兜底分支里，
+ * 一个当它"进行中"（无限轮询）、一个当它"失败"，谁都没意识到自己在给一个没想过的值下结论。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class RuntimePublishStatusTest {
+
+    @Test
+    @DisplayName("三分判定互斥且穷尽：每个状态恰好命中一个")
+    void everyStatusFallsInExactlyOneCategory() {
+        List<String> problems = new ArrayList<>();
+        for (RuntimePublishStatus status : RuntimePublishStatus.values()) {
+            int hits = (status.isAdvancing() ? 1 : 0)
+                + (status.needsHumanAction() ? 1 : 0)
+                + (status.isSettled() ? 1 : 0);
+            if (hits != 1) {
+                problems.add(status.name() + " 命中了 " + hits + " 个分类（应恰好 1 个）"
+                    + "：isAdvancing=" + status.isAdvancing()
+                    + ", needsHumanAction=" + status.needsHumanAction()
+                    + ", isSettled=" + status.isSettled());
+            }
+        }
+        if (!problems.isEmpty()) {
+            fail("RuntimePublishStatus 三分判定不互斥或有遗漏：\n  - " + String.join("\n  - ", problems)
+                + "\n新增枚举值时必须同时决定它属于哪一类，不能靠消费方的兜底分支替它决定。");
+        }
+    }
+
+    @Test
+    @DisplayName("BLOCKED 只需人工介入：既不自行推进也不算已定局")
+    void blockedNeedsHumanActionOnly() {
+        // 调度器的 findDueCandidates 只捞 PENDING 与租约过期的 PROCESSING，永远不会再碰 BLOCKED；
+        // 出口只有 retryGateBlocked（重评）与 overrideGateBlocked（紧急豁免），都由人触发。
+        assertTrue(RuntimePublishStatus.BLOCKED.needsHumanAction());
+        assertFalse(RuntimePublishStatus.BLOCKED.isAdvancing(),
+            "把 BLOCKED 当成'还会自己往前走'会让改进闭环无限轮询——这正是本次修复的缺陷");
+        assertFalse(RuntimePublishStatus.BLOCKED.isSettled(),
+            "把 BLOCKED 当成'已定局'会让重评后本可继续的发布被提前关掉");
+    }
+
+    @Test
+    @DisplayName("PARTIAL 会随 ACK 到齐继续推进，不是终态")
+    void partialKeepsAdvancing() {
+        // RuntimePublishTaskService#refreshAckStatus 每收到一条 ACK 重算一次聚合，
+        // PUBLISHED → PARTIAL → APPLIED 由实例 ACK 驱动，无需人介入。
+        assertTrue(RuntimePublishStatus.PARTIAL.isAdvancing());
+        assertFalse(RuntimePublishStatus.PARTIAL.isSettled());
+    }
+
+    @Test
+    @DisplayName("终态集合固定为 APPLIED / SUPERSEDED / FAILED")
+    void settledSetIsPinned() {
+        List<RuntimePublishStatus> settled = List.of(RuntimePublishStatus.values()).stream()
+            .filter(RuntimePublishStatus::isSettled)
+            .toList();
+        assertEquals(
+            List.of(RuntimePublishStatus.APPLIED,
+                RuntimePublishStatus.SUPERSEDED,
+                RuntimePublishStatus.FAILED),
+            settled,
+            "终态集合变化会直接改变改进闭环停不停轮询、模型实验页判不判失败，改动前请确认两个消费方都跟上了");
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/gateway/CustomerWorkFacadeReadOnlyAlignmentTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/gateway/CustomerWorkFacadeReadOnlyAlignmentTest.java
@@ -1,0 +1,132 @@
+package com.richard.fyoung.customeradmin.common.gateway;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>跨库门面写入姿态门禁</b>：每个 {@link CustomerWorkFacade} 都必须显式声明只读与否，
+ * 且"自称只读"与"真的只读"不得分家。
+ *
+ * <p><b>为什么需要这个测试</b>：{@code faa1c7bf}（收敛 starter 散落装配）把 9 个能力域的建池代码
+ * 收进 {@code CustomerWorkFacade} 时，{@code maxPoolSize} 被逐个搬了过来，而当时只有 callstats
+ * 一处用到的 {@code .readOnly(true)} 没有——它的 javadoc 却原样保留了"连接池<b>只读</b>：
+ * 这里只查客服端的调用日志，写入是 8080 那边的事"。于是从那天起：</p>
+ * <ul>
+ *   <li>后台"智能体调用统计"页的删除按钮，能物理删除客服端<b>运行库</b>的 {@code cw_agent_call_log}；</li>
+ *   <li>五处注释仍在描述一个已不存在的保护，{@code ContentGuardGatewayProvider} 甚至在拿自己
+ *       跟"callstats 的只读池"做对比——那个区别当时已经没了。</li>
+ * </ul>
+ *
+ * <p>这类缺陷编译不报错、单测不变红：每一处单独看都自洽，只有把"注释说的"和"代码做的"放在一起
+ * 才看得出来。常规单测做不到这件事，所以本测试<b>直接扫描源码</b>。</p>
+ *
+ * <p><b>为什么要求"显式声明"而不只是"自称只读的必须为 true"</b>：危险的默认值是 {@code false}
+ * ——忘了想这件事的人会得到一个可写的池，而错误的方向恰好是数据被改。强制每个调用点写出
+ * {@code .readOnly(true)} 或 {@code .readOnly(false)}，是把"忘了决策"变成"编译期就得决策"。
+ * 新增第 13 个门面而不声明，这里会红。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class CustomerWorkFacadeReadOnlyAlignmentTest {
+
+    private static final String ADMIN_SOURCE_ROOT = "customer-admin-server/src/main/java";
+
+    /** 门面装配入口；出现它就意味着这个文件建了一个跨库连接池。 */
+    private static final Pattern BUILDER_CALL = Pattern.compile("CustomerWorkFacade\\.builder\\(");
+
+    /** 显式的写入姿态声明。 */
+    private static final Pattern READ_ONLY_DECL = Pattern.compile("\\.readOnly\\((true|false)\\)");
+
+    /**
+     * javadoc 里"这是个只读门面"的几种说法。
+     *
+     * <p>刻意<b>不</b>匹配裸的"只读"二字：{@code EvalGatewayProvider} 写的是"默认只读当前有效租户"
+     * （说的是租户范围不是连接池），{@code ContentGuardGatewayProvider} 写的是"与 callstats 的只读池不同"
+     * （说的是别人）。用整句短语而不是单个词，才不会把这两处误判成只读门面。
+     * 新增别的说法时加进来，加漏了的后果是漏掉一次校验而不是误报。</p>
+     */
+    private static final List<String> READ_ONLY_CLAIMS = List.of(
+        "只读门面", "连接池<b>只读</b>", "只读接入", "只读数据源");
+
+    @Test
+    @DisplayName("每个跨库门面都显式声明 readOnly，且自称只读的必须真的只读")
+    void facadeReadOnlyPostureMustBeExplicitAndTruthful() throws IOException {
+        List<Path> providers = findFacadeProviders();
+        if (providers.isEmpty()) {
+            fail("未扫描到任何 CustomerWorkFacade.builder( 调用点，测试的定位逻辑可能已失效");
+        }
+
+        List<String> problems = new ArrayList<>();
+        for (Path file : providers) {
+            String source = Files.readString(file, StandardCharsets.UTF_8);
+            String name = file.getFileName().toString();
+
+            Matcher declared = READ_ONLY_DECL.matcher(source);
+            if (!declared.find()) {
+                problems.add(name + "：建了跨库连接池却没有显式声明 .readOnly(true/false)。"
+                    + "这个决定不能靠默认值——默认是可写，而忘了想的后果是客服端运行库被误写。");
+                continue;
+            }
+            boolean readOnly = "true".equals(declared.group(1));
+            boolean claimsReadOnly = READ_ONLY_CLAIMS.stream().anyMatch(source::contains);
+
+            if (claimsReadOnly && !readOnly) {
+                problems.add(name + "：javadoc 自称只读门面，代码却是 .readOnly(false)。"
+                    + "注释挡不住任何一次误写——要么把它改成 .readOnly(true)，要么删掉那句不成立的描述。");
+            }
+            if (!claimsReadOnly && readOnly) {
+                problems.add(name + "：代码是 .readOnly(true) 但 javadoc 没说明它是只读门面。"
+                    + "下一个人会以为这里能写，请在类注释里写清楚（用词见 READ_ONLY_CLAIMS）。");
+            }
+        }
+
+        if (!problems.isEmpty()) {
+            fail("跨库门面写入姿态不一致，共 " + problems.size() + " 处：\n  - "
+                + String.join("\n  - ", problems));
+        }
+    }
+
+    /** 扫出所有调用 {@code CustomerWorkFacade.builder(} 的 admin 源文件（门面自身除外）。 */
+    private static List<Path> findFacadeProviders() throws IOException {
+        Path root = resolveModulePath(ADMIN_SOURCE_ROOT);
+        if (!Files.exists(root)) {
+            fail("找不到 admin 源码目录：" + root.toAbsolutePath());
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths
+                .filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().endsWith(".java"))
+                .filter(p -> !p.getFileName().toString().equals("CustomerWorkFacade.java"))
+                .filter(CustomerWorkFacadeReadOnlyAlignmentTest::callsFacadeBuilder)
+                .sorted()
+                .toList();
+        }
+    }
+
+    private static boolean callsFacadeBuilder(Path file) {
+        try {
+            return BUILDER_CALL.matcher(Files.readString(file, StandardCharsets.UTF_8)).find();
+        } catch (IOException e) {
+            throw new IllegalStateException("读取源文件失败：" + file, e);
+        }
+    }
+
+    /** 兼容两种工作目录：仓库根（多模块构建）与模块目录（IDE 单模块跑测试）。 */
+    private static Path resolveModulePath(String moduleRelative) {
+        Path fromRepoRoot = Paths.get(moduleRelative);
+        return Files.exists(fromRepoRoot) ? fromRepoRoot : Paths.get("..").resolve(moduleRelative);
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/result/ResultCodeUniquenessTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/result/ResultCodeUniquenessTest.java
@@ -1,0 +1,63 @@
+package com.richard.fyoung.customeradmin.common.result;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>错误码门禁</b>：{@link ResultCode} 的数值不得重复。
+ *
+ * <p><b>为什么需要这个测试</b>：{@code AI_CODING_FEATURE_DISABLED} 与 {@code QUOTA_EXCEEDED}
+ * 曾同时占用 {@code 40043}。后者的注释写着"额度用尽不是权限问题也不是参数问题，<b>单独发码</b>，
+ * 前端据此给'稍后再试'而不是'联系管理员开权限'"——而前端 {@code sse.ts} 正是按
+ * {@code code === 40043} 判定额度用尽的。撞值让"单独发码"这件事当场失效：
+ * 后端返回"该 AI 编码能力未开启"时，前端会把它当成额度用尽来提示。</p>
+ *
+ * <p>枚举撞值编译不报错（两个常量各自合法）、单测也照不出来（没人会去比两个不相干的码），
+ * 只有把全部码值放在一起数一遍才看得见。错误码是<b>对前端的契约</b>，
+ * 一个码值对应一种处理分支，重复即歧义。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class ResultCodeUniquenessTest {
+
+    @Test
+    @DisplayName("错误码数值唯一：同一个码不得对应两种语义")
+    void codesMustBeUnique() {
+        Map<Integer, List<String>> byCode = new LinkedHashMap<>();
+        for (ResultCode rc : ResultCode.values()) {
+            byCode.computeIfAbsent(rc.getCode(), k -> new ArrayList<>()).add(rc.name());
+        }
+
+        List<String> collisions = byCode.entrySet().stream()
+            .filter(e -> e.getValue().size() > 1)
+            .map(e -> e.getKey() + " 被 " + String.join(" / ", e.getValue()) + " 同时占用")
+            .toList();
+
+        if (!collisions.isEmpty()) {
+            fail("ResultCode 存在撞值，共 " + collisions.size() + " 处：\n  - "
+                + String.join("\n  - ", collisions)
+                + "\n错误码是对前端的契约，一个码值只能有一种语义。"
+                + "\n改号时优先动前端<b>没有</b>按值取用的那一个——被前端硬编码的码值一旦变更就是契约变更。");
+        }
+    }
+
+    @Test
+    @DisplayName("额度用尽保持 40043：前端 sse.ts 按该值判定，改动即契约变更")
+    void quotaExceededCodeIsPinnedForFrontend() {
+        // customer-admin-web/src/utils/sse.ts:
+        //   static readonly QUOTA_EXCEEDED = 40043
+        //   isQuotaExceeded() { return this.code === SseHttpError.QUOTA_EXCEEDED }
+        // 前端据此把"额度用尽"渲染成一条普通消息而不是报错弹窗。要改这个值必须同步改前端，
+        // 因此把它钉在这里：单纯为了腾号而改它会直接红。
+        assertEquals(40043, ResultCode.QUOTA_EXCEEDED.getCode(),
+            "QUOTA_EXCEEDED 的码值被前端 sse.ts 硬编码，不能为了给别的码腾位置而改动");
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseServiceTest.java
@@ -167,6 +167,88 @@ class ImprovementCaseServiceTest {
         assertEquals(25L, row.getObservedCalls());
     }
 
+    /**
+     * 门禁阻断必须停掉轮询并把原因抬上来。
+     *
+     * <p>此前 BLOCKED 落在 refreshPublish 的兜底 else 分支里被当成"进行中"，而调度器的
+     * findDueCandidates 只认 PENDING 与租约过期的 PROCESSING、永远不会再捞 BLOCKED——
+     * 于是这条 case 每个扫描周期被捞一次、判一次、再排下一次，状态永远停在 PUBLISHING，
+     * lastError 恒为空所以面板的错误提示条也不显示。</p>
+     */
+    @Test
+    void refreshPublish_shouldStopPollingAndSurfaceReasonWhenGateBlocked() throws Exception {
+        AgentImprovementCase row = publishingRow("task-blocked");
+        RuntimePublishTask task = publishTask("task-blocked", RuntimePublishStatus.BLOCKED);
+        task.setLastError("回归指标未达标：intent 通过率 0.62 低于阈值 0.80");
+        when(publishTaskMapper.selectById("task-blocked")).thenReturn(task);
+        claim(row, "worker-blocked");
+
+        service.processAutomation(row);
+
+        assertEquals(ImprovementCaseStatus.PUBLISH_FAILED.name(), row.getStatus(),
+            "BLOCKED 不会自行推进，必须离开 PUBLISHING，否则面板上永远是不动的「发布中」");
+        assertEquals(Long.MAX_VALUE, row.getNextActionAtMs(),
+            "BLOCKED 必须停掉轮询：调度器不会再捞它，继续排下一次就是无限循环");
+        assertEquals("回归指标未达标：intent 通过率 0.62 低于阈值 0.80", row.getLastError(),
+            "门禁失败摘要要抬到面板上，运营才知道是被门禁拦住而不是责任人拖了");
+    }
+
+    @Test
+    void refreshPublish_shouldKeepPollingWhileStillAdvancing() throws Exception {
+        for (RuntimePublishStatus advancing : List.of(
+            RuntimePublishStatus.PENDING, RuntimePublishStatus.PROCESSING,
+            RuntimePublishStatus.PUBLISHED, RuntimePublishStatus.PARTIAL)) {
+
+            String taskId = "task-" + advancing.name();
+            AgentImprovementCase row = publishingRow(taskId);
+            when(publishTaskMapper.selectById(taskId)).thenReturn(publishTask(taskId, advancing));
+            claim(row, "worker-" + advancing.name());
+
+            service.processAutomation(row);
+
+            assertEquals(ImprovementCaseStatus.PUBLISHING.name(), row.getStatus(),
+                advancing + " 仍会自行推进，不该提前离开 PUBLISHING");
+            assertTrue(row.getNextActionAtMs() < Long.MAX_VALUE,
+                advancing + " 仍会自行推进，必须排下一次扫描");
+        }
+    }
+
+    @Test
+    void refreshPublish_shouldStopPollingWhenPublishSettledAsFailure() throws Exception {
+        for (RuntimePublishStatus settled : List.of(
+            RuntimePublishStatus.FAILED, RuntimePublishStatus.SUPERSEDED)) {
+
+            String taskId = "task-" + settled.name();
+            AgentImprovementCase row = publishingRow(taskId);
+            RuntimePublishTask task = publishTask(taskId, settled);
+            task.setLastError("实例拒绝：schema 校验失败");
+            when(publishTaskMapper.selectById(taskId)).thenReturn(task);
+            claim(row, "worker-" + settled.name());
+
+            service.processAutomation(row);
+
+            assertEquals(ImprovementCaseStatus.PUBLISH_FAILED.name(), row.getStatus(), settled.name());
+            assertEquals(Long.MAX_VALUE, row.getNextActionAtMs(), settled.name());
+            assertEquals("实例拒绝：schema 校验失败", row.getLastError(), settled.name());
+        }
+    }
+
+    /** 处于 PUBLISHING、已关联发布任务的 case（refreshPublish 的入口条件）。 */
+    private AgentImprovementCase publishingRow(String taskId) throws Exception {
+        AgentImprovementCase row = row(ImprovementCaseStatus.PUBLISHING, candidate("model-v1"));
+        row.setPublishTaskId(taskId);
+        when(caseMapper.lockById(1L)).thenReturn(row);
+        return row;
+    }
+
+    private RuntimePublishTask publishTask(String id, RuntimePublishStatus status) {
+        RuntimePublishTask task = new RuntimePublishTask();
+        task.setId(id);
+        task.setStatus(status.name());
+        task.setRevision("revision-42");
+        return task;
+    }
+
     @Test
     void observe_shouldMarkRecurrenceIneffectiveAndLowTrafficInconclusive() throws Exception {
         AgentImprovementCase recurrence = observingRow();

--- a/customer-admin-web/src/components/ImprovementClosurePanel.vue
+++ b/customer-admin-web/src/components/ImprovementClosurePanel.vue
@@ -53,6 +53,25 @@ const STATUS_LABELS: Record<ImprovementCaseStatus, string> = {
   CANCELLED: '已取消',
 }
 
+// 发布任务状态（RuntimePublishStatus）的中文标签。此前"发布状态"那一格直接渲染后端枚举名，
+// 门禁阻断时运营看到的是一个没有翻译的裸 BLOCKED，而那恰恰是最需要看懂的时刻。
+// 用词与渠道绑定抽屉（ChannelBindingDrawer.vue）保持一致。
+const PUBLISH_STATUS_LABELS: Record<string, string> = {
+  PENDING: '待调度',
+  PROCESSING: '处理中',
+  BLOCKED: '门禁阻断',
+  PUBLISHED: '已投递',
+  PARTIAL: '部分生效',
+  APPLIED: '已生效',
+  SUPERSEDED: '已被新版本取代',
+  FAILED: '发布失败',
+}
+const publishStatusLabel = computed(() => {
+  const raw = improvement.value?.publishStatus
+  if (!raw) return '-'
+  return PUBLISH_STATUS_LABELS[raw] ?? raw
+})
+
 const statusType = computed(() => {
   const status = improvement.value?.status
   if (status === 'VERIFIED') return 'success'
@@ -210,7 +229,7 @@ onMounted(load)
           {{ improvement.reevaluationStatus }} / {{ improvement.reevaluationVerdict || '-' }}
         </el-descriptions-item>
         <el-descriptions-item label="发布任务">{{ improvement.publishTaskId || '-' }}</el-descriptions-item>
-        <el-descriptions-item label="发布状态">{{ improvement.publishStatus || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="发布状态">{{ publishStatusLabel }}</el-descriptions-item>
         <el-descriptions-item label="发布 revision">{{ improvement.publishRevision || '-' }}</el-descriptions-item>
         <el-descriptions-item label="观察窗口">
           {{ formatTime(improvement.observationStartedAtMs) }} → {{ formatTime(improvement.observationEndsAtMs) }}

--- a/customer-admin-web/src/views/system/AgentCallStats.vue
+++ b/customer-admin-web/src/views/system/AgentCallStats.vue
@@ -571,7 +571,9 @@ onMounted(() => {
             <el-button link type="primary" @click="openDetail(row)">耗时详情</el-button>
             <el-button link type="primary" @click="openReplayManifest(row)">重放清单</el-button>
             <el-button v-if="filters.source === 'ADMIN'" link type="primary" @click="openInWorkspace(row)">打开会话</el-button>
-            <el-button link type="danger" @click="handleDelete(row)">删除</el-button>
+            <!-- 删除仅 ADMIN 行可用：APP 是客服端运行库，写入方是 8080 那条链路，后台只查不写。
+                 后端 AgentCallStatsService#delete 与只读连接池各有一道防线，这里只是不给出无效按钮 -->
+            <el-button v-if="!sourceIsApp" link type="danger" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>


### PR DESCRIPTION
代码组织审计中查出的三个**真实缺陷**（不是重构建议），均已用门禁测试钉死，且每个门禁都做过负向验证。

## 1. 跨库只读连接池失守 — 后台能删客服端运行库的数据

`faa1c7bf`（收敛 starter 散落装配）把 9 个能力域收进 `CustomerWorkFacade` 时，`maxPoolSize` 被逐个搬了过来，而当时只有 callstats 一处用到的 `.readOnly(true)` 没有 —— Builder 里根本没有这个 setter，starter 侧 `CrossDbGateways:169` 的 `config.setReadOnly(...)` 永远收到 `false`。

后果：后台「智能体调用统计」页的删除按钮能物理删除客服端**运行库**的 `cw_agent_call_log`。五处 javadoc 仍称该池只读，`ContentGuardGatewayProvider:19` 甚至在拿自己跟"callstats 的只读池"做对比 —— 那个区别当时已经没了。

时间线：删除功能 2026-07-24 引入时池子还是只读的（点 APP 行会报错），2026-08-20 的重构把它从"报错"变成了"静默删除生产数据"。没有人是在已失守的池子上有意建功能。

- `CustomerWorkFacade.Builder` 补回 `readOnly` 通路
- callstats APP 与 business-outcome 两个只读门面传 `true`
- **其余 10 个门面显式传 `false`**：危险的默认值恰恰是 `false`，强制每个调用点写出写入姿态，把"忘了决策"变成"必须决策"
- `AgentCallStatsService#delete` 对 APP 源 fast-fail（新错误码 `CUSTOMER_WORK_READONLY`），给业务语义而不是驱动层 SQLException；前端删除按钮对 APP 源隐藏，与已有的「打开会话」同款处理

## 2. `RuntimePublishStatus.BLOCKED` 导致改进闭环无限轮询

该枚举零方法，"还会不会自行推进"被三个消费方各判一遍且在 `BLOCKED` 上正面冲突：

| 消费方 | 对 BLOCKED 的判定 |
|---|---|
| `RuntimePublishTaskMapper.findDueCandidates` | 只捞 PENDING/PROCESSING，**永不再碰** |
| `ModelExperimentEffectiveStateResolver` | 归为 FAILED |
| `ImprovementCaseService#refreshPublish` | 兜底 else 当成"进行中"，继续排下一次 |

后果：门禁一旦阻断发布，该 case 每个扫描周期被捞一次、判一次、再排一次，状态永远停在 `PUBLISHING`；因未走失败分支 `lastError` 恒为空、面板错误提示条不显示，运营只看到不动的「发布中」，直到 SLA 逾期冒出一个误导性的"责任人拖了"。同一行数据在模型实验页却显示「失败」。

- 枚举补 `isAdvancing()` / `needsHumanAction()` / `isSettled()`，判定收敛一处（同 `TicketStatus#isEnded()` 已立的约定）
- `refreshPublish` 改为穷尽三分支，BLOCKED 停轮询并抬出门禁失败摘要（`recordGateDecision` 本就写进了 `last_error`）
- `ModelExperimentEffectiveStateResolver` 改用**穷尽 switch**。注意它问的是"能否宣布整体生效"，与 `isAdvancing()` 问的"还会不会自行推进"是**两个问题**（`PARTIAL` 在前者为否、后者为是），刻意不复用那组判定；改成穷尽 switch 后新增枚举值会编译不过，不再被兜底静默吞成 FAILED
- 面板「发布状态」补中文标签，不再渲染裸 `BLOCKED`

## 3. `ResultCode` 撞值：两个常量同为 40043

`AI_CODING_FEATURE_DISABLED` 与 `QUOTA_EXCEEDED` 都是 40043。后者的注释写着"额度用尽…**单独发码**，前端据此给'稍后再试'而不是'联系管理员开权限'"，而前端 `sse.ts:40` 正是按 `code === 40043` 判定额度用尽 —— "AI 编码能力未开启"会被当成额度用尽处理，"单独发码"当场失效。

前者改号至 40048（前端未按值取用），`QUOTA_EXCEEDED` 保持 40043 不动。

## 门禁测试

每个都做了负向验证，确认能抓到对应回归：

| 门禁 | 负向验证结果 |
|---|---|
| `CustomerWorkFacadeReadOnlyAlignmentTest` | 删掉 `.readOnly(true)` → 红 |
| `RuntimePublishStatusTest` | 加未归类枚举值 → **编译期**即报错 |
| `ResultCodeUniquenessTest` | 改回 40043 → 红，且指名两个撞值常量 |
| `ImprovementCaseServiceTest` | 退回"当作进行中" → 红。补了 BLOCKED/PARTIAL/PUBLISHED 等 3 条（此前仅覆盖 APPLIED 一条分支） |

## 验证

- admin 全量：**1387 通过 / 0 失败 / 0 错误 / 1 跳过，BUILD SUCCESS**
- 前端：`vue-tsc -b && vite build` 通过

## 需要注意

`AI_CODING_FEATURE_DISABLED` 的码值变更（40043 → 40048）是对外契约变更。已确认前端没有按该值分支，但如果有外部调用方按码值判断，需要同步。