### PR TITLE
fix(admin): 修复开发库存在未来迁移时启动失败

### DIFF
--- a/customer-admin-server/src/main/resources/application-dev.yml
+++ b/customer-admin-server/src/main/resources/application-dev.yml
@@ -10,7 +10,10 @@ spring:
     # 而这与当前分支的正确性毫无关系。注意它只对"版本号高于本地最高版本"之外的情况有影响：
     # 未来版本 Flyway 本就默认忽略，一旦本分支的新迁移号超过它们才会暴露成 missing。
     # 生产 profile 刻意不配：那里出现 missing 就是真的漏发布了迁移脚本，必须拦下来。
-    ignore-migration-patterns: "*:missing"
+    # 该属性会整体覆盖 Flyway 默认的 *:future，因此必须把 missing 与 future 同时显式保留。
+    ignore-migration-patterns:
+      - "*:missing"
+      - "*:future"
 
 
 # 本地/测试联调默认打开 OA 域账号登录入口；生产默认关闭，需运维显式设置 ADMIN_LDAP_ENABLED=true 开通。

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/AdminDevFlywayConfigTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/AdminDevFlywayConfigTest.java
@@ -1,0 +1,35 @@
+package com.richard.fyoung.customeradmin;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** admin 本地开发环境 Flyway 跨分支兼容配置门禁。 */
+class AdminDevFlywayConfigTest {
+
+    @Test
+    void shouldIgnoreMissingAndFutureMigrationsInDevelopment() throws Exception {
+        List<PropertySource<?>> sources = new YamlPropertySourceLoader().load(
+            "application-dev", new ClassPathResource("application-dev.yml"));
+
+        assertEquals("*:missing", property(sources,
+            "spring.flyway.ignore-migration-patterns[0]"));
+        assertEquals("*:future", property(sources,
+            "spring.flyway.ignore-migration-patterns[1]"));
+    }
+
+    private Object property(List<PropertySource<?>> sources, String key) {
+        for (PropertySource<?> source : sources) {
+            Object value = source.getProperty(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 问题

共享开发库已应用 V98，而当前分支的本地迁移最高为 V97。开发配置显式设置
`ignore-migration-patterns: "*:missing"` 后，会整体覆盖 Flyway 默认的
`*:future`，导致 V98 被判定为未解析迁移并阻止 ApplicationContext 启动。

## 修复

- 在 dev profile 中显式同时保留 `*:missing` 与 `*:future`。
- 新增配置回归测试，防止后续再次覆盖掉 Flyway 的 future 默认容忍规则。
- 生产 profile、迁移脚本及数据库历史均不做修改。

## 验证

- 定向测试：`AdminDevFlywayConfigTest` 通过。
- 真实 MySQL 启动：成功校验 97 个本地迁移，识别数据库当前版本 V98，并正常启动。
- 健康检查：`/actuator/health` 返回 `{"status":"UP"}`。
- 全量测试：6 个 Reactor 模块全部成功；3308 项测试，0 失败，0 错误，7 跳过。
