### PR TITLE
feat(admin): 审核时选择并绑定用户归属租户

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImpl.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImpl.java
@@ -10,6 +10,8 @@ import com.richard.fyoung.customeradmin.system.role.entity.SysRolePermission;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRolePermissionMapper;
 import com.richard.fyoung.customeradmin.system.role.service.UserRoleResolver;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -49,6 +51,15 @@ public class AdminStpInterfaceImpl implements StpInterface {
 
     @Override
     public List<String> getPermissionList(Object loginId, String loginType) {
+        String userTenant = TenantSession.currentUserTenant();
+        if (userTenant != null) {
+            // Sa-Token 的注解鉴权早于 Web 租户拦截器执行，权限关联查询必须自行绑定用户归属租户。
+            return TenantContext.callWith(userTenant, () -> resolvePermissionList(loginId));
+        }
+        return resolvePermissionList(loginId);
+    }
+
+    private List<String> resolvePermissionList(Object loginId) {
         List<SysRole> roles = rolesOf(loginId);
         if (roles.isEmpty()) {
             return List.of();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/mapper/SysRoleMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/mapper/SysRoleMapper.java
@@ -9,7 +9,7 @@ import org.apache.ibatis.annotations.Update;
 /**
  * 角色 Mapper。
  *
- * <p>下面两个方法专门绕开 MyBatis-Plus 的逻辑删除过滤：{@code sys_role.uk_sys_role_code} 是
+ * <p>下面两个方法专门绕开 MyBatis-Plus 的逻辑删除过滤：{@code sys_role.uk_sys_role_tenant_code} 是
  * <b>不含 deleted 列</b>的纯数据库唯一约束，被软删除的行仍然占着编码，而 {@code LambdaQueryWrapper}
  * 会自动追加 {@code AND deleted=0} 从而查不到它——必须用原生 SQL 才能看见/复活。手法与
  * {@code AiKnowledgeBaseMapper#selectDeletedByName}/{@code reviveDeleted} 完全一致。</p>
@@ -18,17 +18,21 @@ import org.apache.ibatis.annotations.Update;
 public interface SysRoleMapper extends BaseMapper<SysRole> {
 
     /**
-     * 按编码查一条<b>已被软删除</b>的角色行（{@code deleted=1}）。用原生 {@code @Select}，
-     * 不会被自动追加 {@code AND deleted=0}，因此能看见被逻辑删除、但仍占着唯一索引的那一行。
+     * 按租户与编码查一条<b>已被软删除</b>的角色行（{@code deleted=1}）。租户条件必须显式保留，
+     * 与数据库的租户内唯一约束同口径；原生 {@code @Select} 不会被自动追加
+     * {@code AND deleted=0}，因此能看见被逻辑删除、但仍占着唯一索引的那一行。
      */
-    @Select("SELECT * FROM sys_role WHERE role_code = #{roleCode} AND deleted = 1 LIMIT 1")
-    SysRole selectDeletedByRoleCode(@Param("roleCode") String roleCode);
+    @Select("SELECT * FROM sys_role WHERE tenant_id = #{tenantId} "
+        + "AND role_code = #{roleCode} AND deleted = 1 LIMIT 1")
+    SysRole selectDeletedByRoleCode(@Param("tenantId") String tenantId,
+                                    @Param("roleCode") String roleCode);
 
     /**
      * “复活”一个被软删除的角色行：只把 {@code deleted} 置回 0，其余业务字段由调用方随后用
      * {@code updateById} 按新的保存请求整体覆盖（复活后该行对 MyBatis-Plus 重新可见）。
-     * 同样用原生 {@code @Update} 才能命中当前 {@code deleted=1} 的目标行。
+     * 同样用原生 {@code @Update} 才能命中当前 {@code deleted=1} 的目标行，并显式约束归属租户。
      */
-    @Update("UPDATE sys_role SET deleted = 0 WHERE id = #{id} AND deleted = 1")
-    int reviveDeleted(@Param("id") Long id);
+    @Update("UPDATE sys_role SET deleted = 0 WHERE id = #{id} "
+        + "AND tenant_id = #{tenantId} AND deleted = 1")
+    int reviveDeleted(@Param("id") Long id, @Param("tenantId") String tenantId);
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/RoleService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/role/service/RoleService.java
@@ -21,6 +21,7 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.ControlPlanePermissions;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
@@ -37,8 +38,9 @@ import java.util.stream.Collectors;
 /**
  * 角色/权限分配管理。
  *
- * <p>{@code role_code=super_admin} 不可编辑/删除（防止误操作导致系统失去管理入口），
- * 其权限点在读取时合成为全量权限 ID（实际不落 {@code sys_role_permission}，
+ * <p>同时满足 {@code role_code=super_admin} 与 {@code control_plane=1} 的平台超管角色不可编辑/删除
+ * （防止误操作导致系统失去管理入口），其权限点在读取时合成为全量权限 ID（实际不落
+ * {@code sys_role_permission}，
  * 见 {@link com.richard.fyoung.customeradmin.config.AdminStpInterfaceImpl} 的特判）。</p>
  * @author owlzhangfq@gmail.com
  */
@@ -98,16 +100,17 @@ public class RoleService {
         role.setControlPlane(SysRole.CONTROL_PLANE_DISABLED);
         role.setDataScope(resolveDataScope(request.dataScope()).name());
 
-        // 坑：sys_role.uk_sys_role_code 是不含 deleted 列的纯数据库唯一约束，delete() 走逻辑删除，
+        // 坑：sys_role.uk_sys_role_tenant_code 是不含 deleted 列的租户内唯一约束，delete() 走逻辑删除，
         // 被删过的编码仍占着唯一索引。上面的 exists() 会被自动追加 deleted=0 判定“可用”，但直接
         // insert 会撞唯一键抛 DuplicateKeyException（与 AuthService/KnowledgeBaseService 同款坑）。
         // 先查有没有被软删除过的旧行，有就“复活”它再整体覆盖字段，而不是插新行——若只把异常兜成
         // 友好提示，一个编码被删过一次就永久不能再用，那是功能缺陷而不只是错误信息不友好。
-        SysRole softDeleted = roleMapper.selectDeletedByRoleCode(request.roleCode());
+        String tenantId = TenantContext.require();
+        SysRole softDeleted = roleMapper.selectDeletedByRoleCode(tenantId, request.roleCode());
         if (softDeleted != null) {
             guardControlPlaneRole(softDeleted, "恢复");
             List<Long> permissionIds = validateGrantablePermissions(softDeleted, request.permissionIds());
-            roleMapper.reviveDeleted(softDeleted.getId());
+            roleMapper.reviveDeleted(softDeleted.getId(), tenantId);
             role.setId(softDeleted.getId());
             role.setControlPlane(softDeleted.getControlPlane());
             roleMapper.updateById(role);
@@ -169,7 +172,8 @@ public class RoleService {
     }
 
     private void guardSuperAdmin(SysRole role, String action) {
-        if (SystemRoles.SUPER_ADMIN.equals(role.getRoleCode())) {
+        if (SystemRoles.SUPER_ADMIN.equals(role.getRoleCode())
+            && crossTenantAuthority.isControlPlaneRole(role)) {
             throw new BizException(ResultCode.FORBIDDEN, "超级管理员角色不可" + action);
         }
     }
@@ -229,7 +233,8 @@ public class RoleService {
                 Collectors.mapping(SysRolePermission::getPermissionId, Collectors.toList())));
 
         for (RoleVO vo : roles) {
-            if (SystemRoles.SUPER_ADMIN.equals(vo.getRoleCode())) {
+            if (SystemRoles.SUPER_ADMIN.equals(vo.getRoleCode())
+                && Boolean.TRUE.equals(vo.getControlPlane())) {
                 vo.setPermissionIds(superAdminAllIds);
             } else {
                 vo.setPermissionIds(permissionIdsByRole.getOrDefault(vo.getId(), List.of()));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/controller/UserController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/controller/UserController.java
@@ -4,6 +4,7 @@ import cn.dev33.satoken.annotation.SaCheckPermission;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.Result;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalOptionsVO;
 import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
 import com.richard.fyoung.customeradmin.system.user.dto.UserPageQuery;
 import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -43,6 +45,14 @@ public class UserController {
     @GetMapping("/{id}")
     public Result<UserVO> get(@PathVariable Long id) {
         return Result.success(userService.get(id));
+    }
+
+    /** 审核弹窗的租户与角色选项；跨租户可见范围由服务端按控制面能力收敛。 */
+    @SaCheckPermission("user:edit")
+    @GetMapping("/approval-options")
+    public Result<UserApprovalOptionsVO> approvalOptions(
+        @RequestParam(required = false) String tenantId) {
+        return Result.success(userService.approvalOptions(tenantId));
     }
 
     @SaCheckPermission("user:add")

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserApprovalOptionsVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserApprovalOptionsVO.java
@@ -1,0 +1,25 @@
+package com.richard.fyoung.customeradmin.system.user.dto;
+
+import java.util.List;
+
+/**
+ * 注册审核可选项：后端按调用者的跨租户能力收敛租户范围，并只返回目标租户内可用角色。
+ * @author owlzhangfq@gmail.com
+ */
+public record UserApprovalOptionsVO(
+    String selectedTenantId,
+    List<TenantOption> tenants,
+    List<RoleOption> roles) {
+
+    /** 审核可绑定的租户。 */
+    public record TenantOption(String tenantId, String tenantName) {
+    }
+
+    /** 目标租户内可分配的启用角色。 */
+    public record RoleOption(
+        Long id,
+        String roleName,
+        String roleCode,
+        boolean controlPlane) {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserApprovalRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserApprovalRequest.java
@@ -7,11 +7,12 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 /**
- * 自助注册用户审核请求；批准时角色清单必填，拒绝时服务端会清空角色。
+ * 自助注册用户审核请求；批准时目标租户与角色清单必填，拒绝时服务端保持原租户并清空角色。
  * @author owlzhangfq@gmail.com
  */
 public record UserApprovalRequest(
     @NotNull(message = "decision 不能为空") UserApprovalStatus decision,
+    @Size(max = 64, message = "tenantId 不能超过 64 位") String tenantId,
     List<Long> roleIds,
     @Size(max = 255, message = "审核说明不能超过 255 位") String remark) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/dto/UserVO.java
@@ -13,6 +13,8 @@ import java.util.List;
 public class UserVO {
     private Long id;
     private String username;
+    /** 用户当前归属租户。 */
+    private String tenantId;
     private String nickname;
     private Integer status;
     private String approvalStatus;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/system/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
 import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalOptionsVO;
 import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
 import com.richard.fyoung.customeradmin.system.user.dto.UserPageQuery;
 import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
@@ -20,6 +21,10 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.access.TenantAccessSnapshot;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantVO;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -50,17 +55,20 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final CrossTenantAuthority crossTenantAuthority;
     private final SessionRevocationService sessionRevocationService;
+    private final TenantService tenantService;
 
     public UserService(SysUserMapper userMapper, SysUserRoleMapper userRoleMapper,
                        SysRoleMapper roleMapper, PasswordEncoder passwordEncoder,
                        CrossTenantAuthority crossTenantAuthority,
-                       SessionRevocationService sessionRevocationService) {
+                       SessionRevocationService sessionRevocationService,
+                       TenantService tenantService) {
         this.userMapper = userMapper;
         this.userRoleMapper = userRoleMapper;
         this.roleMapper = roleMapper;
         this.passwordEncoder = passwordEncoder;
         this.crossTenantAuthority = crossTenantAuthority;
         this.sessionRevocationService = sessionRevocationService;
+        this.tenantService = tenantService;
     }
 
     public PageResult<UserVO> page(UserPageQuery query) {
@@ -89,6 +97,54 @@ public class UserService {
         UserVO vo = toVoWithoutRoles(user);
         fillRoles(List.of(vo));
         return vo;
+    }
+
+    /**
+     * 返回注册审核可选租户及目标租户内的启用角色。
+     *
+     * <p>普通租户审核人只能看到当前租户；具备控制面能力的审核人才能跨租户选择。角色查询临时进入
+     * 目标租户上下文，前端无需切换整个管理后台视角，也不能通过伪造 tenantId 越权枚举其它租户角色。</p>
+     */
+    public UserApprovalOptionsVO approvalOptions(String requestedTenantId) {
+        String currentTenant = TenantContext.require();
+        boolean canCrossTenant = crossTenantAuthority.hasCurrentUserAuthority();
+        List<TenantVO> activeTenants = tenantService.listActive().stream()
+            .filter(tenant -> tenant.getExpireTime() == null
+                || !tenant.getExpireTime().isBefore(LocalDateTime.now()))
+            .toList();
+        List<TenantVO> visibleTenants = canCrossTenant
+            ? activeTenants
+            : activeTenants.stream()
+                .filter(tenant -> TenantContext.sameTenant(currentTenant, tenant.getTenantCode()))
+                .toList();
+
+        String targetInput = StringUtils.hasText(requestedTenantId)
+            ? requestedTenantId.trim()
+            : currentTenant;
+        if (!TenantContext.sameTenant(currentTenant, targetInput) && !canCrossTenant) {
+            // 先做越权判定再查租户主数据，避免普通租户用户借错误码枚举其它租户是否存在。
+            throw new BizException(ResultCode.TENANT_VIEW_FORBIDDEN);
+        }
+        TenantAccessSnapshot targetSnapshot = tenantService.resolveAccessibleSnapshot(targetInput);
+        if (targetSnapshot == null) {
+            throw new BizException(ResultCode.TENANT_NOT_FOUND);
+        }
+        String targetTenant = targetSnapshot.tenantId();
+
+        List<UserApprovalOptionsVO.RoleOption> roles = TenantContext.callWith(targetTenant,
+            () -> roleMapper.selectList(new LambdaQueryWrapper<SysRole>()
+                    .eq(SysRole::getStatus, 1)
+                    .orderByAsc(SysRole::getRoleName))
+                .stream()
+                .map(role -> new UserApprovalOptionsVO.RoleOption(
+                    role.getId(), role.getRoleName(), role.getRoleCode(),
+                    crossTenantAuthority.isControlPlaneRole(role)))
+                .toList());
+        List<UserApprovalOptionsVO.TenantOption> tenants = visibleTenants.stream()
+            .map(tenant -> new UserApprovalOptionsVO.TenantOption(
+                tenant.getTenantCode(), tenant.getTenantName()))
+            .toList();
+        return new UserApprovalOptionsVO(targetTenant, tenants, roles);
     }
 
     @Transactional(rollbackFor = Exception.class)
@@ -148,8 +204,8 @@ public class UserService {
     }
 
     /**
-     * 审核自助注册用户。批准与角色分配在同一事务完成，拒绝则清空角色；两种决策都会撤销旧会话，
-     * 让用户重新登录后读取新的审核状态和权限集合。
+     * 审核自助注册用户。批准时把用户归属、角色关系一次提交到目标租户；拒绝保持原租户并清空角色。
+     * 租户或安全属性发生变化时撤销旧会话，让用户重新登录后读取新的租户与权限集合。
      */
     @Transactional(rollbackFor = Exception.class)
     public void review(Long id, UserApprovalRequest request) {
@@ -157,31 +213,67 @@ public class UserService {
             throw new BizException(ResultCode.PARAM_INVALID, "审核结果只能是通过或拒绝");
         }
         SysUser user = requireUser(id);
-        List<Long> previousRoleIds = existingRoleIds(id);
+        String sourceTenant = StringUtils.hasText(user.getTenantId())
+            ? TenantContext.canonicalizeTenantId(user.getTenantId())
+            : TenantContext.require();
+        String targetTenant = resolveApprovalTenant(sourceTenant, request);
+        List<Long> previousRoleIds = TenantContext.callWith(sourceTenant, () -> existingRoleIds(id));
+        TenantContext.runWith(sourceTenant, () -> guardExistingControlPlaneAssignment(id));
         List<Long> roleIds;
         if (request.decision() == UserApprovalStatus.APPROVED) {
-            roleIds = validateRoleChange(id, request.roleIds());
+            roleIds = TenantContext.callWith(targetTenant,
+                () -> validateRoleChange(null, request.roleIds()));
             if (roleIds.isEmpty()) {
                 throw new BizException(ResultCode.PARAM_MISSING, "审核通过时必须至少分配一个角色");
             }
         } else {
-            roleIds = validateRoleChange(id, List.of());
+            roleIds = List.of();
         }
 
         boolean approvalChanged = request.decision()
             != UserApprovalStatus.parse(user.getApprovalStatus());
         boolean rolesChanged = !new HashSet<>(previousRoleIds).equals(new HashSet<>(roleIds));
+        boolean tenantChanged = !TenantContext.sameTenant(sourceTenant, targetTenant);
         user.setApprovalStatus(request.decision().name());
+        user.setTenantId(targetTenant);
         user.setApprovalBy(StpUtil.getLoginIdAsLong());
         user.setApprovalTime(LocalDateTime.now());
         user.setApprovalRemark(StringUtils.hasText(request.remark()) ? request.remark().trim() : null);
-        userMapper.updateById(user);
-        replaceRoles(id, roleIds);
+        int userChanged = TenantContext.callWith(sourceTenant, () -> userMapper.updateById(user));
+        if (userChanged != 1) {
+            throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "用户不存在或归属租户已变化");
+        }
+        TenantContext.runWith(sourceTenant, () -> replaceRoles(id, List.of()));
+        TenantContext.runWith(targetTenant, () -> insertRoles(id, roleIds));
 
-        if (approvalChanged || rolesChanged) {
-            requireEpochIncremented(userMapper.incrementAuthEpoch(id));
+        if (approvalChanged || rolesChanged || tenantChanged) {
+            requireEpochIncremented(TenantContext.callWith(targetTenant,
+                () -> userMapper.incrementAuthEpoch(id)));
             sessionRevocationService.revokeUserAfterCommit(id);
         }
+    }
+
+    private String resolveApprovalTenant(String sourceTenant, UserApprovalRequest request) {
+        if (request.decision() == UserApprovalStatus.REJECTED) {
+            if (StringUtils.hasText(request.tenantId())
+                && !TenantContext.sameTenant(sourceTenant, request.tenantId().trim())) {
+                throw new BizException(ResultCode.PARAM_INVALID, "拒绝注册申请时不能变更用户归属租户");
+            }
+            return sourceTenant;
+        }
+        if (!StringUtils.hasText(request.tenantId())) {
+            throw new BizException(ResultCode.PARAM_MISSING, "审核通过时必须选择归属租户");
+        }
+        String requestedTenant = request.tenantId().trim();
+        if (!TenantContext.sameTenant(sourceTenant, requestedTenant)) {
+            // 授权判定先于目标租户查询，普通审核人不能利用错误差异枚举平台租户。
+            crossTenantAuthority.requireCurrentUserAuthority();
+        }
+        TenantAccessSnapshot target = tenantService.resolveAccessibleSnapshot(requestedTenant);
+        if (target == null) {
+            throw new BizException(ResultCode.TENANT_NOT_FOUND);
+        }
+        return target.tenantId();
     }
 
     @Transactional(rollbackFor = Exception.class)
@@ -196,6 +288,10 @@ public class UserService {
 
     private void replaceRoles(Long userId, List<Long> roleIds) {
         userRoleMapper.delete(new LambdaQueryWrapper<SysUserRole>().eq(SysUserRole::getUserId, userId));
+        insertRoles(userId, roleIds);
+    }
+
+    private void insertRoles(Long userId, List<Long> roleIds) {
         if (CollectionUtils.isEmpty(roleIds)) {
             return;
         }
@@ -226,6 +322,9 @@ public class UserService {
         List<SysRole> requestedRoles = roleMapper.selectBatchIds(roleIds);
         if (requestedRoles.size() != roleIds.size()) {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "角色不存在或不属于当前租户");
+        }
+        if (requestedRoles.stream().anyMatch(role -> !Integer.valueOf(1).equals(role.getStatus()))) {
+            throw new BizException(ResultCode.PARAM_INVALID, "不能分配已停用角色");
         }
         boolean touchesControlPlane = crossTenantAuthority.hasAuthority(requestedRoles)
             || hasExistingControlPlaneAssignment(userId);
@@ -304,6 +403,7 @@ public class UserService {
         UserVO vo = new UserVO();
         vo.setId(user.getId());
         vo.setUsername(user.getUsername());
+        vo.setTenantId(user.getTenantId());
         vo.setNickname(user.getNickname());
         vo.setStatus(user.getStatus());
         vo.setApprovalStatus(UserApprovalStatus.parse(user.getApprovalStatus()).name());

--- a/customer-admin-server/src/main/resources/db/migration/V99__tenant_scoped_roles_and_approval_binding.sql
+++ b/customer-admin-server/src/main/resources/db/migration/V99__tenant_scoped_roles_and_approval_binding.sql
@@ -1,0 +1,96 @@
+-- 审核绑定租户前先修正角色领域约束：角色编码只要求租户内唯一，并补齐存量租户的内建管理员角色。
+SET NAMES utf8mb4;
+
+SET @v99_role_table_exists = (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' AND table_name = 'sys_role');
+SET @v99_role_columns = (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'sys_role'
+      AND column_name IN ('tenant_id', 'role_code', 'deleted', 'data_scope', 'control_plane'));
+SET @v99_preflight_sql = IF(@v99_role_table_exists = 1 AND @v99_role_columns = 5,
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v99_sys_role_preflight_failed__`');
+PREPARE v99_preflight_stmt FROM @v99_preflight_sql;
+EXECUTE v99_preflight_stmt;
+DEALLOCATE PREPARE v99_preflight_stmt;
+
+-- 若历史环境曾手工移除全局唯一键，先阻止带租户内重复编码的数据进入正式约束。
+SET @v99_duplicate_role_codes = (SELECT COUNT(*) FROM (
+    SELECT `tenant_id`, `role_code`
+    FROM `sys_role`
+    GROUP BY `tenant_id`, `role_code`
+    HAVING COUNT(*) > 1
+) AS duplicate_role_codes);
+SET @v99_duplicate_guard_sql = IF(@v99_duplicate_role_codes = 0,
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v99_duplicate_tenant_role_code__`');
+PREPARE v99_duplicate_guard_stmt FROM @v99_duplicate_guard_sql;
+EXECUTE v99_duplicate_guard_stmt;
+DEALLOCATE PREPARE v99_duplicate_guard_stmt;
+
+-- 兼容已经人工按本迁移目标改过索引的环境；同名但结构错误时 fail-fast，避免静默留下伪约束。
+SET @v99_old_index_shape = (SELECT CONCAT(MIN(`non_unique`), ':',
+        GROUP_CONCAT(`column_name` ORDER BY `seq_in_index` SEPARATOR ','))
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'sys_role'
+      AND index_name = 'uk_sys_role_code');
+SET @v99_target_index_shape = (SELECT CONCAT(MIN(`non_unique`), ':',
+        GROUP_CONCAT(`column_name` ORDER BY `seq_in_index` SEPARATOR ','))
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'sys_role'
+      AND index_name = 'uk_sys_role_tenant_code');
+SET @v99_index_guard_sql = IF(
+    (@v99_old_index_shape IS NULL OR @v99_old_index_shape IN ('0:role_code', '0:tenant_id,role_code'))
+        AND (@v99_target_index_shape IS NULL OR @v99_target_index_shape = '0:tenant_id,role_code'),
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v99_role_index_preflight_failed__`');
+PREPARE v99_index_guard_stmt FROM @v99_index_guard_sql;
+EXECUTE v99_index_guard_stmt;
+DEALLOCATE PREPARE v99_index_guard_stmt;
+
+SET @v99_drop_global_index_sql = IF(@v99_old_index_shape IS NULL, 'SELECT 1',
+    'ALTER TABLE `sys_role` DROP INDEX `uk_sys_role_code`');
+PREPARE v99_drop_global_index_stmt FROM @v99_drop_global_index_sql;
+EXECUTE v99_drop_global_index_stmt;
+DEALLOCATE PREPARE v99_drop_global_index_stmt;
+
+SET @v99_add_tenant_index_sql = IF(@v99_target_index_shape IS NULL,
+    'ALTER TABLE `sys_role` ADD UNIQUE KEY `uk_sys_role_tenant_code` (`tenant_id`, `role_code`)',
+    'SELECT 1');
+PREPARE v99_add_tenant_index_stmt FROM @v99_add_tenant_index_sql;
+EXECUTE v99_add_tenant_index_stmt;
+DEALLOCATE PREPARE v99_add_tenant_index_stmt;
+
+-- V49 之后创建租户时会初始化 tenant_admin；旧唯一键使第二个租户必然撞键。
+-- 迁移完成后为全部可用存量租户补齐内建角色，审核页才能真正选择目标租户的角色。
+INSERT INTO `sys_role`
+    (`role_name`, `role_code`, `remark`, `status`, `tenant_id`, `data_scope`, `control_plane`)
+SELECT '租户管理员', 'tenant_admin', '租户开通时自动创建，拥有本租户内全部管理权限',
+       1, t.`tenant_code`, 'TENANT', 0
+FROM `sys_tenant` t
+WHERE t.`deleted` = 0
+  AND t.`status` = 'ACTIVE'
+  AND NOT EXISTS (
+      SELECT 1 FROM `sys_role` r
+      WHERE r.`tenant_id` = t.`tenant_code`
+        AND r.`role_code` = 'tenant_admin'
+  );
+
+-- 与 ControlPlanePermissions 保持同一安全边界：tenant_admin 获得租户内管理权限，
+-- 但不能获得租户、菜单、登录图、系统工具、配置发布、计费写入和敏感词写入等控制面权限。
+INSERT INTO `sys_role_permission` (`role_id`, `permission_id`, `tenant_id`)
+SELECT r.`id`, p.`id`, r.`tenant_id`
+FROM `sys_role` r
+CROSS JOIN `sys_permission` p
+LEFT JOIN `sys_role_permission` rp
+  ON rp.`role_id` = r.`id`
+ AND rp.`permission_id` = p.`id`
+WHERE r.`role_code` = 'tenant_admin'
+  AND r.`deleted` = 0
+  AND rp.`id` IS NULL
+  AND p.`perm_code` NOT IN (
+      'tenant', 'menu', 'login-image', 'system-tool', 'config-version',
+      'billing:quota-edit', 'billing:price-edit', 'billing:export', 'billing:aggregate',
+      'sensitive-word:add', 'sensitive-word:edit', 'sensitive-word:delete'
+  )
+  AND p.`perm_code` NOT LIKE 'tenant:%'
+  AND p.`perm_code` NOT LIKE 'menu:%'
+  AND p.`perm_code` NOT LIKE 'login-image:%'
+  AND p.`perm_code` NOT LIKE 'system-tool:%'
+  AND p.`perm_code` NOT LIKE 'config-version:%';

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImplTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/config/AdminStpInterfaceImplTest.java
@@ -4,17 +4,24 @@ import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.richard.fyoung.customeradmin.system.permission.entity.SysPermission;
 import com.richard.fyoung.customeradmin.system.permission.mapper.SysPermissionMapper;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
+import com.richard.fyoung.customeradmin.system.role.entity.SysRolePermission;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRolePermissionMapper;
 import com.richard.fyoung.customeradmin.system.role.service.UserRoleResolver;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,12 +46,20 @@ class AdminStpInterfaceImplTest {
             new CrossTenantAuthority(userRoleResolver));
     }
 
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
     @Test
     void getPermissionList_shouldNotTrustSuperAdminRoleCodeWithoutControlPlaneFlag() {
         when(userRoleResolver.enabledRolesOf(7L)).thenReturn(List.of(role(1L, "super_admin", 0)));
         when(rolePermissionMapper.selectList(any())).thenReturn(List.of());
 
-        assertEquals(List.of(), stpInterface.getPermissionList(7L, "login"));
+        try (MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            tenantSession.when(TenantSession::currentUserTenant).thenReturn(null);
+            assertEquals(List.of(), stpInterface.getPermissionList(7L, "login"));
+        }
         verify(permissionMapper, never()).selectList(any(Wrapper.class));
     }
 
@@ -56,7 +71,35 @@ class AdminStpInterfaceImplTest {
         permission.setPermCode("tenant:view");
         when(permissionMapper.selectList(null)).thenReturn(List.of(permission));
 
-        assertEquals(List.of("tenant:view"), stpInterface.getPermissionList(7L, "login"));
+        try (MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            tenantSession.when(TenantSession::currentUserTenant).thenReturn(null);
+            assertEquals(List.of("tenant:view"), stpInterface.getPermissionList(7L, "login"));
+        }
+    }
+
+    @Test
+    void getPermissionList_shouldBindUserTenantForOrdinaryRolePermissionQueries() {
+        when(userRoleResolver.enabledRolesOf(7L)).thenReturn(List.of(role(2L, "developer", 0)));
+        SysRolePermission relation = new SysRolePermission();
+        relation.setRoleId(2L);
+        relation.setPermissionId(11L);
+        when(rolePermissionMapper.selectList(any())).thenAnswer(invocation -> {
+            assertEquals("tenant-a", TenantContext.require());
+            return List.of(relation);
+        });
+        SysPermission permission = new SysPermission();
+        permission.setPermCode("workspace");
+        when(permissionMapper.selectBatchIds(List.of(11L))).thenAnswer(invocation -> {
+            assertEquals("tenant-a", TenantContext.require());
+            return List.of(permission);
+        });
+
+        try (MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            tenantSession.when(TenantSession::currentUserTenant).thenReturn("tenant-a");
+
+            assertEquals(List.of("workspace"), stpInterface.getPermissionList(7L, "login"));
+        }
+        assertFalse(TenantContext.isPresent(), "鉴权结束后不能泄漏用户归属租户上下文");
     }
 
     private SysRole role(Long id, String roleCode, int controlPlane) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/role/service/RoleServiceDataScopeTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/role/service/RoleServiceDataScopeTest.java
@@ -14,6 +14,8 @@ import com.richard.fyoung.customeradmin.system.role.mapper.SysRolePermissionMapp
 import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -21,6 +23,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +47,7 @@ class RoleServiceDataScopeTest {
 
     @BeforeEach
     void setUp() {
+        TenantContext.set("tenant-a");
         roleMapper = mock(SysRoleMapper.class);
         permissionMapper = mock(SysPermissionMapper.class);
         rolePermissionMapper = mock(SysRolePermissionMapper.class);
@@ -52,6 +56,11 @@ class RoleServiceDataScopeTest {
         service = new RoleService(roleMapper, rolePermissionMapper, permissionMapper, userRoleMapper,
             crossTenantAuthority);
         when(roleMapper.exists(any())).thenReturn(false);
+    }
+
+    @AfterEach
+    void clearTenantContext() {
+        TenantContext.clear();
     }
 
     /** 不传范围时按最小权限落 SELF，而不是留空由 SQL 默认值兜底——留空会让"是否设过"变得不可知。 */
@@ -110,7 +119,7 @@ class RoleServiceDataScopeTest {
     @Test
     void create_shouldRejectRevivingDeletedControlPlaneRoleFromOrdinaryUser() {
         SysRole operator = controlPlaneRole(3L);
-        when(roleMapper.selectDeletedByRoleCode("operator")).thenReturn(operator);
+        when(roleMapper.selectDeletedByRoleCode("tenant-a", "operator")).thenReturn(operator);
         when(crossTenantAuthority.isControlPlaneRole(operator)).thenReturn(true);
         when(crossTenantAuthority.hasCurrentUserAuthority()).thenReturn(false);
 
@@ -118,7 +127,7 @@ class RoleServiceDataScopeTest {
             () -> service.create(request("operator", "TENANT")));
 
         assertEquals(ResultCode.FORBIDDEN, exception.getResultCode());
-        verify(roleMapper, never()).reviveDeleted(3L);
+        verify(roleMapper, never()).reviveDeleted(3L, "tenant-a");
     }
 
     @Test
@@ -146,6 +155,58 @@ class RoleServiceDataScopeTest {
         verify(roleMapper).deleteById(5L);
         verify(rolePermissionMapper).delete(any());
         verify(userRoleMapper).delete(any());
+    }
+
+    @Test
+    void update_shouldNotTreatTenantRoleCodeAsControlPlaneSuperAdmin() {
+        SysRole tenantRole = new SysRole();
+        tenantRole.setId(8L);
+        tenantRole.setRoleCode("super_admin");
+        tenantRole.setControlPlane(SysRole.CONTROL_PLANE_DISABLED);
+        when(roleMapper.selectById(8L)).thenReturn(tenantRole);
+        when(crossTenantAuthority.isControlPlaneRole(tenantRole)).thenReturn(false);
+
+        service.update(8L, request("tenant_super_admin", "TENANT"));
+
+        verify(roleMapper).updateById(tenantRole);
+    }
+
+    @Test
+    void get_shouldNotSynthesizeAllPermissionsForTenantRoleNamedSuperAdmin() {
+        SysRole tenantRole = new SysRole();
+        tenantRole.setId(8L);
+        tenantRole.setRoleCode("super_admin");
+        tenantRole.setControlPlane(SysRole.CONTROL_PLANE_DISABLED);
+        SysPermission allPermission = new SysPermission();
+        allPermission.setId(1L);
+        SysRolePermission assigned = new SysRolePermission();
+        assigned.setRoleId(8L);
+        assigned.setPermissionId(2L);
+        when(roleMapper.selectById(8L)).thenReturn(tenantRole);
+        when(crossTenantAuthority.isControlPlaneRole(tenantRole)).thenReturn(false);
+        when(permissionMapper.selectList(null)).thenReturn(List.of(allPermission));
+        when(rolePermissionMapper.selectList(any())).thenReturn(List.of(assigned));
+
+        RoleVO role = service.get(8L);
+
+        assertFalse(role.getControlPlane());
+        assertEquals(List.of(2L), role.getPermissionIds());
+    }
+
+    @Test
+    void delete_shouldStillProtectControlPlaneSuperAdmin() {
+        SysRole superAdmin = new SysRole();
+        superAdmin.setId(1L);
+        superAdmin.setRoleCode("super_admin");
+        superAdmin.setControlPlane(SysRole.CONTROL_PLANE_ENABLED);
+        when(roleMapper.selectById(1L)).thenReturn(superAdmin);
+        when(crossTenantAuthority.isControlPlaneRole(superAdmin)).thenReturn(true);
+        when(crossTenantAuthority.hasCurrentUserAuthority()).thenReturn(true);
+
+        BizException exception = assertThrows(BizException.class, () -> service.delete(1L));
+
+        assertEquals(ResultCode.FORBIDDEN, exception.getResultCode());
+        verify(roleMapper, never()).deleteById(1L);
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserApprovalTenantBindingIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserApprovalTenantBindingIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.richard.fyoung.customeradmin.system.user.service;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.richard.fyoung.customeradmin.auth.service.SessionRevocationService;
+import com.richard.fyoung.customeradmin.datascope.DataScope;
+import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.access.TenantAccessSnapshot;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** 用户审核绑定租户的真 MySQL 行级隔离回归。 */
+@SpringBootTest
+@ActiveProfiles("dev")
+@Transactional
+class UserApprovalTenantBindingIntegrationTest {
+
+    @Autowired
+    private SysUserMapper userMapper;
+
+    @Autowired
+    private SysUserRoleMapper userRoleMapper;
+
+    @Autowired
+    private SysRoleMapper roleMapper;
+
+    @BeforeAll
+    static void checkMysqlReachable() {
+        assumeTrue(reachable(), "MySQL 不可达，跳过用户审核租户绑定真库测试");
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void review_shouldMoveUserAndRoleRelationAcrossTenantBoundaries() {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+        String targetTenant = "approval_" + suffix;
+        SysUser user = pendingUser("approval_user_" + suffix);
+        TenantContext.runWith(TenantContext.DEFAULT, () -> userMapper.insert(user));
+
+        SysRole targetRole = tenantRole("approval_role_" + suffix);
+        TenantContext.runWith(targetTenant, () -> roleMapper.insert(targetRole));
+
+        CrossTenantAuthority crossTenantAuthority = mock(CrossTenantAuthority.class);
+        SessionRevocationService revocationService = mock(SessionRevocationService.class);
+        TenantService tenantService = mock(TenantService.class);
+        when(tenantService.resolveAccessibleSnapshot(targetTenant))
+            .thenReturn(new TenantAccessSnapshot(targetTenant, "ACTIVE", 0L, null));
+        UserService service = new UserService(
+            userMapper,
+            userRoleMapper,
+            roleMapper,
+            mock(PasswordEncoder.class),
+            crossTenantAuthority,
+            revocationService,
+            tenantService);
+
+        try (MockedStatic<StpUtil> stpUtil = org.mockito.Mockito.mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(1L);
+            TenantContext.runWith(TenantContext.DEFAULT, () -> service.review(user.getId(),
+                new UserApprovalRequest(
+                    UserApprovalStatus.APPROVED, targetTenant, List.of(targetRole.getId()), "真库核验")));
+        }
+
+        TenantContext.runWith(TenantContext.DEFAULT, () -> {
+            assertNull(userMapper.selectById(user.getId()), "用户迁移后源租户必须不可见");
+            assertTrue(userRoleMapper.selectList(new LambdaQueryWrapper<SysUserRole>()
+                .eq(SysUserRole::getUserId, user.getId())).isEmpty(), "源租户不能残留角色关系");
+        });
+        TenantContext.runWith(targetTenant, () -> {
+            SysUser moved = userMapper.selectById(user.getId());
+            assertEquals(targetTenant, moved.getTenantId());
+            assertEquals(UserApprovalStatus.APPROVED.name(), moved.getApprovalStatus());
+            assertEquals("真库核验", moved.getApprovalRemark());
+            assertEquals(1L, moved.getAuthEpoch());
+            List<SysUserRole> relations = userRoleMapper.selectList(
+                new LambdaQueryWrapper<SysUserRole>().eq(SysUserRole::getUserId, user.getId()));
+            assertEquals(List.of(targetRole.getId()),
+                relations.stream().map(SysUserRole::getRoleId).toList());
+        });
+        verify(crossTenantAuthority).requireCurrentUserAuthority();
+        verify(revocationService).revokeUserAfterCommit(user.getId());
+    }
+
+    private SysUser pendingUser(String username) {
+        SysUser user = new SysUser();
+        user.setUsername(username);
+        user.setTenantId(TenantContext.DEFAULT);
+        user.setPassword("$2a$10$integration.test.hash");
+        user.setNickname("待审核用户");
+        user.setStatus(1);
+        user.setApprovalStatus(UserApprovalStatus.PENDING.name());
+        return user;
+    }
+
+    private SysRole tenantRole(String roleCode) {
+        SysRole role = new SysRole();
+        role.setRoleName("审核测试角色");
+        role.setRoleCode(roleCode);
+        role.setStatus(1);
+        role.setDataScope(DataScope.TENANT.name());
+        role.setControlPlane(SysRole.CONTROL_PLANE_DISABLED);
+        return role;
+    }
+
+    private static boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", 3306), 1500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceApprovalTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceApprovalTest.java
@@ -8,6 +8,7 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.system.role.entity.SysRole;
 import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
 import com.richard.fyoung.customeradmin.system.user.domain.UserApprovalStatus;
+import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalOptionsVO;
 import com.richard.fyoung.customeradmin.system.user.dto.UserApprovalRequest;
 import com.richard.fyoung.customeradmin.system.user.dto.UserSaveRequest;
 import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
@@ -15,6 +16,11 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.access.TenantAccessSnapshot;
+import com.richard.fyoung.customeradmin.tenant.dto.TenantVO;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,9 +30,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -38,7 +47,9 @@ class UserServiceApprovalTest {
     private SysUserMapper userMapper;
     private SysUserRoleMapper userRoleMapper;
     private SysRoleMapper roleMapper;
+    private CrossTenantAuthority crossTenantAuthority;
     private SessionRevocationService revocationService;
+    private TenantService tenantService;
     private UserService service;
 
     @BeforeEach
@@ -46,16 +57,27 @@ class UserServiceApprovalTest {
         userMapper = mock(SysUserMapper.class);
         userRoleMapper = mock(SysUserRoleMapper.class);
         roleMapper = mock(SysRoleMapper.class);
+        crossTenantAuthority = mock(CrossTenantAuthority.class);
         revocationService = mock(SessionRevocationService.class);
+        tenantService = mock(TenantService.class);
         service = new UserService(
             userMapper,
             userRoleMapper,
             roleMapper,
             mock(PasswordEncoder.class),
-            mock(CrossTenantAuthority.class),
-            revocationService);
+            crossTenantAuthority,
+            revocationService,
+            tenantService);
         when(userRoleMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(List.of());
+        when(userMapper.updateById(any(SysUser.class))).thenReturn(1);
         when(userMapper.incrementAuthEpoch(9L)).thenReturn(1);
+        when(tenantService.resolveAccessibleSnapshot(TenantContext.DEFAULT))
+            .thenReturn(snapshot(TenantContext.DEFAULT));
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
     }
 
     @Test
@@ -68,11 +90,12 @@ class UserServiceApprovalTest {
         try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
             stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(99L);
 
-            service.review(9L,
-                new UserApprovalRequest(UserApprovalStatus.APPROVED, List.of(3L), " 已核验 "));
+            service.review(9L, new UserApprovalRequest(
+                UserApprovalStatus.APPROVED, TenantContext.DEFAULT, List.of(3L), " 已核验 "));
         }
 
         assertEquals(UserApprovalStatus.APPROVED.name(), user.getApprovalStatus());
+        assertEquals(TenantContext.DEFAULT, user.getTenantId());
         assertEquals(99L, user.getApprovalBy());
         assertEquals("已核验", user.getApprovalRemark());
         assertNotNull(user.getApprovalTime());
@@ -82,6 +105,124 @@ class UserServiceApprovalTest {
         assertEquals(3L, relationCaptor.getValue().getRoleId());
         verify(userMapper).incrementAuthEpoch(9L);
         verify(revocationService).revokeUserAfterCommit(9L);
+    }
+
+    @Test
+    void review_shouldMoveUserAndRoleRelationIntoSelectedTenant() {
+        SysUser user = pendingUser();
+        SysRole targetRole = role(30L);
+        when(userMapper.selectById(9L)).thenReturn(user);
+        when(tenantService.resolveAccessibleSnapshot("tenant-a")).thenReturn(snapshot("tenant-a"));
+        when(roleMapper.selectBatchIds(List.of(30L))).thenAnswer(invocation -> {
+            assertEquals("tenant-a", TenantContext.require());
+            return List.of(targetRole);
+        });
+        when(userMapper.updateById(user)).thenAnswer(invocation -> {
+            assertEquals(TenantContext.DEFAULT, TenantContext.require());
+            return 1;
+        });
+        when(userMapper.incrementAuthEpoch(9L)).thenAnswer(invocation -> {
+            assertEquals("tenant-a", TenantContext.require());
+            return 1;
+        });
+        doAnswer(invocation -> {
+            assertEquals("tenant-a", TenantContext.require());
+            return 1;
+        }).when(userRoleMapper).insert(any(SysUserRole.class));
+
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(99L);
+            service.review(9L, new UserApprovalRequest(
+                UserApprovalStatus.APPROVED, "tenant-a", List.of(30L), null));
+        }
+
+        assertEquals("tenant-a", user.getTenantId());
+        verify(crossTenantAuthority).requireCurrentUserAuthority();
+        verify(revocationService).revokeUserAfterCommit(9L);
+        assertFalse(TenantContext.isPresent(), "审核结束后不能泄漏目标租户上下文");
+    }
+
+    @Test
+    void review_shouldRejectUnauthorizedCrossTenantBindingBeforeMutation() {
+        when(userMapper.selectById(9L)).thenReturn(pendingUser());
+        when(tenantService.resolveAccessibleSnapshot("tenant-a")).thenReturn(snapshot("tenant-a"));
+        doThrow(new BizException(ResultCode.TENANT_VIEW_FORBIDDEN))
+            .when(crossTenantAuthority).requireCurrentUserAuthority();
+
+        BizException error = assertThrows(BizException.class, () -> service.review(9L,
+            new UserApprovalRequest(UserApprovalStatus.APPROVED, "tenant-a", List.of(30L), null)));
+
+        assertEquals(ResultCode.TENANT_VIEW_FORBIDDEN, error.getResultCode());
+        verify(userMapper, never()).updateById(any(SysUser.class));
+        verify(userRoleMapper, never()).insert(any(SysUserRole.class));
+    }
+
+    @Test
+    void review_shouldRejectDisabledRoleBeforeMutation() {
+        when(userMapper.selectById(9L)).thenReturn(pendingUser());
+        SysRole disabled = role(3L);
+        disabled.setStatus(0);
+        when(roleMapper.selectBatchIds(List.of(3L))).thenReturn(List.of(disabled));
+
+        BizException error = assertThrows(BizException.class, () -> service.review(9L,
+            new UserApprovalRequest(
+                UserApprovalStatus.APPROVED, TenantContext.DEFAULT, List.of(3L), null)));
+
+        assertEquals(ResultCode.PARAM_INVALID, error.getResultCode());
+        verify(userMapper, never()).updateById(any(SysUser.class));
+    }
+
+    @Test
+    void approvalOptions_shouldReturnTargetTenantRolesWithoutLeakingContext() {
+        when(crossTenantAuthority.hasCurrentUserAuthority()).thenReturn(true);
+        when(tenantService.listActive()).thenReturn(List.of(
+            tenant(TenantContext.DEFAULT, "默认租户"), tenant("tenant-a", "租户 A")));
+        when(tenantService.resolveAccessibleSnapshot("tenant-a")).thenReturn(snapshot("tenant-a"));
+        SysRole role = role(30L);
+        role.setRoleName("租户管理员");
+        role.setRoleCode("tenant_admin");
+        when(roleMapper.selectList(any(LambdaQueryWrapper.class))).thenAnswer(invocation -> {
+            assertEquals("tenant-a", TenantContext.require());
+            return List.of(role);
+        });
+
+        UserApprovalOptionsVO options = TenantContext.callWith(TenantContext.DEFAULT,
+            () -> service.approvalOptions("tenant-a"));
+
+        assertEquals("tenant-a", options.selectedTenantId());
+        assertEquals(List.of(TenantContext.DEFAULT, "tenant-a"),
+            options.tenants().stream().map(UserApprovalOptionsVO.TenantOption::tenantId).toList());
+        assertEquals(List.of(30L),
+            options.roles().stream().map(UserApprovalOptionsVO.RoleOption::id).toList());
+        assertFalse(TenantContext.isPresent(), "选项查询结束后不能泄漏目标租户上下文");
+    }
+
+    @Test
+    void approvalOptions_shouldHideOtherTenantsFromOrdinaryReviewer() {
+        when(crossTenantAuthority.hasCurrentUserAuthority()).thenReturn(false);
+        when(tenantService.listActive()).thenReturn(List.of(
+            tenant(TenantContext.DEFAULT, "默认租户"), tenant("tenant-a", "租户 A")));
+        when(roleMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(List.of(role(3L)));
+
+        UserApprovalOptionsVO options = TenantContext.callWith(TenantContext.DEFAULT,
+            () -> service.approvalOptions(TenantContext.DEFAULT));
+
+        assertEquals(List.of(TenantContext.DEFAULT),
+            options.tenants().stream().map(UserApprovalOptionsVO.TenantOption::tenantId).toList());
+    }
+
+    @Test
+    void approvalOptions_shouldRejectCrossTenantEnumerationBeforeLookup() {
+        when(crossTenantAuthority.hasCurrentUserAuthority()).thenReturn(false);
+        when(tenantService.listActive()).thenReturn(List.of(tenant(TenantContext.DEFAULT, "默认租户")));
+
+        BizException error = assertThrows(BizException.class,
+            () -> TenantContext.callWith(TenantContext.DEFAULT,
+                () -> service.approvalOptions("tenant-a")));
+
+        assertEquals(ResultCode.TENANT_VIEW_FORBIDDEN, error.getResultCode());
+        verify(tenantService, never()).resolveAccessibleSnapshot("tenant-a");
+        verify(roleMapper, never()).selectList(any(LambdaQueryWrapper.class));
     }
 
     @Test
@@ -97,18 +238,22 @@ class UserServiceApprovalTest {
     }
 
     @Test
-    void review_shouldRequireAtLeastOneRoleWhenApproved() {
+    void review_shouldRequireTenantAndAtLeastOneRoleWhenApproved() {
         when(userMapper.selectById(9L)).thenReturn(pendingUser());
 
-        BizException error = assertThrows(BizException.class, () -> service.review(9L,
-            new UserApprovalRequest(UserApprovalStatus.APPROVED, List.of(), null)));
+        BizException missingTenant = assertThrows(BizException.class, () -> service.review(9L,
+            new UserApprovalRequest(UserApprovalStatus.APPROVED, null, List.of(3L), null)));
+        BizException missingRole = assertThrows(BizException.class, () -> service.review(9L,
+            new UserApprovalRequest(
+                UserApprovalStatus.APPROVED, TenantContext.DEFAULT, List.of(), null)));
 
-        assertEquals(ResultCode.PARAM_MISSING, error.getResultCode());
+        assertEquals(ResultCode.PARAM_MISSING, missingTenant.getResultCode());
+        assertEquals(ResultCode.PARAM_MISSING, missingRole.getResultCode());
         verify(userMapper, never()).updateById(any(SysUser.class));
     }
 
     @Test
-    void review_shouldRejectAndClearExistingRolesThenRevokeOldSession() {
+    void review_shouldRejectAndClearExistingRolesWithoutMovingTenant() {
         SysUser user = pendingUser();
         SysUserRole existing = new SysUserRole();
         existing.setUserId(9L);
@@ -118,16 +263,28 @@ class UserServiceApprovalTest {
 
         try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
             stpUtil.when(StpUtil::getLoginIdAsLong).thenReturn(99L);
-            service.review(9L,
-                new UserApprovalRequest(UserApprovalStatus.REJECTED, List.of(3L), "资料不完整"));
+            service.review(9L, new UserApprovalRequest(
+                UserApprovalStatus.REJECTED, TenantContext.DEFAULT, List.of(3L), "资料不完整"));
         }
 
         assertEquals(UserApprovalStatus.REJECTED.name(), user.getApprovalStatus());
+        assertEquals(TenantContext.DEFAULT, user.getTenantId());
         assertEquals("资料不完整", user.getApprovalRemark());
         verify(userRoleMapper).delete(any(LambdaQueryWrapper.class));
         verify(userRoleMapper, never()).insert(any(SysUserRole.class));
         verify(userMapper).incrementAuthEpoch(9L);
         verify(revocationService).revokeUserAfterCommit(9L);
+    }
+
+    @Test
+    void review_shouldNotMoveTenantWhenRejected() {
+        when(userMapper.selectById(9L)).thenReturn(pendingUser());
+
+        BizException error = assertThrows(BizException.class, () -> service.review(9L,
+            new UserApprovalRequest(UserApprovalStatus.REJECTED, "tenant-a", List.of(), null)));
+
+        assertEquals(ResultCode.PARAM_INVALID, error.getResultCode());
+        verify(userMapper, never()).updateById(any(SysUser.class));
     }
 
     @Test
@@ -146,6 +303,7 @@ class UserServiceApprovalTest {
         SysUser user = new SysUser();
         user.setId(9L);
         user.setUsername("richard");
+        user.setTenantId(TenantContext.DEFAULT);
         user.setStatus(1);
         user.setApprovalStatus(UserApprovalStatus.PENDING.name());
         return user;
@@ -157,5 +315,17 @@ class UserServiceApprovalTest {
         role.setStatus(1);
         role.setControlPlane(SysRole.CONTROL_PLANE_DISABLED);
         return role;
+    }
+
+    private TenantAccessSnapshot snapshot(String tenantId) {
+        return new TenantAccessSnapshot(tenantId, "ACTIVE", 0L, null);
+    }
+
+    private TenantVO tenant(String tenantId, String tenantName) {
+        TenantVO tenant = new TenantVO();
+        tenant.setTenantCode(tenantId);
+        tenant.setTenantName(tenantName);
+        tenant.setStatus("ACTIVE");
+        return tenant;
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceControlPlaneTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceControlPlaneTest.java
@@ -13,6 +13,7 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUserRole;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -48,7 +49,7 @@ class UserServiceControlPlaneTest {
         when(passwordEncoder.encode(any())).thenReturn("encoded");
         service = new UserService(
             userMapper, userRoleMapper, roleMapper, passwordEncoder, crossTenantAuthority,
-            sessionRevocationService);
+            sessionRevocationService, mock(TenantService.class));
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceDuplicateUsernameTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceDuplicateUsernameTest.java
@@ -10,6 +10,7 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DuplicateKeyException;
@@ -42,7 +43,8 @@ class UserServiceDuplicateUsernameTest {
             mock(SysRoleMapper.class),
             passwordEncoder,
             mock(CrossTenantAuthority.class),
-            mock(SessionRevocationService.class));
+            mock(SessionRevocationService.class),
+            mock(TenantService.class));
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceRevocationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/system/user/service/UserServiceRevocationTest.java
@@ -8,6 +8,7 @@ import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
 import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
 import com.richard.fyoung.customeradmin.tenant.CrossTenantAuthority;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -38,7 +39,8 @@ class UserServiceRevocationTest {
             mock(SysRoleMapper.class),
             mock(PasswordEncoder.class),
             mock(CrossTenantAuthority.class),
-            revocationService);
+            revocationService,
+            mock(TenantService.class));
         when(userRoleMapper.selectList(any(LambdaQueryWrapper.class))).thenReturn(List.of());
         when(userMapper.incrementAuthEpoch(9L)).thenReturn(1);
     }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/tenant/TenantRoleScopeMigrationIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/tenant/TenantRoleScopeMigrationIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.richard.fyoung.customeradmin.tenant;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** V99 真库迁移：角色编码租户内唯一，并修复存量租户缺少内建角色的问题。 */
+class TenantRoleScopeMigrationIntegrationTest {
+
+    private static final String HOST = System.getenv().getOrDefault("MYSQL_HOST", "localhost");
+    private static final int PORT = Integer.parseInt(System.getenv().getOrDefault("MYSQL_PORT", "3306"));
+    private static final String USERNAME = env("ADMIN_MYSQL_USERNAME", "root");
+    private static final String PASSWORD = env("ADMIN_MYSQL_PASSWORD", "root");
+
+    @Test
+    void migration_shouldBePreflightedAndMatchDbaMirrorByteForByte() throws Exception {
+        String sql;
+        try (var input = new ClassPathResource(
+            "db/migration/V99__tenant_scoped_roles_and_approval_binding.sql").getInputStream()) {
+            sql = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        String mirror = Files.readString(repositoryRoot().resolve(
+            "mysql/02-customer-admin/99-V99__tenant_scoped_roles_and_approval_binding.sql"));
+
+        assertEquals(sql, mirror, "Flyway 迁移与 DBA 镜像必须逐字一致");
+        assertTrue(sql.startsWith("-- 审核绑定租户前先修正角色领域约束"));
+        assertTrue(sql.contains("__customer_admin_v99_sys_role_preflight_failed__"));
+        assertTrue(sql.contains("uk_sys_role_tenant_code"));
+        assertTrue(sql.contains("'tenant_admin'"));
+    }
+
+    @Test
+    void migration_shouldScopeRoleCodesAndProvisionExistingActiveTenants() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过 V99 真库迁移测试");
+        String database = "admin_v99_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过 V99 真库迁移测试");
+
+        try {
+            migrate(database, "98");
+            try (Connection connection = connection(database); Statement statement = connection.createStatement()) {
+                statement.executeUpdate("INSERT INTO sys_tenant "
+                    + "(tenant_code, tenant_name, status) VALUES ('tenant-a', 'Tenant A', 'ACTIVE')");
+                assertEquals("role_code", indexColumns(connection, "uk_sys_role_code"));
+                assertEquals(0, queryInt(connection,
+                    "SELECT COUNT(*) FROM sys_role WHERE tenant_id = 'tenant-a'"));
+            }
+
+            migrate(database, "99");
+            try (Connection connection = connection(database); Statement statement = connection.createStatement()) {
+                assertEquals("tenant_id,role_code", indexColumns(connection, "uk_sys_role_tenant_code"));
+                assertEquals(0, queryInt(connection,
+                    "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() "
+                        + "AND table_name = 'sys_role' AND index_name = 'uk_sys_role_code'"));
+                assertEquals(2, queryInt(connection,
+                    "SELECT COUNT(*) FROM sys_role WHERE role_code = 'tenant_admin' AND deleted = 0"));
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM sys_role WHERE tenant_id = 'tenant-a' "
+                        + "AND role_code = 'tenant_admin' AND data_scope = 'TENANT' AND control_plane = 0"));
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM sys_role_permission rp "
+                        + "JOIN sys_role r ON r.id = rp.role_id "
+                        + "JOIN sys_permission p ON p.id = rp.permission_id "
+                        + "WHERE r.tenant_id = 'tenant-a' AND r.role_code = 'tenant_admin' "
+                        + "AND p.perm_code = 'user:view'"));
+                assertEquals(0, queryInt(connection,
+                    "SELECT COUNT(*) FROM sys_role_permission rp "
+                        + "JOIN sys_role r ON r.id = rp.role_id "
+                        + "JOIN sys_permission p ON p.id = rp.permission_id "
+                        + "WHERE r.tenant_id = 'tenant-a' AND r.role_code = 'tenant_admin' "
+                        + "AND (p.perm_code = 'tenant' OR p.perm_code LIKE 'tenant:%')"));
+
+                statement.executeUpdate("INSERT INTO sys_role "
+                    + "(role_name, role_code, tenant_id) VALUES ('Default Auditor', 'auditor', 'default')");
+                statement.executeUpdate("INSERT INTO sys_role "
+                    + "(role_name, role_code, tenant_id) VALUES ('Tenant Auditor', 'auditor', 'tenant-a')");
+                assertThrows(SQLException.class, () -> statement.executeUpdate("INSERT INTO sys_role "
+                    + "(role_name, role_code, tenant_id) VALUES ('Duplicate', 'auditor', 'tenant-a')"));
+                assertEquals(1, queryInt(connection,
+                    "SELECT COUNT(*) FROM flyway_schema_history WHERE version = '99' AND success = 1"));
+            }
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    private void migrate(String database, String target) {
+        Flyway.configure()
+            .dataSource(databaseUrl(database), USERNAME, PASSWORD)
+            .locations("classpath:db/migration")
+            .placeholderReplacement(false)
+            .target(target)
+            .load()
+            .migrate();
+    }
+
+    private boolean createDatabase(String database) {
+        try (Connection connection = DriverManager.getConnection(serverUrl(), USERNAME, PASSWORD);
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE `" + database
+                + "` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void dropDatabase(String database) {
+        try (Connection connection = DriverManager.getConnection(serverUrl(), USERNAME, PASSWORD);
+             Statement statement = connection.createStatement()) {
+            statement.execute("DROP DATABASE IF EXISTS `" + database + "`");
+        } catch (Exception ignored) {
+            // 测试清理失败不覆盖主断言；数据库名带随机后缀，不会碰共享库。
+        }
+    }
+
+    private Connection connection(String database) throws Exception {
+        return DriverManager.getConnection(databaseUrl(database), USERNAME, PASSWORD);
+    }
+
+    private String indexColumns(Connection connection, String indexName) throws Exception {
+        return queryString(connection,
+            "SELECT GROUP_CONCAT(column_name ORDER BY seq_in_index SEPARATOR ',') "
+                + "FROM information_schema.statistics WHERE table_schema = DATABASE() "
+                + "AND table_name = 'sys_role' AND index_name = '" + indexName + "'");
+    }
+
+    private String queryString(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement(); ResultSet rs = statement.executeQuery(sql)) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+
+    private int queryInt(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement(); ResultSet rs = statement.executeQuery(sql)) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), 1000);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String serverUrl() {
+        return "jdbc:mysql://" + HOST + ":" + PORT
+            + "/?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai";
+    }
+
+    private String databaseUrl(String database) {
+        return "jdbc:mysql://" + HOST + ":" + PORT + "/" + database
+            + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai";
+    }
+
+    private Path repositoryRoot() {
+        Path cwd = Path.of("").toAbsolutePath();
+        return Files.isDirectory(cwd.resolve("mysql/02-customer-admin")) ? cwd : cwd.getParent();
+    }
+
+    private static String env(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/customer-admin-web/src/api/user.ts
+++ b/customer-admin-web/src/api/user.ts
@@ -1,5 +1,12 @@
 import { request } from './request'
-import type { PageResult, UserApprovalRequest, UserPageQuery, UserSaveRequest, UserVO } from '@/types/api'
+import type {
+  PageResult,
+  UserApprovalOptions,
+  UserApprovalRequest,
+  UserPageQuery,
+  UserSaveRequest,
+  UserVO,
+} from '@/types/api'
 
 export function pageUsers(query: UserPageQuery) {
   return request<PageResult<UserVO>>({ url: '/system/user', method: 'get', params: query })
@@ -7,6 +14,15 @@ export function pageUsers(query: UserPageQuery) {
 
 export function getUser(id: number) {
   return request<UserVO>({ url: `/system/user/${id}`, method: 'get' })
+}
+
+/** 审核可选租户及目标租户内的启用角色。 */
+export function getUserApprovalOptions(tenantId?: string) {
+  return request<UserApprovalOptions>({
+    url: '/system/user/approval-options',
+    method: 'get',
+    params: tenantId ? { tenantId } : undefined,
+  })
 }
 
 export function createUser(data: UserSaveRequest) {
@@ -21,7 +37,7 @@ export function deleteUser(id: number) {
   return request<void>({ url: `/system/user/${id}`, method: 'delete' })
 }
 
-/** 审核自助注册用户；批准时角色分配与审核结论由后端在同一事务提交。 */
+/** 审核自助注册用户；批准时租户归属、角色分配与审核结论由后端在同一事务提交。 */
 export function reviewUser(id: number, data: UserApprovalRequest) {
   return request<void>({ url: `/system/user/${id}/approval`, method: 'put', data })
 }

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -79,6 +79,7 @@ export interface ChangePasswordRequest {
 export interface UserVO {
   id: number
   username: string
+  tenantId: string
   nickname: string
   status: number
   approvalStatus: UserApprovalStatus
@@ -106,8 +107,27 @@ export interface UserPageQuery extends PageQuery {
 
 export interface UserApprovalRequest {
   decision: Exclude<UserApprovalStatus, 'PENDING'>
+  tenantId?: string | null
   roleIds?: number[]
   remark?: string | null
+}
+
+export interface UserApprovalTenantOption {
+  tenantId: string
+  tenantName: string
+}
+
+export interface UserApprovalRoleOption {
+  id: number
+  roleName: string
+  roleCode: string
+  controlPlane: boolean
+}
+
+export interface UserApprovalOptions {
+  selectedTenantId: string
+  tenants: UserApprovalTenantOption[]
+  roles: UserApprovalRoleOption[]
 }
 
 // ---------- system.role ----------

--- a/customer-admin-web/src/views/system/UserManage.vue
+++ b/customer-admin-web/src/views/system/UserManage.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue'
 import type { FormInstance } from 'element-plus'
-import { createUser, deleteUser, pageUsers, reviewUser, updateUser } from '@/api/user'
+import {
+  createUser,
+  deleteUser,
+  getUserApprovalOptions,
+  pageUsers,
+  reviewUser,
+  updateUser,
+} from '@/api/user'
 import { pageRoles } from '@/api/role'
 import { fetchCurrentView } from '@/api/tenant'
 import { useAuthStore } from '@/store/auth'
 import { useCrudPage } from '@/composables/useCrudPage'
 import type {
   RoleVO,
+  UserApprovalRoleOption,
   UserApprovalRequest,
   UserApprovalStatus,
+  UserApprovalTenantOption,
   UserPageQuery,
   UserSaveRequest,
   UserVO,
@@ -23,9 +32,13 @@ const formRef = ref<FormInstance>()
 const editingApprovalStatus = ref<UserApprovalStatus>('APPROVED')
 const reviewDialogVisible = ref(false)
 const reviewSubmitting = ref(false)
+const reviewOptionsLoading = ref(false)
 const reviewTarget = ref<UserVO | null>(null)
+const reviewTenantOptions = ref<UserApprovalTenantOption[]>([])
+const reviewRoleOptions = ref<UserApprovalRoleOption[]>([])
 const reviewForm = reactive<UserApprovalRequest>({
   decision: 'APPROVED',
+  tenantId: '',
   roleIds: [],
   remark: '',
 })
@@ -84,14 +97,36 @@ function approvalTagType(status: UserApprovalStatus): 'warning' | 'success' | 'd
   return status === 'PENDING' ? 'warning' : 'danger'
 }
 
-function openReview(row: UserVO) {
+async function openReview(row: UserVO) {
   reviewTarget.value = row
   Object.assign(reviewForm, {
     decision: row.approvalStatus === 'REJECTED' ? 'REJECTED' : 'APPROVED',
-    roleIds: row.roleIds ? [...row.roleIds] : [],
+    tenantId: row.tenantId,
+    roleIds: [],
     remark: row.approvalRemark || '',
   })
   reviewDialogVisible.value = true
+  await loadReviewOptions(row.tenantId)
+}
+
+async function loadReviewOptions(tenantId?: string) {
+  reviewOptionsLoading.value = true
+  try {
+    const options = await getUserApprovalOptions(tenantId)
+    reviewTenantOptions.value = options.tenants
+    reviewRoleOptions.value = options.roles
+    reviewForm.tenantId = options.selectedTenantId
+    reviewForm.roleIds = []
+  } catch {
+    reviewTenantOptions.value = []
+    reviewRoleOptions.value = []
+  } finally {
+    reviewOptionsLoading.value = false
+  }
+}
+
+async function handleReviewTenantChange(tenantId: string) {
+  await loadReviewOptions(tenantId)
 }
 
 async function submitReview() {
@@ -102,14 +137,21 @@ async function submitReview() {
     ElMessage.warning('审核通过时至少分配一个角色')
     return
   }
+  if (reviewForm.decision === 'APPROVED' && !reviewForm.tenantId) {
+    ElMessage.warning('审核通过时请选择归属租户')
+    return
+  }
   reviewSubmitting.value = true
   try {
     await reviewUser(reviewTarget.value.id, {
       decision: reviewForm.decision,
+      tenantId: reviewForm.decision === 'APPROVED' ? reviewForm.tenantId : reviewTarget.value.tenantId,
       roleIds: reviewForm.decision === 'APPROVED' ? reviewForm.roleIds : [],
       remark: reviewForm.remark?.trim() || null,
     })
-    ElMessage.success(reviewForm.decision === 'APPROVED' ? '审核通过，角色权限已生效' : '已拒绝该注册申请')
+    ElMessage.success(reviewForm.decision === 'APPROVED'
+      ? `审核通过，用户已归属 ${reviewForm.tenantId}`
+      : '已拒绝该注册申请')
     reviewDialogVisible.value = false
     await loadList()
   } finally {
@@ -155,6 +197,7 @@ onMounted(async () => {
 
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column prop="username" label="用户名" />
+        <el-table-column prop="tenantId" label="归属租户" min-width="120" />
         <el-table-column prop="nickname" label="昵称" />
         <el-table-column label="角色">
           <template #default="{ row }">{{ row.roleNames?.join('、') || '-' }}</template>
@@ -241,6 +284,7 @@ onMounted(async () => {
       <el-descriptions v-if="reviewTarget" :column="1" border class="review-user">
         <el-descriptions-item label="用户名">{{ reviewTarget.username }}</el-descriptions-item>
         <el-descriptions-item label="昵称">{{ reviewTarget.nickname || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="当前租户">{{ reviewTarget.tenantId }}</el-descriptions-item>
       </el-descriptions>
       <el-form :model="reviewForm" label-width="84px">
         <el-form-item label="审核结果">
@@ -249,12 +293,35 @@ onMounted(async () => {
             <el-radio-button value="REJECTED">拒绝</el-radio-button>
           </el-radio-group>
         </el-form-item>
-        <el-form-item v-if="reviewForm.decision === 'APPROVED'" label="分配角色" required>
-          <el-select v-model="reviewForm.roleIds" multiple style="width: 100%" placeholder="至少选择一个角色">
+        <el-form-item v-if="reviewForm.decision === 'APPROVED'" label="归属租户" required>
+          <el-select
+            v-model="reviewForm.tenantId"
+            filterable
+            style="width: 100%"
+            placeholder="请选择用户归属租户"
+            :loading="reviewOptionsLoading"
+            @change="handleReviewTenantChange"
+          >
             <el-option
-              v-for="role in roleOptions"
+              v-for="tenant in reviewTenantOptions"
+              :key="tenant.tenantId"
+              :label="`${tenant.tenantName} (${tenant.tenantId})`"
+              :value="tenant.tenantId"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="reviewForm.decision === 'APPROVED'" label="分配角色" required>
+          <el-select
+            v-model="reviewForm.roleIds"
+            multiple
+            style="width: 100%"
+            placeholder="至少选择一个目标租户角色"
+            :loading="reviewOptionsLoading"
+          >
+            <el-option
+              v-for="role in reviewRoleOptions"
               :key="role.id"
-              :label="role.roleName"
+              :label="`${role.roleName} (${role.roleCode})`"
               :value="role.id"
               :disabled="role.controlPlane && !crossTenantAuthority"
             />

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -968,7 +968,9 @@ Skill、智能体,并支持对智能体在线聊天与 VibeCoding。技术栈按
 **后台基础与企业治理能力已落地**——后端:RBAC 五表(用户/角色/权限/关联表/操作日志) + 登录改密 +
 本地账号自助注册审核 + 用户/角色/权限/日志四个业务域完整 CRUD + AI 配置域三个 CRUD。自助注册账号固定归入
 `default` 租户并以 `PENDING`、无角色状态创建；允许登录查看审核结果，但角色解析强制返回空集合。管理员审核通过时
-必须在同一事务至少分配一个角色，拒绝时清空角色，两种权限变更都会轮换认证版本并撤销旧会话。模型域已从单表
+必须选择用户归属租户，并在同一事务把用户与至少一个目标租户角色完成绑定；跨租户绑定仅允许控制面角色执行。
+拒绝时保持原租户并清空角色，两种权限变更都会轮换认证版本并撤销旧会话。角色编码以
+`(tenant_id, role_code)` 保证租户内唯一，V99 同步为存量可用租户补齐 `tenant_admin`。模型域已从单表
 AppKey 扩展为模型资产/部署分离、SecretRef
 版本轮换、健康事实、上线认证、引用影响、不可变路由与在线实验；MCP、Skill 继续独立管理。智能体管理包含
 `ai_agent` CRUD + 关联表整体替换式维护 + 启用停用生命周期 + 动态菜单 +
@@ -993,7 +995,8 @@ cd customer-admin-web && npm ci && npm run dev
 | `POST /api/auth/login` | 登录（`admin/admin` 首次登录返回 `forceChangePassword=true`；响应含注册审核状态与说明） |
 | `POST /api/auth/register` | 登录页公开自助注册；仅创建 `default` 租户的 `PENDING` 本地账号，不自动授予角色或菜单 |
 | `POST /api/auth/change-password` / `POST /api/auth/logout` | 改密 / 登出 |
-| `PUT /api/system/user/{id}/approval` | 注册账号审核；通过必须同时分配角色，拒绝清空角色，权限点 `user:edit` |
+| `GET /api/system/user/approval-options?tenantId=...` | 注册审核租户与角色选项；普通审核人仅当前租户，控制面审核人可选择任一可用租户，权限点 `user:edit` |
+| `PUT /api/system/user/{id}/approval` | 注册账号审核；通过必须选择归属租户并分配该租户角色，拒绝保持原租户并清空角色，权限点 `user:edit` |
 | `/api/system/{user,role,permission,log}` | 用户/角色权限/权限树/操作日志 CRUD（`@SaCheckPermission` 权限点校验）；用户分页支持按审核状态筛选 |
 | `/api/aiconfig/model` · `/asset-options` | 模型部署 CRUD 与模型资产选择；响应只返回 SecretRef 元数据，不回显凭据材料 |
 | `/api/aiconfig/model/{id}/{impact,health,health-events,certification,certification-runs}` | 引用影响、健康事实与当前/历史上线认证；见 §6.34 |

--- a/mysql/02-customer-admin/99-V99__tenant_scoped_roles_and_approval_binding.sql
+++ b/mysql/02-customer-admin/99-V99__tenant_scoped_roles_and_approval_binding.sql
@@ -1,0 +1,96 @@
+-- 审核绑定租户前先修正角色领域约束：角色编码只要求租户内唯一，并补齐存量租户的内建管理员角色。
+SET NAMES utf8mb4;
+
+SET @v99_role_table_exists = (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' AND table_name = 'sys_role');
+SET @v99_role_columns = (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'sys_role'
+      AND column_name IN ('tenant_id', 'role_code', 'deleted', 'data_scope', 'control_plane'));
+SET @v99_preflight_sql = IF(@v99_role_table_exists = 1 AND @v99_role_columns = 5,
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v99_sys_role_preflight_failed__`');
+PREPARE v99_preflight_stmt FROM @v99_preflight_sql;
+EXECUTE v99_preflight_stmt;
+DEALLOCATE PREPARE v99_preflight_stmt;
+
+-- 若历史环境曾手工移除全局唯一键，先阻止带租户内重复编码的数据进入正式约束。
+SET @v99_duplicate_role_codes = (SELECT COUNT(*) FROM (
+    SELECT `tenant_id`, `role_code`
+    FROM `sys_role`
+    GROUP BY `tenant_id`, `role_code`
+    HAVING COUNT(*) > 1
+) AS duplicate_role_codes);
+SET @v99_duplicate_guard_sql = IF(@v99_duplicate_role_codes = 0,
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v99_duplicate_tenant_role_code__`');
+PREPARE v99_duplicate_guard_stmt FROM @v99_duplicate_guard_sql;
+EXECUTE v99_duplicate_guard_stmt;
+DEALLOCATE PREPARE v99_duplicate_guard_stmt;
+
+-- 兼容已经人工按本迁移目标改过索引的环境；同名但结构错误时 fail-fast，避免静默留下伪约束。
+SET @v99_old_index_shape = (SELECT CONCAT(MIN(`non_unique`), ':',
+        GROUP_CONCAT(`column_name` ORDER BY `seq_in_index` SEPARATOR ','))
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'sys_role'
+      AND index_name = 'uk_sys_role_code');
+SET @v99_target_index_shape = (SELECT CONCAT(MIN(`non_unique`), ':',
+        GROUP_CONCAT(`column_name` ORDER BY `seq_in_index` SEPARATOR ','))
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'sys_role'
+      AND index_name = 'uk_sys_role_tenant_code');
+SET @v99_index_guard_sql = IF(
+    (@v99_old_index_shape IS NULL OR @v99_old_index_shape IN ('0:role_code', '0:tenant_id,role_code'))
+        AND (@v99_target_index_shape IS NULL OR @v99_target_index_shape = '0:tenant_id,role_code'),
+    'SELECT 1', 'SELECT * FROM `__customer_admin_v99_role_index_preflight_failed__`');
+PREPARE v99_index_guard_stmt FROM @v99_index_guard_sql;
+EXECUTE v99_index_guard_stmt;
+DEALLOCATE PREPARE v99_index_guard_stmt;
+
+SET @v99_drop_global_index_sql = IF(@v99_old_index_shape IS NULL, 'SELECT 1',
+    'ALTER TABLE `sys_role` DROP INDEX `uk_sys_role_code`');
+PREPARE v99_drop_global_index_stmt FROM @v99_drop_global_index_sql;
+EXECUTE v99_drop_global_index_stmt;
+DEALLOCATE PREPARE v99_drop_global_index_stmt;
+
+SET @v99_add_tenant_index_sql = IF(@v99_target_index_shape IS NULL,
+    'ALTER TABLE `sys_role` ADD UNIQUE KEY `uk_sys_role_tenant_code` (`tenant_id`, `role_code`)',
+    'SELECT 1');
+PREPARE v99_add_tenant_index_stmt FROM @v99_add_tenant_index_sql;
+EXECUTE v99_add_tenant_index_stmt;
+DEALLOCATE PREPARE v99_add_tenant_index_stmt;
+
+-- V49 之后创建租户时会初始化 tenant_admin；旧唯一键使第二个租户必然撞键。
+-- 迁移完成后为全部可用存量租户补齐内建角色，审核页才能真正选择目标租户的角色。
+INSERT INTO `sys_role`
+    (`role_name`, `role_code`, `remark`, `status`, `tenant_id`, `data_scope`, `control_plane`)
+SELECT '租户管理员', 'tenant_admin', '租户开通时自动创建，拥有本租户内全部管理权限',
+       1, t.`tenant_code`, 'TENANT', 0
+FROM `sys_tenant` t
+WHERE t.`deleted` = 0
+  AND t.`status` = 'ACTIVE'
+  AND NOT EXISTS (
+      SELECT 1 FROM `sys_role` r
+      WHERE r.`tenant_id` = t.`tenant_code`
+        AND r.`role_code` = 'tenant_admin'
+  );
+
+-- 与 ControlPlanePermissions 保持同一安全边界：tenant_admin 获得租户内管理权限，
+-- 但不能获得租户、菜单、登录图、系统工具、配置发布、计费写入和敏感词写入等控制面权限。
+INSERT INTO `sys_role_permission` (`role_id`, `permission_id`, `tenant_id`)
+SELECT r.`id`, p.`id`, r.`tenant_id`
+FROM `sys_role` r
+CROSS JOIN `sys_permission` p
+LEFT JOIN `sys_role_permission` rp
+  ON rp.`role_id` = r.`id`
+ AND rp.`permission_id` = p.`id`
+WHERE r.`role_code` = 'tenant_admin'
+  AND r.`deleted` = 0
+  AND rp.`id` IS NULL
+  AND p.`perm_code` NOT IN (
+      'tenant', 'menu', 'login-image', 'system-tool', 'config-version',
+      'billing:quota-edit', 'billing:price-edit', 'billing:export', 'billing:aggregate',
+      'sensitive-word:add', 'sensitive-word:edit', 'sensitive-word:delete'
+  )
+  AND p.`perm_code` NOT LIKE 'tenant:%'
+  AND p.`perm_code` NOT LIKE 'menu:%'
+  AND p.`perm_code` NOT LIKE 'login-image:%'
+  AND p.`perm_code` NOT LIKE 'system-tool:%'
+  AND p.`perm_code` NOT LIKE 'config-version:%';


### PR DESCRIPTION
## 变更说明 / What

- 修复新注册用户点击智能体时，Sa-Token 权限解析早于 Web 租户拦截器执行而触发 `TenantContextMissingException` 的问题；权限查询现在按登录用户归属租户显式绑定上下文。
- 注册审核弹窗新增归属租户选择，并按目标租户动态加载启用角色；用户列表同步展示当前归属租户。
- 审核通过时，在同一事务内迁移 `sys_user.tenant_id`、清理源租户角色关系、写入目标租户角色、递增认证版本并撤销旧会话。
- 跨租户绑定只允许控制面角色，普通租户审核人不能枚举或写入其他租户；拒绝审核不能改变用户归属租户。
- 新增 V99 Flyway 迁移及 DBA 镜像：角色编码改为 `(tenant_id, role_code)` 租户内唯一，并为存量可用租户补齐不含控制面权限的 `tenant_admin`。
- 将软删除角色恢复逻辑同步收敛到显式租户条件，避免数据库约束改为租户内唯一后出现跨租户恢复歧义。

## 类型 / Type

- [x] feat 新功能
- [x] fix 修复
- [x] docs 文档
- [ ] refactor / test / chore

## 验证 / Verification

- `mvn ... clean test -Djacoco.skip=true -Dtest='!RedisSessionPersistenceTest'`：6 个模块全部成功，3336 tests，0 failures，0 errors，7 skipped；仅按项目本地门禁约定排除依赖特定 Redis 密码的测试。
- `TenantRoleScopeMigrationIntegrationTest`：真实 MySQL 从 V98 升级 V99、租户内唯一约束、存量租户角色与权限回填通过。
- `UserApprovalTenantBindingIntegrationTest`：真实 MySQL 跨租户迁移用户、角色关系、认证版本与源租户不可见性通过。
- `npm ci && VITE_API_BASE_URL=/api npm run build`：管理端生产构建通过。
- 浏览器端到端：注册待审核用户，管理员选择目标租户与 `tenant_admin` 完成审核，用户重新登录后可进入 Java 智能体并取得工作区权限。
- Flyway V99 与 `mysql/02-customer-admin` DBA 镜像逐字一致，`git diff --check` 通过。

## 自查 / Checklist

- [x] `mvn test` 全绿（新增功能附了单元测试）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循“接口 + 默认实现（@ConditionalOnMissingBean）”约定（本 PR 未新增外部后端）
- [x] 必要时更新了 README / 配置项说明
