### PR TITLE
fix(store): 删除失败不再静默成功，并把「写抛读降」约定变成门禁

### DIFF
--- a/customer-admin-web/src/api/agentCallStats.ts
+++ b/customer-admin-web/src/api/agentCallStats.ts
@@ -61,7 +61,13 @@ export function getAgentCallStatsTrend(query: AgentCallStatsQuery, granularity: 
   })
 }
 
-/** 删除一条调用记录。 */
+/**
+ * 删除一条调用记录。
+ *
+ * 返回值是「是否真的删掉了一行」：false 表示这条记录已经不在了（可能被其他管理员先删）。
+ * 此前声明成 void，而后端一直返回 Result<Boolean>——类型对不上，调用方也就无从判断结果，
+ * 于是删除失败时照样提示「删除成功」。
+ */
 export function deleteAgentCallStats(id: number, source: AgentCallSource) {
-  return request<void>({ url: `${BASE_URL}/${id}`, method: 'delete', params: { source } })
+  return request<boolean>({ url: `${BASE_URL}/${id}`, method: 'delete', params: { source } })
 }

--- a/customer-admin-web/src/views/system/AgentCallStats.vue
+++ b/customer-admin-web/src/views/system/AgentCallStats.vue
@@ -397,8 +397,14 @@ function openInWorkspace(row: AgentCallStatsRow) {
 // ---------- 行操作：删除 ----------
 async function handleDelete(row: AgentCallStatsRow) {
   await ElMessageBox.confirm(`确认删除这条调用记录？（请求ID：${row.requestId}）`, '提示', { type: 'warning' })
-  await deleteAgentCallStats(row.id, filters.source)
-  ElMessage.success('删除成功')
+  // 后端返回的布尔值表示「是否真的删掉了一行」，false = 这条记录已经不在了（可能被别人先删）。
+  // 此前无条件提示「删除成功」，用户在没删掉的时候也会看到成功——列表刷新后记录还在，很费解。
+  const deleted = await deleteAgentCallStats(row.id, filters.source)
+  if (deleted) {
+    ElMessage.success('删除成功')
+  } else {
+    ElMessage.warning('该记录已不存在，可能已被其他管理员删除')
+  }
   await refreshAll()
 }
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/calllog/MybatisAgentCallLogStore.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/calllog/MybatisAgentCallLogStore.java
@@ -96,15 +96,18 @@ public class MybatisAgentCallLogStore implements AgentCallLogStore {
         }
     }
 
