### PR TITLE
feat(admin): 增加自助注册审核流程

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
@@ -4,10 +4,12 @@ import cn.dev33.satoken.stp.StpUtil;
 import com.richard.fyoung.customeradmin.auth.dto.ChangePasswordRequest;
 import com.richard.fyoung.customeradmin.auth.dto.LoginRequest;
 import com.richard.fyoung.customeradmin.auth.dto.LoginResponse;
+import com.richard.fyoung.customeradmin.auth.dto.RegisterRequest;
 import com.richard.fyoung.customeradmin.auth.dto.SsoLoginRequest;
 import com.richard.fyoung.customeradmin.auth.service.AuthService;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.user.service.UserRegistrationService;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,14 +28,23 @@ import java.util.List;
 public class AuthController {
 
     private final AuthService authService;
+    private final UserRegistrationService userRegistrationService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, UserRegistrationService userRegistrationService) {
         this.authService = authService;
+        this.userRegistrationService = userRegistrationService;
     }
 
     @PostMapping("/login")
     public Result<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         return Result.success(authService.login(request));
+    }
+
+    /** 本地账号自助注册：只创建待审核、无角色的最小权限账号。 */
+    @PostMapping("/register")
+    public Result<Void> register(@Valid @RequestBody RegisterRequest request) {
+        userRegistrationService.register(request);
+        return Result.success();
     }
 
     /** OA 域账号（LDAP/AD）单点登录，与上面的账号密码登录入口共存，前端登录页 Tab 切换。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginResponse.java
@@ -5,5 +5,6 @@ package com.richard.fyoung.customeradmin.auth.dto;
  * （账号当前密码仍等于初始化种子哈希值，见 {@code AuthService#login}）。
  * @author owlzhangfq@gmail.com
  */
