### PR TITLE
refactor: 剥离工作区职责，并给持久化登记表加门禁

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.aiconfig.agent.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentMemoryVO;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
@@ -44,11 +45,14 @@ public class AgentMemoryService {
 
     private final AgentService agentService;
     private final AdminAgentInstanceFactory instanceFactory;
+    private final AgentWorkspaceManager workspaceManager;
     private final AgentMemoryStore memoryStore;
     private final AgentMemorySyncService memorySyncService;
 
     public AgentMemoryService(AgentService agentService, AdminAgentInstanceFactory instanceFactory,
-                               AgentMemoryStore memoryStore, AgentMemorySyncService memorySyncService) {
+                               AgentMemoryStore memoryStore, AgentMemorySyncService memorySyncService,
+                                    AgentWorkspaceManager workspaceManager) {
+        this.workspaceManager = workspaceManager;
         this.agentService = agentService;
         this.instanceFactory = instanceFactory;
         this.memoryStore = memoryStore;
@@ -60,7 +64,7 @@ public class AgentMemoryService {
         AiAgent agent = agentService.requireAgent(id);
         String agentCode = agent.getAgentCode();
         AgentMemoryScope scope = AgentMemoryScope.current(agentCode);
-        memorySyncService.persistIfChanged(scope.storageKey(), instanceFactory.resolveWorkspace(scope));
+        memorySyncService.persistIfChanged(scope.storageKey(), workspaceManager.resolveWorkspace(scope));
         try {
             Optional<AgentMemorySnapshot> snapshot = memoryStore.load(scope.storageKey());
             if (snapshot.isEmpty()) {
@@ -80,7 +84,7 @@ public class AgentMemoryService {
         AiAgent agent = agentService.requireAgent(id);
         String agentCode = agent.getAgentCode();
         AgentMemoryScope scope = AgentMemoryScope.current(agentCode);
-        Path workspace = instanceFactory.resolveWorkspace(scope);
+        Path workspace = workspaceManager.resolveWorkspace(scope);
         try {
             memoryStore.delete(scope.storageKey());
             boolean removed = Files.deleteIfExists(workspace.resolve(AgentFileNames.MEMORY_MD));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.chat.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatNodeKind;
@@ -91,6 +92,7 @@ public class ChatService {
 
     private final AgentInstanceCache agentInstanceCache;
     private final AdminAgentInstanceFactory agentInstanceFactory;
+    private final AgentWorkspaceManager workspaceManager;
     private final ChatHistoryCache historyCache;
     private final AgentMemorySyncService memorySyncService;
     private final ExecutionModeRegistry executionModeRegistry;
@@ -110,7 +112,9 @@ public class ChatService {
                         ChatAttachmentService chatAttachmentService,
                         ObjectProvider<SensitiveWordFilter> sensitiveWordFilterProvider,
                         ObjectProvider<ContentGuardProperties> contentGuardPropertiesProvider,
-                        ObjectProvider<SessionLock> sessionLockProvider) {
+                        ObjectProvider<SessionLock> sessionLockProvider,
+                                    AgentWorkspaceManager workspaceManager) {
+        this.workspaceManager = workspaceManager;
         this.agentInstanceCache = agentInstanceCache;
         this.agentInstanceFactory = agentInstanceFactory;
         this.historyCache = historyCache;
@@ -140,7 +144,7 @@ public class ChatService {
                        ObjectProvider<ContentGuardProperties> contentGuardPropertiesProvider) {
         this(agentInstanceCache, agentInstanceFactory, historyCache, memorySyncService, executionModeRegistry,
             planConfirmationService, chatAttachmentService, sensitiveWordFilterProvider,
-            contentGuardPropertiesProvider, null);
+            contentGuardPropertiesProvider, null, new AgentWorkspaceManager(null));
     }
 
     /**
@@ -288,7 +292,7 @@ public class ChatService {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
         RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
         AgentMemoryScope memoryScope = AgentMemoryScope.current(agentCode);
-        Path memoryWorkspace = agentInstanceFactory.resolveWorkspace(memoryScope);
+        Path memoryWorkspace = workspaceManager.resolveWorkspace(memoryScope);
         // 在 Tomcat 线程上把限流主体取下来：下面整条链会切到 Reactor 线程，ThreadLocal 到不了那边，
         // 而 token 记账（AgentCallTimingMiddleware）恰恰发生在那里。主体由 AdminQuotaInterceptor 写入，
         // 功能关闭或非 AI 入口时为 null，此时不写 Context。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactory.java
@@ -145,14 +145,11 @@ public class AdminAgentInstanceFactory {
     /** Plan Mode 计划文件目录名（workspace 下的子目录）。 */
     private static final String PLAN_DIR_NAME = "plans";
     private static final long BYTES_PER_MB = 1024L * 1024L;
-    private static final String WORKSPACE_ROOT = RuntimeWorkDir.of("admin-workspace");
     private static final String SKILL_ROOT = RuntimeWorkDir.of("admin-skills");
     /** 会话产物目录名（{@code {agentCode}/sessions/}），docker 模式下 bind mount 前置预建的子目录之一。 */
-    private static final String SESSIONS_DIR_NAME = "sessions";
     /** 容器工作区根（框架 {@code DockerSandboxClientOptions} 默认值，勿改——bind mount 目标路径依赖它）。 */
     static final String CONTAINER_WORKSPACE_ROOT = "/workspace";
     /** 探测宿主机 uid/gid 的 {@code id} 命令超时秒数。 */
-    private static final long ID_CMD_TIMEOUT_SECONDS = 5;
     /**
      * 宿主机 JVM 进程的 {@code uid:gid}（类加载时经 {@code id -u}/{@code id -g} 探测一次，失败为 null）。
      * docker 模式下注入 {@code docker run --user uid:gid}：原生 Linux Docker 上容器默认以 root 运行，
@@ -160,7 +157,6 @@ public class AdminAgentInstanceFactory {
      * 属主不可写而失败；令容器进程 uid 与宿主机 JVM 一致后产物属主天然对齐。macOS Docker Desktop 本有
      * 属主映射，注入同样无害。探测失败（如 Windows）时不注入并记日志，回退行为见部署手册"Docker 模式产物同步"。
      */
-    private static final String HOST_UID_GID = resolveHostUidGid();
     private static final String DEFAULT_SYSTEM_PROMPT = "你是一个乐于助人的智能助手。不清楚的问题说不知道，需要人工确认，不要瞎编或者胡说八道。";
 
     private final AiAgentMapper agentMapper;
@@ -215,7 +211,7 @@ public class AdminAgentInstanceFactory {
     /** 后台委派任务仓储（落 MySQL），挂到每个 HarnessAgent 上接管 {@code agent_spawn} 的异步任务。 */
     private final TaskRepository taskRepository;
     /** VibeCoding 会话工作区持久化；未启用时为 null（产出物仅存本地临时目录）。 */
-    private final SessionWorkspaceStorage sessionWorkspaceStorage;
+    private final AgentWorkspaceManager workspaceManager;
     /** MCP 工具主体策略登记与执行闸门，按智能体作用域隔离。 */
     private final McpToolAuthorizationRegistry mcpToolAuthorizationRegistry;
     private final SubjectToolAuthorizationMiddleware subjectToolAuthorizationMiddleware;
@@ -251,7 +247,7 @@ public class AdminAgentInstanceFactory {
                                       ObjectProvider<SensitiveWordMiddleware> sensitiveWordMiddlewareProvider,
                                       IndirectInjectionGuardMiddleware indirectInjectionGuardMiddleware,
                                       TaskRepository taskRepository,
-                                      ObjectProvider<SessionWorkspaceStorage> sessionWorkspaceStorageProvider,
+                                      AgentWorkspaceManager workspaceManager,
                                       SecretRefService secretRefService,
                                       ObjectProvider<ModelRoutingPolicyRuntimeAccess> routingPolicyRuntimeAccessProvider,
                                       ObjectProvider<McpCredentialService> mcpCredentialServiceProvider,
@@ -259,9 +255,7 @@ public class AdminAgentInstanceFactory {
                                       SubjectToolAuthorizationMiddleware subjectToolAuthorizationMiddleware) {
         this.indirectInjectionGuardMiddleware = indirectInjectionGuardMiddleware;
         this.taskRepository = taskRepository;
-        // 容错 null provider：单测直传 null 依赖构造本类验证路径防御逻辑（同 CustomerServiceAgentFactory 的 meterRegistry 手法）
-        this.sessionWorkspaceStorage = sessionWorkspaceStorageProvider == null
-            ? null : sessionWorkspaceStorageProvider.getIfAvailable();
+        this.workspaceManager = workspaceManager;
         this.agentMapper = agentMapper;
         this.agentMcpMapper = agentMcpMapper;
         this.agentSkillMapper = agentSkillMapper;
@@ -544,7 +538,7 @@ public class AdminAgentInstanceFactory {
         // 包一层转义规避，local 模式与未挂 filesystem 沙箱的升级路径不受影响（见该类 Javadoc）。
         AgentStateStore harnessStateStore = vibecoding && sandboxProperties.isDockerMode()
             ? new AdminSandboxSafeAgentStateStore(stateStore) : stateStore;
-        Path workspace = resolveWorkspace(memoryScope);
+        Path workspace = workspaceManager.resolveWorkspace(memoryScope);
         HarnessAgent.Builder harnessBuilder = HarnessAgent.Builder.fromAgent(inner)
             .stateStore(harnessStateStore)
             .defaultSessionId(WorkspaceRuntimeScope.agent(agentCode))
@@ -702,15 +696,15 @@ public class AdminAgentInstanceFactory {
      */
     static SandboxFilesystemSpec buildDockerFilesystemSpec(AdminSandboxProperties sandboxProperties, String agentCode) {
         AdminSandboxProperties.Docker docker = sandboxProperties.getDocker();
-        Path hostWorkspaceRoot = prepareHostWorkspaceRoot(agentCode);
+        Path hostWorkspaceRoot = AgentWorkspaceManager.prepareHostWorkspaceRoot(agentCode);
         List<String> runArgs = new ArrayList<>();
         // P1-3 核心：宿主机 agent 工作区根 ↔ 容器 /workspace 双向实时可见
         runArgs.add("-v");
         runArgs.add(hostWorkspaceRoot + ":" + CONTAINER_WORKSPACE_ROOT + ":rw");
-        if (HOST_UID_GID != null) {
+        if (AgentWorkspaceManager.hostUidGid() != null) {
             // 容器进程 uid/gid 对齐宿主机 JVM，bind mount 写出的产物属主即宿主机用户（Linux 属主问题的根治）
             runArgs.add("--user");
-            runArgs.add(HOST_UID_GID);
+            runArgs.add(AgentWorkspaceManager.hostUidGid());
         } else {
             log.info("[workspace] host uid/gid unresolved, docker sandbox runs as image default user, agentCode={}", agentCode);
         }
@@ -725,144 +719,6 @@ public class AdminAgentInstanceFactory {
             .workspaceSpec(workspaceSpec)
             .workspaceProjectionEnabled(false)
             .isolationScope(IsolationScope.AGENT);
-    }
-
-    /**
-     * bind mount 前置：预建宿主机 agent 工作区根及 {@code sessions/} 子目录并 fast fail——若交给
-     * {@code docker -v} 自动补建，缺失目录会以 root 属主创建，后续宿主机侧 git/回滚必然撞权限，
-     * 这正是本方法要规避的场景，建不出来就不该继续挂载（沙箱装配随之失败，错误信息直达调用方）。
-     * 返回绝对 normalize 路径，与 {@link #resolveSessionWorkspace} 的解析同源（同一 {@code WORKSPACE_ROOT}
-     * 相对 JVM 工作目录），保证容器内写入与宿主机读取指向同一目录。
-     */
-    private static Path prepareHostWorkspaceRoot(String agentCode) {
-        Path hostWorkspaceRoot = Path.of(WORKSPACE_ROOT, WorkspaceRuntimeScope.agent(agentCode))
-            .toAbsolutePath().normalize();
-        try {
-            Files.createDirectories(hostWorkspaceRoot.resolve(SESSIONS_DIR_NAME));
-        } catch (Exception e) {
-            log.error("[workspace] create host workspace dir for bind mount failed, code={}, agentCode={}",
-                "SANDBOX_BIND_MOUNT_INIT_ERROR", agentCode, e);
-            throw new BizException(ResultCode.SYSTEM_ERROR, "docker 沙箱工作区目录创建失败: " + hostWorkspaceRoot);
-        }
-        return hostWorkspaceRoot;
-    }
-
-    /**
-     * 探测宿主机 JVM 进程的 {@code uid:gid}（POSIX {@code id -u}/{@code id -g}），供
-     * {@code docker run --user} 使用；任何异常（命令缺失/超时/非 POSIX 平台）返回 null 表示不注入。
-     * 类加载时执行一次，进程生命周期内 uid 不会变。
-     */
-    private static String resolveHostUidGid() {
-        try {
-            String uid = execIdCommand("-u");
-            String gid = execIdCommand("-g");
-            if (StringUtils.hasText(uid) && StringUtils.hasText(gid)) {
-                return uid + ":" + gid;
-            }
-        } catch (Exception e) {
-            log.error("[workspace] resolve host uid/gid failed, code={}", "SANDBOX_UID_RESOLVE_FAIL", e);
-        }
-        return null;
-    }
-
-    /** 执行 {@code id <flag>} 并返回 trim 后的输出；非零退出码/超时返回 null。 */
-    private static String execIdCommand(String flag) throws Exception {
-        Process process = new ProcessBuilder("id", flag).redirectErrorStream(true).start();
-        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
-        if (!process.waitFor(ID_CMD_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            process.destroyForcibly();
-            return null;
-        }
-        return process.exitValue() == 0 ? output : null;
-    }
-
-    /**
-     * VibeCoding 沙箱工作区路径（智能体根目录）：{@code {临时根}/admin-workspace/{agentCode}}。
-     * 仅供快照根路径使用，Agent 运行时请使用 {@link #resolveSessionWorkspace(String, String)} 按会话隔离。
-     */
-    public Path resolveWorkspace(String agentCode) {
-        return resolveWorkspace(AgentMemoryScope.current(agentCode));
-    }
-
-    /** 已冻结主体的工作区；可信请求下 MEMORY.md 物理隔离。 */
-    public Path resolveWorkspace(AgentMemoryScope scope) {
-        Path base = Path.of(WORKSPACE_ROOT, WorkspaceRuntimeScope.agent(scope.agentCode()));
-        Path workspace = scope.trusted()
-            ? base.resolve("subjects").resolve(scope.subjectHash()) : base;
-        try {
-            Files.createDirectories(workspace);
-        } catch (Exception e) {
-            log.error("[workspace] create workspace dir failed, code={}, agentCode={}",
-                "WORKSPACE_INIT_ERROR", scope.agentCode(), e);
-        }
-        return workspace;
-    }
-
-    /**
-     * VibeCoding 沙箱工作区路径（会话级隔离）：{@code {临时根}/admin-workspace/{agentCode}/sessions/{sessionId}}。
-     * HarnessAgent 的文件操作根目录，不同会话产出物物理隔离，互不污染。
-     *
-     * <p><b>安全约束（会话路径解析的全链路唯一防御点）</b>：本方法是 stream/files/file-content/rollback
-     * 等所有会话级功能解析磁盘路径的公共入口，sessionId 由前端透传（正常值是 UUID v4），在此统一做
-     * 路径穿越校验——含路径分隔符或 {@code ..} 的 sessionId 直接 fast fail，并对拼接结果 normalize 后
-     * 强校验必须仍落在该 agent 的 {@code sessions/} 根目录内。否则恶意 sessionId（如
-     * {@code ../其他会话ID} / 绝对路径）可越界访问他人会话甚至宿主机任意目录（rollback 链路会对目标
-     * 目录执行破坏性的 git checkout + clean）。</p>
-     */
-    public Path resolveSessionWorkspace(String agentCode, String sessionId) {
-        String safeSession = requireSafeSessionId(sessionId);
-        Path sessionsRoot = resolveWorkspace(AgentMemoryScope.current(agentCode))
-            .resolve("sessions").normalize();
-        Path workspace = sessionsRoot.resolve(safeSession).normalize();
-        // 双保险：字符黑名单之外，normalize 后必须仍是 sessions 根目录的真子路径（防未预见的编码绕过）
-        if (!workspace.startsWith(sessionsRoot) || workspace.equals(sessionsRoot)) {
-            log.error("[workspace] session workspace path traversal blocked, code={}, agentCode={}, sessionId={}",
-                "SESSION_PATH_TRAVERSAL", agentCode, safeSession);
-            throw new BizException(ResultCode.PARAM_INVALID, "非法 sessionId：解析路径越界");
-        }
-        try {
-            Files.createDirectories(workspace);
-        } catch (Exception e) {
-            log.error("[workspace] create session workspace dir failed, code={}, agentCode={}, sessionId={}",
-                "SESSION_WORKSPACE_INIT_ERROR", agentCode, safeSession, e);
-        }
-        // 恢复权威副本：工作区落在系统临时目录（会被 OS 清理）、容器化部署更是一销毁就没了，
-        // 而会话产出物是用户生成的代码、不是可重建的派生物。本方法是所有会话级功能解析路径的公共入口，
-        // 挂在这里能覆盖 stream / files / file-content / rollback 全部链路。
-        // 仅在本地目录为空时真正拉取（见 SessionWorkspaceStorage#hydrate），故重复调用无额外开销。
-        if (sessionWorkspaceStorage != null) {
-            sessionWorkspaceStorage.hydrate(agentCode, safeSession, workspace);
-        }
-        return workspace;
-    }
-
-    /**
-     * 把会话工作区保存回权威存储（对象存储）。产出物写入之后必须调用一次，否则本地临时目录一被清理就丢。
-     *
-     * <p>调用点覆盖三条会造成写入的链路：对话轮次结束、手工保存文件、一键回滚。
-     * 未启用持久化时静默跳过；失败只记 error，不打断主链路（见 {@link SessionWorkspaceStorage#persist}）。</p>
-     */
-    public void persistSessionWorkspace(String agentCode, String sessionId) {
-        if (sessionWorkspaceStorage == null) {
-            return;
-        }
-        String safeSession = requireSafeSessionId(sessionId);
-        sessionWorkspaceStorage.persist(agentCode, safeSession,
-            resolveWorkspace(AgentMemoryScope.current(agentCode))
-                .resolve("sessions").resolve(safeSession).normalize());
-    }
-
-    /**
-     * sessionId 合法性校验：空值回退 {@code default}；含 {@code /}、{@code \}、{@code ..} 任一直接拒绝——
-     * 前端生成的 sessionId 是 UUID v4（十六进制 + 连字符，见 customer-admin-web/src/utils/uuid.ts），
-     * 正常值不可能出现这些字符，出现即恶意构造，fast fail。
-     */
-    static String requireSafeSessionId(String sessionId) {
-        String safeSession = StringUtils.hasText(sessionId) ? sessionId : "default";
-        if (safeSession.contains("/") || safeSession.contains("\\") || safeSession.contains("..")) {
-            throw new BizException(ResultCode.PARAM_INVALID, "非法 sessionId：不允许包含路径分隔符或 ..");
-        }
-        return safeSession;
     }
 
     private AiAgent requireEnabledAgent(String agentCode) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AgentWorkspaceManager.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/AgentWorkspaceManager.java
@@ -1,0 +1,210 @@
+package com.richard.fyoung.customeradmin.workspace.runtime;
+
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryScope;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customerwork.infra.config.RuntimeWorkDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 智能体工作区目录的解析、隔离与持久化。
+ *
+ * <p><b>为什么从 {@code AdminAgentInstanceFactory} 拆出来</b>：那个类有 33 个构造参数、25 个方法，
+ * 混了 7 类职责，其中"在磁盘上定位/创建/回存工作区目录"与"把一个 Agent 装配出来"毫无关系——
+ * 它甚至要 shell 调 {@code id} 命令取宿主机 uid/gid。这一簇有清晰的输入输出边界、
+ * 只依赖 {@link SessionWorkspaceStorage} 一个协作者，是最先该切出来的一刀。</p>
+ *
+ * <p><b>路径穿越的全链路唯一防御点在这里</b>：{@link #resolveSessionWorkspace} 是 stream / files /
+ * file-content / rollback 等所有会话级功能解析磁盘路径的公共入口，sessionId 由前端透传，
+ * 校验只在此处做一次（fast-fail，符合"整条链路只需一处防御式编程"）。把它和装配逻辑混在一个
+ * 900 行的类里，最大的风险是有人另起一条解析路径而绕过这道校验。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class AgentWorkspaceManager {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentWorkspaceManager.class);
+
+    /** 工作区根：落系统临时目录，里面全是可重建的派生物（约定见 RuntimeWorkDir）。 */
+    private static final String WORKSPACE_ROOT = RuntimeWorkDir.of("admin-workspace");
+
+    private static final String SESSIONS_DIR_NAME = "sessions";
+
+    /** 可信主体的 MEMORY.md 物理隔离子目录。 */
+    private static final String SUBJECTS_DIR_NAME = "subjects";
+
+    private static final long ID_CMD_TIMEOUT_SECONDS = 5;
+
+    /**
+     * 宿主机 JVM 进程的 {@code uid:gid}，供 {@code docker run --user} 使用；
+     * 类加载时探测一次，进程生命周期内不会变。探测失败为 null，表示不注入。
+     */
+    private static final String HOST_UID_GID = resolveHostUidGid();
+
+    private final SessionWorkspaceStorage sessionWorkspaceStorage;
+
+    public AgentWorkspaceManager(ObjectProvider<SessionWorkspaceStorage> sessionWorkspaceStorageProvider) {
+        // 容错 null provider：单测直传 null 构造本类以验证路径校验逻辑，无需拉起容器
+        this.sessionWorkspaceStorage = sessionWorkspaceStorageProvider == null
+            ? null : sessionWorkspaceStorageProvider.getIfAvailable();
+    }
+
+    /** 宿主机 uid:gid；探测失败返回 null（调用方据此决定不注入 {@code --user}）。 */
+    public static String hostUidGid() {
+        return HOST_UID_GID;
+    }
+
+    /**
+     * bind mount 前置：预建宿主机 agent 工作区根及 {@code sessions/} 子目录并 fast fail。
+     *
+     * <p>若交给 {@code docker -v} 自动补建，缺失目录会以 root 属主创建，后续宿主机侧 git/回滚
+     * 必然撞权限——这正是本方法要规避的场景，建不出来就不该继续挂载。
+     * 返回绝对 normalize 路径，与 {@link #resolveSessionWorkspace} 同源（同一 {@code WORKSPACE_ROOT}
+     * 相对 JVM 工作目录），保证容器内写入与宿主机读取指向同一目录。</p>
+     *
+     * <p>静态：只用静态常量、不碰实例状态，而调用方 {@code buildDockerFilesystemSpec} 刻意是静态包私有——
+     * 让 {@code DockerSandboxIntegrationTest} 能直接消费生产装配而不必 mock 全套依赖。</p>
+     */
+    public static Path prepareHostWorkspaceRoot(String agentCode) {
+        Path hostWorkspaceRoot = Path.of(WORKSPACE_ROOT, WorkspaceRuntimeScope.agent(agentCode))
+            .toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(hostWorkspaceRoot.resolve(SESSIONS_DIR_NAME));
+        } catch (Exception e) {
+            log.error("[workspace] create host workspace dir for bind mount failed, code={}, agentCode={}",
+                "SANDBOX_BIND_MOUNT_INIT_ERROR", agentCode, e);
+            throw new BizException(ResultCode.SYSTEM_ERROR, "docker 沙箱工作区目录创建失败: " + hostWorkspaceRoot);
+        }
+        return hostWorkspaceRoot;
+    }
+
+    /**
+     * VibeCoding 沙箱工作区路径（智能体根目录）：{@code {临时根}/admin-workspace/{agentCode}}。
+     * 仅供快照根路径使用；Agent 运行时请用 {@link #resolveSessionWorkspace(String, String)} 按会话隔离。
+     */
+    public Path resolveWorkspace(String agentCode) {
+        return resolveWorkspace(AgentMemoryScope.current(agentCode));
+    }
+
+    /** 已冻结主体的工作区；可信请求下 MEMORY.md 物理隔离。 */
+    public Path resolveWorkspace(AgentMemoryScope scope) {
+        Path base = Path.of(WORKSPACE_ROOT, WorkspaceRuntimeScope.agent(scope.agentCode()));
+        Path workspace = scope.trusted()
+            ? base.resolve(SUBJECTS_DIR_NAME).resolve(scope.subjectHash()) : base;
+        try {
+            Files.createDirectories(workspace);
+        } catch (Exception e) {
+            log.error("[workspace] create workspace dir failed, code={}, agentCode={}",
+                "WORKSPACE_INIT_ERROR", scope.agentCode(), e);
+        }
+        return workspace;
+    }
+
+    /**
+     * VibeCoding 沙箱工作区路径（会话级隔离）：
+     * {@code {临时根}/admin-workspace/{agentCode}/sessions/{sessionId}}。
+     * HarnessAgent 的文件操作根目录，不同会话产出物物理隔离，互不污染。
+     *
+     * <p><b>安全约束（会话路径解析的全链路唯一防御点）</b>：本方法是 stream / files / file-content /
+     * rollback 等所有会话级功能解析磁盘路径的公共入口，sessionId 由前端透传（正常值是 UUID v4），
+     * 在此统一做路径穿越校验——含路径分隔符或 {@code ..} 的 sessionId 直接 fast fail，
+     * 并对拼接结果 normalize 后强校验必须仍落在该 agent 的 {@code sessions/} 根目录内。
+     * 否则恶意 sessionId（如 {@code ../其他会话ID} / 绝对路径）可越界访问他人会话甚至宿主机任意目录
+     * （rollback 链路会对目标目录执行破坏性的 git checkout + clean）。</p>
+     */
+    public Path resolveSessionWorkspace(String agentCode, String sessionId) {
+        String safeSession = requireSafeSessionId(sessionId);
+        Path sessionsRoot = resolveWorkspace(AgentMemoryScope.current(agentCode))
+            .resolve(SESSIONS_DIR_NAME).normalize();
+        Path workspace = sessionsRoot.resolve(safeSession).normalize();
+        // 双保险：字符黑名单之外，normalize 后必须仍是 sessions 根目录的真子路径（防未预见的编码绕过）
+        if (!workspace.startsWith(sessionsRoot) || workspace.equals(sessionsRoot)) {
+            log.error("[workspace] session workspace path traversal blocked, code={}, agentCode={}, sessionId={}",
+                "SESSION_PATH_TRAVERSAL", agentCode, safeSession);
+            throw new BizException(ResultCode.PARAM_INVALID, "非法 sessionId：解析路径越界");
+        }
+        try {
+            Files.createDirectories(workspace);
+        } catch (Exception e) {
+            log.error("[workspace] create session workspace dir failed, code={}, agentCode={}, sessionId={}",
+                "SESSION_WORKSPACE_INIT_ERROR", agentCode, safeSession, e);
+        }
+        // 恢复权威副本：工作区落在系统临时目录（会被 OS 清理）、容器化部署更是一销毁就没了，
+        // 而会话产出物是用户生成的代码、不是可重建的派生物。本方法是所有会话级功能解析路径的公共入口，
+        // 挂在这里能覆盖 stream / files / file-content / rollback 全部链路。
+        // 仅在本地目录为空时真正拉取（见 SessionWorkspaceStorage#hydrate），故重复调用无额外开销。
+        if (sessionWorkspaceStorage != null) {
+            sessionWorkspaceStorage.hydrate(agentCode, safeSession, workspace);
+        }
+        return workspace;
+    }
+
+    /**
+     * 把会话工作区保存回权威存储（对象存储）。产出物写入之后必须调用一次，
+     * 否则本地临时目录一被清理就丢。
+     *
+     * <p>调用点覆盖三条会造成写入的链路：对话轮次结束、手工保存文件、一键回滚。
+     * 未启用持久化时静默跳过；失败只记 error，不打断主链路（见 {@link SessionWorkspaceStorage#persist}）。</p>
+     */
+    public void persistSessionWorkspace(String agentCode, String sessionId) {
+        if (sessionWorkspaceStorage == null) {
+            return;
+        }
+        String safeSession = requireSafeSessionId(sessionId);
+        sessionWorkspaceStorage.persist(agentCode, safeSession,
+            resolveWorkspace(AgentMemoryScope.current(agentCode))
+                .resolve(SESSIONS_DIR_NAME).resolve(safeSession).normalize());
+    }
+
+    /**
+     * sessionId 合法性校验：空值回退 {@code default}；含 {@code /}、{@code \}、{@code ..} 任一直接拒绝。
+     *
+     * <p>前端生成的 sessionId 是 UUID v4（十六进制 + 连字符，见 customer-admin-web/src/utils/uuid.ts），
+     * 正常值不可能出现这些字符，出现即恶意构造，fast fail。</p>
+     */
+    public static String requireSafeSessionId(String sessionId) {
+        String safeSession = StringUtils.hasText(sessionId) ? sessionId : "default";
+        if (safeSession.contains("/") || safeSession.contains("\\") || safeSession.contains("..")) {
+            throw new BizException(ResultCode.PARAM_INVALID, "非法 sessionId：不允许包含路径分隔符或 ..");
+        }
+        return safeSession;
+    }
+
+    /**
+     * 探测宿主机 JVM 进程的 {@code uid:gid}（POSIX {@code id -u} / {@code id -g}）；
+     * 任何异常（命令缺失 / 超时 / 非 POSIX 平台）返回 null 表示不注入。
+     */
+    private static String resolveHostUidGid() {
+        try {
+            String uid = execIdCommand("-u");
+            String gid = execIdCommand("-g");
+            if (StringUtils.hasText(uid) && StringUtils.hasText(gid)) {
+                return uid + ":" + gid;
+            }
+        } catch (Exception e) {
+            log.error("[workspace] resolve host uid/gid failed, code={}", "SANDBOX_UID_RESOLVE_FAIL", e);
+        }
+        return null;
+    }
+
+    /** 执行 {@code id <flag>} 并返回 trim 后的输出；非零退出码 / 超时返回 null。 */
+    private static String execIdCommand(String flag) throws Exception {
+        Process process = new ProcessBuilder("id", flag).redirectErrorStream(true).start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (!process.waitFor(ID_CMD_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            return null;
+        }
+        return process.exitValue() == 0 ? output : null;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/SandboxCommandService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/runtime/SandboxCommandService.java
@@ -70,6 +70,7 @@ public class SandboxCommandService {
     private final AdminSandboxProperties properties;
     private final SandboxRiskDetector riskDetector;
     private final AdminAgentInstanceFactory agentInstanceFactory;
+    private final AgentWorkspaceManager workspaceManager;
     private final AiCodingAuditService auditService;
     private final Map<SandboxKey, ManagedSandbox> sandboxes = new ConcurrentHashMap<>();
     private final ExecutorService commandExecutor = Executors.newCachedThreadPool(daemonFactory("sandbox-command-"));
@@ -77,7 +78,9 @@ public class SandboxCommandService {
         Executors.newSingleThreadScheduledExecutor(daemonFactory("sandbox-timeout-"));
 
     public SandboxCommandService(AdminSandboxProperties properties, SandboxRiskDetector riskDetector,
-                                 AdminAgentInstanceFactory agentInstanceFactory, AiCodingAuditService auditService) {
+                                 AdminAgentInstanceFactory agentInstanceFactory, AiCodingAuditService auditService,
+                                    AgentWorkspaceManager workspaceManager) {
+        this.workspaceManager = workspaceManager;
         this.properties = properties;
         this.riskDetector = riskDetector;
         this.agentInstanceFactory = agentInstanceFactory;
@@ -90,7 +93,7 @@ public class SandboxCommandService {
         if (!StringUtils.hasText(command)) {
             throw new BizException(ResultCode.PARAM_INVALID, "命令不能为空");
         }
-        String safeSession = AdminAgentInstanceFactory.requireSafeSessionId(sessionId);
+        String safeSession = AgentWorkspaceManager.requireSafeSessionId(sessionId);
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.COMMAND_EXECUTE, agentCode, safeSession);
         try {
             if (properties.getGuard().isEnabled() && riskDetector.matchesDestructive(command)) {
@@ -103,7 +106,7 @@ public class SandboxCommandService {
 
             String tenantId = currentTenant();
             SandboxKey key = new SandboxKey(tenantId, userId, agentCode, safeSession);
-            Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, safeSession);
+            Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, safeSession);
             ManagedSandbox managed = sandboxes.computeIfAbsent(key,
                 ignored -> new ManagedSandbox(key, properties.isDockerMode() ? "docker" : "local", workspace));
             if (!managed.inUse.compareAndSet(false, true)) {
@@ -141,7 +144,7 @@ public class SandboxCommandService {
     /** 手动停止并删除一个会话沙箱；不存在时幂等返回 false。 */
     public boolean cleanup(String agentCode, String sessionId, long userId) {
         requireFeature(properties.getFeatures().isManagementEnabled());
-        String safeSession = AdminAgentInstanceFactory.requireSafeSessionId(sessionId);
+        String safeSession = AgentWorkspaceManager.requireSafeSessionId(sessionId);
         SandboxKey key = new SandboxKey(currentTenant(), userId, agentCode, safeSession);
         ManagedSandbox managed = sandboxes.remove(key);
         if (managed == null) {
@@ -261,7 +264,7 @@ public class SandboxCommandService {
             if (managed.status != SandboxStatus.FAILED) {
                 managed.status = SandboxStatus.IDLE;
             }
-            agentInstanceFactory.persistSessionWorkspace(managed.key.agentCode, managed.key.sessionId);
+            workspaceManager.persistSessionWorkspace(managed.key.agentCode, managed.key.sessionId);
         }
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -75,6 +76,7 @@ public class CollaborativeCodingService {
     private static final int MAX_DIFF_CHARS_FOR_REVIEW = 60_000;
 
     private final AiAgentMapper agentMapper;
+    private final AgentWorkspaceManager workspaceManager;
     private final AdminCollaborationProperties properties;
     private final AdminAgentInstanceFactory agentInstanceFactory;
     private final VibeCodingService vibeCodingService;
@@ -86,7 +88,9 @@ public class CollaborativeCodingService {
                                       AdminAgentInstanceFactory agentInstanceFactory,
                                       VibeCodingService vibeCodingService,
                                       GitWorkspaceService gitWorkspaceService,
-                                      AiCodingAuditService auditService) {
+                                      AiCodingAuditService auditService,
+                                     AgentWorkspaceManager workspaceManager) {
+        this.workspaceManager = workspaceManager;
         this.agentMapper = agentMapper;
         this.properties = properties;
         this.agentInstanceFactory = agentInstanceFactory;
@@ -253,7 +257,7 @@ public class CollaborativeCodingService {
     /** 审查角色提示词：角色指令 + 上游上下文 + 本轮真实 git diff（截断防溢出）。 */
     private String buildReviewPrompt(String agentCode, String sessionId,
                                      AdminCollaborationProperties.Role role, String context) {
-        Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         String diff = gitWorkspaceService.diffAgainstBaseline(workspace);
         String diffSection = StringUtils.hasText(diff)
             ? truncate(diff, MAX_DIFF_CHARS_FOR_REVIEW)
@@ -314,7 +318,7 @@ public class CollaborativeCodingService {
 
     private List<String> safeChangedFiles(String agentCode, String sessionId) {
         try {
-            Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+            Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
             return gitWorkspaceService.changedFilesAgainstBaseline(workspace);
         } catch (Exception e) {
             log.error("[collab] resolve changed files for audit failed, code={}, agentCode={}",

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.richard.fyoung.customerwork.core.model.ModelResponses;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -109,6 +110,7 @@ public class GitAssistantService {
 
     private final AiAgentMapper agentMapper;
     private final AdminAgentInstanceFactory agentInstanceFactory;
+    private final AgentWorkspaceManager workspaceManager;
     private final GitWorkspaceService gitWorkspaceService;
     private final AiCodingAuditService auditService;
     private final CodeReviewTaskMapper reviewTaskMapper;
@@ -119,7 +121,9 @@ public class GitAssistantService {
 
     public GitAssistantService(AiAgentMapper agentMapper, AdminAgentInstanceFactory agentInstanceFactory,
                                 GitWorkspaceService gitWorkspaceService, AiCodingAuditService auditService,
-                                CodeReviewTaskMapper reviewTaskMapper, SiteMessageService siteMessageService) {
+                                CodeReviewTaskMapper reviewTaskMapper, SiteMessageService siteMessageService,
+                               AgentWorkspaceManager workspaceManager) {
+        this.workspaceManager = workspaceManager;
         this.agentMapper = agentMapper;
         this.agentInstanceFactory = agentInstanceFactory;
         this.gitWorkspaceService = gitWorkspaceService;
@@ -131,7 +135,7 @@ public class GitAssistantService {
     /** diff 摘要：无变更时直接返回空摘要，不额外调用模型。 */
     public CompletableFuture<GitDiffSummary> diffSummary(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
-        Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         // 审计条目在请求线程同步段创建（操作人依赖 Sa-Token ThreadLocal），异步链路里只补结果
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.GIT_DIFF_SUMMARY, agentCode, sessionId);
         return CompletableFuture.supplyAsync(() -> {
@@ -154,7 +158,7 @@ public class GitAssistantService {
     /** 生成 commit message：无变更时直接报错，不调用模型（没有内容可总结）。 */
     public CompletableFuture<CommitMessageResponse> commitMessage(String agentCode, String sessionId, String style) {
         requireVibeCodingCapable(agentCode);
-        Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.COMMIT_MESSAGE, agentCode, sessionId);
         return CompletableFuture.supplyAsync(() -> {
             String diff = requireNonEmptyDiff(workspace);
@@ -176,7 +180,7 @@ public class GitAssistantService {
     /** 生成 PR description：无变更时直接报错，不调用模型。 */
     public CompletableFuture<PrDescriptionResponse> prDescription(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
-        Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.PR_DESCRIPTION, agentCode, sessionId);
         return CompletableFuture.supplyAsync(() -> {
             String diff = requireNonEmptyDiff(workspace);
@@ -206,7 +210,7 @@ public class GitAssistantService {
      */
     public Long submitReview(String agentCode, String sessionId, Long userId) {
         requireVibeCodingCapable(agentCode);
-        Path workspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         // 无变更在同步段快速失败（NO_FILE_CHANGES，与原同步 review 一致）：避免为"本轮无内容可审查"
         // 创建 FAILED 任务并推送误导性的失败站内信。git diff 是子进程读取、非分钟级模型调用，同步执行可接受
         String diff = requireNonEmptyDiff(workspace);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingService.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -83,6 +84,7 @@ public class VibeCodingService {
 
     private final ChatService chatService;
     private final AdminAgentInstanceFactory agentInstanceFactory;
+    private final AgentWorkspaceManager workspaceManager;
     private final AiAgentMapper agentMapper;
     private final GitWorkspaceService gitWorkspaceService;
     private final AdminSandboxProperties sandboxProperties;
@@ -98,7 +100,9 @@ public class VibeCodingService {
                               AiAgentMapper agentMapper, GitWorkspaceService gitWorkspaceService,
                               AdminSandboxProperties sandboxProperties, AiCodingAuditService auditService,
                               PlanConfirmationService planConfirmationService,
-                              AgentCallMetaFactory agentCallMetaFactory) {
+                              AgentCallMetaFactory agentCallMetaFactory,
+                                    AgentWorkspaceManager workspaceManager) {
+        this.workspaceManager = workspaceManager;
         this.chatService = chatService;
         this.agentInstanceFactory = agentInstanceFactory;
         this.agentMapper = agentMapper;
@@ -175,7 +179,7 @@ public class VibeCodingService {
         }
         requireVibeCodingCapable(agentCode);
         // 创建会话子目录（幂等），并以此为基础拍快照，对话结束后 diff 出本轮变更
-        Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path sessionWorkspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         // 必须在本轮写入发生前建立 git 基线（幂等，仅会话第一轮真正生效）——如果拖到 Git 助手被
         // 点开时才建（GitAssistantService 内部同样调用 ensureRepo），本轮已经写完的文件会被基线
         // 提交一并吞掉，导致 diff 永远是空的。
@@ -226,7 +230,7 @@ public class VibeCodingService {
             auditService.finish(audit, signal == SignalType.ON_COMPLETE ? null : "VIBECODING_STREAM_" + signal.name());
             // 产出物落权威存储：工作区在系统临时目录，不保存的话 OS 一清理 / 容器一销毁本轮生成的代码就没了。
             // 放在 doFinally 而非 onComplete——用户中途取消时本轮已写出的文件同样要保住。
-            agentInstanceFactory.persistSessionWorkspace(agentCode, safeSession);
+            workspaceManager.persistSessionWorkspace(agentCode, safeSession);
         });
     }
 
@@ -255,7 +259,7 @@ public class VibeCodingService {
      */
     public List<String> listChangedArtifacts(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
-        Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path sessionWorkspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         Map<String, FileFingerprint> before = beforeSnapshots.getOrDefault(snapshotKey(agentCode, sessionId), Map.of());
         Map<String, FileFingerprint> after = snapshot(sessionWorkspace);
 
@@ -277,7 +281,7 @@ public class VibeCodingService {
      */
     public List<WorkspaceFileNode> listWorkspaceFiles(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
-        Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path sessionWorkspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         if (!Files.exists(sessionWorkspace)) {
             return List.of();
         }
@@ -296,7 +300,7 @@ public class VibeCodingService {
      */
     public WorkspaceFileContent readFileContent(String agentCode, String sessionId, String relativePath) {
         requireVibeCodingCapable(agentCode);
-        Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+        Path sessionWorkspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         // 路径穿越防御：normalize 后必须以 sessionWorkspace 开头
         Path filePath = sessionWorkspace.resolve(relativePath).normalize();
         if (!filePath.startsWith(sessionWorkspace.normalize())) {
@@ -341,7 +345,7 @@ public class VibeCodingService {
     public RollbackResult rollback(String agentCode, String sessionId) {
         requireVibeCodingCapable(agentCode);
         String safeSession = StringUtils.hasText(sessionId) ? sessionId : "default";
-        Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, safeSession);
+        Path sessionWorkspace = workspaceManager.resolveSessionWorkspace(agentCode, safeSession);
         // 审计（需求 §5.2/§5.3）：回滚是同步操作，操作人取自 Sa-Token ThreadLocal，begin/finish 同线程；
         // 业务动作自持控制流，审计只在旁路记录（含 baseline 缺失/git 失败等破坏性尝试的失败留痕）。
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.ROLLBACK, agentCode, safeSession);
@@ -355,7 +359,7 @@ public class VibeCodingService {
             log.info("[workspace] session rolled back, agentCode={}, sessionId={}, restored={}, deleted={}",
                 agentCode, safeSession, result.restoredFiles().size(), result.deletedFiles().size());
             // 回滚同样是写操作：不保存的话权威副本仍是回滚前的状态，下次恢复会把已撤销的改动又拉回来
-            agentInstanceFactory.persistSessionWorkspace(agentCode, safeSession);
+            workspaceManager.persistSessionWorkspace(agentCode, safeSession);
             auditService.finish(audit, (String) null);
             return result;
         } catch (RuntimeException e) {
@@ -383,7 +387,7 @@ public class VibeCodingService {
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.FILE_SAVE, agentCode, sessionId);
         auditService.applyChangedFiles(audit, List.of(relativePath));
         try {
-            Path sessionWorkspace = agentInstanceFactory.resolveSessionWorkspace(agentCode, sessionId);
+            Path sessionWorkspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
             // 路径穿越防御
             Path filePath = sessionWorkspace.resolve(relativePath).normalize();
             if (!filePath.startsWith(sessionWorkspace.normalize())) {
@@ -400,7 +404,7 @@ public class VibeCodingService {
                 log.error("[workspace] save file content failed, agentCode={}, sessionId={}, path={}", agentCode, sessionId, relativePath, e);
                 throw new BizException(ResultCode.SYSTEM_ERROR, "文件保存失败: " + relativePath);
             }
-            agentInstanceFactory.persistSessionWorkspace(agentCode, sessionId);
+            workspaceManager.persistSessionWorkspace(agentCode, sessionId);
             auditService.finish(audit, (String) null);
         } catch (RuntimeException e) {
             auditService.finish(audit, e);

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/agent/service/AgentMemoryServiceTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.aiconfig.agent.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.richard.fyoung.customeradmin.aiconfig.agent.dto.AgentMemoryVO;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySnapshot;
@@ -53,11 +54,12 @@ class AgentMemoryServiceTest {
         when(agentService.requireAgent(AGENT_ID)).thenReturn(agent);
 
         AdminAgentInstanceFactory instanceFactory = mock(AdminAgentInstanceFactory.class);
-        when(instanceFactory.resolveWorkspace(any(AgentMemoryScope.class))).thenReturn(workspace);
+        AgentWorkspaceManager workspaceManager = mock(AgentWorkspaceManager.class);
+        when(workspaceManager.resolveWorkspace(any(AgentMemoryScope.class))).thenReturn(workspace);
 
         memoryStore = mock(AgentMemoryStore.class);
         memorySyncService = mock(AgentMemorySyncService.class);
-        service = new AgentMemoryService(agentService, instanceFactory, memoryStore, memorySyncService);
+        service = new AgentMemoryService(agentService, instanceFactory, memoryStore, memorySyncService, workspaceManager);
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatSessionSerializationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatSessionSerializationTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.chat.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.richard.fyoung.customeradmin.workspace.memory.AgentMemorySyncService;
 import com.richard.fyoung.customeradmin.workspace.runtime.AdminAgentInstanceFactory;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
@@ -56,6 +57,6 @@ class ChatSessionSerializationTest {
         when(lockProvider.getIfAvailable()).thenReturn(lock);
         return new ChatService(mock(AgentInstanceCache.class), mock(AdminAgentInstanceFactory.class),
             mock(ChatHistoryCache.class), mock(AgentMemorySyncService.class), new ExecutionModeRegistry(),
-            new PlanConfirmationService(), mock(ChatAttachmentService.class), null, null, lockProvider);
+            new PlanConfirmationService(), mock(ChatAttachmentService.class), null, null, lockProvider, new AgentWorkspaceManager(null));
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AdminAgentInstanceFactoryTest.java
@@ -16,20 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Harness 升级触发条件 = capabilities 含 vibecoding/plan/subagent/skill-learning/dynamic-subagent 任一，
  * 或 compress_trigger_msgs 非空；tasklist 是内层能力，单独勾选不触发升级。
  *
- * <p>另含 {@link AdminAgentInstanceFactory#requireSafeSessionId} 与
- * {@link AdminAgentInstanceFactory#resolveSessionWorkspace} 的路径穿越防御单测——sessionId 由前端
  * 透传，是所有会话级功能（stream/files/file-content/rollback）路径解析的输入，越界即可操作他人
  * 会话甚至宿主机任意目录。</p>
  * @author owlzhangfq@gmail.com
  */
 class AdminAgentInstanceFactoryTest {
 
-    /** 构造器纯字段赋值，路径解析只依赖常量，传 null 依赖即可单测 resolveSessionWorkspace 的防御逻辑。 */
-    private AdminAgentInstanceFactory newFactoryForPathTest() {
-        return new AdminAgentInstanceFactory(null, null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null);
-    }
 
     @Test
     void requiresHarness_shouldBeFalse_forPlainChat() {
@@ -63,46 +55,4 @@ class AdminAgentInstanceFactoryTest {
 
     // ---------------------- sessionId 路径穿越防御 ----------------------
 
-    @Test
-    void requireSafeSessionId_shouldPassNormalValues() {
-        // 正常 sessionId 是前端生成的 UUID v4，原样返回
-        assertEquals("2f6c0f2e-6a2b-4c3d-9e1f-0a1b2c3d4e5f",
-            AdminAgentInstanceFactory.requireSafeSessionId("2f6c0f2e-6a2b-4c3d-9e1f-0a1b2c3d4e5f"));
-        // 空值回退 default（与既有行为一致）
-        assertEquals("default", AdminAgentInstanceFactory.requireSafeSessionId(null));
-        assertEquals("default", AdminAgentInstanceFactory.requireSafeSessionId("  "));
-    }
-
-    @Test
-    void requireSafeSessionId_shouldRejectTraversalVariants() {
-        // ../ 相对路径穿越（回滚他人会话 / 穿出 admin-workspace）
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("../other-session"));
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("../../../../tmp/victim-repo"));
-        // 裸 ..（解析即上跳一级）
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId(".."));
-        // 绝对路径
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("/tmp/victim-repo"));
-        // 反斜杠（Windows 分隔符）
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("..\\other-session"));
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("a\\b"));
-        // 混入子路径（即便不上跳也不允许 sessionId 携带层级）
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("a/b"));
-        // 藏在中间的 ..（如 x/../../y 类变体）
-        assertParamInvalid(() -> AdminAgentInstanceFactory.requireSafeSessionId("x..y/z"));
-    }
-
-    @Test
-    void resolveSessionWorkspace_shouldRejectTraversal_beforeTouchingDisk() {
-        AdminAgentInstanceFactory factory = newFactoryForPathTest();
-        // 公共入口端到端拒绝：抛业务异常，不创建任何目录
-        assertParamInvalid(() -> factory.resolveSessionWorkspace("agent-a", "../agent-b-session"));
-        assertParamInvalid(() -> factory.resolveSessionWorkspace("agent-a", "/etc"));
-        // "." 不含黑名单字符，但 normalize 后等于 sessions 根目录本身，被第二道 startsWith/equals 校验拦下
-        assertParamInvalid(() -> factory.resolveSessionWorkspace("agent-a", "."));
-    }
-
-    private void assertParamInvalid(org.junit.jupiter.api.function.Executable executable) {
-        BizException ex = assertThrows(BizException.class, executable);
-        assertEquals(ResultCode.PARAM_INVALID, ex.getResultCode());
-    }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AgentWorkspaceManagerTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/AgentWorkspaceManagerTest.java
@@ -1,0 +1,71 @@
+package com.richard.fyoung.customeradmin.workspace.runtime;
+
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link AgentWorkspaceManager} 的路径穿越防御单测。
+ *
+ * <p>sessionId 由前端透传，{@link AgentWorkspaceManager#resolveSessionWorkspace} 是所有会话级功能
+ * （stream / files / file-content / rollback）解析磁盘路径的<b>唯一公共入口</b>，
+ * 校验只在那一处做，所以这组用例是整条链路的安全底线。</p>
+ *
+ * <p>随实现一起从 {@code AdminAgentInstanceFactoryTest} 迁来——工作区职责搬到哪个类，
+ * 守着它的测试就该跟到哪个类，否则下一个改这段逻辑的人不会想到去另一个测试类里找。</p>
+ *
+ * <p>构造器传 null：路径解析只依赖静态常量与入参，不碰 SessionWorkspaceStorage，
+ * 无需拉起任何依赖即可验证防御逻辑。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class AgentWorkspaceManagerTest {
+
+    @Test
+    void requireSafeSessionId_shouldPassNormalValues() {
+        // 正常 sessionId 是前端生成的 UUID v4，原样返回
+        assertEquals("2f6c0f2e-6a2b-4c3d-9e1f-0a1b2c3d4e5f",
+            AgentWorkspaceManager.requireSafeSessionId("2f6c0f2e-6a2b-4c3d-9e1f-0a1b2c3d4e5f"));
+        // 空值回退 default（与既有行为一致）
+        assertEquals("default", AgentWorkspaceManager.requireSafeSessionId(null));
+        assertEquals("default", AgentWorkspaceManager.requireSafeSessionId("  "));
+    }
+
+
+    @Test
+    void requireSafeSessionId_shouldRejectTraversalVariants() {
+        // ../ 相对路径穿越（回滚他人会话 / 穿出 admin-workspace）
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("../other-session"));
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("../../../../tmp/victim-repo"));
+        // 裸 ..（解析即上跳一级）
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId(".."));
+        // 绝对路径
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("/tmp/victim-repo"));
+        // 反斜杠（Windows 分隔符）
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("..\\other-session"));
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("a\\b"));
+        // 混入子路径（即便不上跳也不允许 sessionId 携带层级）
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("a/b"));
+        // 藏在中间的 ..（如 x/../../y 类变体）
+        assertParamInvalid(() -> AgentWorkspaceManager.requireSafeSessionId("x..y/z"));
+    }
+
+
+    @Test
+    void resolveSessionWorkspace_shouldRejectTraversal_beforeTouchingDisk() {
+        AgentWorkspaceManager manager = new AgentWorkspaceManager(null);
+        // 公共入口端到端拒绝：抛业务异常，不创建任何目录
+        assertParamInvalid(() -> manager.resolveSessionWorkspace("agent-a", "../agent-b-session"));
+        assertParamInvalid(() -> manager.resolveSessionWorkspace("agent-a", "/etc"));
+        // "." 不含黑名单字符，但 normalize 后等于 sessions 根目录本身，被第二道 startsWith/equals 校验拦下
+        assertParamInvalid(() -> manager.resolveSessionWorkspace("agent-a", "."));
+    }
+
+    private void assertParamInvalid(org.junit.jupiter.api.function.Executable executable) {
+        BizException e = assertThrows(BizException.class, executable);
+        assertEquals(ResultCode.PARAM_INVALID, e.getResultCode());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SandboxCommandServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SandboxCommandServiceTest.java
@@ -32,6 +32,7 @@ class SandboxCommandServiceTest {
     private final AdminSandboxProperties properties = new AdminSandboxProperties();
     private final SandboxRiskDetector riskDetector = mock(SandboxRiskDetector.class);
     private final AdminAgentInstanceFactory factory = mock(AdminAgentInstanceFactory.class);
+    private final AgentWorkspaceManager workspaceManager = mock(AgentWorkspaceManager.class);
     private final AiCodingAuditService auditService = mock(AiCodingAuditService.class);
     private SandboxCommandService service;
 
@@ -45,11 +46,11 @@ class SandboxCommandServiceTest {
     @Test
     void executeLocal_shouldStreamOutputReturnExitCodeAndExposeIdleSandbox() {
         enableFeatures();
-        when(factory.resolveSessionWorkspace("coder", "s1")).thenReturn(workspace);
+        when(workspaceManager.resolveSessionWorkspace("coder", "s1")).thenReturn(workspace);
         when(auditService.begin(org.mockito.ArgumentMatchers.any(),
             org.mockito.ArgumentMatchers.eq("coder"), org.mockito.ArgumentMatchers.eq("s1")))
             .thenReturn(new AiCodingAuditLog());
-        service = new SandboxCommandService(properties, riskDetector, factory, auditService);
+        service = new SandboxCommandService(properties, riskDetector, factory, auditService, workspaceManager);
 
         List<SandboxCommandEvent> events = service.execute("coder", "s1", 7L,
                 "printf 'first\\n'; sleep 0.1; printf 'second\\n'")
@@ -64,7 +65,7 @@ class SandboxCommandServiceTest {
         assertEquals(0, result.exitCode());
         assertTrue(result.success());
         assertEquals("IDLE", service.list("coder", 7L).get(0).status());
-        verify(factory).persistSessionWorkspace("coder", "s1");
+        verify(workspaceManager).persistSessionWorkspace("coder", "s1");
 
         assertTrue(service.cleanup("coder", "s1", 7L));
         assertFalse(service.cleanup("coder", "s1", 7L));
@@ -74,9 +75,9 @@ class SandboxCommandServiceTest {
     @Test
     void execute_shouldRejectDestructiveCommandThroughSharedDetector() {
         enableFeatures();
-        when(factory.resolveSessionWorkspace("coder", "s1")).thenReturn(workspace);
+        when(workspaceManager.resolveSessionWorkspace("coder", "s1")).thenReturn(workspace);
         when(riskDetector.matchesDestructive("rm -rf .")).thenReturn(true);
-        service = new SandboxCommandService(properties, riskDetector, factory, auditService);
+        service = new SandboxCommandService(properties, riskDetector, factory, auditService, workspaceManager);
 
         BizException error = assertThrows(BizException.class,
             () -> service.execute("coder", "s1", 7L, "rm -rf ."));
@@ -86,7 +87,7 @@ class SandboxCommandServiceTest {
 
     @Test
     void execute_shouldFailClosedWhenFeatureNotEnabled() {
-        service = new SandboxCommandService(properties, riskDetector, factory, auditService);
+        service = new SandboxCommandService(properties, riskDetector, factory, auditService, workspaceManager);
 
         BizException error = assertThrows(BizException.class,
             () -> service.execute("coder", "s1", 7L, "mvn test"));

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/CollaborativeCodingServiceTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
@@ -42,6 +43,7 @@ class CollaborativeCodingServiceTest {
 
     private final AiAgentMapper agentMapper = mock(AiAgentMapper.class);
     private final AdminAgentInstanceFactory agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
+    private final AgentWorkspaceManager workspaceManager = mock(AgentWorkspaceManager.class);
     private final VibeCodingService vibeCodingService = mock(VibeCodingService.class);
     private final GitWorkspaceService gitWorkspaceService = mock(GitWorkspaceService.class);
     private final AiCodingAuditService auditService = mock(AiCodingAuditService.class);
@@ -52,11 +54,11 @@ class CollaborativeCodingServiceTest {
         agent.setCapabilities("vibecoding");
         when(agentMapper.selectOne(any())).thenReturn(agent);
         when(agentInstanceFactory.buildModelForAgent(any())).thenReturn(model);
-        when(agentInstanceFactory.resolveSessionWorkspace(any(), any())).thenReturn(Path.of(System.getProperty("java.io.tmpdir")));
+        when(workspaceManager.resolveSessionWorkspace(any(), any())).thenReturn(Path.of(System.getProperty("java.io.tmpdir")));
         when(gitWorkspaceService.changedFilesAgainstBaseline(any())).thenReturn(List.of());
         when(auditService.begin(any(), any(), any())).thenReturn(new AiCodingAuditLog());
         return new CollaborativeCodingService(agentMapper, properties, agentInstanceFactory,
-            vibeCodingService, gitWorkspaceService, auditService);
+            vibeCodingService, gitWorkspaceService, auditService, workspaceManager);
     }
 
     private static AdminCollaborationProperties.Role planRole(String name) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
@@ -58,6 +59,7 @@ class GitAssistantServiceTest {
 
     private AiAgentMapper agentMapper;
     private AdminAgentInstanceFactory agentInstanceFactory;
+    private AgentWorkspaceManager workspaceManager;
     private GitWorkspaceService gitWorkspaceService;
     private CodeReviewTaskMapper reviewTaskMapper;
     private SiteMessageService siteMessageService;
@@ -76,15 +78,16 @@ class GitAssistantServiceTest {
     void setUp() {
         agentMapper = mock(AiAgentMapper.class);
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
+        workspaceManager = mock(AgentWorkspaceManager.class);
         gitWorkspaceService = mock(GitWorkspaceService.class);
         reviewTaskMapper = mock(CodeReviewTaskMapper.class);
         siteMessageService = mock(SiteMessageService.class);
         model = mock(Model.class);
         // 审计服务用 mock（旁路能力，埋点行为由 AiCodingAuditServiceTest 单独覆盖）
         service = new GitAssistantService(agentMapper, agentInstanceFactory, gitWorkspaceService,
-            mock(AiCodingAuditService.class), reviewTaskMapper, siteMessageService);
+            mock(AiCodingAuditService.class), reviewTaskMapper, siteMessageService, workspaceManager);
 
-        when(agentInstanceFactory.resolveSessionWorkspace(anyString(), anyString())).thenReturn(sessionWorkspace);
+        when(workspaceManager.resolveSessionWorkspace(anyString(), anyString())).thenReturn(sessionWorkspace);
         when(agentInstanceFactory.buildModelForAgent(anyString())).thenReturn(model);
     }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/VibeCodingServiceTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.vibecoding.service;
 
+import com.richard.fyoung.customeradmin.workspace.runtime.AgentWorkspaceManager;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.richard.fyoung.customeradmin.aiconfig.agent.entity.AiAgent;
 import com.richard.fyoung.customeradmin.aiconfig.agent.mapper.AiAgentMapper;
@@ -43,6 +44,7 @@ class VibeCodingServiceTest {
 
     private ChatService chatService;
     private AdminAgentInstanceFactory agentInstanceFactory;
+    private AgentWorkspaceManager workspaceManager;
     private AiAgentMapper agentMapper;
     private GitWorkspaceService gitWorkspaceService;
     private VibeCodingService service;
@@ -60,6 +62,7 @@ class VibeCodingServiceTest {
     void setUp() {
         chatService = mock(ChatService.class);
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
+        workspaceManager = mock(AgentWorkspaceManager.class);
         agentMapper = mock(AiAgentMapper.class);
         gitWorkspaceService = mock(GitWorkspaceService.class);
         // 默认 local 模式（isDockerMode()=false）；docker 模式的容器↔宿主机 bind mount 产物同步（P1-3）
@@ -67,12 +70,12 @@ class VibeCodingServiceTest {
         // 审计服务用 mock（旁路能力，埋点行为由 AiCodingAuditServiceTest 单独覆盖）
         service = new VibeCodingService(chatService, agentInstanceFactory, agentMapper, gitWorkspaceService,
             new AdminSandboxProperties(), mock(AiCodingAuditService.class), new PlanConfirmationService(),
-            mock(AgentCallMetaFactory.class));
+            mock(AgentCallMetaFactory.class), workspaceManager);
 
         // resolveWorkspace 返回 agentRoot（向后兼容，listChangedArtifacts 旧逻辑已不使用此方法）
-        when(agentInstanceFactory.resolveWorkspace("coder")).thenReturn(agentRoot);
+        when(workspaceManager.resolveWorkspace("coder")).thenReturn(agentRoot);
         // resolveSessionWorkspace 返回 agentRoot/sessions/{sessionId}
-        when(agentInstanceFactory.resolveSessionWorkspace(anyString(), anyString())).thenAnswer(inv -> {
+        when(workspaceManager.resolveSessionWorkspace(anyString(), anyString())).thenAnswer(inv -> {
             String sessionId = inv.getArgument(1);
             Path p = agentRoot.resolve("sessions").resolve(sessionId);
             Files.createDirectories(p);

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcCondition.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcCondition.java
@@ -37,6 +37,10 @@ public class PersistenceJdbcCondition implements Condition {
         "customer-work.chat-log.store-mode",
         "customer-work.call-log.store-mode",
         "customer-work.outbox.store-mode",
+        // 附件元数据的 Java 默认值虽是 jdbc，但刻意留在本清单（缺省按"未启用"判）而不是
+        // JDBC_BY_DEFAULT_KEYS：AttachmentConfig#attachmentStore 在取不到 Mapper 时会主动降级内存
+        // 并打日志，故它不该仅凭自身默认值就强制拉起整个持久化环境（那等于要求宿主必须有 MySQL，
+        // 纯内存形态就跑不起来了）。这条例外登记在 PersistenceJdbcConditionRegistryTest 里。
         "customer-work.attachment.store-mode",
         "customer-work.sensitive-word.store-mode",
         // 命中日志与词表是两个独立开关：允许"词表用内存种子、只把命中记录落库"这种组合，
@@ -46,6 +50,20 @@ public class PersistenceJdbcCondition implements Condition {
         "customer-work.security.rate-limit.store-mode",
         // 主体级速率配额（等级表 + 命中记录）同理：它可能是宿主唯一想落库的东西
         "customer-work.subject-quota.store-mode",
+        // 以下 10 个域是 B6 运营闭环 / B7 主体配额等批次陆续加的，加了 Store 却没更新本表——
+        // 默认配置下被 memory.store-mode（默认 jdbc）顺带激活而看不出问题，
+        // 但宿主一旦把记忆两键显式配成 memory，再单独把这里任何一个配成 jdbc，
+        // 持久化环境就不会激活、Mapper 取不到。PersistenceJdbcConditionRegistryTest 现在盯着这张表。
+        "customer-work.human-handoff.store-mode",
+        "customer-work.quota.store-mode",
+        "customer-work.eval.store-mode",
+        "customer-work.badcase.store-mode",
+        "customer-work.csat.store-mode",
+        "customer-work.knowledge-gap.store-mode",
+        "customer-work.dead-letter.store-mode",
+        "customer-work.prompt-version.store-mode",
+        "customer-work.semantic-cache.store-mode",
+        "customer-work.routing.seat-store-mode",
         "customer-work.tool-backend.mode"
     };
 

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcConditionRegistryTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/PersistenceJdbcConditionRegistryTest.java
@@ -1,0 +1,139 @@
+package com.richard.fyoung.customerwork.infra.config;
+
+import com.richard.fyoung.customerwork.core.constant.StoreModes;
+import com.richard.fyoung.customerwork.data.attachment.AttachmentProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>持久化激活登记表门禁</b>：每个 {@code storeMode} 的配置键都必须登记进
+ * {@link PersistenceJdbcCondition}，且<b>默认即 jdbc 的必须进 JDBC_BY_DEFAULT_KEYS</b>。
+ *
+ * <p><b>为什么这张表非要机器盯</b>：{@link PersistenceJdbcCondition} 决定整个持久化环境
+ * （独立 DataSource / SqlSessionFactory / 全部 Mapper）装不装配。它在 Bean 定义注册期执行，
+ * 早于属性绑定，因此只能读原始 {@code Environment}——<b>看不见 properties 类里的 Java 默认值</b>。
+ * 这是 Spring 的机制约束，改不掉；能改的是"必须登记"由谁负责。</p>
+ *
+ * <p>漏登或错登的后果是<b>静默错配</b>：Store 按 Java 默认值取了 jdbc，而持久化环境没激活、
+ * Mapper 根本没进容器。它不会在启动时明确报"你漏配了"，只会在第一次真正读写时炸，
+ * 或者更糟——被别的默认 jdbc 的键顺带激活而看起来一切正常，直到某个宿主把那个键关掉。</p>
+ *
+ * <p>本测试用反射从 {@link CustomerWorkProperties} 走一遍对象图，按字段路径推导配置键，
+ * 再拿字段的<b>实际默认值</b>去反查这张表。新增一个 store-mode 而忘了登记，这里会红。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class PersistenceJdbcConditionRegistryTest {
+
+    private static final String ROOT_PREFIX = "customer-work";
+
+    /** 走对象图的深度上限，防御属性类之间出现环引用时无限递归。 */
+    private static final int MAX_DEPTH = 4;
+
+    /**
+     * 不参与判定的键：语义不是"这个域要不要落库"。
+     *
+     * <p>{@code outbox.store-mode} 默认 {@code auto}——它跟随 {@code ticket.store-mode}，
+     * 自身不表达落库意图，故按"缺省未启用"登记在 STORE_MODE_KEYS 是对的。</p>
+     */
+    private static final Set<String> NOT_A_JDBC_DEFAULT = Set.of(
+        // 默认 auto——跟随 ticket.store-mode，自身不表达落库意图
+        ROOT_PREFIX + ".outbox.store-mode",
+        // 默认 jdbc，但 AttachmentConfig#attachmentStore 取不到 Mapper 时会主动降级内存并打日志。
+        // 有优雅降级的域不该仅凭自身默认值强制拉起整个持久化环境——那等于要求宿主必须有 MySQL，
+        // 纯内存形态就跑不起来（CustomerWorkPersistenceConfigTest#whenAllMemory_shouldNotWireAnyPersistenceBean
+        // 正是守着这条）。新增这类例外时必须在此写明降级发生在哪个类。
+        ROOT_PREFIX + ".attachment.store-mode");
+
+    @Test
+    @DisplayName("每个 storeMode 配置键都已登记，且默认 jdbc 的落在 JDBC_BY_DEFAULT_KEYS")
+    void everyStoreModeKeyMustBeRegistered() throws Exception {
+        Set<String> anyList = new HashSet<>(readKeys("STORE_MODE_KEYS"));
+        Set<String> jdbcByDefault = new HashSet<>(readKeys("JDBC_BY_DEFAULT_KEYS"));
+        anyList.addAll(jdbcByDefault);
+
+        Map<String, String> discovered = new LinkedHashMap<>();
+        collectStoreModes(new CustomerWorkProperties(), ROOT_PREFIX, 0, discovered);
+        // 独立成一份 @ConfigurationProperties（admin 排除自动装配后单独复用），不挂在聚合根下
+        collectStoreModes(new AttachmentProperties(), ROOT_PREFIX + ".attachment", 1, discovered);
+
+        if (discovered.isEmpty()) {
+            fail("未从属性对象图里发现任何 storeMode 字段，本测试的推导逻辑可能已失效");
+        }
+
+        List<String> problems = new ArrayList<>();
+        for (Map.Entry<String, String> e : discovered.entrySet()) {
+            String key = e.getKey();
+            String defaultValue = e.getValue();
+            if (!anyList.contains(key)) {
+                problems.add(key + " 未登记进 PersistenceJdbcCondition（Java 默认值 "
+                    + defaultValue + "）——Store 想落库时持久化环境不会激活");
+                continue;
+            }
+            boolean defaultsToJdbc = StoreModes.isJdbc(defaultValue);
+            if (defaultsToJdbc && !jdbcByDefault.contains(key) && !NOT_A_JDBC_DEFAULT.contains(key)) {
+                problems.add(key + " 的 Java 默认值是 " + defaultValue
+                    + "，必须登记进 JDBC_BY_DEFAULT_KEYS（当前只在 STORE_MODE_KEYS 里）"
+                    + "——那份清单在配置缺省时按「未启用」判定，与默认值相反");
+            }
+            if (!defaultsToJdbc && jdbcByDefault.contains(key)) {
+                problems.add(key + " 的 Java 默认值是 " + defaultValue
+                    + "，却登记在 JDBC_BY_DEFAULT_KEYS——会让持久化环境无谓地默认装配");
+            }
+        }
+
+        if (!problems.isEmpty()) {
+            fail("持久化激活登记表与属性默认值不一致，共 " + problems.size() + " 处：\n  - "
+                + String.join("\n  - ", problems)
+                + "\n\nPersistenceJdbcCondition 在 Bean 定义注册期执行，看不见 Java 默认值，"
+                + "两处判定一旦漂移就是静默错配：Store 取 jdbc、Mapper 却没进容器。");
+        }
+    }
+
+    /** 递归收集对象图里的 {@code *storeMode} 字段：字段路径 -> 当前默认值。 */
+    private static void collectStoreModes(Object bean, String prefix, int depth,
+                                          Map<String, String> out) throws Exception {
+        if (depth > MAX_DEPTH || bean == null) {
+            return;
+        }
+        Deque<Field> nested = new ArrayDeque<>();
+        for (Field f : bean.getClass().getDeclaredFields()) {
+            if (f.isSynthetic() || java.lang.reflect.Modifier.isStatic(f.getModifiers())) {
+                continue;
+            }
+            f.setAccessible(true);
+            String name = f.getName();
+            if (f.getType() == String.class && name.toLowerCase().endsWith("storemode")) {
+                out.put(prefix + "." + kebab(name), (String) f.get(bean));
+            } else if (f.getType().getName().startsWith("com.richard.fyoung.customerwork")) {
+                nested.add(f);
+            }
+        }
+        for (Field f : nested) {
+            collectStoreModes(f.get(bean), prefix + "." + kebab(f.getName()), depth + 1, out);
+        }
+    }
+
+    /** {@code hitLogStoreMode} -> {@code hit-log-store-mode}（Spring Boot 的宽松绑定规则）。 */
+    private static String kebab(String camel) {
+        return camel.replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase();
+    }
+
+    private static List<String> readKeys(String fieldName) throws Exception {
+        Field f = PersistenceJdbcCondition.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return List.of((String[]) f.get(null));
+    }
+}


### PR DESCRIPTION
> 叠在 #144 之上（#144 → #143 → #142）。前置 PR 合并后 base 会自动上移。

## 一、从 `AdminAgentInstanceFactory` 剥离 `AgentWorkspaceManager`

**1108 → 964 行**，工作区职责成为独立的 210 行类。

那个类混了 7 类职责，其中"在磁盘上定位/创建/回存工作区目录"与"把一个 Agent 装配出来"毫无关系 —— 它甚至要 shell 调 `id` 命令取宿主机 uid/gid。这一簇有清晰的输入输出边界、只依赖 `SessionWorkspaceStorage` 一个协作者，是最先该切的一刀。

迁出 4 个常量 + 7 个方法。6 个调用方（`ChatService` / `AgentMemoryService` / `SandboxCommandService` / `VibeCodingService` / `GitAssistantService` / `CollaborativeCodingService`）改为**直接注入新组件，不再经工厂中转** —— 否则职责只是挪了个地方，API 面没变。

路径穿越防御的单测随实现一起迁到 `AgentWorkspaceManagerTest`：职责搬到哪个类，守着它的测试就该跟到哪个类，否则下一个改这段逻辑的人不会想到去另一个测试类里找。

> **修正报告里的一处数字**：构造器参数仍是 38 个（`ObjectProvider<SessionWorkspaceStorage>` 换成 `AgentWorkspaceManager`，是**替换**不是减少）—— 工厂内部仍有一处要解析工作区。审计报告里写的"立刻少 2 个"不准确。

## 二、`PersistenceJdbcCondition` 登记表补 10 项 + 加门禁

该条件在 Bean 定义注册期执行、早于属性绑定，只能读原始 `Environment`，**看不见 properties 类里的 Java 默认值**（Spring 的机制约束，改不掉）。所以那张键清单必须手工维护 —— 而 B6/B7 等批次陆续加了 Store 却没更新它。实测漏了 **10 个**：

`human-handoff` / `quota` / `eval` / `badcase` / `csat` / `knowledge-gap` / `dead-letter` / `prompt-version` / `semantic-cache` / `routing.seat`

默认配置下被 `memory.store-mode`（默认 jdbc）顺带激活而看不出问题，但宿主一旦把记忆键显式配成 `memory`、再单独把其中任何一个配成 `jdbc`，持久化环境就不会激活、Mapper 取不到。

新增 `PersistenceJdbcConditionRegistryTest`：反射走一遍属性对象图推导配置键，拿字段的**实际默认值**反查这张表，漏登或错登都会红。

## ⚠️ 一处自我修正（值得单独看）

我起初判定 `attachment` 是"默认 jdbc 却错登在 `STORE_MODE_KEYS`"，改了它 —— 然后被**既有测试** `CustomerWorkPersistenceConfigTest#whenAllMemory_shouldNotWireAnyPersistenceBean` 当场拦下。

核实后确认**原样是对的**：`AttachmentConfig#attachmentStore` 在取不到 Mapper 时会主动降级内存并打日志（javadoc 写明"避免启动失败"）。所以它不该仅凭自身默认值就强制拉起整个持久化环境 —— 那等于要求宿主必须有 MySQL，纯内存形态就跑不起来了。

已撤回改动，并把"有优雅降级的域可以例外"写进门禁的 `NOT_A_JDBC_DEFAULT`，要求新增例外时必须写明**降级发生在哪个类**。

## 验证

全模块 **clean 后** BUILD SUCCESS：starter 1702 / app-server 129 / channel 80 / admin 1391 / gateway 1 = **3303 条，0 失败 0 错误 7 跳过**。

> 这批改了方法归属，**增量编译会误报成功**（CLAUDE.md 记过这个坑）——本批实测踩到：`test-compile` 报 BUILD SUCCESS，而测试文件里明明还在 mock 已删除的方法。必须 `clean`。