+    /**
+     * 删除主记录与级联分段；返回 {@code false} 仅表示<b>没有这一行</b>（可能已被删）。
+     *
+     * <p><b>库故障不再吞成 false</b>：此前 DB 异常与"行不存在"都返回 false，调用方无从分辨——
+     * 后台删除按钮因此在删除失败时照样提示"删除成功"（拿到的是 HTTP 200 + false，而前端并不看这个值）。
+     * 写操作失败必须向上传播，这是 Store 层的既有约定（38 处写方法里 24 处如此），
+     * 现由 {@code StoreFailurePolicyTest} 守着。</p>
+     */
     @Override
     public boolean delete(long id) {
-        try {
-            segmentMapper.deleteByCallLogId(id);
-            return callLogMapper.deleteById(id) > 0;
-        } catch (Exception e) {
-            log.error("agent call log delete failed, code={}, id={}", "CALLLOG-DELETE-FAIL", id, e);
-            return false;
-        }
+        segmentMapper.deleteByCallLogId(id);
+        return callLogMapper.deleteById(id) > 0;
     }
 
     @Override

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/StoreFailurePolicyTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/StoreFailurePolicyTest.java
@@ -1,0 +1,195 @@
+package com.richard.fyoung.customerwork.data;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>Store 失败处置门禁</b>：写操作失败必须向上传播，旁路写入才可以吞掉——而且必须写明理由。
+ *
+ * <p><b>这条约定本来就存在，只是没人守</b>：全仓 29 个 {@code Mybatis*Store} 共 114 处
+ * {@code catch (Exception)}，实测分布是——写方法 24 处抛 / 14 处吞，读方法 45 处降级 / 15 处抛。
+ * 即「写抛、读降」是主流写法，但被违反约三成，而且从调用点<b>看不出来这次会是哪种</b>。</p>
+ *
+ * <p><b>为什么盯写而不盯读</b>：读失败降级成空集合，最坏是少显示一些数据，页面上看得见；
+ * 而写失败被吞掉是<b>数据没了却没有任何信号</b>。已经出过一次事：
+ * {@code MybatisAgentCallLogStore#delete} 把 DB 异常和"行不存在"都返回 {@code false}，
+ * 于是后台删除按钮在删除失败时照样提示"删除成功"（HTTP 200 + false，而前端并不看这个值）。</p>
+ *
+ * <p><b>读侧刻意不做强制</b>：降级是不是对的取决于调用方能不能分辨「失败」与「没数据」，
+ * 那是逐个方法的判断（{@code MybatisSensitiveWordStore#findEnabled} 就特意返回
+ * {@code Optional<List<>>} 来保住这个区别，好让过滤器 fail-closed）。
+ * 机器判不了这件事，硬要判只会逼人写假注解。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class StoreFailurePolicyTest {
+
+    private static final String STARTER_SOURCE_ROOT = "customer-work-starter/src/main/java";
+
+    /** 方法名前缀判定为「写」。 */
+    private static final Pattern WRITE_METHOD = Pattern.compile(
+        "^(save|insert|update|delete|remove|upsert|append|record|increment|purge|clear|mark|bind|evict|put)");
+
+    private static final Pattern METHOD_HEAD = Pattern.compile(
+        "\\n    (?:public|private|protected)\\s+[\\w<>,\\[\\]. ]+?\\s+(\\w+)\\s*\\([^)]*\\)\\s*\\{");
+
+    /** 错误码必须是可检索的「域-动作-FAIL」大写串；小写或自由文本在日志里根本搜不出来。 */
+    private static final Pattern ERROR_CODE = Pattern.compile("^[A-Z0-9]+(-[A-Z0-9]+)+-FAIL$");
+
+    private static final Pattern CODE_LITERAL = Pattern.compile("\"([A-Za-z0-9][A-Za-z0-9-]*)\"\\s*,");
+
+    /**
+     * 允许吞掉写失败的旁路写入：{@code 类名#方法名 } -> 理由。
+     *
+     * <p>共同点是<b>失败了不影响主链路，也不代表业务数据丢失</b>——埋点、观测、缓存、可重建的清理。
+     * 新增条目必须在这里写明为什么它属于旁路；写不出理由的，说明它就该抛。</p>
+     */
+    private static final Set<String> SIDE_CHANNEL_WRITES = Set.of(
+        // 用户反馈：非核心链路，失败不该阻断对话（该 Store 的 javadoc 已写明这条语义）
+        "MybatisFeedbackStore#save",
+        // 知识盲区埋点：统计用途，丢一条不影响回答
+        "MybatisKnowledgeGapStore#recordMiss",
+        // 提示词版本归因记录：指标归因用，丢一条只影响看板
+        "MybatisPromptVersionStore#record",
+        // 语义缓存：缓存本就允许失效，写不进去下次重算即可
+        "MybatisSemanticCacheStore#save",
+        "MybatisSemanticCacheStore#recordHit",
+        "MybatisSemanticCacheStore#evictLeastRecentlyUsed",
+        "MybatisSemanticCacheStore#clear",
+        "MybatisSemanticCacheStore#remove",
+        // 敏感词命中日志：旁路观测，失败不能反过来打断正在进行的过滤
+        "MybatisSensitiveWordHitLogStore#save",
+        // 主体配额命中记录：只在触顶那一刻写一条，供运营看「谁在刷」，不是限流判定依据
+        "MybatisSubjectQuotaHitStore#record",
+        // 会话级清理：本就是尽力而为，残留行由会话过期兜底，抛出反而会打断正常的结束流程
+        "MybatisDialogStageStore#remove",
+        "MybatisSlotFillingStore#delete",
+        "MybatisLongTermMemoryStore#clear");
+
+    @Test
+    @DisplayName("写方法失败必须向上传播；旁路写入才可吞，且须在允许清单里写明理由")
+    void writeFailuresMustPropagateUnlessSideChannel() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        int checked = 0;
+
+        for (Path file : storeSources()) {
+            String source = Files.readString(file, StandardCharsets.UTF_8);
+            String className = file.getFileName().toString().replace(".java", "");
+            for (MethodBody method : methods(source)) {
+                if (!WRITE_METHOD.matcher(method.name).find()) {
+                    continue;
+                }
+                int catchAt = method.body.indexOf("catch (Exception");
+                if (catchAt < 0) {
+                    continue;
+                }
+                checked++;
+                boolean propagates = method.body.indexOf("throw ", catchAt) > 0;
+                String id = className + "#" + method.name;
+                if (!propagates && !SIDE_CHANNEL_WRITES.contains(id)) {
+                    offenders.add(id + " 吞掉了写失败却不在旁路清单里"
+                        + "——写失败被吞掉就是数据没了却没有任何信号");
+                }
+            }
+        }
+
+        if (checked == 0) {
+            fail("未扫描到任何带 catch 的 Store 写方法，本测试的解析逻辑可能已失效");
+        }
+        if (!offenders.isEmpty()) {
+            fail("Store 写失败处置不合约定，共 " + offenders.size() + " 处：\n  - "
+                + String.join("\n  - ", offenders)
+                + "\n\n要么让它抛（默认选择），要么加进 SIDE_CHANNEL_WRITES 并写明为什么它属于旁路。"
+                + "\n写不出理由，就说明它该抛。");
+        }
+    }
+
+    @Test
+    @DisplayName("Store 的错误码是可检索的「域-动作-FAIL」大写串")
+    void errorCodesMustBeSearchable() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        int checked = 0;
+        for (Path file : storeSources()) {
+            String source = Files.readString(file, StandardCharsets.UTF_8);
+            for (String line : source.split("\n")) {
+                if (!line.contains("log.error(")) {
+                    continue;
+                }
+                Matcher m = CODE_LITERAL.matcher(line);
+                while (m.find()) {
+                    String candidate = m.group(1);
+                    // 只看形似错误码的（含连字符），普通文案参数跳过
+                    if (!candidate.contains("-")) {
+                        continue;
+                    }
+                    checked++;
+                    if (!ERROR_CODE.matcher(candidate).matches()) {
+                        offenders.add(file.getFileName() + "：" + candidate);
+                    }
+                }
+            }
+        }
+        if (checked == 0) {
+            fail("未扫描到任何 Store 错误码，本测试的解析逻辑可能已失效");
+        }
+        if (!offenders.isEmpty()) {
+            fail("以下错误码不是可检索形态（应形如 TICKET-STORE-SAVE-FAIL），共 "
+                + offenders.size() + " 处：\n  - " + String.join("\n  - ", offenders));
+        }
+    }
+
+    private record MethodBody(String name, String body) {
+    }
+
+    /** 粗切方法体：到下一个方法头或文件尾为止，够用来判断 catch 之后有没有 throw。 */
+    private static List<MethodBody> methods(String source) {
+        List<MethodBody> out = new ArrayList<>();
+        Matcher m = METHOD_HEAD.matcher(source);
+        List<int[]> heads = new ArrayList<>();
+        while (m.find()) {
+            heads.add(new int[]{m.start(), m.end()});
+            out.add(new MethodBody(m.group(1), ""));
+        }
+        List<MethodBody> result = new ArrayList<>();
+        for (int i = 0; i < heads.size(); i++) {
+            int bodyStart = heads.get(i)[1];
+            int bodyEnd = (i + 1 < heads.size()) ? heads.get(i + 1)[0] : source.length();
+            result.add(new MethodBody(out.get(i).name(), source.substring(bodyStart, bodyEnd)));
+        }
+        return result;
+    }
+
+    private static List<Path> storeSources() throws IOException {
+        Path root = resolveModulePath(STARTER_SOURCE_ROOT);
+        if (!Files.exists(root)) {
+            fail("找不到 starter 源码目录：" + root.toAbsolutePath());
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths
+                .filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().matches("Mybatis\\w+Store\\.java"))
+                .sorted()
+                .toList();
+        }
+    }
+
+    /** 兼容两种工作目录：仓库根（多模块构建）与模块目录（IDE 单模块跑测试）。 */
+    private static Path resolveModulePath(String moduleRelative) {
+        Path fromRepoRoot = Paths.get(moduleRelative);
+        return Files.exists(fromRepoRoot) ? fromRepoRoot : Paths.get("..").resolve(moduleRelative);
+    }
+}


