### PR TITLE
refactor: 把抄了 N 遍的共用逻辑收成一处

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentService.java
@@ -203,7 +203,7 @@ public class AgentService {
 
     /**
      * 保存门禁：同步实测主模型连通性，非成功即抛业务异常阻止保存。防御只做这一处（后端保存链路），
-     * 运行时不再重复校验（运行时靠 FailoverModel 主备容错兜底）。
+     * 运行时不再重复校验（运行时靠 AdminFailoverModel 主备容错兜底）。
      */
     private void assertPrimaryModelConnectivity(Long modelId) {
         try {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/experiment/service/ModelExperimentArmEvaluationService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/experiment/service/ModelExperimentArmEvaluationService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.aiconfig.experiment.service;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,7 +36,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 在线实验启动前的两臂离线质量评测。
@@ -194,13 +194,7 @@ public class ModelExperimentArmEvaluationService {
         if (CollectionUtils.isEmpty(responses)) {
             throw new IllegalStateException("model returned empty response");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new IllegalStateException("model returned empty text");
         }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminFailoverModel.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminFailoverModel.java
@@ -1,23 +1,24 @@
 package com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover;
 
+import com.richard.fyoung.customerwork.core.model.failover.FailoverModel;
 import java.util.List;
 
 /**
  * 主备容错模型（admin 薄壳）：降级/熔断语义已下沉到
- * {@link com.richard.fyoung.customerwork.core.model.failover.FailoverModel}，本类只保留 admin 侧的构造入口
+ * {@link FailoverModel}，本类只保留 admin 侧的构造入口
  * （候选类型 {@code Candidate} 直接继承自父类，调用方 {@code AdminAgentInstanceFactory} 无需改动）。
  *
  * <p>动态智能体运行时沿用父类默认的"流中途失败也切下一候选"语义：智能体调用多为工具编排与整段结果，
  * 宁可重发也要拿到完整回答。</p>
  * @author owlzhangfq@gmail.com
  */
-public class FailoverModel extends com.richard.fyoung.customerwork.core.model.failover.FailoverModel {
+public class AdminFailoverModel extends FailoverModel {
 
     /**
      * @param candidates 有序候选（主在前备在后），至少一个
      * @param registry   熔断状态登记表
      */
-    public FailoverModel(List<Candidate> candidates, ModelCircuitBreakerRegistry registry) {
+    public AdminFailoverModel(List<Candidate> candidates, AdminModelCircuitBreakerRegistry registry) {
         super(candidates, registry);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminModelCircuitBreakerRegistry.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminModelCircuitBreakerRegistry.java
@@ -1,11 +1,12 @@
 package com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover;
 
+import com.richard.fyoung.customerwork.core.model.failover.ModelCircuitBreakerRegistry;
 import com.richard.fyoung.customeradmin.config.AdminModelFailoverProperties;
 import org.springframework.stereotype.Component;
 
 /**
  * 模型熔断状态登记表（admin 薄壳）：熔断语义已下沉到
- * {@link com.richard.fyoung.customerwork.core.model.failover.ModelCircuitBreakerRegistry}，
+ * {@link ModelCircuitBreakerRegistry}，
  * 本类只负责把 admin 的配置属性 {@code admin.model.failover.*} 绑到父类构造参数，并作为 Spring Bean 暴露。
  *
  * <p>阈值/时长在 Bean 构造时取定：{@link AdminModelFailoverProperties} 是普通
@@ -13,10 +14,10 @@ import org.springframework.stereotype.Component;
  * @author owlzhangfq@gmail.com
  */
 @Component
-public class ModelCircuitBreakerRegistry
-        extends com.richard.fyoung.customerwork.core.model.failover.ModelCircuitBreakerRegistry {
+public class AdminModelCircuitBreakerRegistry
+        extends ModelCircuitBreakerRegistry {
 
-    public ModelCircuitBreakerRegistry(AdminModelFailoverProperties properties) {
+    public AdminModelCircuitBreakerRegistry(AdminModelFailoverProperties properties) {
         super(properties.getFailureThreshold(), properties.getOpenDurationSeconds());
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminModelFailoverProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminModelFailoverProperties.java
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 /**
- * 智能体模型主备容错熔断参数（见 {@code ModelCircuitBreakerRegistry} / {@code FailoverModel}）。
+ * 智能体模型主备容错熔断参数（见 {@code AdminModelCircuitBreakerRegistry} / {@code AdminFailoverModel}）。
  * 主模型连续失败达 {@link #failureThreshold} 次即熔断 {@link #openDurationSeconds} 秒，
  * 期间请求直接走备模型；熔断到期自动半开（重置计数、允许再次尝试主模型）。
  * @author owlzhangfq@gmail.com

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.knowledge.service;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
@@ -366,13 +367,7 @@ public class KnowledgeService {
         if (CollectionUtils.isEmpty(responses)) {
             throw new BizException(ResultCode.GIT_ASSISTANT_AI_FAILED, "模型未返回任何内容");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new BizException(ResultCode.GIT_ASSISTANT_AI_FAILED, "模型返回内容为空");
         }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -27,8 +27,8 @@ import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
 import com.richard.fyoung.customeradmin.aiconfig.model.service.ModelConfigAccess;
 import com.richard.fyoung.customeradmin.aiconfig.model.service.ModelRoutingPolicyRuntimeAccess;
 import com.richard.fyoung.customeradmin.aiconfig.model.runtime.AdminModelFactory;
-import com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover.FailoverModel;
-import com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover.ModelCircuitBreakerRegistry;
+import com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover.AdminFailoverModel;
+import com.richard.fyoung.customeradmin.aiconfig.model.runtime.failover.AdminModelCircuitBreakerRegistry;
 import com.richard.fyoung.customeradmin.aiconfig.secret.service.SecretRefService;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkill;
 import com.richard.fyoung.customeradmin.aiconfig.skill.entity.AiSkillVersion;
@@ -186,7 +186,7 @@ public class AdminAgentInstanceFactory {
     private final AdminSandboxProperties sandboxProperties;
     private final SandboxGuardMiddleware sandboxGuardMiddleware;
     private final ExecutionModeMiddleware executionModeMiddleware;
-    private final ModelCircuitBreakerRegistry circuitBreakerRegistry;
+    private final AdminModelCircuitBreakerRegistry circuitBreakerRegistry;
     private final AgentMemorySyncService memorySyncService;
     /** 分段耗时采集中间件（starter 提供，admin 显式装配），挂在内层 ReActAgent 上采集每次调用的分段耗时。 */
     private final AgentCallTimingMiddleware agentCallTimingMiddleware;
@@ -239,7 +239,7 @@ public class AdminAgentInstanceFactory {
                                       AdminMcpFactory mcpFactory, AdminSandboxProperties sandboxProperties,
                                       SandboxGuardMiddleware sandboxGuardMiddleware,
                                       ExecutionModeMiddleware executionModeMiddleware,
-                                      ModelCircuitBreakerRegistry circuitBreakerRegistry,
+                                      AdminModelCircuitBreakerRegistry circuitBreakerRegistry,
                                       AgentMemorySyncService memorySyncService,
                                       AgentCallTimingMiddleware agentCallTimingMiddleware,
                                       ToolKindRegistry agentCallToolKindRegistry,
@@ -530,7 +530,7 @@ public class AdminAgentInstanceFactory {
 
     /**
      * 在内层 ReActAgent 上叠加 Harness 能力：vibecoding 沙箱 / plan 计划模式 / skill-learning 技能自进化 /
-     * 上下文压缩 / 子智能体编排。非 vibecoding 时不挂 filesystem 沙箱（SandboxSafeAgentStateStore 也只是
+     * 上下文压缩 / 子智能体编排。非 vibecoding 时不挂 filesystem 沙箱（AdminSandboxSafeAgentStateStore 也只是
      * docker filesystem 的 sessionId 转义问题，同样不需要），workspace 仍复用 {@link #resolveWorkspace}。
      */
     private HarnessAgent buildHarnessAgent(AiAgent agent, List<String> capabilities, ReActAgent inner,
@@ -540,10 +540,10 @@ public class AdminAgentInstanceFactory {
 
         // Docker 模式下 HarnessAgent 内部的 SessionSandboxStateStore 会给沙箱状态槽位拼出带 "/"
         // 的 sessionId（IsolationScope 四种取值全部如此，框架侧硬编码），而 MysqlAgentStateStore
-        // 拒绝接受含路径分隔符的 sessionId，两者组合必然抛异常——用 SandboxSafeAgentStateStore
+        // 拒绝接受含路径分隔符的 sessionId，两者组合必然抛异常——用 AdminSandboxSafeAgentStateStore
         // 包一层转义规避，local 模式与未挂 filesystem 沙箱的升级路径不受影响（见该类 Javadoc）。
         AgentStateStore harnessStateStore = vibecoding && sandboxProperties.isDockerMode()
-            ? new SandboxSafeAgentStateStore(stateStore) : stateStore;
+            ? new AdminSandboxSafeAgentStateStore(stateStore) : stateStore;
         Path workspace = resolveWorkspace(memoryScope);
         HarnessAgent.Builder harnessBuilder = HarnessAgent.Builder.fromAgent(inner)
             .stateStore(harnessStateStore)
@@ -890,8 +890,8 @@ public class AdminAgentInstanceFactory {
 
     /**
      * 按智能体主备模型配置构建运行时 {@link Model}：无备用模型时行为与旧逻辑完全一致（直接返回单个主模型，
-     * 不包 {@link FailoverModel}）；有备用模型时按 {@code sort_order} 组装有序候选（主在前备在后）包成
-     * {@link FailoverModel}，运行时主模型失败自动按序切备并带熔断记忆。
+     * 不包 {@link AdminFailoverModel}）；有备用模型时按 {@code sort_order} 组装有序候选（主在前备在后）包成
+     * {@link AdminFailoverModel}，运行时主模型失败自动按序切备并带熔断记忆。
      */
     private Model buildAgentModel(AiAgent agent) {
         if (agent.getModelRoutePolicyId() != null) {
@@ -906,13 +906,13 @@ public class AdminAgentInstanceFactory {
         if (CollectionUtils.isEmpty(backupModelIds)) {
             return primaryModel;
         }
-        List<FailoverModel.Candidate> candidates = new ArrayList<>();
-        candidates.add(new FailoverModel.Candidate(agent.getModelId(), primaryModel));
+        List<AdminFailoverModel.Candidate> candidates = new ArrayList<>();
+        candidates.add(new AdminFailoverModel.Candidate(agent.getModelId(), primaryModel));
         for (Long backupModelId : backupModelIds) {
-            candidates.add(new FailoverModel.Candidate(backupModelId, buildModel(backupModelId)));
+            candidates.add(new AdminFailoverModel.Candidate(backupModelId, buildModel(backupModelId)));
         }
         log.info("[workspace] failover model built: agentCode={} candidates={}", agent.getAgentCode(), candidates.size());
-        return new FailoverModel(candidates, circuitBreakerRegistry);
+        return new AdminFailoverModel(candidates, circuitBreakerRegistry);
     }
 
     private Model buildPolicyModel(AiAgent agent) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminSandboxSafeAgentStateStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminSandboxSafeAgentStateStore.java
@@ -1,10 +1,11 @@
 package com.richard.fyoung.customeradmin.workspace.runtime;
 
+import com.richard.fyoung.customerwork.core.runtime.SandboxSafeAgentStateStore;
 import io.agentscope.core.state.AgentStateStore;
 
 /**
  * {@link AgentStateStore} 装饰器的 admin 侧薄壳，实现在 starter 的
- * {@link com.richard.fyoung.customerwork.core.runtime.SandboxSafeAgentStateStore}（两侧唯一实现）。
+ * {@link SandboxSafeAgentStateStore}（两侧唯一实现）。
  *
  * <p>装饰目的：规避 {@code agentscope-harness}（2.0.0 GA）与 {@code agentscope-extensions-mysql}
  * （2.0.0 GA）组合使用时的官方框架 bug——{@code HarnessAgent} 的 {@code SessionSandboxStateStore}
@@ -20,9 +21,9 @@ import io.agentscope.core.state.AgentStateStore;
  * {@link AdminAgentInstanceFactory#build}），local 模式不受影响。</p>
  * @author owlzhangfq@gmail.com
  */
-public class SandboxSafeAgentStateStore extends com.richard.fyoung.customerwork.core.runtime.SandboxSafeAgentStateStore {
+public class AdminSandboxSafeAgentStateStore extends SandboxSafeAgentStateStore {
 
-    public SandboxSafeAgentStateStore(AgentStateStore delegate) {
+    public AdminSandboxSafeAgentStateStore(AgentStateStore delegate) {
         super(delegate);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -276,13 +277,7 @@ public class CollaborativeCodingService {
         if (CollectionUtils.isEmpty(responses)) {
             throw new BizException(ResultCode.COLLAB_ROLE_FAILED, "模型未返回任何内容");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new BizException(ResultCode.COLLAB_ROLE_FAILED, "模型返回内容为空");
         }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -341,7 +342,7 @@ public class GitAssistantService {
      */
     private ReviewResult parseReviewResult(String modelText, boolean diffTruncated) {
         String truncateNote = diffTruncated ? "[注意] diff 过大已截断，仅审查前 " + MAX_DIFF_CHARS_FOR_REVIEW + " 字符。" : "";
-        String json = extractJsonObject(modelText);
+        String json = ModelResponses.extractJsonObject(modelText);
         if (json != null) {
             try {
                 ReviewResult parsed = objectMapper.readValue(json, ReviewResult.class);
@@ -387,14 +388,6 @@ public class GitAssistantService {
     }
 
     /** 截取文本中第一个 {@code '{'} 到最后一个 {@code '}'} 之间的子串（容忍模型在 JSON 前后夹带说明/代码块标记）。 */
-    private String extractJsonObject(String text) {
-        if (!StringUtils.hasText(text)) {
-            return null;
-        }
-        int start = text.indexOf('{');
-        int end = text.lastIndexOf('}');
-        return (start >= 0 && end > start) ? text.substring(start, end + 1) : null;
-    }
 
     private String requireNonEmptyDiff(Path workspace) {
         String diff = gitWorkspaceService.diffAgainstBaseline(workspace);
@@ -429,13 +422,7 @@ public class GitAssistantService {
         if (responses == null || responses.isEmpty()) {
             throw new BizException(ResultCode.GIT_ASSISTANT_AI_FAILED, "模型未返回任何内容");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new BizException(ResultCode.GIT_ASSISTANT_AI_FAILED, "模型返回内容为空");
         }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminFailoverModelTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminFailoverModelTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  * 且沿用父类默认的"流中途失败也切下一候选"语义。降级/熔断的完整语义由 starter 的同名测试覆盖。
  * @author owlzhangfq@gmail.com
  */
-class FailoverModelTest {
+class AdminFailoverModelTest {
 
     /** 可选"先吐一个分片再失败"的桩模型。 */
     private static final class StubModel implements Model {
@@ -46,17 +46,17 @@ class FailoverModelTest {
         }
     }
 
-    private ModelCircuitBreakerRegistry newRegistry() {
+    private AdminModelCircuitBreakerRegistry newRegistry() {
         AdminModelFailoverProperties props = new AdminModelFailoverProperties();
         props.setFailureThreshold(3);
         props.setOpenDurationSeconds(60);
-        return new ModelCircuitBreakerRegistry(props);
+        return new AdminModelCircuitBreakerRegistry(props);
     }
 
     @Test
     void shouldExtendSharedFailoverModel() {
-        FailoverModel model = new FailoverModel(
-            List.of(new FailoverModel.Candidate(1L, new StubModel("p", false))), newRegistry());
+        AdminFailoverModel model = new AdminFailoverModel(
+            List.of(new AdminFailoverModel.Candidate(1L, new StubModel("p", false))), newRegistry());
 
         assertInstanceOf(com.richard.fyoung.customerwork.core.model.failover.FailoverModel.class, model);
         assertEquals("p", model.getModelName());
@@ -66,8 +66,8 @@ class FailoverModelTest {
     void shouldKeepMidStreamFailover_forDynamicAgentRuntime() {
         StubModel primary = new StubModel("p", true);
         StubModel backup = new StubModel("b", false);
-        FailoverModel model = new FailoverModel(
-            List.of(new FailoverModel.Candidate(1L, primary), new FailoverModel.Candidate(2L, backup)),
+        AdminFailoverModel model = new AdminFailoverModel(
+            List.of(new AdminFailoverModel.Candidate(1L, primary), new AdminFailoverModel.Candidate(2L, backup)),
             newRegistry());
 
         List<ChatResponse> out = model.stream(List.<Msg>of(), null, null).collectList().block();

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminModelCircuitBreakerRegistryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/failover/AdminModelCircuitBreakerRegistryTest.java
@@ -12,15 +12,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 熔断本身的语义（阈值/半开/重置）由 starter 的同名测试覆盖，这里不重复。
  * @author owlzhangfq@gmail.com
  */
-class ModelCircuitBreakerRegistryTest {
+class AdminModelCircuitBreakerRegistryTest {
 
     private static final Long MODEL_ID = 1L;
 
-    private ModelCircuitBreakerRegistry newRegistry(int threshold, int openSeconds) {
+    private AdminModelCircuitBreakerRegistry newRegistry(int threshold, int openSeconds) {
         AdminModelFailoverProperties props = new AdminModelFailoverProperties();
         props.setFailureThreshold(threshold);
         props.setOpenDurationSeconds(openSeconds);
-        return new ModelCircuitBreakerRegistry(props);
+        return new AdminModelCircuitBreakerRegistry(props);
     }
 
     @Test
@@ -31,7 +31,7 @@ class ModelCircuitBreakerRegistryTest {
 
     @Test
     void shouldApplyFailureThresholdFromProperties() {
-        ModelCircuitBreakerRegistry registry = newRegistry(2, 60);
+        AdminModelCircuitBreakerRegistry registry = newRegistry(2, 60);
 
         registry.recordFailure(MODEL_ID);
         assertFalse(registry.isOpen(MODEL_ID)); // 1 次未达配置阈值 2
@@ -43,7 +43,7 @@ class ModelCircuitBreakerRegistryTest {
     @Test
     void shouldApplyOpenDurationFromProperties() {
         // openDurationSeconds=0：熔断窗口即刻到期，isOpen 走半开分支放行
-        ModelCircuitBreakerRegistry registry = newRegistry(1, 0);
+        AdminModelCircuitBreakerRegistry registry = newRegistry(1, 0);
 
         registry.recordFailure(MODEL_ID);
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/entity/AuditFieldFillAlignmentTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/entity/AuditFieldFillAlignmentTest.java
@@ -1,0 +1,126 @@
+package com.richard.fyoung.customeradmin.common.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>审计字段填充策略门禁</b>：{@code createBy} / {@code createTime} 只能 {@code INSERT}，
+ * {@code updateBy} / {@code updateTime} 只能 {@code INSERT_UPDATE}。
+ *
+ * <p><b>为什么只管策略、不抽基类</b>：审计字段确实在几十个实体里各写一遍，但那属于"长得像"
+ * 而不是"同一个真相"——加一个新实体不需要改动其余 41 个，不满足项目判定重复的标准
+ * （改一处必须同步改 N 处、且漏改不报错）。更要紧的是这些实体的审计形状<b>本就不同</b>：
+ * 版本/修订类表（{@code ai_knowledge_base_version}、{@code ai_skill_version}、
+ * {@code ai_config_version} 等）是追加写、从不更新，因此只有 create 侧、表里压根没有
+ * {@code update_by} / {@code update_time} 列。强行让它们继承一个四字段基类，
+ * MyBatis-Plus 会生成引用不存在列的 SQL。</p>
+ *
+ * <p><b>真正会静默出事的是策略写反</b>：{@code createBy} 若标成 {@code INSERT_UPDATE}，
+ * 每次更新都会把创建人覆盖成当前操作人——编译不报错、测试不变红、页面照常显示一个人名，
+ * 只是那个人名从此是最后改的人。等到要追溯"这条配置最初是谁建的"时，数据已经没了。
+ * 本测试把两组策略钉死。</p>
+ *
+ * <p>另有一批实体（{@code ai_agent_memory}、{@code ai_model_health_snapshot} 等）不标注解，
+ * 由建表语句的 {@code DEFAULT CURRENT_TIMESTAMP} / {@code ON UPDATE CURRENT_TIMESTAMP} 填充。
+ * 那是另一种正当写法，本测试<b>不</b>强制它们改用注解——只要求"一旦标了注解，策略就必须对"。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class AuditFieldFillAlignmentTest {
+
+    private static final String ADMIN_SOURCE_ROOT = "customer-admin-server/src/main/java";
+
+    /** 审计字段 -> 唯一允许的填充策略。 */
+    private static final Map<String, String> REQUIRED_FILL = Map.of(
+        "createBy", "INSERT",
+        "createTime", "INSERT",
+        "updateBy", "INSERT_UPDATE",
+        "updateTime", "INSERT_UPDATE");
+
+    /** 实体的判据：MyBatis-Plus 的 {@code @TableName}。VO / DTO 不该有 fill 注解，故排除在外。 */
+    private static final Pattern ENTITY_MARKER = Pattern.compile("@TableName\\s*\\(");
+
+    @Test
+    @DisplayName("审计字段的 fill 策略不得写反：createBy 标成 INSERT_UPDATE 会静默覆盖创建人")
+    void auditFieldFillStrategyMustBeConsistent() throws IOException {
+        List<String> problems = new ArrayList<>();
+        int checked = 0;
+
+        for (Path file : entitySources()) {
+            String source = Files.readString(file, StandardCharsets.UTF_8);
+            for (Map.Entry<String, String> e : REQUIRED_FILL.entrySet()) {
+                String field = e.getKey();
+                String required = e.getValue();
+                Matcher m = Pattern.compile(
+                        "((?:@TableField\\([^)]*\\)\\s*)?)private\\s+(?:Long|LocalDateTime)\\s+"
+                            + field + "\\s*;")
+                    .matcher(source);
+                if (!m.find()) {
+                    continue;
+                }
+                Matcher fill = Pattern.compile("FieldFill\\.(\\w+)").matcher(m.group(1));
+                if (!fill.find()) {
+                    // 未标注解：由建表语句的 DEFAULT CURRENT_TIMESTAMP 填充，是另一种正当写法
+                    continue;
+                }
+                checked++;
+                if (!required.equals(fill.group(1))) {
+                    problems.add(file.getFileName() + "#" + field
+                        + " 的 fill 是 FieldFill." + fill.group(1) + "，应为 FieldFill." + required);
+                }
+            }
+        }
+
+        if (checked == 0) {
+            fail("未扫描到任何带 fill 注解的审计字段，测试的定位逻辑可能已失效");
+        }
+        if (!problems.isEmpty()) {
+            fail("审计字段填充策略不一致，共 " + problems.size() + " 处：\n  - "
+                + String.join("\n  - ", problems)
+                + "\ncreateBy / createTime 只能 INSERT；updateBy / updateTime 只能 INSERT_UPDATE。"
+                + "\n把 createBy 标成 INSERT_UPDATE 会让每次更新覆盖创建人，且全程不报错。");
+        }
+    }
+
+    private static List<Path> entitySources() throws IOException {
+        Path root = resolveModulePath(ADMIN_SOURCE_ROOT);
+        if (!Files.exists(root)) {
+            fail("找不到 admin 源码目录：" + root.toAbsolutePath());
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths
+                .filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().endsWith(".java"))
+                .filter(p -> {
+                    try {
+                        return ENTITY_MARKER.matcher(
+                            Files.readString(p, StandardCharsets.UTF_8)).find();
+                    } catch (IOException e) {
+                        throw new IllegalStateException("读取源文件失败：" + p, e);
+                    }
+                })
+                .sorted()
+                .toList();
+        }
+    }
+
+    /** 兼容两种工作目录：仓库根（多模块构建）与模块目录（IDE 单模块跑测试）。 */
+    private static Path resolveModulePath(String moduleRelative) {
+        Path fromRepoRoot = Paths.get(moduleRelative);
+        return Files.exists(fromRepoRoot) ? fromRepoRoot : Paths.get("..").resolve(moduleRelative);
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/DockerSandboxIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/DockerSandboxIntegrationTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
  *
  * <p>覆盖需求 §4.6.2：①容器内写文件→编译运行→读回 + bind mount 产物实时落宿主机（含跨会话
  * {@code MEMORY.md} 的宿主机持久化、{@code --user} 下的产物属主对齐）；②沙箱资源获取失败时快速抛错
- * 不挂起；③sessionId 转义（{@link SandboxSafeAgentStateStore}）在 docker 模式同样生效；④破坏性命令识别
+ * 不挂起；③sessionId 转义（{@link AdminSandboxSafeAgentStateStore}）在 docker 模式同样生效；④破坏性命令识别
  * （{@link SandboxRiskDetector}）与模式无关，docker 模式一样拦得住。</p>
  * @author owlzhangfq@gmail.com
  */
@@ -160,9 +160,9 @@ class DockerSandboxIntegrationTest {
     @Test
     void sessionIdWithSlash_isEscaped_beforeReachingStore() {
         // docker 模式下框架给沙箱状态槽位拼出带 "/" 的 sessionId，MysqlAgentStateStore 会拒绝——
-        // SandboxSafeAgentStateStore 装饰器在转发前把分隔符转义掉（见其 Javadoc）。此保证与是否真起容器无关。
+        // AdminSandboxSafeAgentStateStore 装饰器在转发前把分隔符转义掉（见其 Javadoc）。此保证与是否真起容器无关。
         AgentStateStore delegate = mock(AgentStateStore.class);
-        SandboxSafeAgentStateStore safe = new SandboxSafeAgentStateStore(delegate);
+        AdminSandboxSafeAgentStateStore safe = new AdminSandboxSafeAgentStateStore(delegate);
 
         safe.exists("agent", "sandbox/agent/slot");
         safe.delete("agent", "a\\b");

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/AgentTicketController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/AgentTicketController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerworkapp.web.HttpErrors;
 import com.richard.fyoung.customerwork.data.chatlog.ChatLogService;
 import com.richard.fyoung.customerwork.data.chatlog.ChatMessage;
 import com.richard.fyoung.customerwork.core.common.PageResult;
@@ -271,19 +272,7 @@ public class AgentTicketController {
     private <T> Mono<T> blocking(Callable<T> callable) {
         return Mono.fromCallable(callable)
             .subscribeOn(Schedulers.boundedElastic())
-            .onErrorMap(this::translate);
+            .onErrorMap(HttpErrors::translate);
     }
 
-    private Throwable translate(Throwable e) {
-        if (e instanceof ResponseStatusException) {
-            return e;
-        }
-        if (e instanceof NoSuchElementException) {
-            return new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-        if (e instanceof IllegalStateException) {
-            return new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
-        }
-        return e;
-    }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/ApprovalController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/ApprovalController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerworkapp.web.HttpErrors;
 import com.richard.fyoung.customerwork.capability.approval.ApprovalRequest;
 import com.richard.fyoung.customerwork.capability.approval.ApprovalStatus;
 import com.richard.fyoung.customerwork.capability.approval.PendingApprovalService;
@@ -77,7 +78,7 @@ public class ApprovalController {
         String resolvedOperator = resolveOperator(exchange, operator);
         return Mono.fromCallable(() -> approvalService.approve(id, resolvedOperator))
             .doOnNext(req -> audit(req, "approve", resolvedOperator, null))
-            .onErrorMap(this::translate);
+            .onErrorMap(HttpErrors::translate);
     }
 
     @Operation(summary = "拒绝审批单")
@@ -89,7 +90,7 @@ public class ApprovalController {
         String resolvedOperator = resolveOperator(exchange, operator);
         return Mono.fromCallable(() -> approvalService.deny(id, resolvedOperator, note))
             .doOnNext(req -> audit(req, "deny", resolvedOperator, note))
-            .onErrorMap(this::translate);
+            .onErrorMap(HttpErrors::translate);
     }
 
     /**
@@ -117,15 +118,6 @@ public class ApprovalController {
     }
 
     /** 领域异常 → HTTP 状态：不存在 404，重复决策 409。 */
-    private Throwable translate(Throwable e) {
-        if (e instanceof NoSuchElementException) {
-            return new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-        if (e instanceof IllegalStateException) {
-            return new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
-        }
-        return e;
-    }
 
     private ApprovalStatus parseStatus(String status) {
         try {

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/AttachmentController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/AttachmentController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerwork.safety.security.UserPrincipals;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentParseService;
 import com.richard.fyoung.customerwork.data.attachment.ChatAttachment;
 import com.richard.fyoung.customerwork.safety.security.UserAuthWebFilter;
@@ -72,7 +73,7 @@ public class AttachmentController {
         @RequestPart("file") FilePart file,
         @RequestPart(value = "sessionId", required = false) String sessionId,
         ServerWebExchange exchange) {
-        UserPrincipal principal = principal(exchange);
+        UserPrincipal principal = UserPrincipals.require(exchange);
         if (sessionId != null && !sessionId.isBlank()) {
             sessionGuard.requireOwned(sessionId, principal.userId());
         }
@@ -112,11 +113,4 @@ public class AttachmentController {
             attachment.getErrorMessage());
     }
 
-    private UserPrincipal principal(ServerWebExchange exchange) {
-        UserPrincipal principal = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
-        if (principal == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
-        }
-        return principal;
-    }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/CsatController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/CsatController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerwork.safety.security.UserPrincipals;
 import com.richard.fyoung.customerwork.capability.csat.CsatService;
 import com.richard.fyoung.customerwork.capability.csat.CsatSummary;
 import com.richard.fyoung.customerwork.capability.csat.CsatSurvey;
@@ -53,7 +54,7 @@ public class CsatController {
     public Mono<ResponseEntity<CsatSurvey>> status(@PathVariable String sessionId,
                                                    ServerWebExchange exchange) {
         return Mono.fromCallable(() -> {
-                sessionGuard.requireOwned(sessionId, principal(exchange).userId());
+                sessionGuard.requireOwned(sessionId, UserPrincipals.require(exchange).userId());
                 return csatService.find(sessionId)
                     .map(ResponseEntity::ok)
                     .orElseGet(() -> ResponseEntity.notFound().build());
@@ -69,7 +70,7 @@ public class CsatController {
                                    @RequestParam(required = false) String comment,
                                    ServerWebExchange exchange) {
         return Mono.fromCallable(() -> {
-                sessionGuard.requireOwned(sessionId, principal(exchange).userId());
+                sessionGuard.requireOwned(sessionId, UserPrincipals.require(exchange).userId());
                 return csatService.submit(sessionId, score, comment);
             })
             .subscribeOn(Schedulers.boundedElastic());
@@ -89,11 +90,4 @@ public class CsatController {
             .subscribeOn(Schedulers.boundedElastic());
     }
 
-    private UserPrincipal principal(ServerWebExchange exchange) {
-        UserPrincipal principal = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
-        if (principal == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
-        }
-        return principal;
-    }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/FeedbackController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/FeedbackController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerwork.safety.security.UserPrincipals;
 import com.richard.fyoung.customerwork.core.dto.FeedbackRequest;
 import com.richard.fyoung.customerwork.capability.feedback.FeedbackService;
 import com.richard.fyoung.customerwork.capability.feedback.MessageFeedback;
@@ -53,7 +54,7 @@ public class FeedbackController {
     @PostMapping
     public Mono<MessageFeedback> submit(@Valid @RequestBody FeedbackRequest request, ServerWebExchange exchange) {
         return Mono.fromCallable(() -> {
-            sessionGuard.requireOwned(request.sessionId(), principal(exchange).userId());
+            sessionGuard.requireOwned(request.sessionId(), UserPrincipals.require(exchange).userId());
             requireMessageInSession(request.messageId(), request.sessionId());
             return feedbackService.submit(
                 request.sessionId(), request.messageId(), request.type(), request.comment());
@@ -67,7 +68,7 @@ public class FeedbackController {
             MessageFeedback feedback = feedbackService.find(messageId)
                 .orElseThrow(() -> new ResponseStatusException(
                     HttpStatus.NOT_FOUND, "feedback not found: " + messageId));
-            sessionGuard.requireOwned(feedback.sessionId(), principal(exchange).userId());
+            sessionGuard.requireOwned(feedback.sessionId(), UserPrincipals.require(exchange).userId());
             return feedback;
         });
     }
@@ -77,18 +78,11 @@ public class FeedbackController {
     public Mono<List<MessageFeedback>> listBySession(@RequestParam String sessionId,
                                                      ServerWebExchange exchange) {
         return Mono.fromCallable(() -> {
-            sessionGuard.requireOwned(sessionId, principal(exchange).userId());
+            sessionGuard.requireOwned(sessionId, UserPrincipals.require(exchange).userId());
             return feedbackService.findBySession(sessionId);
         });
     }
 
-    private UserPrincipal principal(ServerWebExchange exchange) {
-        UserPrincipal principal = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
-        if (principal == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
-        }
-        return principal;
-    }
 
     /** 消息不存在或不属于当前会话统一 404，不能让可伪造的 messageId 覆盖他人反馈。 */
     private ChatMessage requireMessageInSession(String messageId, String sessionId) {

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/HandoffController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/HandoffController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerworkapp.web.HttpErrors;
 import com.richard.fyoung.customerwork.capability.handoff.HandoffService;
 import com.richard.fyoung.customerwork.capability.handoff.HandoffStatus;
 import com.richard.fyoung.customerwork.capability.handoff.HandoffTicket;
@@ -84,7 +85,7 @@ public class HandoffController {
         String operator = requireAgent(exchange);
         return Mono.fromCallable(() -> handoffService.claim(id, operator))
             .doOnNext(t -> audit(t, "claim", operator, null))
-            .onErrorMap(this::translate);
+            .onErrorMap(HttpErrors::translate);
     }
 
     @Operation(summary = "结案回收给 AI", description = "CLAIMED → RESOLVED，未接单先结案返回 409")
@@ -95,7 +96,7 @@ public class HandoffController {
         String operator = requireAgent(exchange);
         return Mono.fromCallable(() -> handoffService.resolve(id, note, operator))
             .doOnNext(t -> audit(t, "resolve", operator, note))
-            .onErrorMap(this::translate);
+            .onErrorMap(HttpErrors::translate);
     }
 
     /** 工单流转审计留痕（合规追溯：谁在何时对哪张工单做了何种流转）。 */
@@ -114,15 +115,6 @@ public class HandoffController {
     }
 
     /** 领域异常 → HTTP 状态：不存在 404，状态机冲突 409。 */
-    private Throwable translate(Throwable e) {
-        if (e instanceof NoSuchElementException) {
-            return new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-        if (e instanceof IllegalStateException) {
-            return new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
-        }
-        return e;
-    }
 
     private HandoffStatus parseStatus(String status) {
         try {

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserOrderController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserOrderController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerwork.safety.security.UserPrincipals;
 import com.richard.fyoung.customerworkapp.dao.UserOrderDao;
 import com.richard.fyoung.customerworkapp.dao.UserOrderDao.OrderView;
 import com.richard.fyoung.customerworkapp.dao.UserOrderDao.OwnedOrder;
@@ -42,7 +43,7 @@ public class UserOrderController {
     @Operation(summary = "我的订单列表", description = "当前用户全部订单，按下单时间倒序；不含物流轨迹")
     @GetMapping
     public Mono<List<OrderView>> list(ServerWebExchange exchange) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             requireEnabled();
             return orderDao.listByUser(user.userId());
@@ -52,7 +53,7 @@ public class UserOrderController {
     @Operation(summary = "订单详情", description = "含物流轨迹；非本人和不存在统一返回 404")
     @GetMapping("/{orderId}")
     public Mono<OrderView> detail(@PathVariable String orderId, ServerWebExchange exchange) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             requireEnabled();
             OwnedOrder owned = orderDao.findById(orderId)
@@ -67,13 +68,6 @@ public class UserOrderController {
     // ---- 内部 ----
 
     /** 从 exchange 属性取当前用户主体（过滤器已保证存在，此处为单一防御点）。 */
-    private UserPrincipal principal(ServerWebExchange exchange) {
-        UserPrincipal user = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
-        if (user == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
-        }
-        return user;
-    }
 
     /** 订单数据源未启用（mode!=jdbc）时语义化 503。 */
     private void requireEnabled() {
@@ -86,11 +80,18 @@ public class UserOrderController {
     private <T> Mono<T> blocking(Callable<T> callable) {
         return Mono.fromCallable(callable)
             .subscribeOn(Schedulers.boundedElastic())
-            .onErrorMap(this::translate);
+            .onErrorMap(this::mapError);
     }
 
-    /** 领域异常 → HTTP 状态：ResponseStatusException 原样透传；查询异常 503。 */
-    private Throwable translate(Throwable e) {
+    /**
+     * 领域异常 → HTTP 状态：ResponseStatusException 原样透传；查询异常 503。
+     *
+     * <p>与 {@code AgentOrderController#mapError} 同一套策略、故同名。<b>刻意不用
+     * {@code HttpErrors.translate}</b>：那边把 IllegalStateException 映射成 409（状态机拒绝流转，
+     * 客户端应刷新重试），而订单链路的 IllegalState 表达的是下游不可用，应给 503（稍后重试）。
+     * 两者只是长得像，合并会让订单接口在下游抖动时返回 409，把客户端引向错误的重试姿势。</p>
+     */
+    private Throwable mapError(Throwable e) {
         if (e instanceof ResponseStatusException) {
             return e;
         }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserQuotaController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserQuotaController.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerwork.safety.security.UserPrincipals;
 import com.richard.fyoung.customerwork.safety.security.UserAuthWebFilter;
 import com.richard.fyoung.customerwork.safety.security.UserPrincipal;
 import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
@@ -53,7 +54,7 @@ public class UserQuotaController {
     @Operation(summary = "我的额度", description = "当前滚动窗口内的 token 与次数用量；-1 表示该维度不限")
     @GetMapping
     public Mono<Map<String, Object>> myQuota(ServerWebExchange exchange) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         // 等级按租户隔离，判定必须在用户归属租户下进行
         String tenantId = user.tenantId() == null || user.tenantId().isBlank()
             ? TenantContext.DEFAULT : user.tenantId();
@@ -75,11 +76,4 @@ public class UserQuotaController {
     }
 
     /** 从 exchange 属性取当前用户主体（过滤器已保证存在，此处为单一防御点）。 */
-    private UserPrincipal principal(ServerWebExchange exchange) {
-        UserPrincipal user = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
-        if (user == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
-        }
-        return user;
-    }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserTicketController.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/controller/UserTicketController.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customerworkapp.controller;
 
+import com.richard.fyoung.customerworkapp.web.HttpErrors;
+import com.richard.fyoung.customerwork.safety.security.UserPrincipals;
 import com.richard.fyoung.customerwork.data.chatlog.ChatLogService;
 import com.richard.fyoung.customerwork.data.chatlog.ChatMessage;
 import com.richard.fyoung.customerwork.core.common.PageResult;
@@ -84,7 +86,7 @@ public class UserTicketController {
         description = "用户级唯一活跃会话：已有进行中会话返回 409（体带 sessionId/ticketId/status），否则建单")
     @PostMapping("/sessions")
     public Mono<ResponseEntity<Map<String, Object>>> createSession(ServerWebExchange exchange) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             // 用户级唯一活跃会话：命中进行中工单则拒绝新建，回传现有会话信息供前端跳转
             Optional<Ticket> active = ticketService.findActiveByUser(user.userId());
@@ -107,7 +109,7 @@ public class UserTicketController {
                                                  @RequestParam(required = false) String status,
                                                  @RequestParam(defaultValue = "1") int page,
                                                  @RequestParam(defaultValue = "20") int size) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         TicketQuery query = new TicketQuery(parseStatus(status), null, null, null, user.userId(), page, size);
         return blocking(() -> {
             PageResult<Ticket> result = ticketService.findPage(query);
@@ -121,7 +123,7 @@ public class UserTicketController {
     @Operation(summary = "工单详情", description = "含事件轨迹；非本人和不存在统一返回 404")
     @GetMapping("/tickets/{id}")
     public Mono<Map<String, Object>> getTicket(@PathVariable String id, ServerWebExchange exchange) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             Ticket ticket = ownedTicket(id, user);
             Map<String, Object> body = new LinkedHashMap<>();
@@ -136,7 +138,7 @@ public class UserTicketController {
     public Mono<List<ChatMessage>> messages(@PathVariable String sessionId, ServerWebExchange exchange,
                                             @RequestParam(required = false) Long beforeId,
                                             @RequestParam(defaultValue = "" + DEFAULT_MESSAGE_LIMIT) int limit) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             sessionGuard.requireOwned(sessionId, user.userId());
             return chatLogService.historyBySession(sessionId, beforeId, limit);
@@ -147,7 +149,7 @@ public class UserTicketController {
     @PostMapping("/tickets/{id}/handoff")
     public Mono<Ticket> handoff(@PathVariable String id, ServerWebExchange exchange,
                                 @RequestBody(required = false) ReasonRequest request) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             Ticket ticket = ownedTicket(id, user);
             return ticketService.requestHandoff(ticket.getSessionId(), reasonOf(request),
@@ -158,7 +160,7 @@ public class UserTicketController {
     @Operation(summary = "确认解决", description = "WAITING_CONFIRM → RESOLVED，非法状态 409")
     @PostMapping("/tickets/{id}/confirm")
     public Mono<Ticket> confirm(@PathVariable String id, ServerWebExchange exchange) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             ownedTicket(id, user);
             return ticketService.confirm(id, TicketActorType.USER, user.userId());
@@ -169,7 +171,7 @@ public class UserTicketController {
     @PostMapping("/tickets/{id}/reject")
     public Mono<Ticket> reject(@PathVariable String id, ServerWebExchange exchange,
                                @RequestBody(required = false) ReasonRequest request) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             ownedTicket(id, user);
             return ticketService.reject(id, reasonOf(request), TicketActorType.USER, user.userId());
@@ -182,7 +184,7 @@ public class UserTicketController {
     @PostMapping("/tickets/{id}/reopen")
     public Mono<ResponseEntity<Object>> reopen(@PathVariable String id, ServerWebExchange exchange,
                                @RequestBody(required = false) ReasonRequest request) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         return blocking(() -> {
             Ticket ticket = ownedTicket(id, user);
             // 用户级唯一活跃会话不变式：reopen 本质是"新开一张活跃工单"，需与 createSession 同样的前置校验，
@@ -204,7 +206,7 @@ public class UserTicketController {
     @PostMapping("/tickets/{id}/close")
     public Mono<Ticket> close(@PathVariable String id, ServerWebExchange exchange,
                               @RequestBody(required = false) CloseRequest request) {
-        UserPrincipal user = principal(exchange);
+        UserPrincipal user = UserPrincipals.require(exchange);
         boolean force = request != null && Boolean.TRUE.equals(request.force());
         String reason = request == null ? null : request.reason();
         return blocking(() -> {
@@ -220,13 +222,6 @@ public class UserTicketController {
     // ---- 内部 ----
 
     /** 从 exchange 属性取当前用户主体（过滤器已保证存在，此处为单一防御点）。 */
-    private UserPrincipal principal(ServerWebExchange exchange) {
-        UserPrincipal user = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
-        if (user == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
-        }
-        return user;
-    }
 
     /** 加载工单并校验归属：不存在与非本人统一 404。 */
     private Ticket ownedTicket(String id, UserPrincipal user) {
@@ -268,20 +263,8 @@ public class UserTicketController {
     private <T> Mono<T> blocking(Callable<T> callable) {
         return Mono.fromCallable(callable)
             .subscribeOn(Schedulers.boundedElastic())
-            .onErrorMap(this::translate);
+            .onErrorMap(HttpErrors::translate);
     }
 
     /** 领域异常 → HTTP 状态：已是 ResponseStatusException 原样透传；不存在 404；状态机冲突 409。 */
-    private Throwable translate(Throwable e) {
-        if (e instanceof ResponseStatusException) {
-            return e;
-        }
-        if (e instanceof NoSuchElementException) {
-            return new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-        if (e instanceof IllegalStateException) {
-            return new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
-        }
-        return e;
-    }
 }

--- a/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/web/HttpErrors.java
+++ b/customer-work-app-server/src/main/java/com/richard/fyoung/customerworkapp/web/HttpErrors.java
@@ -1,0 +1,50 @@
+package com.richard.fyoung.customerworkapp.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.NoSuchElementException;
+
+/**
+ * 领域异常到 HTTP 状态码的映射——工单 / 审批 / 转人工三条链路共用一处口径。
+ *
+ * <p>这段映射此前在 4 个 Controller 里各写一遍，且已经漂移出两个版本
+ * （两份带 {@code ResponseStatusException} 直通守卫、两份不带；行为上等价，
+ * 因为它既不是 {@code NoSuchElementException} 也不是 {@code IllegalStateException}，
+ * 本来就会走到末尾原样返回——但两个版本并存本身就说明有人抄过去时改了半截）。</p>
+ *
+ * <p><b>不是所有 {@code IllegalStateException} 都该映射成 409</b>：
+ * {@code AgentOrderController#mapError} 刻意把它映射成 503 加一句固定文案
+ * （"订单系统暂时不可用"），因为那条链路的 IllegalState 表达的是下游不可用而不是状态冲突。
+ * 那是另一个概念，刻意不并入本类——合并会让订单接口在下游抖动时返回 409，
+ * 而客户端对 409 的处置是"刷新重试"，对 503 才是"稍后重试"。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class HttpErrors {
+
+    private HttpErrors() {
+    }
+
+    /**
+     * 把领域异常翻译成带 HTTP 语义的异常；已经是 {@link ResponseStatusException} 的原样返回。
+     *
+     * <ul>
+     *   <li>{@link NoSuchElementException} → 404，实体不存在</li>
+     *   <li>{@link IllegalStateException} → 409，状态机拒绝本次流转（如工单已被别的坐席抢走）</li>
+     *   <li>其余原样抛出，交给框架按 500 处理</li>
+     * </ul>
+     */
+    public static Throwable translate(Throwable e) {
+        if (e instanceof ResponseStatusException) {
+            return e;
+        }
+        if (e instanceof NoSuchElementException) {
+            return new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+        if (e instanceof IllegalStateException) {
+            return new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        }
+        return e;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/assist/ConversationSummaryService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/assist/ConversationSummaryService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.assist;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customerwork.data.chatlog.ChatMessage;
@@ -147,7 +148,7 @@ public class ConversationSummaryService {
 
     /** 解析模型返回的摘要 JSON（容忍前后夹带说明/代码块标记）；结构不完整或异常返回 empty 交由上层降级。 */
     private Optional<ConversationSummary> parse(String modelText) {
-        String json = extractJsonObject(modelText);
+        String json = ModelResponses.extractJsonObject(modelText);
         if (json == null) {
             return Optional.empty();
         }
@@ -190,13 +191,7 @@ public class ConversationSummaryService {
         if (responses == null || responses.isEmpty()) {
             throw new IllegalStateException("summary model returned empty response");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new IllegalStateException("summary model returned no text content");
         }
@@ -241,14 +236,6 @@ public class ConversationSummaryService {
         }
     }
 
-    private String extractJsonObject(String text) {
-        if (!StringUtils.hasText(text)) {
-            return null;
-        }
-        int start = text.indexOf('{');
-        int end = text.lastIndexOf('}');
-        return (start >= 0 && end > start) ? text.substring(start, end + 1) : null;
-    }
 
     private List<String> nullSafe(List<String> list) {
         return list == null ? List.of() : new ArrayList<>(list);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/EvalConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/eval/EvalConfig.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.eval;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.richard.fyoung.customerwork.capability.eval.mapper.EvalCaseMapper;
 import com.richard.fyoung.customerwork.capability.eval.mapper.EvalDatasetReleaseMapper;
 import com.richard.fyoung.customerwork.capability.eval.mapper.EvalDatasetSnapshotMapper;
@@ -22,7 +23,6 @@ import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 评测能力装配。
@@ -132,13 +132,7 @@ public class EvalConfig {
                 if (responses == null || responses.isEmpty()) {
                     throw new IllegalStateException("judge model returned empty response");
                 }
-                String text = responses.stream()
-                    .flatMap(response -> response.getContent().stream())
-                    .filter(TextBlock.class::isInstance)
-                    .map(TextBlock.class::cast)
-                    .map(TextBlock::getText)
-                    .filter(StringUtils::hasText)
-                    .collect(Collectors.joining());
+                String text = ModelResponses.text(responses);
                 return Msg.builder()
                     .role(MsgRole.ASSISTANT)
                     .name("judge")

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/routing/TicketClassifier.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/capability/routing/TicketClassifier.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.capability.routing;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customerwork.capability.assist.ConversationSummary;
@@ -17,7 +18,6 @@ import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 工单分类器（智能路由中控·工单智能分配的分类环节）：一次性 LLM 调用，从工单 reason + 会话摘要推断
@@ -88,7 +88,7 @@ public class TicketClassifier {
     }
 
     private TicketClassification parse(String modelText, String emotionHint) {
-        String json = extractJsonObject(modelText);
+        String json = ModelResponses.extractJsonObject(modelText);
         if (json == null) {
             log.error("[TicketClassifier] classify json degraded (no json), code={}", "TICKET-CLASSIFY-DEGRADE");
             return TicketClassification.fallback(emotionHint);
@@ -132,27 +132,13 @@ public class TicketClassifier {
         if (responses == null || responses.isEmpty()) {
             throw new IllegalStateException("classify model returned empty response");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new IllegalStateException("classify model returned no text content");
         }
         return text.trim();
     }
 
-    private String extractJsonObject(String text) {
-        if (!StringUtils.hasText(text)) {
-            return null;
-        }
-        int start = text.indexOf('{');
-        int end = text.lastIndexOf('}');
-        return (start >= 0 && end > start) ? text.substring(start, end + 1) : null;
-    }
 
     private String nullToEmpty(String s) {
         return s == null ? "" : s;

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/model/ModelResponses.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/model/ModelResponses.java
@@ -1,0 +1,70 @@
+package com.richard.fyoung.customerwork.core.model;
+
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 模型响应的文本提取——框架 {@link ChatResponse} 到纯文本的<b>唯一</b>适配点。
+ *
+ * <p><b>为什么要有这个类</b>：把响应里的 {@link TextBlock} 抠出来拼成字符串这段六行流水，
+ * 此前在 7 个地方逐字重复——starter 的会话总结 / 工单分类 / 评测裁判 / 视觉 OCR，
+ * admin 的代码知识库 / 协作编程 / Git 助手。它不是业务逻辑，是<b>框架 API 的适配层</b>：
+ * AgentScope 升级只要动了 {@code getContent()} 的形状或 {@code TextBlock} 的位置，
+ * 就要改 7 处。跨模块共享的东西定义在双方的公共依赖 starter 上，
+ * 不靠"两边各写一份、口头保持一致"。</p>
+ *
+ * <p><b>刻意只做提取，不管异常</b>：7 个调用方对"拿不到文本"的处置各不相同——
+ * starter 抛 {@link IllegalStateException}（不感知任何业务错误码体系），
+ * admin 抛携带 {@code ResultCode} 的业务异常，且各自的错误码不同。
+ * 把异常也收进来就得让 starter 认识 admin 的错误码，那是反向依赖。
+ * 同理也<b>不</b>合并调用方"列表为空"与"有响应但无文本"这两个判断：
+ * 前者是模型调用什么都没返回，后者是返回了但只有工具调用/图片，
+ * 排查时是两条不同的线索，合并等于把诊断信息丢掉。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class ModelResponses {
+
+    private ModelResponses() {
+    }
+
+    /**
+     * 按顺序拼接响应里全部非空文本块；{@code null} / 空列表返回空串。
+     *
+     * <p>返回空串代表"模型没给出任何文本"，调用方自行决定这算不算错误、抛什么。</p>
+     */
+    public static String text(List<ChatResponse> responses) {
+        if (responses == null || responses.isEmpty()) {
+            return "";
+        }
+        return responses.stream()
+            .flatMap(response -> response.getContent().stream())
+            .filter(TextBlock.class::isInstance)
+            .map(TextBlock.class::cast)
+            .map(TextBlock::getText)
+            .filter(StringUtils::hasText)
+            .collect(Collectors.joining());
+    }
+
+    /**
+     * 从模型输出里截出最外层 JSON 对象；截不出返回 {@code null}。
+     *
+     * <p>模型即便被要求"只输出 JSON"，也常带上 ```json 围栏或一句解释，
+     * 所以取首个 <code>{</code> 到末个 <code>}</code> 之间的整段，而不是直接把整段文本喂给解析器。
+     * 这段逻辑此前在会话总结 / 工单分类 / Git 助手三处逐字重复——
+     * 解析口径一旦漂移（本项目踩过 Jackson {@code readTree} 尾部 token 的坑），
+     * 修好一处另外两处照旧。</p>
+     */
+    public static String extractJsonObject(String text) {
+        if (!StringUtils.hasText(text)) {
+            return null;
+        }
+        int start = text.indexOf('{');
+        int end = text.lastIndexOf('}');
+        return (start >= 0 && end > start) ? text.substring(start, end + 1) : null;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/ModelVisionOcrService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/ModelVisionOcrService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.attachment;
 
+import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
@@ -16,7 +17,6 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * 基于 AgentScope 视觉模型的 OCR 实现：图片 Base64 → {@link ImageBlock} 拼 OCR 提示词 {@link TextBlock}
@@ -63,13 +63,7 @@ public class ModelVisionOcrService implements VisionOcrService {
         if (responses == null || responses.isEmpty()) {
             throw new IllegalStateException("vision model returned empty response");
         }
-        String text = responses.stream()
-            .flatMap(response -> response.getContent().stream())
-            .filter(TextBlock.class::isInstance)
-            .map(TextBlock.class::cast)
-            .map(TextBlock::getText)
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining());
+        String text = ModelResponses.text(responses);
         if (!StringUtils.hasText(text)) {
             throw new IllegalStateException("vision model returned no text content");
         }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/UserPrincipals.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/safety/security/UserPrincipals.java
@@ -1,0 +1,37 @@
+package com.richard.fyoung.customerwork.safety.security;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * 从 exchange 取出已鉴权用户身份——{@link UserAuthWebFilter} 的读取侧。
+ *
+ * <p>过滤器把 {@link UserPrincipal} 放进 {@link UserAuthWebFilter#PRINCIPAL_ATTR}，
+ * 每个受保护端点再取出来。取的这三行此前在 6 个 Controller 里各写一遍，
+ * 而且写出了两种变量名（{@code user} 与 {@code principal}）——复制粘贴的痕迹。</p>
+ *
+ * <p>放在过滤器旁边而不是某个 Controller 模块里：写入方与读取方是同一件事的两半，
+ * 属性键 {@code PRINCIPAL_ATTR} 换了名字时，两边应该一起改、一起编译报错。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class UserPrincipals {
+
+    private UserPrincipals() {
+    }
+
+    /**
+     * 取当前请求的用户身份；未鉴权直接抛 401。
+     *
+     * <p>fast-fail：能走到受保护端点却没有身份，说明过滤器链装配漏了，
+     * 这种情况要立刻炸出来，而不是让下游拿着 null 继续跑。</p>
+     */
+    public static UserPrincipal require(ServerWebExchange exchange) {
+        UserPrincipal principal = exchange.getAttribute(UserAuthWebFilter.PRINCIPAL_ATTR);
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthenticated");
+        }
+        return principal;
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/model/ModelResponsesTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/model/ModelResponsesTest.java
@@ -1,0 +1,150 @@
+package com.richard.fyoung.customerwork.core.model;
+
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * {@link ModelResponses} 的行为测试 + <b>不得再各写一份</b>的门禁。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class ModelResponsesTest {
+
+    private static final List<String> MODULE_SOURCE_ROOTS = List.of(
+        "customer-work-starter/src/main/java",
+        "customer-admin-server/src/main/java",
+        "customer-work-app-server/src/main/java",
+        "customer-channel/src/main/java");
+
+    @Test
+    @DisplayName("拼接全部非空文本块，跳过非文本内容")
+    void textJoinsAllTextBlocks() {
+        List<ChatResponse> responses = List.of(
+            response("你好"),
+            response(""),
+            response("，世界"));
+        assertEquals("你好，世界", ModelResponses.text(responses));
+    }
+
+    @Test
+    @DisplayName("null 与空列表返回空串，由调用方决定这算不算错误")
+    void textTreatsMissingResponsesAsEmpty() {
+        assertEquals("", ModelResponses.text(null));
+        assertEquals("", ModelResponses.text(List.of()));
+    }
+
+    @Test
+    @DisplayName("从围栏与解释文字里截出最外层 JSON 对象")
+    void extractJsonObjectStripsSurroundingNoise() {
+        assertEquals("{\"intent\":\"consult\"}",
+            ModelResponses.extractJsonObject("好的，结果如下：\n```json\n{\"intent\":\"consult\"}\n```"));
+        // 取首个 { 到末个 }：嵌套对象要整段拿回来，不能在第一个 } 处截断
+        assertEquals("{\"a\":{\"b\":1}}",
+            ModelResponses.extractJsonObject("前言 {\"a\":{\"b\":1}} 后记"));
+    }
+
+    @Test
+    @DisplayName("截不出 JSON 时返回 null 而不是空串：调用方要能区分「没有」与「空对象」")
+    void extractJsonObjectReturnsNullWhenAbsent() {
+        assertNull(ModelResponses.extractJsonObject(null));
+        assertNull(ModelResponses.extractJsonObject("   "));
+        assertNull(ModelResponses.extractJsonObject("模型拒绝回答"));
+        assertNull(ModelResponses.extractJsonObject("}{"));
+    }
+
+    /**
+     * 门禁：TextBlock 提取流水不得在 {@link ModelResponses} 之外重新出现。
+     *
+     * <p>它是框架 API 的适配层——AgentScope 升级动了 {@code getContent()} 或 {@code TextBlock}
+     * 就要跟着改。此前它在 7 个文件里逐字重复，跨 starter 与 admin 两个模块。</p>
+     */
+    @Test
+    @DisplayName("门禁：模型文本提取只能有一处实现")
+    void textExtractionMustNotBeReimplemented() throws IOException {
+        Pattern extraction = Pattern.compile("\\.filter\\(TextBlock\\.class::isInstance\\)");
+        List<String> offenders = sources()
+            .filter(p -> !p.getFileName().toString().equals("ModelResponses.java"))
+            .filter(p -> extraction.matcher(read(p)).find())
+            .map(p -> p.getFileName().toString())
+            .sorted()
+            .toList();
+
+        if (!offenders.isEmpty()) {
+            fail("模型文本提取只能走 ModelResponses.text(...)，以下文件又各写了一份："
+                + offenders + "\n它是框架 API 的适配层，散开之后框架升级要改 N 处，"
+                + "而漏掉的那处只有跑到才发现。");
+        }
+    }
+
+    @Test
+    @DisplayName("门禁：JSON 对象截取只能有一处实现")
+    void jsonExtractionMustNotBeReimplemented() throws IOException {
+        Pattern method = Pattern.compile("String\\s+extractJsonObject\\s*\\(");
+        List<String> offenders = sources()
+            .filter(p -> !p.getFileName().toString().equals("ModelResponses.java"))
+            .filter(p -> method.matcher(read(p)).find())
+            .map(p -> p.getFileName().toString())
+            .sorted()
+            .toList();
+
+        if (!offenders.isEmpty()) {
+            fail("extractJsonObject 只能走 ModelResponses，以下文件又各写了一份：" + offenders
+                + "\n解析口径一旦漂移（项目踩过 Jackson readTree 尾部 token 的坑），"
+                + "修好一处另外几处照旧。");
+        }
+    }
+
+    private static ChatResponse response(String text) {
+        return ChatResponse.builder()
+            .content(List.of(TextBlock.builder().text(text).build()))
+            .build();
+    }
+
+    private static Stream<Path> sources() throws IOException {
+        List<Path> roots = MODULE_SOURCE_ROOTS.stream()
+            .map(ModelResponsesTest::resolveModulePath)
+            .filter(Files::exists)
+            .toList();
+        if (roots.isEmpty()) {
+            fail("未定位到任何模块源码目录，门禁的路径解析可能已失效");
+        }
+        return roots.stream().flatMap(root -> {
+            try {
+                return Files.walk(root)
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().endsWith(".java"));
+            } catch (IOException e) {
+                throw new IllegalStateException("遍历源码目录失败：" + root, e);
+            }
+        });
+    }
+
+    private static String read(Path p) {
+        try {
+            return Files.readString(p, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("读取源文件失败：" + p, e);
+        }
+    }
+
+    /** 兼容两种工作目录：仓库根（多模块构建）与模块目录（IDE 单模块跑测试）。 */
+    private static Path resolveModulePath(String moduleRelative) {
+        Path fromRepoRoot = Paths.get(moduleRelative);
+        return Files.exists(fromRepoRoot) ? fromRepoRoot : Paths.get("..").resolve(moduleRelative);
+    }
+}


### PR DESCRIPTION
> 叠在 #143 之上（#143 叠在 #142）。前置 PR 合并后 base 会自动上移。

审计里判定"改一处漏改另一处会出错、且编译期不报错"的四组重复。每组都配了门禁；长得像但语义不同的**刻意没合**，见文末。

## 一、模型响应文本提取 ×8 → `ModelResponses`

`responses.stream().flatMap(getContent).filter(TextBlock).map(getText).joining()` 这段六行流水在 **8 个文件**里逐字重复，跨 starter 与 admin 两个模块。它不是业务逻辑，是**框架 API 的适配层** —— AgentScope 升级动了 `getContent()` 或 `TextBlock` 就要改 8 处。

同源的 `extractJsonObject`（从模型输出抠 JSON）另有 3 份，而解析口径漂移过（项目踩过 Jackson `readTree` 尾部 token 的坑），修好一处另外两处照旧。

两个刻意的边界：
- **只做提取，不管异常** —— 8 个调用方对"拿不到文本"的处置各不相同（starter 抛 `IllegalStateException`，admin 抛带 `ResultCode` 的业务异常且错误码各异）。收进来就得让 starter 认识 admin 的错误码，那是反向依赖
- **不合并调用方的两个判断** —— "列表为空"与"有响应但无文本"是两条不同的排查线索：前者是模型调用什么都没返回，后者是返回了但只有工具调用/图片

> 第 8 处（`ModelExperimentArmEvaluationService`）是**门禁测试首次运行时抓出来的** —— 我先前的重复窗口扫描漏了它。

## 二、`principal(exchange)` ×6 → `UserPrincipals.require`

取 `UserPrincipal` 并抛 401 的三行，6 个 Controller 各写一遍，还写出了两种变量名（`user` / `principal`）。放在 `UserAuthWebFilter` 旁边（starter）：写入方与读取方是同一件事的两半，`PRINCIPAL_ATTR` 换名字时两边应该一起编译报错。

## 三、`translate(Throwable)` ×4 → `HttpErrors.translate`

`NoSuchElement→404` / `IllegalState→409` 的映射，4 份里已经漂出两个版本（两份带 `ResponseStatusException` 直通守卫、两份不带）。

## 四、3 个薄壳与父类同名 → 加 `Admin` 前缀

`FailoverModel` / `ModelCircuitBreakerRegistry` / `SandboxSafeAgentStateStore` 的 admin 薄壳与 starter 父类同名，导致 `extends` 子句必须写全限定名、连 `import` 都写不了。改名后恢复正常 import。

另：`UserOrderController.translate` 改名 `mapError` 与 `AgentOrderController` 对齐 —— 它和 `HttpErrors.translate` 同名不同义，同包下两个 `translate` 表示两回事本身就是隐患。

## 门禁

- `ModelResponsesTest`：文本提取与 JSON 截取各只能有一处实现（扫四个模块源码）+ 4 条行为测试
- `AuditFieldFillAlignmentTest`：`createBy`/`createTime` 只能 `INSERT`，`updateBy`/`updateTime` 只能 `INSERT_UPDATE`

## ⚠️ 撤回原方案：ORG-1「抽 AiBaseEntity」不成立

审计报告里说"21 个实体各抄一遍审计字段，应抽 `AiBaseEntity`"。动手前复核，这个方案是**错的**：

1. **审计形状本就不同** —— 版本/修订类表（`ai_knowledge_base_version`、`ai_skill_version`、`ai_config_version` 等）是追加写、从不更新，表里压根没有 `update_by` / `update_time` 列。强行继承四字段基类会让 MyBatis-Plus 生成引用不存在列的 SQL
2. **另有 19 个实体不标注解**（`ai_agent_memory`、`ai_model_health_snapshot` 等），由建表语句的 `DEFAULT CURRENT_TIMESTAMP` 填充 —— 是另一种正当写法，不是漏标
3. **fill 策略实测 100% 一致**，不存在漂移

按项目自己的判据（改一处必须同步改 N 处、且漏改不报错），加一个新实体并不需要改动其余 41 个 —— 不满足"真重复"。

故只保留会**静默出事**的那一条：把 `createBy` 标成 `INSERT_UPDATE` 会让每次更新覆盖创建人，编译不报错、测试不变红、页面照常显示一个人名，只是那个人名从此是最后改的人。由 `AuditFieldFillAlignmentTest` 钉死。

## 刻意不合并

`AgentOrderController#mapError` 与 `UserOrderController#mapError` 把 `IllegalState` 映射成 **503 + 固定文案**，与 `HttpErrors` 的 **409 + 原始消息**是两种策略：订单链路的 `IllegalState` 表达的是下游不可用。客户端对 409 的处置是"刷新重试"、对 503 才是"稍后重试"，合并会把客户端引向错误的重试姿势。

## 验证

全模块 BUILD SUCCESS：**starter 1701 / app-server 129 / channel 80 / admin 1391 / gateway 1 = 3302 条，0 失败 0 错误 7 跳过**（排除本机 Redis 无密码的 `RedisSessionPersistenceTest`）。