### PR TITLE
fix(admin): 新建用户重复时提示用户名已存在

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserService.java
@@ -17,6 +17,7 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +37,8 @@ import java.util.stream.Collectors;
  */
 @Service
 public class UserService {
+
+    private static final String DUPLICATE_USERNAME_MESSAGE = "用户名已存在";
 
     private final SysUserMapper userMapper;
     private final SysUserRoleMapper userRoleMapper;
@@ -87,7 +90,7 @@ public class UserService {
             throw new BizException(ResultCode.PARAM_MISSING, "新建用户必须设置初始密码");
         }
         if (userMapper.exists(new LambdaQueryWrapper<SysUser>().eq(SysUser::getUsername, request.username()))) {
-            throw new BizException(ResultCode.RESOURCE_DUPLICATE, "用户名已存在");
+            throw duplicateUsernameException();
         }
         List<Long> roleIds = validateRoleChange(null, request.roleIds());
         SysUser user = new SysUser();
@@ -95,8 +98,18 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(request.password()));
         user.setNickname(request.nickname());
         user.setStatus(request.status() == null ? 1 : request.status());
-        userMapper.insert(user);
+        // exists() 只能减少常规冲突，无法覆盖并发创建，也看不到被逻辑删除但仍占唯一键的用户。
+        // 数据库唯一约束是最终防线；这里将其转换为稳定业务错误，供前端统一请求拦截器直接提示。
+        try {
+            userMapper.insert(user);
+        } catch (DuplicateKeyException e) {
+            throw duplicateUsernameException();
+        }
         replaceRoles(user.getId(), roleIds);
+    }
+
+    private BizException duplicateUsernameException() {
+        return new BizException(ResultCode.RESOURCE_DUPLICATE, DUPLICATE_USERNAME_MESSAGE);
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceDuplicateUsernameTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceDuplicateUsernameTest.java
@@ -1,0 +1,80 @@
+package com.richard.fyoung.customeradmin.system.user.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.auth.service.SessionRevocationService;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** 用户名唯一约束冲突的友好错误回归测试。 */
+class UserServiceDuplicateUsernameTest {
+
+    private SysUserMapper userMapper;
+    private UserService service;
+
+    @BeforeEach
+    void setUp() {
+        userMapper = mock(SysUserMapper.class);
+        PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+        when(passwordEncoder.encode(any())).thenReturn("encoded");
+        service = new UserService(
+            userMapper,
+            mock(SysUserRoleMapper.class),
+            mock(SysRoleMapper.class),
+            passwordEncoder,
+            mock(CrossTenantAuthority.class),
+            mock(SessionRevocationService.class));
+    }
+
+    @Test
+    void create_shouldReturnFriendlyErrorWhenUsernameAlreadyExists() {
+        when(userMapper.exists(any(LambdaQueryWrapper.class))).thenReturn(true);
+
+        BizException exception = assertThrows(BizException.class,
+            () -> service.create(request("richard")));
+
+        assertDuplicateUsername(exception);
+        verify(userMapper, never()).insert(any(SysUser.class));
+    }
+
+    @Test
+    void create_shouldReturnFriendlyErrorWhenDatabaseUniqueConstraintWins() {
+        when(userMapper.exists(any(LambdaQueryWrapper.class))).thenReturn(false);
+        when(userMapper.insert(any(SysUser.class)))
+            .thenThrow(new DuplicateKeyException("sys_user.uk_sys_user_username"));
+
+        BizException exception = assertThrows(BizException.class,
+            () -> service.create(request("richard")));
+
+        assertDuplicateUsername(exception);
+        verify(userMapper).insert(any(SysUser.class));
+    }
+
+    private void assertDuplicateUsername(BizException exception) {
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, exception.getResultCode());
+        assertEquals("用户名已存在", exception.getMessage());
+    }
+
+    private UserSaveRequest request(String username) {
+        return new UserSaveRequest(username, "password", "测试用户", 1, List.of());
+    }
+}


### PR DESCRIPTION
## 修改内容

- 将新建用户时的数据库用户名唯一键冲突转换为 `RESOURCE_DUPLICATE` 业务错误。
- 统一返回“用户名已存在”，让现有前端请求拦截器直接展示友好提示。
- 新增回归测试，覆盖预检查发现重复和数据库唯一约束最终拦截两条路径。

## 根因

`sys_user.uk_sys_user_username` 不包含逻辑删除字段。MyBatis-Plus 的常规 `exists()` 会过滤已逻辑删除的用户，并且预检查也无法消除并发创建竞争，因此插入仍可能抛出 `DuplicateKeyException`，最终被全局异常处理器转换成系统异常。

## 验证

- 定向回归：2 个测试通过，0 失败、0 错误。
- Maven 全量门禁：3307 个测试，0 失败、0 错误、7 跳过；6 个模块全部 `SUCCESS`。
- 真实 MySQL + Chrome：接口返回业务码 `30004` 和“用户名已存在”；页面 Toast 正确展示，创建弹窗保持打开。
- `git diff --check` 通过。

前端已有统一的非零业务响应提示逻辑，因此本次无需修改前端文件，也不会产生重复 Toast。