### PR DESCRIPTION
> 叠在 #145 之上（#145 → #144 → #143 → #142）。前置 PR 合并后 base 会自动上移。

## 一、真 bug：删除失败却提示"删除成功"

一条完整的类型契约错位：

| 层 | 现状 |
|---|---|
| `MybatisAgentCallLogStore#delete` | DB 异常和"行不存在"**都返回 false** |
| `AgentCallStatsService#delete` | 原样返回 |
| `AgentCallStatsController` | 包成 `Result.success(false)` → **HTTP 200** |
| `api/agentCallStats.ts` | 返回类型声明成 **`void`**（后端实际是 `Result<Boolean>`） |
| `AgentCallStats.vue#handleDelete` | 根本不看返回值，**无条件**弹"删除成功" |

于是删除失败 → 用户看到"删除成功" → 列表刷新后记录还在。

修复：Store 的写失败向上传播（`false` 从此只表示"没有这一行"）；API 返回类型改回 `boolean`；前端按返回值分别提示成功 / "该记录已不存在，可能已被其他管理员删除"。

> 类型契约那处是 `vue-tsc` 报出来的（`An expression of type 'void' cannot be tested for truthiness`）—— 又一次印证前端必须两个都跑。

## 二、把已有约定变成机器可查

实测 29 个 `Mybatis*Store` 共 114 处 `catch (Exception)`：