-public record LoginResponse(String token, String nickname, boolean forceChangePassword) {
+public record LoginResponse(String token, String nickname, boolean forceChangePassword,
+                            String approvalStatus, String approvalRemark) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/RegisterRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/RegisterRequest.java
@@ -1,0 +1,27 @@
+package com.richard.fyoung.customeradmin.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 后台本地账号自助注册请求。
+ * @author owlzhangfq@gmail.com
+ */
+public record RegisterRequest(
+    @NotBlank(message = "username 不能为空")
+    @Size(min = 3, max = 32, message = "用户名长度需在 3~32 位之间")
+    @Pattern(regexp = "^[A-Za-z0-9._-]+$", message = "用户名只能包含字母、数字、点、下划线和短横线")
+    String username,
+
+    @NotBlank(message = "password 不能为空")
+    @Size(min = 6, max = 32, message = "密码长度需在 6~32 位之间")
+    String password,
+
+    @NotBlank(message = "confirmPassword 不能为空")
+    @Size(min = 6, max = 32, message = "确认密码长度需在 6~32 位之间")
+    String confirmPassword,
+
+    @Size(max = 64, message = "昵称长度不能超过 64 位")
+    String nickname) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import com.richard.fyoung.customeradmin.system.log.entity.SysOperationLog;
 import com.richard.fyoung.customeradmin.system.log.mapper.OperationLogMapper;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
@@ -114,7 +115,7 @@ public class AuthService {
         userMapper.updateById(user);
 
         boolean forceChangePassword = INITIAL_ADMIN_PASSWORD_HASH.equals(user.getPassword());
-        return new LoginResponse(StpUtil.getTokenValue(), user.getNickname(), forceChangePassword);
+        return loginResponse(user, forceChangePassword);
     }
 
     /**
@@ -158,7 +159,7 @@ public class AuthService {
         userMapper.updateById(user);
 
         // LDAP 账号密码由企业域控统一管理，不走本地初始密码强制改密逻辑
-        return new LoginResponse(StpUtil.getTokenValue(), user.getNickname(), false);
+        return loginResponse(user, false);
     }
 
     public void logout() {
@@ -296,6 +297,7 @@ public class AuthService {
         created.setNickname(username);
         created.setLoginType(LDAP_LOGIN_TYPE);
         created.setStatus(1);
+        created.setApprovalStatus(UserApprovalStatus.APPROVED.name());
         // 显式写租户而非依赖拦截器或 DDL 默认值，让账号归属在领域代码里保持可见。
         created.setTenantId(TenantContext.DEFAULT);
         try {
@@ -367,6 +369,12 @@ public class AuthService {
             ur.setRoleId(role.getId());
             userRoleMapper.insert(ur);
         }
+    }
+
+    private LoginResponse loginResponse(SysUser user, boolean forceChangePassword) {
+        UserApprovalStatus approvalStatus = UserApprovalStatus.parse(user.getApprovalStatus());
+        return new LoginResponse(StpUtil.getTokenValue(), user.getNickname(), forceChangePassword,
+            approvalStatus.name(), user.getApprovalRemark());
     }
 
     private String resolveClientIp() {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/SaTokenConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/SaTokenConfig.java
@@ -22,6 +22,7 @@ public class SaTokenConfig implements WebMvcConfigurer {
             .addPathPatterns("/api/**")
             .excludePathPatterns(
                 "/api/auth/login",
+                "/api/auth/register",
                 "/api/auth/sso-login",
                 // 内网工作台脚本回调：ScriptCat 脚本运行在目标站点页面里，拿不到后台登录态，
                 // 改用个人访问令牌鉴权（见 WorkbenchAgentController，自行校验 X-Workbench-Token）

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/UserRoleResolver.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/UserRoleResolver.java
@@ -3,7 +3,10 @@ package com.richard.fyoung.customeradmin.system.role.service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.TenantSession;
 import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
@@ -28,10 +31,13 @@ public class UserRoleResolver {
 
     private final SysUserRoleMapper userRoleMapper;
     private final SysRoleMapper roleMapper;
+    private final SysUserMapper userMapper;
 
-    public UserRoleResolver(SysUserRoleMapper userRoleMapper, SysRoleMapper roleMapper) {
+    public UserRoleResolver(SysUserRoleMapper userRoleMapper, SysRoleMapper roleMapper,
+                            SysUserMapper userMapper) {
         this.userRoleMapper = userRoleMapper;
         this.roleMapper = roleMapper;
+        this.userMapper = userMapper;
     }
 
     /**
@@ -49,6 +55,10 @@ public class UserRoleResolver {
 
     private List<SysRole> doQuery(Object loginId) {
         Long userId = Long.valueOf(loginId.toString());
+        SysUser user = userMapper.selectById(userId);
+        if (user == null || !UserApprovalStatus.parse(user.getApprovalStatus()).allowsPermissions()) {
+            return List.of();
+        }
         List<Long> roleIds = userRoleMapper.selectList(
                 new LambdaQueryWrapper<SysUserRole>().eq(SysUserRole::getUserId, userId))
             .stream().map(SysUserRole::getRoleId).toList();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/controller/UserController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/controller/UserController.java
@@ -2,9 +2,10 @@ package com.richard.fyoung.customeradmin.system.user.controller;
 
 import cn.dev33.satoken.annotation.SaCheckPermission;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
-import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
+import com.richard.fyoung.customeradmin.system.user.dto.UserPageQuery;
 import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
 import com.richard.fyoung.customeradmin.system.user.dto.UserVO;
 import com.richard.fyoung.customeradmin.system.user.service.UserService;
@@ -34,7 +35,7 @@ public class UserController {
 
     @SaCheckPermission("user:view")
     @GetMapping
-    public Result<PageResult<UserVO>> page(PageQuery query) {
+    public Result<PageResult<UserVO>> page(UserPageQuery query) {
         return Result.success(userService.page(query));
     }
 
@@ -57,6 +58,15 @@ public class UserController {
     @PutMapping("/{id}")
     public Result<Void> update(@PathVariable Long id, @Valid @RequestBody UserSaveRequest request) {
         userService.update(id, request);
+        return Result.success();
+    }
+
+    @SaCheckPermission("user:edit")
+    @OperationLog(operation = "审核注册用户", target = "sys_user")
+    @PutMapping("/{id}/approval")
+    public Result<Void> review(@PathVariable Long id,
+                               @Valid @RequestBody UserApprovalRequest request) {
+        userService.review(id, request);
         return Result.success();
     }
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/domain/UserApprovalStatus.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/domain/UserApprovalStatus.java
@@ -1,0 +1,39 @@
+package com.richard.fyoung.customeradmin.system.user.domain;
+
+/**
+ * 后台自助注册审核状态。
+ *
+ * <p>账号启停由 {@code sys_user.status} 表达，注册准入由本状态表达，两者不能复用：
+ * 待审核用户允许登录查看首页，而被禁用用户必须拒绝登录。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public enum UserApprovalStatus {
+
+    /** 自助注册后等待管理员审核。 */
+    PENDING,
+
+    /** 管理员已审核通过，可以按已分配角色获取权限。 */
+    APPROVED,
+
+    /** 管理员审核拒绝，不授予任何角色权限。 */
+    REJECTED;
+
+    /** 只有审核通过的账号可以解析角色与权限。 */
+    public boolean allowsPermissions() {
+        return this == APPROVED;
+    }
+
+    /**
+     * 数据库值按最小权限解析：空值或脏值一律视为待审核，避免异常数据意外放权。
+     */
+    public static UserApprovalStatus parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return PENDING;
+        }
+        try {
+            return valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return PENDING;
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserApprovalRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserApprovalRequest.java
@@ -1,0 +1,17 @@
+package com.richard.fyoung.customeradmin.system.user.dto;
+
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * 自助注册用户审核请求；批准时角色清单必填，拒绝时服务端会清空角色。
+ * @author owlzhangfq@gmail.com
+ */
+public record UserApprovalRequest(
+    @NotNull(message = "decision 不能为空") UserApprovalStatus decision,
+    List<Long> roleIds,
+    @Size(max = 255, message = "审核说明不能超过 255 位") String remark) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserPageQuery.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserPageQuery.java
@@ -1,0 +1,17 @@
+package com.richard.fyoung.customeradmin.system.user.dto;
+
+import com.richard.fyoung.customeradmin.common.page.PageQuery;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * 用户分页查询，额外支持按注册审核状态筛选。
+ * @author owlzhangfq@gmail.com
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class UserPageQuery extends PageQuery {
+
+    private UserApprovalStatus approvalStatus;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserVO.java
@@ -15,6 +15,10 @@ public class UserVO {
     private String username;
     private String nickname;
     private Integer status;
+    private String approvalStatus;
+    private Long approvalBy;
+    private LocalDateTime approvalTime;
+    private String approvalRemark;
     private LocalDateTime lastLoginTime;
     private String lastLoginIp;
     private LocalDateTime createTime;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/entity/SysUser.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/entity/SysUser.java
@@ -51,6 +51,14 @@ public class SysUser {
     private String levelCode;
     /** 0禁用 / 1启用。 */
     private Integer status;
+    /** PENDING 待审核 / APPROVED 已通过 / REJECTED 已拒绝。 */
+    private String approvalStatus;
+    /** 最近一次审核人 sys_user.id。 */
+    private Long approvalBy;
+    /** 最近一次审核时间。 */
+    private LocalDateTime approvalTime;
+    /** 最近一次审核说明；拒绝原因可在登录后首页展示。 */
+    private String approvalRemark;
     /** 认证版本；安全属性变化时原子递增，禁止通用 updateById 用旧值覆盖。 */
     @TableField(updateStrategy = FieldStrategy.NEVER)
     private Long authEpoch;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/mapper/SysUserMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/mapper/SysUserMapper.java
@@ -31,7 +31,8 @@ public interface SysUserMapper extends BaseMapper<SysUser> {
      * 不会被 MyBatis-Plus 自动追加 {@code AND deleted=0}，能正常命中当前 deleted=1 的目标行。
      */
     @Update("UPDATE sys_user SET deleted = 0, status = 1, login_type = 'LDAP', nickname = #{username}, "
-        + "password = NULL, auth_epoch = auth_epoch + 1, update_time = NOW() WHERE id = #{id}")
+        + "password = NULL, approval_status = 'APPROVED', approval_by = NULL, approval_time = NULL, "
+        + "approval_remark = NULL, auth_epoch = auth_epoch + 1, update_time = NOW() WHERE id = #{id}")
     int reviveDeletedUser(@Param("id") Long id, @Param("username") String username);
 
     /** 安全属性变化时原子递增认证版本，避免并发更新丢失撤权。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserRegistrationService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserRegistrationService.java
@@ -1,0 +1,74 @@
+package com.richard.fyoung.customeradmin.system.user.service;
+
+import com.richard.fyoung.customeradmin.auth.dto.RegisterRequest;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customerwork.safety.tenant.CrossTenantOperations;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 后台本地账号自助注册。
+ *
+ * <p>公开注册只创建最小权限账号：固定归入 {@code default} 租户、审核状态为 PENDING、
+ * 不写任何用户角色关系。用户名全局唯一，已软删除的同名账号也不能被匿名注册者复活。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Service
+public class UserRegistrationService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserRegistrationService.class);
+    private static final String LOCAL_LOGIN_TYPE = "LOCAL";
+
+    private final SysUserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserRegistrationService(SysUserMapper userMapper, PasswordEncoder passwordEncoder) {
+        this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void register(RegisterRequest request) {
+        if (!request.password().equals(request.confirmPassword())) {
+            throw new BizException(ResultCode.PARAM_INVALID, "两次输入的密码不一致");
+        }
+        String username = request.username().trim();
+        SysUser occupied = CrossTenantOperations.execute(
+            () -> userMapper.selectByUsernameIgnoreLogicDelete(username));
+        if (occupied != null) {
+            throw duplicateUsername();
+        }
+
+        SysUser user = new SysUser();
+        user.setUsername(username);
+        user.setTenantId(TenantContext.DEFAULT);
+        user.setPassword(passwordEncoder.encode(request.password()));
+        user.setNickname(StringUtils.hasText(request.nickname()) ? request.nickname().trim() : username);
+        user.setLoginType(LOCAL_LOGIN_TYPE);
+        user.setStatus(1);
+        user.setApprovalStatus(UserApprovalStatus.PENDING.name());
+
+        try {
+            TenantContext.runWith(TenantContext.DEFAULT, () -> userMapper.insert(user));
+        } catch (DuplicateKeyException e) {
+            // 预查与插入之间仍可能有并发注册，数据库唯一键是最终事实来源。
+            throw duplicateUsername();
+        }
+        log.info("self-registration created pending admin account, userId={}, username={}",
+            user.getId(), username);
+    }
+
+    private BizException duplicateUsername() {
+        return new BizException(ResultCode.RESOURCE_DUPLICATE, "用户名已存在");
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserService.java
@@ -1,15 +1,18 @@
 package com.richard.fyoung.customeradmin.system.user.service;
 
+import cn.dev33.satoken.stp.StpUtil;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.richard.fyoung.customeradmin.auth.service.SessionRevocationService;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
-import com.richard.fyoung.customeradmin.common.page.PageQuery;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
+import com.richard.fyoung.customeradmin.system.user.dto.UserPageQuery;
 import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
 import com.richard.fyoung.customeradmin.system.user.dto.UserVO;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
@@ -24,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -59,7 +63,7 @@ public class UserService {
         this.sessionRevocationService = sessionRevocationService;
     }
 
-    public PageResult<UserVO> page(PageQuery query) {
+    public PageResult<UserVO> page(UserPageQuery query) {
         LambdaQueryWrapper<SysUser> wrapper = new LambdaQueryWrapper<>();
         if (StringUtils.hasText(query.getKeyword())) {
             wrapper.and(w -> w.like(SysUser::getUsername, query.getKeyword())
@@ -67,6 +71,9 @@ public class UserService {
         }
         if (query.getStatus() != null) {
             wrapper.eq(SysUser::getStatus, query.getStatus());
+        }
+        if (query.getApprovalStatus() != null) {
+            wrapper.eq(SysUser::getApprovalStatus, query.getApprovalStatus().name());
         }
         wrapper.orderBy(true, "asc".equalsIgnoreCase(query.getSortOrder()), SysUser::getCreateTime);
 
@@ -98,6 +105,7 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(request.password()));
         user.setNickname(request.nickname());
         user.setStatus(request.status() == null ? 1 : request.status());
+        user.setApprovalStatus(UserApprovalStatus.APPROVED.name());
         // exists() 只能减少常规冲突，无法覆盖并发创建，也看不到被逻辑删除但仍占唯一键的用户。
         // 数据库唯一约束是最终防线；这里将其转换为稳定业务错误，供前端统一请求拦截器直接提示。
         try {
@@ -116,6 +124,10 @@ public class UserService {
     public void update(Long id, UserSaveRequest request) {
         SysUser user = requireUser(id);
         List<Long> roleIds = validateRoleChange(id, request.roleIds());
+        if (!UserApprovalStatus.parse(user.getApprovalStatus()).allowsPermissions()
+            && !roleIds.isEmpty()) {
+            throw new BizException(ResultCode.PARAM_INVALID, "待审核或已拒绝用户请通过审核操作分配角色");
+        }
         List<Long> previousRoleIds = existingRoleIds(id);
         boolean statusChanged = request.status() != null && !Objects.equals(user.getStatus(), request.status());
         boolean passwordChanged = StringUtils.hasText(request.password());
@@ -130,6 +142,43 @@ public class UserService {
         userMapper.updateById(user);
         replaceRoles(id, roleIds);
         if (statusChanged || passwordChanged || rolesChanged) {
+            requireEpochIncremented(userMapper.incrementAuthEpoch(id));
+            sessionRevocationService.revokeUserAfterCommit(id);
+        }
+    }
+
+    /**
+     * 审核自助注册用户。批准与角色分配在同一事务完成，拒绝则清空角色；两种决策都会撤销旧会话，
+     * 让用户重新登录后读取新的审核状态和权限集合。
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public void review(Long id, UserApprovalRequest request) {
+        if (request.decision() == UserApprovalStatus.PENDING) {
+            throw new BizException(ResultCode.PARAM_INVALID, "审核结果只能是通过或拒绝");
+        }
+        SysUser user = requireUser(id);
+        List<Long> previousRoleIds = existingRoleIds(id);
+        List<Long> roleIds;
+        if (request.decision() == UserApprovalStatus.APPROVED) {
+            roleIds = validateRoleChange(id, request.roleIds());
+            if (roleIds.isEmpty()) {
+                throw new BizException(ResultCode.PARAM_MISSING, "审核通过时必须至少分配一个角色");
+            }
+        } else {
+            roleIds = validateRoleChange(id, List.of());
+        }
+
+        boolean approvalChanged = request.decision()
+            != UserApprovalStatus.parse(user.getApprovalStatus());
+        boolean rolesChanged = !new HashSet<>(previousRoleIds).equals(new HashSet<>(roleIds));
+        user.setApprovalStatus(request.decision().name());
+        user.setApprovalBy(StpUtil.getLoginIdAsLong());
+        user.setApprovalTime(LocalDateTime.now());
+        user.setApprovalRemark(StringUtils.hasText(request.remark()) ? request.remark().trim() : null);
+        userMapper.updateById(user);
+        replaceRoles(id, roleIds);
+
+        if (approvalChanged || rolesChanged) {
             requireEpochIncremented(userMapper.incrementAuthEpoch(id));
             sessionRevocationService.revokeUserAfterCommit(id);
         }
@@ -257,6 +306,10 @@ public class UserService {
         vo.setUsername(user.getUsername());
         vo.setNickname(user.getNickname());
         vo.setStatus(user.getStatus());
+        vo.setApprovalStatus(UserApprovalStatus.parse(user.getApprovalStatus()).name());
+        vo.setApprovalBy(user.getApprovalBy());
+        vo.setApprovalTime(user.getApprovalTime());
+        vo.setApprovalRemark(user.getApprovalRemark());
         vo.setLastLoginTime(user.getLastLoginTime());
         vo.setLastLoginIp(user.getLastLoginIp());
         vo.setCreateTime(user.getCreateTime());

--- a/customer-admin-server/src/main/resources/db/migration/V98__admin_self_registration_approval.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V98__admin_self_registration_approval.sql
@@ -1,0 +1,49 @@
+-- 后台本地账号自助注册审核：账号启停与注册准入分离，并保留最近一次审核事实。
+SET NAMES utf8mb4;
+
+SET @v98_user_exists = (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' AND table_name = 'sys_user');
+SET @v98_preflight_sql = IF(@v98_user_exists = 1,
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v98_sys_user_preflight_failed__`');
+PREPARE v98_preflight_stmt FROM @v98_preflight_sql;
+EXECUTE v98_preflight_stmt;
+DEALLOCATE PREPARE v98_preflight_stmt;
+
+SET @v98_user_columns = CONCAT(
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_status'), '',
+       ', ADD COLUMN `approval_status` VARCHAR(16) NOT NULL DEFAULT ''APPROVED'' COMMENT ''注册审核状态：PENDING/APPROVED/REJECTED'' AFTER `status`'),
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_by'), '',
+       ', ADD COLUMN `approval_by` BIGINT DEFAULT NULL COMMENT ''最近一次审核人 sys_user.id'' AFTER `approval_status`'),
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_time'), '',
+       ', ADD COLUMN `approval_time` DATETIME DEFAULT NULL COMMENT ''最近一次审核时间'' AFTER `approval_by`'),
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_remark'), '',
+       ', ADD COLUMN `approval_remark` VARCHAR(255) DEFAULT NULL COMMENT ''最近一次审核说明或拒绝原因'' AFTER `approval_time`')
+);
+SET @v98_user_ddl = IF(@v98_user_columns = '', 'SELECT 1',
+    CONCAT('ALTER TABLE `sys_user` ', SUBSTRING(@v98_user_columns, 3)));
+PREPARE v98_user_stmt FROM @v98_user_ddl;
+EXECUTE v98_user_stmt;
+DEALLOCATE PREPARE v98_user_stmt;
+
+-- 兼容人工预建了可空列的环境；只补空值，不覆盖已经进入审核流程的状态。
+UPDATE `sys_user`
+SET `approval_status` = 'APPROVED'
+WHERE `approval_status` IS NULL OR TRIM(`approval_status`) = '';
+
+-- 人工预建列也要收敛到正式契约，不能只补值后仍留下 nullable / 无默认值的漂移结构。
+ALTER TABLE `sys_user`
+    MODIFY COLUMN `approval_status` VARCHAR(16) NOT NULL DEFAULT 'APPROVED'
+        COMMENT '注册审核状态：PENDING/APPROVED/REJECTED' AFTER `status`;
+
+SET @v98_approval_index_exists = (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'sys_user'
+      AND index_name = 'idx_sys_user_approval');
+SET @v98_approval_index_sql = IF(@v98_approval_index_exists > 0, 'SELECT 1',
+    'ALTER TABLE `sys_user` ADD INDEX `idx_sys_user_approval` (`tenant_id`, `approval_status`, `deleted`, `create_time`)');
+PREPARE v98_approval_index_stmt FROM @v98_approval_index_sql;
+EXECUTE v98_approval_index_stmt;
+DEALLOCATE PREPARE v98_approval_index_stmt;

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/role/service/UserRoleResolverApprovalTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/role/service/UserRoleResolverApprovalTest.java
@@ -1,0 +1,94 @@
+package com.richard.fyoung.customeradmin.system.role.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserRoleResolverApprovalTest {
+
+    private SysUserRoleMapper userRoleMapper;
+    private SysRoleMapper roleMapper;
+    private SysUserMapper userMapper;
+    private UserRoleResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        userRoleMapper = mock(SysUserRoleMapper.class);
+        roleMapper = mock(SysRoleMapper.class);
+        userMapper = mock(SysUserMapper.class);
+        resolver = new UserRoleResolver(userRoleMapper, roleMapper, userMapper);
+    }
+
+    @Test
+    void enabledRolesOf_shouldReturnNoRolesBeforeApprovalEvenIfRelationExists() {
+        when(userMapper.selectById(9L)).thenReturn(user(UserApprovalStatus.PENDING));
+
+        try (MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            tenantSession.when(TenantSession::currentUserTenant).thenReturn(null);
+            assertEquals(List.of(), resolver.enabledRolesOf(9L));
+        }
+
+        verify(userRoleMapper, never()).selectList(any(LambdaQueryWrapper.class));
+        verify(roleMapper, never()).selectBatchIds(any());
+    }
+
+    @Test
+    void enabledRolesOf_shouldFailClosedWhenApprovalStatusIsMissing() {
+        SysUser user = new SysUser();
+        user.setId(9L);
+        when(userMapper.selectById(9L)).thenReturn(user);
+
+        try (MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            tenantSession.when(TenantSession::currentUserTenant).thenReturn(null);
+            assertEquals(List.of(), resolver.enabledRolesOf(9L));
+        }
+
+        verify(userRoleMapper, never()).selectList(any(LambdaQueryWrapper.class));
+    }
+
+    @Test
+    void enabledRolesOf_shouldResolveEnabledRolesAfterApproval() {
+        SysUserRole relation = new SysUserRole();
+        relation.setRoleId(3L);
+        SysRole role = new SysRole();
+        role.setId(3L);
+        role.setStatus(1);
+        when(userMapper.selectById(9L)).thenReturn(user(UserApprovalStatus.APPROVED));
+        when(userRoleMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(List.of(relation));
+        when(roleMapper.selectBatchIds(List.of(3L))).thenReturn(List.of(role));
+
+        List<SysRole> roles;
+        try (MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            tenantSession.when(TenantSession::currentUserTenant).thenReturn(null);
+            roles = resolver.enabledRolesOf(9L);
+        }
+
+        assertEquals(List.of(role), roles);
+    }
+
+    private SysUser user(UserApprovalStatus status) {
+        SysUser user = new SysUser();
+        user.setId(9L);
+        user.setApprovalStatus(status.name());
+        return user;
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/UserRegistrationApprovalMigrationIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/UserRegistrationApprovalMigrationIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.richard.fyoung.customeradmin.system.user;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** V98 真库迁移：自助注册审核列、存量账号兼容及 DBA 镜像契约。 */
+class UserRegistrationApprovalMigrationIntegrationTest {
+
+    private static final String HOST = System.getenv().getOrDefault("MYSQL_HOST", "localhost");
+    private static final int PORT = Integer.parseInt(System.getenv().getOrDefault("MYSQL_PORT", "3306"));
+    private static final String USERNAME = env("ADMIN_MYSQL_USERNAME", "root");
+    private static final String PASSWORD = env("ADMIN_MYSQL_PASSWORD", "root");
+
+    @Test
+    void migration_shouldBePreflightedAndMatchDbaMirrorByteForByte() throws Exception {
+        String sql;
+        try (var input = new ClassPathResource(
+            "db/migration/V98__admin_self_registration_approval.sql").getInputStream()) {
+            sql = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        String mirror = Files.readString(repositoryRoot().resolve(
+            "mysql/02-customer-admin/98-V98__admin_self_registration_approval.sql"));
+
+        assertEquals(sql, mirror, "Flyway 迁移与 DBA 镜像必须逐字一致");
+        assertTrue(sql.startsWith("-- 后台本地账号自助注册审核"));
+        assertTrue(sql.contains("SET NAMES utf8mb4;"));
+        assertTrue(sql.contains("__customer_admin_v98_sys_user_preflight_failed__"));
+        assertTrue(sql.contains("DEFAULT ''APPROVED''"));
+        assertTrue(sql.contains("idx_sys_user_approval"));
+    }
+
+    @Test
+    void migration_shouldApproveLegacyUsersAndAllowPendingRegistrations() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过 V98 真库迁移测试");
+        String database = "admin_v98_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过 V98 真库迁移测试");
+
+        try {
+            migrate(database, "97");
+            try (Connection connection = connection(database)) {
+                assertFalse(columnExists(connection, "approval_status"),
+                    "V97 快照不应提前包含注册审核列");
+            }
+
+            migrate(database, "98");
+            try (Connection connection = connection(database);
+                 Statement statement = connection.createStatement()) {
+                assertEquals("APPROVED", queryString(connection,
+                    "SELECT approval_status FROM sys_user WHERE username = 'admin'"),
+                    "存量管理员必须保持已批准，升级后不能丢权限");
+                assertEquals("NO", queryString(connection,
+                    "SELECT is_nullable FROM information_schema.columns WHERE table_schema = DATABASE() "
+                        + "AND table_name = 'sys_user' AND column_name = 'approval_status'"));
+                assertEquals("APPROVED", queryString(connection,
+                    "SELECT column_default FROM information_schema.columns WHERE table_schema = DATABASE() "
+                        + "AND table_name = 'sys_user' AND column_name = 'approval_status'"));
+
+                statement.executeUpdate("INSERT INTO sys_user (username, password, nickname) "
+                    + "VALUES ('v98-admin-created', 'hash', 'Admin Created')");
+                statement.executeUpdate("INSERT INTO sys_user "
+                    + "(username, password, nickname, approval_status) "
+                    + "VALUES ('v98-self-register', 'hash', 'Self Register', 'PENDING')");
+
+                assertEquals("APPROVED", queryString(connection,
+                    "SELECT approval_status FROM sys_user WHERE username = 'v98-admin-created'"));
+                assertEquals("PENDING", queryString(connection,
+                    "SELECT approval_status FROM sys_user WHERE username = 'v98-self-register'"));
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(DISTINCT index_name) FROM information_schema.statistics WHERE table_schema = DATABASE() "
+                        + "AND table_name = 'sys_user' AND index_name = 'idx_sys_user_approval'"));
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM flyway_schema_history WHERE version = '98' AND success = 1"));
+            }
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    private void migrate(String database, String target) {
+        Flyway.configure()
+            .dataSource(databaseUrl(database), USERNAME, PASSWORD)
+            .locations("classpath:db/migration")
+            .placeholderReplacement(false)
+            .target(target)
+            .load()
+            .migrate();
+    }
+
+    private boolean createDatabase(String database) {
+        try (Connection connection = DriverManager.getConnection(serverUrl(), USERNAME, PASSWORD);
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE `" + database
+                + "` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void dropDatabase(String database) {
+        try (Connection connection = DriverManager.getConnection(serverUrl(), USERNAME, PASSWORD);
+             Statement statement = connection.createStatement()) {
+            statement.execute("DROP DATABASE IF EXISTS `" + database + "`");
+        } catch (Exception ignored) {
+            // 测试清理失败不覆盖主断言；数据库名带随机后缀，不会碰共享库。
+        }
+    }
+
+    private Connection connection(String database) throws Exception {
+        return DriverManager.getConnection(databaseUrl(database), USERNAME, PASSWORD);
+    }
+
+    private boolean columnExists(Connection connection, String column) throws Exception {
+        return queryInt(connection,
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() "
+                + "AND table_name = 'sys_user' AND column_name = '" + column + "'") == 1;
+    }
+
+    private String queryString(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement(); ResultSet rs = statement.executeQuery(sql)) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+
+    private int queryInt(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement(); ResultSet rs = statement.executeQuery(sql)) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), 1000);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String serverUrl() {
+        return "jdbc:mysql://" + HOST + ":" + PORT
+            + "/?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai";
+    }
+
+    private String databaseUrl(String database) {
+        return "jdbc:mysql://" + HOST + ":" + PORT + "/" + database
+            + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai";
+    }
+
+    private Path repositoryRoot() {
+        Path cwd = Path.of("").toAbsolutePath();
+        return Files.isDirectory(cwd.resolve("mysql/02-customer-admin")) ? cwd : cwd.getParent();
+    }
+
+    private static String env(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserRegistrationServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserRegistrationServiceTest.java
@@ -1,0 +1,101 @@
+package com.richard.fyoung.customeradmin.system.user.service;
+
+import com.richard.fyoung.customeradmin.auth.dto.RegisterRequest;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserRegistrationServiceTest {
+
+    private SysUserMapper userMapper;
+    private PasswordEncoder passwordEncoder;
+    private UserRegistrationService service;
+
+    @BeforeEach
+    void setUp() {
+        userMapper = mock(SysUserMapper.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        service = new UserRegistrationService(userMapper, passwordEncoder);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void register_shouldCreatePendingDefaultTenantUserWithoutLeakingContext() {
+        when(passwordEncoder.encode("secret12")).thenReturn("encoded");
+        when(userMapper.insert(any(SysUser.class))).thenAnswer(invocation -> {
+            invocation.<SysUser>getArgument(0).setId(21L);
+            return 1;
+        });
+
+        service.register(new RegisterRequest("richard", "secret12", "secret12", " Richard "));
+
+        ArgumentCaptor<SysUser> userCaptor = ArgumentCaptor.forClass(SysUser.class);
+        verify(userMapper).insert(userCaptor.capture());
+        SysUser user = userCaptor.getValue();
+        assertEquals("richard", user.getUsername());
+        assertEquals("Richard", user.getNickname());
+        assertEquals("encoded", user.getPassword());
+        assertEquals("LOCAL", user.getLoginType());
+        assertEquals(1, user.getStatus());
+        assertEquals(UserApprovalStatus.PENDING.name(), user.getApprovalStatus());
+        assertEquals(TenantContext.DEFAULT, user.getTenantId());
+        assertNull(TenantContext.get(), "公开注册结束后不能把 default 租户泄漏给复用线程");
+    }
+
+    @Test
+    void register_shouldRejectPasswordConfirmationMismatchBeforeWriting() {
+        BizException error = assertThrows(BizException.class, () -> service.register(
+            new RegisterRequest("richard", "secret12", "secret13", "Richard")));
+
+        assertEquals(ResultCode.PARAM_INVALID, error.getResultCode());
+        verify(userMapper, never()).insert(any(SysUser.class));
+    }
+
+    @Test
+    void register_shouldRejectSoftDeletedUsernameInsteadOfRevivingIt() {
+        SysUser deleted = new SysUser();
+        deleted.setId(9L);
+        deleted.setDeleted(1);
+        when(userMapper.selectByUsernameIgnoreLogicDelete("richard")).thenReturn(deleted);
+
+        BizException error = assertThrows(BizException.class, () -> service.register(
+            new RegisterRequest("richard", "secret12", "secret12", "Richard")));
+
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, error.getResultCode());
+        verify(userMapper, never()).insert(any(SysUser.class));
+    }
+
+    @Test
+    void register_shouldTranslateConcurrentUniqueKeyRaceToBusinessError() {
+        when(passwordEncoder.encode("secret12")).thenReturn("encoded");
+        when(userMapper.insert(any(SysUser.class))).thenThrow(new DuplicateKeyException("duplicate"));
+
+        BizException error = assertThrows(BizException.class, () -> service.register(
+            new RegisterRequest("richard", "secret12", "secret12", "Richard")));
+
+        assertEquals(ResultCode.RESOURCE_DUPLICATE, error.getResultCode());
+        assertEquals("用户名已存在", error.getMessage());
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceApprovalTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceApprovalTest.java
@@ -1,0 +1,161 @@
+package com.richard.fyoung.customeradmin.system.user.service;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.auth.service.SessionRevocationService;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
+import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserServiceApprovalTest {
+
+    private SysUserMapper userMapper;
+    private SysUserRoleMapper userRoleMapper;
+    private SysRoleMapper roleMapper;
+    private SessionRevocationService revocationService;
+    private UserService service;
+
+    @BeforeEach
+    void setUp() {
+        userMapper = mock(SysUserMapper.class);
+        userRoleMapper = mock(SysUserRoleMapper.class);
+        roleMapper = mock(SysRoleMapper.class);
+        revocationService = mock(SessionRevocationService.class);
+        service = new UserService(
+            userMapper,
+            userRoleMapper,
+            roleMapper,
+            mock(PasswordEncoder.class),
+            mock(CrossTenantAuthority.class),
+            revocationService);
+        when(userRoleMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(List.of());
+        when(userMapper.incrementAuthEpoch(9L)).thenReturn(1);
+    }
+
+    @Test
+    void review_shouldApproveAndAssignRoleAtomicallyThenRevokeOldSession() {
+        SysUser user = pendingUser();
+        SysRole role = role(3L);
+        when(userMapper.selectById(9L)).thenReturn(user);
+        when(roleMapper.selectBatchIds(List.of(3L))).thenReturn(List.of(role));
+
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(99L);
+
+            service.review(9L,
+                new UserApprovalRequest(UserApprovalStatus.APPROVED, List.of(3L), " 已核验 "));
+        }
+
+        assertEquals(UserApprovalStatus.APPROVED.name(), user.getApprovalStatus());
+        assertEquals(99L, user.getApprovalBy());
+        assertEquals("已核验", user.getApprovalRemark());
+        assertNotNull(user.getApprovalTime());
+        ArgumentCaptor<SysUserRole> relationCaptor = ArgumentCaptor.forClass(SysUserRole.class);
+        verify(userRoleMapper).insert(relationCaptor.capture());
+        assertEquals(9L, relationCaptor.getValue().getUserId());
+        assertEquals(3L, relationCaptor.getValue().getRoleId());
+        verify(userMapper).incrementAuthEpoch(9L);
+        verify(revocationService).revokeUserAfterCommit(9L);
+    }
+
+    @Test
+    void create_shouldKeepAdminCreatedUserApproved() {
+        UserSaveRequest request = new UserSaveRequest(
+            "managed-user", "secret12", "Managed User", 1, List.of());
+
+        service.create(request);
+
+        ArgumentCaptor<SysUser> userCaptor = ArgumentCaptor.forClass(SysUser.class);
+        verify(userMapper).insert(userCaptor.capture());
+        assertEquals(UserApprovalStatus.APPROVED.name(), userCaptor.getValue().getApprovalStatus());
+    }
+
+    @Test
+    void review_shouldRequireAtLeastOneRoleWhenApproved() {
+        when(userMapper.selectById(9L)).thenReturn(pendingUser());
+
+        BizException error = assertThrows(BizException.class, () -> service.review(9L,
+            new UserApprovalRequest(UserApprovalStatus.APPROVED, List.of(), null)));
+
+        assertEquals(ResultCode.PARAM_MISSING, error.getResultCode());
+        verify(userMapper, never()).updateById(any(SysUser.class));
+    }
+
+    @Test
+    void review_shouldRejectAndClearExistingRolesThenRevokeOldSession() {
+        SysUser user = pendingUser();
+        SysUserRole existing = new SysUserRole();
+        existing.setUserId(9L);
+        existing.setRoleId(3L);
+        when(userMapper.selectById(9L)).thenReturn(user);
+        when(userRoleMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(List.of(existing));
+
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(99L);
+            service.review(9L,
+                new UserApprovalRequest(UserApprovalStatus.REJECTED, List.of(3L), "资料不完整"));
+        }
+
+        assertEquals(UserApprovalStatus.REJECTED.name(), user.getApprovalStatus());
+        assertEquals("资料不完整", user.getApprovalRemark());
+        verify(userRoleMapper).delete(any(LambdaQueryWrapper.class));
+        verify(userRoleMapper, never()).insert(any(SysUserRole.class));
+        verify(userMapper).incrementAuthEpoch(9L);
+        verify(revocationService).revokeUserAfterCommit(9L);
+    }
+
+    @Test
+    void update_shouldNotAssignRolesBeforeApproval() {
+        when(userMapper.selectById(9L)).thenReturn(pendingUser());
+        when(roleMapper.selectBatchIds(List.of(3L))).thenReturn(List.of(role(3L)));
+
+        BizException error = assertThrows(BizException.class, () -> service.update(9L,
+            new UserSaveRequest("richard", null, "Richard", 1, List.of(3L))));
+
+        assertEquals(ResultCode.PARAM_INVALID, error.getResultCode());
+        verify(userMapper, never()).updateById(any(SysUser.class));
+    }
+
+    private SysUser pendingUser() {
+        SysUser user = new SysUser();
+        user.setId(9L);
+        user.setUsername("richard");
+        user.setStatus(1);
+        user.setApprovalStatus(UserApprovalStatus.PENDING.name());
+        return user;
+    }
+
+    private SysRole role(Long id) {
+        SysRole role = new SysRole();
+        role.setId(id);
+        role.setStatus(1);
+        role.setControlPlane(SysRole.CONTROL_PLANE_DISABLED);
+        return role;
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceControlPlaneTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceControlPlaneTest.java
@@ -6,6 +6,7 @@ import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
 import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
@@ -131,6 +132,7 @@ class UserServiceControlPlaneTest {
         user.setId(id);
         user.setUsername("existing");
         user.setStatus(1);
+        user.setApprovalStatus(UserApprovalStatus.APPROVED.name());
         return user;
     }
 

--- a/customer-admin-web/src/api/auth.ts
+++ b/customer-admin-web/src/api/auth.ts
@@ -1,5 +1,10 @@
 import { request } from './request'
-import type { ChangePasswordRequest, LoginRequest, LoginResponse, SsoLoginRequest } from '@/types/api'
+import type { ChangePasswordRequest, LoginRequest, LoginResponse, RegisterRequest, SsoLoginRequest } from '@/types/api'
+
+/** 登录页自助注册。新账号默认进入待审核态，不自动登录。 */
+export function register(data: RegisterRequest) {
+  return request<void>({ url: '/auth/register', method: 'post', data })
+}
 
 export function login(data: LoginRequest) {
   return request<LoginResponse>({ url: '/auth/login', method: 'post', data })

--- a/customer-admin-web/src/api/user.ts
+++ b/customer-admin-web/src/api/user.ts
@@ -1,7 +1,7 @@
 import { request } from './request'
-import type { PageQuery, PageResult, UserSaveRequest, UserVO } from '@/types/api'
+import type { PageResult, UserApprovalRequest, UserPageQuery, UserSaveRequest, UserVO } from '@/types/api'
 
-export function pageUsers(query: PageQuery) {
+export function pageUsers(query: UserPageQuery) {
   return request<PageResult<UserVO>>({ url: '/system/user', method: 'get', params: query })
 }
 
@@ -19,4 +19,9 @@ export function updateUser(id: number, data: UserSaveRequest) {
 
 export function deleteUser(id: number) {
   return request<void>({ url: `/system/user/${id}`, method: 'delete' })
+}
+
+/** 审核自助注册用户；批准时角色分配与审核结论由后端在同一事务提交。 */
+export function reviewUser(id: number, data: UserApprovalRequest) {
+  return request<void>({ url: `/system/user/${id}/approval`, method: 'put', data })
 }

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -60,6 +60,7 @@ async function handleLogout() {
       <el-header class="layout-header">
         <div class="header-left">
           <el-button
+            v-if="auth.isApproved"
             class="collapse-btn"
             text
             :icon="menuStore.collapsed ? 'Expand' : 'Fold'"
@@ -67,7 +68,7 @@ async function handleLogout() {
           />
         </div>
         <div class="header-right">
-          <TenantSwitcher />
+          <TenantSwitcher v-if="auth.isApproved" />
           <el-button
             class="collapse-btn"
             text
@@ -75,7 +76,7 @@ async function handleLogout() {
             :title="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
             @click="themeStore.toggleDark()"
           />
-          <NotificationBell />
+          <NotificationBell v-if="auth.isApproved" />
           <el-dropdown>
             <span class="user-info">{{ auth.nickname }}<el-icon><ArrowDown /></el-icon></span>
           <template #dropdown>
@@ -87,8 +88,8 @@ async function handleLogout() {
           </el-dropdown>
         </div>
       </el-header>
-      <TabsBar />
-      <AppBreadcrumb />
+      <TabsBar v-if="auth.isApproved" />
+      <AppBreadcrumb v-if="auth.isApproved" />
       <el-main class="layout-main" :class="{ 'layout-main--home': route.name === 'Home' }">
         <!-- 只精确缓存 WorkspaceView：TabsBar 让"已打开的标签"在视觉上常驻，但底下的路由组件此前没配
              keep-alive，标签切走再切回其实是整个组件重新 mount——WorkspaceView 里的对话/VibeCoding

--- a/customer-admin-web/src/router/index.ts
+++ b/customer-admin-web/src/router/index.ts
@@ -80,6 +80,11 @@ router.beforeEach(async (to) => {
   if (auth.forceChangePassword && to.name !== 'ChangePassword') {
     return { name: 'ChangePassword' }
   }
+  // 待审核/已拒绝账号即使手工输入已知地址，也只能停留在首页。真正的数据权限仍由后端
+  // UserRoleResolver + 接口权限校验兜底；这里负责把前端可见范围收敛到“首页 + 品牌 Logo”。
+  if (!auth.isApproved && to.name !== 'Home') {
+    return { name: 'Home' }
+  }
 
   const menuStore = useMenuStore()
   if (!menuStore.routesRegistered) {

--- a/customer-admin-web/src/store/auth.ts
+++ b/customer-admin-web/src/store/auth.ts
@@ -1,11 +1,21 @@
 import { defineStore } from 'pinia'
 import { fetchMyPermissions, logout as logoutApi } from '@/api/auth'
-import type { LoginResponse } from '@/types/api'
+import type { LoginResponse, UserApprovalStatus } from '@/types/api'
 
 const STORAGE_TOKEN_KEY = 'admin-token'
 const STORAGE_NICKNAME_KEY = 'admin-nickname'
 const STORAGE_USERNAME_KEY = 'admin-username'
 const STORAGE_FORCE_CHANGE_PASSWORD_KEY = 'admin-force-change-password'
+const STORAGE_APPROVAL_STATUS_KEY = 'admin-approval-status'
+const STORAGE_APPROVAL_REMARK_KEY = 'admin-approval-remark'
+
+function storedApprovalStatus(): UserApprovalStatus {
+  const value = localStorage.getItem(STORAGE_APPROVAL_STATUS_KEY)
+  if (value === null) {
+    return 'APPROVED'
+  }
+  return value === 'PENDING' || value === 'APPROVED' || value === 'REJECTED' ? value : 'PENDING'
+}
 
 interface AuthState {
   token: string | null
@@ -14,6 +24,8 @@ interface AuthState {
    * 供「系统管理 - 用户管理」编辑用户后判断是不是在改自己、需要同步刷新右上角昵称缓存。 */
   username: string | null
   forceChangePassword: boolean
+  approvalStatus: UserApprovalStatus
+  approvalRemark: string | null
   permissions: string[]
 }
 
@@ -25,10 +37,14 @@ export const useAuthStore = defineStore('auth', {
     // 必须持久化，不能只活在内存里：若只存内存，浏览器在改密页意外刷新（如表单原生提交触发的整页刷新）
     // 会让这个强制改密的门禁悄悄消失，用户绕过强制改密直接进入系统。
     forceChangePassword: localStorage.getItem(STORAGE_FORCE_CHANGE_PASSWORD_KEY) === 'true',
+    // 兼容升级前已存在的登录态：旧缓存没有审核字段，而既有账号迁移后默认均为 APPROVED。
+    approvalStatus: storedApprovalStatus(),
+    approvalRemark: localStorage.getItem(STORAGE_APPROVAL_REMARK_KEY),
     permissions: [],
   }),
   getters: {
     isLoggedIn: (state) => !!state.token,
+    isApproved: (state) => state.approvalStatus === 'APPROVED',
   },
   actions: {
     applyLoginResult(result: LoginResponse, username: string) {
@@ -36,10 +52,18 @@ export const useAuthStore = defineStore('auth', {
       this.nickname = result.nickname
       this.username = username
       this.forceChangePassword = result.forceChangePassword
+      this.approvalStatus = result.approvalStatus
+      this.approvalRemark = result.approvalRemark
       localStorage.setItem(STORAGE_TOKEN_KEY, result.token)
       localStorage.setItem(STORAGE_NICKNAME_KEY, result.nickname)
       localStorage.setItem(STORAGE_USERNAME_KEY, username)
       localStorage.setItem(STORAGE_FORCE_CHANGE_PASSWORD_KEY, String(result.forceChangePassword))
+      localStorage.setItem(STORAGE_APPROVAL_STATUS_KEY, result.approvalStatus)
+      if (result.approvalRemark) {
+        localStorage.setItem(STORAGE_APPROVAL_REMARK_KEY, result.approvalRemark)
+      } else {
+        localStorage.removeItem(STORAGE_APPROVAL_REMARK_KEY)
+      }
     },
     /** 「用户管理」编辑资料时若改的是当前登录用户自己，用这个同步刷新右上角展示的昵称缓存，
      * 否则要等下次重新登录才会更新——旧 bug：编辑自己的昵称后页面仍显示登录时缓存的旧值。 */
@@ -62,11 +86,15 @@ export const useAuthStore = defineStore('auth', {
       this.nickname = null
       this.username = null
       this.forceChangePassword = false
+      this.approvalStatus = 'APPROVED'
+      this.approvalRemark = null
       this.permissions = []
       localStorage.removeItem(STORAGE_TOKEN_KEY)
       localStorage.removeItem(STORAGE_NICKNAME_KEY)
       localStorage.removeItem(STORAGE_USERNAME_KEY)
       localStorage.removeItem(STORAGE_FORCE_CHANGE_PASSWORD_KEY)
+      localStorage.removeItem(STORAGE_APPROVAL_STATUS_KEY)
+      localStorage.removeItem(STORAGE_APPROVAL_REMARK_KEY)
     },
     async logout() {
       try {

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -57,6 +57,17 @@ export interface LoginResponse {
   token: string
   nickname: string
   forceChangePassword: boolean
+  approvalStatus: UserApprovalStatus
+  approvalRemark: string | null
+}
+
+export type UserApprovalStatus = 'PENDING' | 'APPROVED' | 'REJECTED'
+
+export interface RegisterRequest {
+  username: string
+  password: string
+  confirmPassword: string
+  nickname?: string | null
 }
 
 export interface ChangePasswordRequest {
@@ -70,6 +81,10 @@ export interface UserVO {
   username: string
   nickname: string
   status: number
+  approvalStatus: UserApprovalStatus
+  approvalBy: number | null
+  approvalTime: string | null
+  approvalRemark: string | null
   lastLoginTime: string | null
   lastLoginIp: string | null
   createTime: string
@@ -83,6 +98,16 @@ export interface UserSaveRequest {
   nickname?: string | null
   status?: number | null
   roleIds?: number[] | null
+}
+
+export interface UserPageQuery extends PageQuery {
+  approvalStatus?: UserApprovalStatus
+}
+
+export interface UserApprovalRequest {
+  decision: Exclude<UserApprovalStatus, 'PENDING'>
+  roleIds?: number[]
+  remark?: string | null
 }
 
 // ---------- system.role ----------

--- a/customer-admin-web/src/views/Home.vue
+++ b/customer-admin-web/src/views/Home.vue
@@ -1,14 +1,30 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useAuthStore } from '@/store/auth'
 
 const auth = useAuthStore()
+
+const homeMessage = computed(() => {
+  if (auth.approvalStatus === 'PENDING') {
+    return '账号正在等待管理员审核，审核并分配角色后即可查看菜单。'
+  }
+  if (auth.approvalStatus === 'REJECTED') {
+    return auth.approvalRemark
+      ? `账号审核未通过：${auth.approvalRemark}`
+      : '账号审核未通过，请联系管理员。'
+  }
+  if (auth.permissions.length === 0) {
+    return '账号尚未分配可用权限，请联系管理员。'
+  }
+  return '请从左侧菜单选择要管理的模块。'
+})
 </script>
 
 <template>
   <div class="home-page">
     <img src="/home-cover.jpg" alt="首页" class="home-cover" />
     <p class="home-tip">
-      <strong>{{ auth.nickname }}</strong>，请从左侧菜单选择要管理的模块。
+      <strong>{{ auth.nickname }}</strong>，{{ homeMessage }}
     </p>
   </div>
 </template>

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -2,16 +2,19 @@
 import { onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { FormInstance, FormRules } from 'element-plus'
-import { login, ssoLogin } from '@/api/auth'
+import { login, register, ssoLogin } from '@/api/auth'
 import { fetchLoginCarouselUrls } from '@/api/login-image'
 import { useAuthStore } from '@/store/auth'
 import { useMenuStore } from '@/store/menu'
 import FooterCopyright from '@/components/FooterCopyright.vue'
+import type { RegisterRequest } from '@/types/api'
 
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 const menuStore = useMenuStore()
+
+const authPanel = ref<'login' | 'register'>('login')
 
 /** local：账号密码登录（数据库） / sso：OA 域账号登录（LDAP/AD） */
 const loginMode = ref<'local' | 'sso'>('local')
@@ -22,6 +25,40 @@ const form = reactive({ username: '', password: '', rememberMe: false })
 const rules: FormRules = {
   username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
   password: [{ required: true, message: '请输入密码', trigger: 'blur' }],
+}
+
+const registerFormRef = ref<FormInstance>()
+const registerSubmitting = ref(false)
+const registerForm = reactive<RegisterRequest>({
+  username: '',
+  nickname: '',
+  password: '',
+  confirmPassword: '',
+})
+const registerRules: FormRules = {
+  username: [
+    { required: true, message: '请输入用户名', trigger: 'blur' },
+    { min: 3, max: 32, message: '用户名长度为 3 至 32 位', trigger: 'blur' },
+    { pattern: /^[A-Za-z0-9._-]+$/, message: '仅支持字母、数字、点、下划线和短横线', trigger: 'blur' },
+  ],
+  nickname: [{ max: 64, message: '昵称不能超过 64 位', trigger: 'blur' }],
+  password: [
+    { required: true, message: '请输入密码', trigger: 'blur' },
+    { min: 6, max: 32, message: '密码长度为 6 至 32 位', trigger: 'blur' },
+  ],
+  confirmPassword: [
+    { required: true, message: '请再次输入密码', trigger: 'blur' },
+    {
+      validator: (_rule, value, callback) => {
+        if (value !== registerForm.password) {
+          callback(new Error('两次输入的密码不一致'))
+          return
+        }
+        callback()
+      },
+      trigger: 'blur',
+    },
+  ],
 }
 
 // “记住我”只记住用户名 + 是否勾选（不在前端存明文密码）；密码本身交给浏览器自带的密码管理器
@@ -43,6 +80,17 @@ function switchMode(mode: 'local' | 'sso') {
   loginMode.value = mode
   form.password = ''
   loadRememberedUsername(mode)
+  formRef.value?.clearValidate()
+}
+
+function openRegister() {
+  authPanel.value = 'register'
+  registerFormRef.value?.clearValidate()
+}
+
+function backToLogin() {
+  authPanel.value = 'login'
+  loginMode.value = 'local'
   formRef.value?.clearValidate()
 }
 
@@ -92,12 +140,31 @@ async function handleSubmit() {
     submitting.value = false
   }
 }
+
+async function handleRegister() {
+  const valid = await registerFormRef.value?.validate().catch(() => false)
+  if (!valid) {
+    return
+  }
+  registerSubmitting.value = true
+  try {
+    const username = registerForm.username
+    await register(registerForm)
+    ElMessage.success('注册成功，请登录后等待管理员审核')
+    registerFormRef.value?.resetFields()
+    backToLogin()
+    form.username = username
+    form.password = ''
+  } finally {
+    registerSubmitting.value = false
+  }
+}
 </script>
 
 <template>
   <div class="login-page">
     <div class="bg-carousel">
-      <el-carousel type="fade" height="100%" :interval="2000" arrow="never" indicator-position="none">
+      <el-carousel height="100%" :interval="2000" arrow="never" indicator-position="none">
         <el-carousel-item v-for="img in bgImages" :key="img">
           <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
         </el-carousel-item>
@@ -108,7 +175,14 @@ async function handleSubmit() {
       <template #header>
         <div class="login-title">智能体客服后台管理系统</div>
       </template>
-      <div class="login-tabs">
+      <div class="access-flow" aria-label="账号开通流程">
+        <span>注册账号</span>
+        <i />
+        <span>管理员审核</span>
+        <i />
+        <span>开通菜单</span>
+      </div>
+      <div v-if="authPanel === 'login'" class="login-tabs">
         <div
           class="login-tab"
           :class="{ active: loginMode === 'local' }"
@@ -124,7 +198,14 @@ async function handleSubmit() {
           OA 登录
         </div>
       </div>
-      <el-form ref="formRef" :model="form" :rules="rules" @keyup.enter="handleSubmit" @submit.prevent>
+      <el-form
+        v-if="authPanel === 'login'"
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        @keyup.enter="handleSubmit"
+        @submit.prevent
+      >
         <el-form-item prop="username">
           <el-input
             v-model="form.username"
@@ -153,6 +234,76 @@ async function handleSubmit() {
             登录
           </el-button>
         </el-form-item>
+        <div v-if="loginMode === 'local'" class="panel-switch">
+          还没有账号？<el-button link type="primary" @click="openRegister">立即注册</el-button>
+        </div>
+      </el-form>
+      <el-form
+        v-else
+        ref="registerFormRef"
+        :model="registerForm"
+        :rules="registerRules"
+        @keyup.enter="handleRegister"
+        @submit.prevent
+      >
+        <div class="register-heading">
+          <strong>注册本地账号</strong>
+          <span>注册后可登录查看审核状态，菜单将在管理员分配角色后开通。</span>
+        </div>
+        <el-form-item prop="username">
+          <el-input
+            v-model="registerForm.username"
+            placeholder="用户名（3-32 位）"
+            size="large"
+            autocomplete="username"
+            :prefix-icon="'User'"
+          />
+        </el-form-item>
+        <el-form-item prop="nickname">
+          <el-input
+            v-model="registerForm.nickname"
+            placeholder="昵称（选填）"
+            size="large"
+            autocomplete="name"
+            :prefix-icon="'Postcard'"
+          />
+        </el-form-item>
+        <el-form-item prop="password">
+          <el-input
+            v-model="registerForm.password"
+            type="password"
+            placeholder="密码（6-32 位）"
+            size="large"
+            show-password
+            autocomplete="new-password"
+            :prefix-icon="'Lock'"
+          />
+        </el-form-item>
+        <el-form-item prop="confirmPassword">
+          <el-input
+            v-model="registerForm.confirmPassword"
+            type="password"
+            placeholder="再次输入密码"
+            size="large"
+            show-password
+            autocomplete="new-password"
+            :prefix-icon="'Lock'"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button
+            type="primary"
+            size="large"
+            style="width: 100%"
+            :loading="registerSubmitting"
+            @click="handleRegister"
+          >
+            提交注册
+          </el-button>
+        </el-form-item>
+        <div class="panel-switch">
+          已有账号？<el-button link type="primary" @click="backToLogin">返回登录</el-button>
+        </div>
       </el-form>
     </el-card>
     <FooterCopyright dark />
@@ -210,7 +361,7 @@ async function handleSubmit() {
 .login-card {
   position: relative;
   z-index: 1;
-  width: 360px;
+  width: 390px;
   margin-bottom: auto;
   margin-top: auto;
   background: rgba(255, 255, 255, 0.92);
@@ -226,6 +377,22 @@ html.dark .login-card {
   text-align: center;
   font-size: 18px;
   font-weight: 600;
+}
+
+.access-flow {
+  display: grid;
+  grid-template-columns: auto 1fr auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 14px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.access-flow i {
+  height: 1px;
+  background: var(--el-border-color);
 }
 
 .login-tabs {
@@ -249,6 +416,37 @@ html.dark .login-card {
   color: var(--el-color-primary);
   border-bottom-color: var(--el-color-primary);
   font-weight: 600;
+}
+
+.register-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 2px 0 16px;
+}
+
+.register-heading strong {
+  color: var(--el-text-color-primary);
+  font-size: 16px;
+}
+
+.register-heading span {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.panel-switch {
+  margin-top: -4px;
+  text-align: center;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    width: calc(100% - 32px);
+  }
 }
 
 /* FooterCopyright 是子组件，scoped 样式默认不穿透，显式提到背景遮罩之上 */

--- a/customer-admin-web/src/views/system/UserManage.vue
+++ b/customer-admin-web/src/views/system/UserManage.vue
@@ -1,24 +1,40 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted, reactive, ref } from 'vue'
 import type { FormInstance } from 'element-plus'
-import { createUser, deleteUser, pageUsers, updateUser } from '@/api/user'
+import { createUser, deleteUser, pageUsers, reviewUser, updateUser } from '@/api/user'
 import { pageRoles } from '@/api/role'
 import { fetchCurrentView } from '@/api/tenant'
 import { useAuthStore } from '@/store/auth'
 import { useCrudPage } from '@/composables/useCrudPage'
-import type { PageQuery, RoleVO, UserSaveRequest, UserVO } from '@/types/api'
+import type {
+  RoleVO,
+  UserApprovalRequest,
+  UserApprovalStatus,
+  UserPageQuery,
+  UserSaveRequest,
+  UserVO,
+} from '@/types/api'
 
 const auth = useAuthStore()
 
 const roleOptions = ref<RoleVO[]>([])
 const crossTenantAuthority = ref(false)
 const formRef = ref<FormInstance>()
+const editingApprovalStatus = ref<UserApprovalStatus>('APPROVED')
+const reviewDialogVisible = ref(false)
+const reviewSubmitting = ref(false)
+const reviewTarget = ref<UserVO | null>(null)
+const reviewForm = reactive<UserApprovalRequest>({
+  decision: 'APPROVED',
+  roleIds: [],
+  remark: '',
+})
 
 const {
   loading, list, total, query,
   dialogVisible, dialogMode, form,
-  loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
-} = useCrudPage<UserVO, PageQuery, UserSaveRequest>({
+  loadList, handleSearch, openCreate, openEdit: openEditCrud, handleSubmit, handleDelete,
+} = useCrudPage<UserVO, UserPageQuery, UserSaveRequest>({
   page: pageUsers,
   formRef,
   create: createUser,
@@ -34,11 +50,72 @@ const {
     }
   },
   remove: (row) => deleteUser(row.id),
-  initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '', status: undefined }),
+  initQuery: () => ({
+    pageNum: 1,
+    pageSize: 10,
+    keyword: '',
+    status: undefined,
+    approvalStatus: undefined,
+  }),
   initForm: () => ({ username: '', password: '', nickname: '', status: 1, roleIds: [] }),
-  toForm: (row) => ({ username: row.username, password: '', nickname: row.nickname, status: row.status, roleIds: row.roleIds }),
+  toForm: (row) => ({
+    username: row.username,
+    password: '',
+    nickname: row.nickname,
+    status: row.status,
+    roleIds: row.approvalStatus === 'APPROVED' ? row.roleIds : [],
+  }),
   deleteConfirm: (row) => `确认删除用户「${row.username}」？`,
 })
+
+function openEdit(row: UserVO) {
+  editingApprovalStatus.value = row.approvalStatus
+  openEditCrud(row)
+}
+
+function approvalText(status: UserApprovalStatus) {
+  return { PENDING: '待审核', APPROVED: '已通过', REJECTED: '已拒绝' }[status]
+}
+
+function approvalTagType(status: UserApprovalStatus): 'warning' | 'success' | 'danger' {
+  if (status === 'APPROVED') {
+    return 'success'
+  }
+  return status === 'PENDING' ? 'warning' : 'danger'
+}
+
+function openReview(row: UserVO) {
+  reviewTarget.value = row
+  Object.assign(reviewForm, {
+    decision: row.approvalStatus === 'REJECTED' ? 'REJECTED' : 'APPROVED',
+    roleIds: row.roleIds ? [...row.roleIds] : [],
+    remark: row.approvalRemark || '',
+  })
+  reviewDialogVisible.value = true
+}
+
+async function submitReview() {
+  if (!reviewTarget.value) {
+    return
+  }
+  if (reviewForm.decision === 'APPROVED' && !reviewForm.roleIds?.length) {
+    ElMessage.warning('审核通过时至少分配一个角色')
+    return
+  }
+  reviewSubmitting.value = true
+  try {
+    await reviewUser(reviewTarget.value.id, {
+      decision: reviewForm.decision,
+      roleIds: reviewForm.decision === 'APPROVED' ? reviewForm.roleIds : [],
+      remark: reviewForm.remark?.trim() || null,
+    })
+    ElMessage.success(reviewForm.decision === 'APPROVED' ? '审核通过，角色权限已生效' : '已拒绝该注册申请')
+    reviewDialogVisible.value = false
+    await loadList()
+  } finally {
+    reviewSubmitting.value = false
+  }
+}
 
 async function loadRoleOptions() {
   try {
@@ -67,6 +144,11 @@ onMounted(async () => {
           <el-option label="启用" :value="1" />
           <el-option label="禁用" :value="0" />
         </el-select>
+        <el-select v-model="query.approvalStatus" placeholder="审核状态" style="width: 130px" clearable>
+          <el-option label="待审核" value="PENDING" />
+          <el-option label="已通过" value="APPROVED" />
+          <el-option label="已拒绝" value="REJECTED" />
+        </el-select>
         <el-button type="primary" @click="handleSearch">搜索</el-button>
         <el-button v-permission="'user:add'" type="primary" @click="openCreate">新建用户</el-button>
       </div>
@@ -82,10 +164,25 @@ onMounted(async () => {
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '禁用' }}</el-tag>
           </template>
         </el-table-column>
+        <el-table-column label="审核状态" width="100">
+          <template #default="{ row }">
+            <el-tag :type="approvalTagType(row.approvalStatus)">{{ approvalText(row.approvalStatus) }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="approvalRemark" label="审核说明" min-width="140" show-overflow-tooltip />
         <el-table-column prop="lastLoginTime" label="最近登录" width="180" />
         <el-table-column prop="createTime" label="创建时间" width="180" />
-        <el-table-column label="操作" width="160" fixed="right">
+        <el-table-column label="操作" width="220" fixed="right">
           <template #default="{ row }">
+            <el-button
+              v-if="row.approvalStatus !== 'APPROVED'"
+              v-permission="'user:edit'"
+              link
+              type="primary"
+              @click="openReview(row)"
+            >
+              {{ row.approvalStatus === 'PENDING' ? '审核' : '重新审核' }}
+            </el-button>
             <el-button v-permission="'user:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
             <el-button v-permission="'user:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
           </template>
@@ -114,7 +211,13 @@ onMounted(async () => {
           <el-input v-model="form.nickname!" />
         </el-form-item>
         <el-form-item label="角色">
-          <el-select v-model="form.roleIds" multiple style="width: 100%">
+          <el-select
+            v-model="form.roleIds"
+            multiple
+            style="width: 100%"
+            :disabled="dialogMode === 'edit' && editingApprovalStatus !== 'APPROVED'"
+            :placeholder="dialogMode === 'edit' && editingApprovalStatus !== 'APPROVED' ? '请通过审核操作分配角色' : '请选择角色'"
+          >
             <el-option
               v-for="role in roleOptions"
               :key="role.id"
@@ -133,6 +236,46 @@ onMounted(async () => {
         <el-button type="primary" @click="handleSubmit">确定</el-button>
       </template>
     </el-dialog>
+
+    <el-dialog v-model="reviewDialogVisible" title="注册账号审核" width="520px">
+      <el-descriptions v-if="reviewTarget" :column="1" border class="review-user">
+        <el-descriptions-item label="用户名">{{ reviewTarget.username }}</el-descriptions-item>
+        <el-descriptions-item label="昵称">{{ reviewTarget.nickname || '-' }}</el-descriptions-item>
+      </el-descriptions>
+      <el-form :model="reviewForm" label-width="84px">
+        <el-form-item label="审核结果">
+          <el-radio-group v-model="reviewForm.decision">
+            <el-radio-button value="APPROVED">通过</el-radio-button>
+            <el-radio-button value="REJECTED">拒绝</el-radio-button>
+          </el-radio-group>
+        </el-form-item>
+        <el-form-item v-if="reviewForm.decision === 'APPROVED'" label="分配角色" required>
+          <el-select v-model="reviewForm.roleIds" multiple style="width: 100%" placeholder="至少选择一个角色">
+            <el-option
+              v-for="role in roleOptions"
+              :key="role.id"
+              :label="role.roleName"
+              :value="role.id"
+              :disabled="role.controlPlane && !crossTenantAuthority"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="审核说明">
+          <el-input
+            v-model="reviewForm.remark"
+            type="textarea"
+            :rows="3"
+            maxlength="255"
+            show-word-limit
+            :placeholder="reviewForm.decision === 'REJECTED' ? '建议填写拒绝原因' : '选填'"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="reviewDialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="reviewSubmitting" @click="submitReview">确认审核</el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
@@ -141,5 +284,9 @@ onMounted(async () => {
   display: flex;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.review-user {
+  margin-bottom: 18px;
 }
 </style>

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -965,8 +965,11 @@ Skill、智能体,并支持对智能体在线聊天与 VibeCoding。技术栈按
 与仓库根目录平级),用 Element Plus 做中后台 UI、Pinia 做状态管理、原生 `fetch` + `ReadableStream`
 手写 SSE 解析(POST + 自定义 Authorization 头,原生 `EventSource` 做不到)。
 
-**后台基础与企业治理能力已落地**——后端:RBAC 五表(用户/角色/权限/关联表/操作日志) + 登录改密 + 用户/角色/权限/
-日志四个业务域完整 CRUD + AI 配置域三个 CRUD。模型域已从单表 AppKey 扩展为模型资产/部署分离、SecretRef
+**后台基础与企业治理能力已落地**——后端:RBAC 五表(用户/角色/权限/关联表/操作日志) + 登录改密 +
+本地账号自助注册审核 + 用户/角色/权限/日志四个业务域完整 CRUD + AI 配置域三个 CRUD。自助注册账号固定归入
+`default` 租户并以 `PENDING`、无角色状态创建；允许登录查看审核结果，但角色解析强制返回空集合。管理员审核通过时
+必须在同一事务至少分配一个角色，拒绝时清空角色，两种权限变更都会轮换认证版本并撤销旧会话。模型域已从单表
+AppKey 扩展为模型资产/部署分离、SecretRef
 版本轮换、健康事实、上线认证、引用影响、不可变路由与在线实验；MCP、Skill 继续独立管理。智能体管理包含
 `ai_agent` CRUD + 关联表整体替换式维护 + 启用停用生命周期 + 动态菜单 +
 菜单版本号轮询；智能体运行时包含 `AdminAgentInstanceFactory` 动态装配 + `AgentInstanceCache` 缓存 + Chat
@@ -987,9 +990,11 @@ cd customer-admin-web && npm ci && npm run dev
 
 | 入口 | 能力 |
 |---|---|
-| `POST /api/auth/login` | 登录（`admin/admin` 首次登录返回 `forceChangePassword=true`） |
+| `POST /api/auth/login` | 登录（`admin/admin` 首次登录返回 `forceChangePassword=true`；响应含注册审核状态与说明） |
+| `POST /api/auth/register` | 登录页公开自助注册；仅创建 `default` 租户的 `PENDING` 本地账号，不自动授予角色或菜单 |
 | `POST /api/auth/change-password` / `POST /api/auth/logout` | 改密 / 登出 |
-| `/api/system/{user,role,permission,log}` | 用户/角色权限/权限树/操作日志 CRUD（`@SaCheckPermission` 权限点校验） |
+| `PUT /api/system/user/{id}/approval` | 注册账号审核；通过必须同时分配角色，拒绝清空角色，权限点 `user:edit` |
+| `/api/system/{user,role,permission,log}` | 用户/角色权限/权限树/操作日志 CRUD（`@SaCheckPermission` 权限点校验）；用户分页支持按审核状态筛选 |
 | `/api/aiconfig/model` · `/asset-options` | 模型部署 CRUD 与模型资产选择；响应只返回 SecretRef 元数据，不回显凭据材料 |
 | `/api/aiconfig/model/{id}/{impact,health,health-events,certification,certification-runs}` | 引用影响、健康事实与当前/历史上线认证；见 §6.34 |
 | `POST /api/aiconfig/model/{id}/test-connectivity` · `/health-checks` · `/certifications` | 异步连通/健康探测与同步上线认证；认证绑定端点 revision、SecretRef version 与有效期 |
@@ -1010,7 +1015,7 @@ cd customer-admin-web && npm ci && npm run dev
 | `/api/aiconfig/agent` | 智能体 CRUD（modelId 必填/mcpIds·skillIds·knowledgeBaseIds 可选多选）；保存时把当前 KB/Skill versionId 冻结到关联行，资产后续编辑不让既有 Agent 静默漂移 |
 | `PUT /api/aiconfig/agent/{id}/enable` / `disable` | 智能体启用/停用（联动动态菜单 + 运行时缓存失效） |
 | `GET /api/aiconfig/agent/{id}/memory` / `DELETE …/memory` | 智能体跨会话长期记忆查看/清空（`capabilities` 含 `memory` 时生效；权威存储默认落库 `ai_agent_memory`，配置 `admin.agent-memory.disk-root` 后改存磁盘） |
-| `GET /api/menu/routes` | 按当前用户权限点过滤的菜单树，`workspace` 节点下挂启用中的智能体动态节点 |
+| `GET /api/menu/routes` | 按当前用户权限点过滤的菜单树；待审核/已拒绝账号恒为空，前端只保留首页与品牌 Logo；`workspace` 节点下挂启用中的智能体动态节点 |
 | `GET /api/menu/version` | 菜单版本号（进程内自增），前端轻量轮询，仅版本变化才拉全量菜单 |
 | `POST /api/workspace/{agentCode}/chat/stream` | 智能体在线聊天（SSE，权限点复用 `workspace`，停用智能体报 `AGENT_DISABLED`） |
 | `POST /api/workspace/{agentCode}/vibecoding/stream` | VibeCoding 对话（SSE，仅 `capabilities` 含 `vibecoding` 的智能体可用） |

--- a/mysql/02-customer-admin/98-V98__admin_self_registration_approval.sql
+++ b/mysql/02-customer-admin/98-V98__admin_self_registration_approval.sql
@@ -1,0 +1,49 @@
+-- 后台本地账号自助注册审核：账号启停与注册准入分离，并保留最近一次审核事实。
+SET NAMES utf8mb4;
+
+SET @v98_user_exists = (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' AND table_name = 'sys_user');
+SET @v98_preflight_sql = IF(@v98_user_exists = 1,
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v98_sys_user_preflight_failed__`');
+PREPARE v98_preflight_stmt FROM @v98_preflight_sql;
+EXECUTE v98_preflight_stmt;
+DEALLOCATE PREPARE v98_preflight_stmt;
+
+SET @v98_user_columns = CONCAT(
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_status'), '',
+       ', ADD COLUMN `approval_status` VARCHAR(16) NOT NULL DEFAULT ''APPROVED'' COMMENT ''注册审核状态：PENDING/APPROVED/REJECTED'' AFTER `status`'),
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_by'), '',
+       ', ADD COLUMN `approval_by` BIGINT DEFAULT NULL COMMENT ''最近一次审核人 sys_user.id'' AFTER `approval_status`'),
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_time'), '',
+       ', ADD COLUMN `approval_time` DATETIME DEFAULT NULL COMMENT ''最近一次审核时间'' AFTER `approval_by`'),
+    IF(EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
+        AND table_name = 'sys_user' AND column_name = 'approval_remark'), '',
+       ', ADD COLUMN `approval_remark` VARCHAR(255) DEFAULT NULL COMMENT ''最近一次审核说明或拒绝原因'' AFTER `approval_time`')
+);
+SET @v98_user_ddl = IF(@v98_user_columns = '', 'SELECT 1',
+    CONCAT('ALTER TABLE `sys_user` ', SUBSTRING(@v98_user_columns, 3)));
+PREPARE v98_user_stmt FROM @v98_user_ddl;
+EXECUTE v98_user_stmt;
+DEALLOCATE PREPARE v98_user_stmt;
+
+-- 兼容人工预建了可空列的环境；只补空值，不覆盖已经进入审核流程的状态。
+UPDATE `sys_user`
+SET `approval_status` = 'APPROVED'
+WHERE `approval_status` IS NULL OR TRIM(`approval_status`) = '';
+
+-- 人工预建列也要收敛到正式契约，不能只补值后仍留下 nullable / 无默认值的漂移结构。
+ALTER TABLE `sys_user`
+    MODIFY COLUMN `approval_status` VARCHAR(16) NOT NULL DEFAULT 'APPROVED'
+        COMMENT '注册审核状态：PENDING/APPROVED/REJECTED' AFTER `status`;
+
+SET @v98_approval_index_exists = (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'sys_user'
+      AND index_name = 'idx_sys_user_approval');
+SET @v98_approval_index_sql = IF(@v98_approval_index_exists > 0, 'SELECT 1',
+    'ALTER TABLE `sys_user` ADD INDEX `idx_sys_user_approval` (`tenant_id`, `approval_status`, `deleted`, `create_time`)');
+PREPARE v98_approval_index_stmt FROM @v98_approval_index_sql;
+EXECUTE v98_approval_index_stmt;
+DEALLOCATE PREPARE v98_approval_index_stmt;


### PR DESCRIPTION
## 概要

- 在登录页增加本地账号自助注册入口，新账号固定归入 `default` 租户并以 `PENDING`、无角色状态创建
- 增加独立注册审核状态，管理员审核通过时必须在同一事务分配至少一个角色，拒绝时清空角色
- 待审核或已拒绝账号允许登录查看审核结果，但后端角色解析强制返回空集合，前端只保留首页和品牌 Logo
- 审核或角色变化后递增认证版本并撤销旧会话，用户重新登录后读取最新菜单权限
- 增加 V98 Flyway 迁移及逐字一致的 DBA SQL 镜像，兼容存量账号和 LDAP/管理端创建链路
- 用户管理增加审核状态筛选、审核窗口与审核说明，功能文档同步更新

## 验证

- `JAVA_HOME=/Users/zhangfuqiang/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home ADMIN_MYSQL_PASSWORD=root mvn -B -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.xml clean test -Djacoco.skip=true -Dtest='!RedisSessionPersistenceTest' -DfailIfNoSpecifiedTests=false`
  - 6 个 Maven 模块全部成功
  - 3321 tests，0 failures，0 errors，7 skipped
- `cd customer-admin-web && npm run build`
- 真实 MySQL 完成 V1 到 V98 迁移、存量账号回填与 DBA 镜像一致性验证
- 真实 Chrome 完成注册、待审核登录、零菜单、直接路由拦截、管理员审核分配角色、旧会话失效和重新登录获得菜单的完整闭环
- `git diff --check` 通过