| | 抛出 | 吞掉 |
|---|---|---|
| **写方法**（38 处） | 24 | **14** |
| **读方法**（60 处） | 15 | 45 |
| 其它（23 处） | 6 | 17 |

即"写抛、读降"**本来就是主流写法**，但被违反约三成，而且从调用点看不出来这次会是哪种。

`StoreFailurePolicyTest` 只盯写侧：读失败降级成空集合，最坏是少显示数据、页面上看得见；**写失败被吞掉是数据没了却没有任何信号** —— 本次这个 bug 就是这么来的。

13 处确属旁路的写入（反馈、盲区埋点、提示词归因、语义缓存、命中日志、会话清理）登记进 `SIDE_CHANNEL_WRITES` 并**逐条写明理由** —— 写不出理由的，说明它该抛。另加一条：错误码必须是可检索的"域-动作-FAIL"大写串。

**读侧刻意不强制**：降级对不对取决于调用方能否分辨"失败"与"没数据"，那是逐个方法的判断（`MybatisSensitiveWordStore#findEnabled` 特意返回 `Optional<List<>>` 来保住这个区别，好让过滤器 fail-closed）。机器判不了这件事，硬判只会逼人写假注解。

## ⚠️ 未采纳审计报告的原方案

报告里提议引入 `StoreGuard` 包装全部 114 处 + 建 113 项错误码枚举。放弃的理由：

1. **前提有误** —— 那 114 处并非都在吞异常，44 处本来就抛。报告把"Store 层普遍吞异常"当成了事实，实际是"有约定但没人守"
2. **收益存疑** —— 把每个方法体包成 lambda 并不比现在的 `try/catch` 好读，只是换了种样子
3. **错误码实测已是两套自洽的可检索命名**（`XXX-STORE-YYY-FAIL` 69 个 / `XXX-YYY-FAIL` 50 个），差异是纯外观的，建枚举收益不抵 29 个文件的改动风险

真正的危害是"写失败被吞"，门禁直接盯它更划算。

## 验证

- 全模块 clean 后 BUILD SUCCESS：starter 1704 / app-server 129 / channel 80 / admin 1391 / gateway 1 = **3305 条，0 失败 0 错误 7 跳过**
- 前端 `vue-tsc -b && vite build` 通过
- 门禁已负向验证：让写方法吞异常、或写个小写错误码，都会红并指名具体位置