### PR TITLE
feat(admin): redesign agent conversation trace and restore history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,11 @@ jobs:
         working-directory: ${{ matrix.project }}
         run: npm ci
 
+      - name: Run frontend unit tests
+        if: ${{ matrix.project == 'customer-admin-web' }}
+        working-directory: ${{ matrix.project }}
+        run: npm test
+
       - name: Type-check and build
         working-directory: ${{ matrix.project }}
         run: npm run build

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/mapper/ChatSessionStateQueryMapper.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/mapper/ChatSessionStateQueryMapper.java
@@ -7,8 +7,8 @@ import java.util.List;
 /**
  * 会话状态表 {@code ai_chat_session_state}（框架 {@code MysqlAgentStateStore} 自建、无 DO）的只读分页查询。
  *
- * <p>不迁移、不建表、不写 DO——仅对既有框架表做轻量只读查询：按 {@code session_id} 前缀
- * （{@code {agentCode}:%}，命中主键最左前缀）分页取出本页会话 id，SQL 侧完成分页与排序，
+ * <p>不迁移、不建表、不写 DO——仅对既有框架表做轻量只读查询：按当前主体状态前缀与旧租户状态前缀
+ * （均命中主键最左前缀）分页取出本页会话 id，SQL 侧完成兼容合并、分页与排序，
  * 上层只对本页 20 个会话逐个 resolve 整段 {@code AgentState}，避免把该智能体全部会话的 longtext
  * blob 都拉进内存。SQL 写在 {@code resources/mapper/ChatSessionStateQueryMapper.xml}。
  * 由 {@code CustomerAdminServerApplication} 的 {@code @MapperScan("...**.mapper")} 自动扫描。</p>
@@ -17,13 +17,15 @@ import java.util.List;
 public interface ChatSessionStateQueryMapper {
 
     /**
-     * 分页取某智能体的会话 id（完整带 {@code {agentCode}:} 前缀），按最后更新时间倒序。
+     * 分页取某智能体的物理会话 id（仍带状态 userId 前缀），按最后更新时间倒序。
      *
      * <p>一个会话在表里对应多行（不同 {@code state_key}/{@code item_index}），故 {@code GROUP BY session_id}
      * 后用 {@code MAX(updated_at)} 作为该会话的最后活跃时间排序——不硬编码框架内部的 {@code state_key} 取值，
      * 对多行结构保持稳健。</p>
      *
-     * @param agentCode 智能体编码（会话 id 前缀，SQL 内以 {@code CONCAT(#{agentCode}, ':%')} 拼 LIKE，防注入）
+     * @param stateUserId 当前可信主体的状态 userId
+     * @param legacyStateUserId 主体隔离启用前的租户级状态 userId，只读兼容已有历史
+     * @param agentCode 智能体编码，用于会话归属表过滤
      * @param offset    偏移量（{@code (page-1)*size}）
      * @param limit     每页条数
      */
@@ -33,6 +35,7 @@ public interface ChatSessionStateQueryMapper {
      */
     List<String> pageSessionIds(@Param("tenantId") String tenantId,
                                 @Param("stateUserId") String stateUserId,
+                                @Param("legacyStateUserId") String legacyStateUserId,
                                 @Param("agentCode") String agentCode,
                                 @Param("ownerUserId") Long ownerUserId,
                                 @Param("offset") long offset,
@@ -41,6 +44,7 @@ public interface ChatSessionStateQueryMapper {
     /** 某智能体的去重会话总数（{@code COUNT(DISTINCT session_id)}），供分页总数。 */
     long countSessions(@Param("tenantId") String tenantId,
                        @Param("stateUserId") String stateUserId,
+                       @Param("legacyStateUserId") String legacyStateUserId,
                        @Param("agentCode") String agentCode,
                        @Param("ownerUserId") Long ownerUserId);
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryService.java
@@ -2,17 +2,18 @@ package com.richard.fyoung.customeradmin.workspace.chat.service;
 
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.datascope.DataScopeContext;
+import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageAttachmentVO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatMessageVO;
 import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryScope;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentStateAccessor;
-import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryScope;
-import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
-import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import com.richard.fyoung.customeradmin.workspace.runtime.WorkspaceRuntimeScope;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentStore;
 import com.richard.fyoung.customerwork.data.attachment.ChatAttachment;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -74,8 +75,9 @@ public class ChatHistoryService {
     }
 
     /**
-     * 历史会话列表（按最后更新时间倒序、SQL 级分页）。mapper 只查出本页会话 id（带
-     * {@code {agentCode}:} 前缀），去前缀后逐个 resolve 完整上下文组装摘要——context 为空的会话跳过，
+     * 历史会话列表（按最后更新时间倒序、SQL 级分页）。mapper 合并当前主体分区与旧租户分区，
+     * 只查出本页物理会话 id；服务按物理前缀选择对应 state userId，逐个 resolve 完整上下文组装摘要。
+     * context 为空的会话跳过，
      * 因此本页返回条数可能略少于 {@code size}（顺序仍以 SQL 的 updated_at 倒序为准）。
      *
      * @param page 页码（从 1 起）
@@ -89,7 +91,9 @@ public class ChatHistoryService {
         String tenantId = tenantProperties.isEnabled() ? TenantContext.require() : TenantContext.DEFAULT;
         AgentMemoryScope memoryScope = AgentMemoryScope.current(agentCode);
         String stateUserId = memoryScope.stateUserId();
-        long total = sessionStateQueryMapper.countSessions(tenantId, stateUserId, agentCode, ownerUserId);
+        String legacyStateUserId = WorkspaceRuntimeScope.agent(agentCode);
+        long total = sessionStateQueryMapper.countSessions(
+            tenantId, stateUserId, legacyStateUserId, agentCode, ownerUserId);
         List<ChatSessionSummary> summaries = new ArrayList<>();
 
         PageResult<ChatSessionSummary> result = new PageResult<>();
@@ -103,18 +107,16 @@ public class ChatHistoryService {
 
         long offset = (page - 1) * size;
         List<String> prefixedSessionIds = sessionStateQueryMapper.pageSessionIds(
-            tenantId, stateUserId, agentCode, ownerUserId, offset, size);
+            tenantId, stateUserId, legacyStateUserId, agentCode, ownerUserId, offset, size);
         if (CollectionUtils.isEmpty(prefixedSessionIds)) {
             return result;
         }
 
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
-        String prefix = stateUserId + ":";
         for (String prefixedSessionId : prefixedSessionIds) {
-            // mapper 查出的是完整带前缀 id，resolve 用的是去前缀的裸 sessionId（与写入侧 listSessionIds 语义对齐）
-            String sessionId = prefixedSessionId.startsWith(prefix)
-                ? prefixedSessionId.substring(prefix.length()) : prefixedSessionId;
-            List<Msg> context = agentStateAccessor.resolve(agent, stateUserId, sessionId).getContext();
+            String sourceStateUserId = sourceStateUserId(prefixedSessionId, stateUserId, legacyStateUserId);
+            String sessionId = stripStateUserId(prefixedSessionId, sourceStateUserId);
+            List<Msg> context = agentStateAccessor.resolve(agent, sourceStateUserId, sessionId).getContext();
             if (context.isEmpty()) {
                 continue;
             }
@@ -133,7 +135,7 @@ public class ChatHistoryService {
         }
 
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
-        AgentState state = agentStateAccessor.resolve(agent, memoryScope.stateUserId(), sessionId);
+        List<Msg> context = resolveCurrentOrLegacyContext(agent, memoryScope, agentCode, sessionId);
         // 该会话的附件按绑定的 message_id 分组（未绑定的跳过）：查询失败 listBySession 已内置兜底返回空列表，
         // 不影响历史返回。附件通常按用户消息挂载，一条消息可带多个附件。
         Map<String, List<ChatMessageAttachmentVO>> attachmentsByMessage = attachmentStore.listBySession(sessionId).stream()
@@ -142,7 +144,7 @@ public class ChatHistoryService {
                 Collectors.mapping(this::toAttachmentVO, Collectors.toList())));
 
         List<ChatMessageVO> messages = new ArrayList<>();
-        for (Msg msg : state.getContext()) {
+        for (Msg msg : context) {
             if (msg.getRole() != MsgRole.USER && msg.getRole() != MsgRole.ASSISTANT) {
                 continue;
             }
@@ -172,13 +174,40 @@ public class ChatHistoryService {
      */
     public Optional<ChatSessionSummary> getSessionSummary(String agentCode, String sessionId) {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
-        List<Msg> context = agentStateAccessor.resolve(
-            agent, AgentMemoryScope.current(agentCode).stateUserId(), sessionId).getContext();
+        AgentMemoryScope memoryScope = AgentMemoryScope.current(agentCode);
+        List<Msg> context = resolveCurrentOrLegacyContext(agent, memoryScope, agentCode, sessionId);
         if (context.isEmpty()) {
             return Optional.empty();
         }
         return Optional.of(new ChatSessionSummary(sessionId, previewOf(context),
             context.get(context.size() - 1).getTimestamp(), context.size()));
+    }
+
+    /** 当前主体分区没有该会话时回读旧租户分区，保证主体隔离升级前的已授权历史仍可查看。 */
+    private List<Msg> resolveCurrentOrLegacyContext(Agent agent, AgentMemoryScope memoryScope,
+                                                     String agentCode, String sessionId) {
+        String stateUserId = memoryScope.stateUserId();
+        List<Msg> current = agentStateAccessor.resolve(agent, stateUserId, sessionId).getContext();
+        String legacyStateUserId = WorkspaceRuntimeScope.agent(agentCode);
+        if (!current.isEmpty() || stateUserId.equals(legacyStateUserId)) {
+            return current;
+        }
+        return agentStateAccessor.resolve(agent, legacyStateUserId, sessionId).getContext();
+    }
+
+    /** mapper 优先返回当前主体分区的物理 id；不存在时才返回旧租户分区 id。 */
+    private String sourceStateUserId(String prefixedSessionId, String stateUserId, String legacyStateUserId) {
+        if (prefixedSessionId.startsWith(stateUserId + ":")) {
+            return stateUserId;
+        }
+        if (prefixedSessionId.startsWith(legacyStateUserId + ":")) {
+            return legacyStateUserId;
+        }
+        throw new IllegalStateException("Unexpected chat state session scope");
+    }
+
+    private String stripStateUserId(String prefixedSessionId, String sourceStateUserId) {
+        return prefixedSessionId.substring(sourceStateUserId.length() + 1);
     }
 
     private String previewOf(List<Msg> context) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/security/AdminAgentIdentityInterceptor.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/security/AdminAgentIdentityInterceptor.java
@@ -1,0 +1,57 @@
+package com.richard.fyoung.customeradmin.workspace.security;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentity;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentityContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectType;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
+
+/**
+ * 后台 Agent 资源的可信登录主体入口。
+ *
+ * <p>Agent 状态与长期记忆都按 {@link AgentInvocationIdentity} 分区。模型调用路径原先由配额拦截器
+ * 顺带写入身份，而历史列表、历史消息与记忆管理不消耗配额，因此没有经过该拦截器，造成写入使用
+ * 主体分区、读取却退回旧的共享分区。本拦截器只负责身份，不判定或记录额度。</p>
+ *
+ * <p>线程由 Tomcat 复用，请求完成必须清理；异步 SSE 在控制器返回后还会切换处理线程，因此同步段
+ * 结束时也要清理请求线程里的值（Agent 链路所需身份已在返回前写入 Reactor Context）。未登录请求
+ * 同样先清理可能残留的旧值，实际鉴权仍由 Sa-Token 权限注解负责。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public class AdminAgentIdentityInterceptor implements AsyncHandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        AgentInvocationIdentityContext.clear();
+        if (!StpUtil.isLogin()) {
+            return true;
+        }
+        AgentInvocationIdentityContext.set(new AgentInvocationIdentity(
+            tenantOf(), QuotaSubjectType.ADMIN_USER, StpUtil.getLoginIdAsString(), true)
+            .withChannel(AgentInvocationIdentity.CHANNEL_ADMIN));
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        AgentInvocationIdentityContext.clear();
+    }
+
+    @Override
+    public void afterConcurrentHandlingStarted(HttpServletRequest request, HttpServletResponse response,
+                                               Object handler) {
+        AgentInvocationIdentityContext.clear();
+    }
+
+    /** 登录态里的租户；单租户模式或登录态未带租户时统一使用默认租户。 */
+    private static String tenantOf() {
+        String tenantId = TenantSession.effectiveTenant();
+        return tenantId == null || tenantId.isBlank() ? TenantContext.DEFAULT : tenantId;
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/security/AdminAgentIdentityWebConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/security/AdminAgentIdentityWebConfig.java
@@ -1,0 +1,22 @@
+package com.richard.fyoung.customeradmin.workspace.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** 为所有后台 Agent 状态读写入口注册可信主体，不与主体配额开关绑定。 */
+@Configuration
+public class AdminAgentIdentityWebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminAgentIdentityInterceptor())
+            .addPathPatterns(
+                "/api/workspace/**",
+                "/api/aiconfig/agent-task/**",
+                "/api/aiconfig/agent/*/memory")
+            // 先建立身份，再由后续配额拦截器在真正调模型的路径上判定与记账。
+            .order(Ordered.LOWEST_PRECEDENCE - 20);
+    }
+}

--- a/customer-admin-server/src/main/resources/mapper/ChatSessionStateQueryMapper.xml
+++ b/customer-admin-server/src/main/resources/mapper/ChatSessionStateQueryMapper.xml
@@ -14,28 +14,47 @@
 <mapper namespace="com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper">
 
     <select id="pageSessionIds" resultType="java.lang.String">
-        SELECT state.session_id
+        SELECT COALESCE(
+                   MAX(CASE
+                       WHEN state.session_id LIKE CONCAT(#{stateUserId}, ':%') THEN state.session_id
+                   END),
+                   MAX(state.session_id)
+               ) AS session_id
         FROM ai_chat_session_state state
         INNER JOIN ai_workspace_session owner
                ON owner.tenant_id = #{tenantId}
                AND owner.agent_code = #{agentCode}
-               AND owner.session_id = SUBSTRING(state.session_id, CHAR_LENGTH(#{stateUserId}) + 2)
+               AND owner.session_id = CASE
+                   WHEN state.session_id LIKE CONCAT(#{stateUserId}, ':%')
+                       THEN SUBSTRING(state.session_id, CHAR_LENGTH(#{stateUserId}) + 2)
+                   ELSE SUBSTRING(state.session_id, CHAR_LENGTH(#{legacyStateUserId}) + 2)
+               END
                <if test="ownerUserId != null">AND owner.owner_user_id = #{ownerUserId}</if>
         WHERE state.session_id LIKE CONCAT(#{stateUserId}, ':%')
-        GROUP BY state.session_id
-        ORDER BY MAX(state.updated_at) DESC
+           OR (#{stateUserId} != #{legacyStateUserId}
+               AND state.session_id LIKE CONCAT(#{legacyStateUserId}, ':%')
+               AND state.session_id NOT LIKE CONCAT(#{legacyStateUserId}, '::subject::%'))
+        GROUP BY owner.session_id
+        ORDER BY MAX(state.updated_at) DESC, owner.session_id DESC
         LIMIT #{offset}, #{limit}
     </select>
 
     <select id="countSessions" resultType="long">
-        SELECT COUNT(DISTINCT state.session_id)
+        SELECT COUNT(DISTINCT owner.session_id)
         FROM ai_chat_session_state state
         INNER JOIN ai_workspace_session owner
                ON owner.tenant_id = #{tenantId}
                AND owner.agent_code = #{agentCode}
-               AND owner.session_id = SUBSTRING(state.session_id, CHAR_LENGTH(#{stateUserId}) + 2)
+               AND owner.session_id = CASE
+                   WHEN state.session_id LIKE CONCAT(#{stateUserId}, ':%')
+                       THEN SUBSTRING(state.session_id, CHAR_LENGTH(#{stateUserId}) + 2)
+                   ELSE SUBSTRING(state.session_id, CHAR_LENGTH(#{legacyStateUserId}) + 2)
+               END
                <if test="ownerUserId != null">AND owner.owner_user_id = #{ownerUserId}</if>
         WHERE state.session_id LIKE CONCAT(#{stateUserId}, ':%')
+           OR (#{stateUserId} != #{legacyStateUserId}
+               AND state.session_id LIKE CONCAT(#{legacyStateUserId}, ':%')
+               AND state.session_id NOT LIKE CONCAT(#{legacyStateUserId}, '::subject::%'))
     </select>
 
 </mapper>

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatHistoryServiceTest.java
@@ -6,16 +6,23 @@ import com.richard.fyoung.customeradmin.workspace.chat.dto.ChatSessionSummary;
 import com.richard.fyoung.customeradmin.workspace.chat.mapper.ChatSessionStateQueryMapper;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentInstanceCache;
 import com.richard.fyoung.customeradmin.workspace.runtime.AgentStateAccessor;
+import com.richard.fyoung.customeradmin.workspace.runtime.WorkspaceRuntimeScope;
+import com.richard.fyoung.customeradmin.workspace.memory.AgentMemoryScope;
 import com.richard.fyoung.customeradmin.tenant.AdminTenantProperties;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentParseStatus;
 import com.richard.fyoung.customerwork.data.attachment.AttachmentStore;
 import com.richard.fyoung.customerwork.data.attachment.ChatAttachment;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentity;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentityContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectType;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.AgentStateStore;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,7 +41,7 @@ import static org.mockito.Mockito.when;
  * ① 顺序以 mapper 返回的 updated_at 倒序为准、去掉 {@code {agentCode}:} 前缀后逐个组装；
  * ② offset 按 {@code (page-1)*size} 计算；
  * ③ context 为空的会话跳过（本页可能略少于 size）；
- * ④ 总数为 0 时短路、不再查页数据。
+ * ④ 当前主体分区与升级前租户分区可合并读取；⑤ 总数为 0 时短路、不再查页数据。
  * @author owlzhangfq@gmail.com
  */
 class ChatHistoryServiceTest {
@@ -68,11 +75,21 @@ class ChatHistoryServiceTest {
         when(agentInstanceCache.getOrBuild(AGENT_CODE)).thenReturn(agent);
     }
 
+    @AfterEach
+    void clearContexts() {
+        AgentInvocationIdentityContext.clear();
+        TenantContext.clear();
+    }
+
     /** 给某个裸 sessionId 备好一段上下文（首条为用户消息，供 preview 取值）。 */
     private void stubContext(String sessionId, Msg... msgs) {
+        stubContext(AGENT_CODE, sessionId, msgs);
+    }
+
+    private void stubContext(String stateUserId, String sessionId, Msg... msgs) {
         AgentState state = mock(AgentState.class);
         when(state.getContext()).thenReturn(List.of(msgs));
-        when(agentStateAccessor.resolve(agent, AGENT_CODE, sessionId)).thenReturn(state);
+        when(agentStateAccessor.resolve(agent, stateUserId, sessionId)).thenReturn(state);
     }
 
     private Msg userMsg(String text) {
@@ -85,9 +102,11 @@ class ChatHistoryServiceTest {
 
     @Test
     void listSessions_shouldPageInSqlOrder_stripPrefix_andBuildSummaries() {
-        when(sessionStateQueryMapper.countSessions(TENANT_ID, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(5L);
+        when(sessionStateQueryMapper.countSessions(
+            TENANT_ID, AGENT_CODE, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(5L);
         when(sessionStateQueryMapper.pageSessionIds(
-            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(OWNER_USER_ID), eq(0L), eq(20L)))
+            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(AGENT_CODE),
+            eq(OWNER_USER_ID), eq(0L), eq(20L)))
             .thenReturn(List.of("coder:s1", "coder:s2"));
         stubContext("s1", userMsg("你好"), assistantMsg("在的"));
         stubContext("s2", userMsg("在吗"));
@@ -108,9 +127,11 @@ class ChatHistoryServiceTest {
 
     @Test
     void listSessions_shouldComputeOffset_fromPageAndSize() {
-        when(sessionStateQueryMapper.countSessions(TENANT_ID, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(50L);
+        when(sessionStateQueryMapper.countSessions(
+            TENANT_ID, AGENT_CODE, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(50L);
         when(sessionStateQueryMapper.pageSessionIds(
-            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(OWNER_USER_ID), eq(20L), eq(20L)))
+            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(AGENT_CODE),
+            eq(OWNER_USER_ID), eq(20L), eq(20L)))
             .thenReturn(List.of("coder:s3"));
         stubContext("s3", userMsg("第三页第一条"));
 
@@ -118,16 +139,19 @@ class ChatHistoryServiceTest {
 
         // offset = (2-1)*20 = 20
         verify(sessionStateQueryMapper).pageSessionIds(
-            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(OWNER_USER_ID), eq(20L), eq(20L));
+            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(AGENT_CODE),
+            eq(OWNER_USER_ID), eq(20L), eq(20L));
         assertEquals(1, result.getList().size());
         assertEquals("s3", result.getList().get(0).sessionId());
     }
 
     @Test
     void listSessions_shouldSkipEmptyContextSessions_soPageMayBeShorterThanSize() {
-        when(sessionStateQueryMapper.countSessions(TENANT_ID, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(2L);
+        when(sessionStateQueryMapper.countSessions(
+            TENANT_ID, AGENT_CODE, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(2L);
         when(sessionStateQueryMapper.pageSessionIds(
-            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(OWNER_USER_ID), eq(0L), eq(20L)))
+            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(AGENT_CODE),
+            eq(OWNER_USER_ID), eq(0L), eq(20L)))
             .thenReturn(List.of("coder:empty", "coder:s2"));
         stubContext("empty"); // 空上下文
         stubContext("s2", userMsg("在吗"));
@@ -193,8 +217,51 @@ class ChatHistoryServiceTest {
     }
 
     @Test
+    void listSessions_shouldMergeCurrentSubjectAndLegacyTenantScopes() {
+        TenantContext.set(TENANT_ID);
+        AgentInvocationIdentityContext.set(new AgentInvocationIdentity(
+            TENANT_ID, QuotaSubjectType.ADMIN_USER, OWNER_USER_ID.toString(), true));
+        String stateUserId = AgentMemoryScope.current(AGENT_CODE).stateUserId();
+        String legacyStateUserId = WorkspaceRuntimeScope.agent(AGENT_CODE);
+
+        when(sessionStateQueryMapper.countSessions(
+            TENANT_ID, stateUserId, legacyStateUserId, AGENT_CODE, OWNER_USER_ID)).thenReturn(2L);
+        when(sessionStateQueryMapper.pageSessionIds(
+            TENANT_ID, stateUserId, legacyStateUserId, AGENT_CODE, OWNER_USER_ID, 0L, 20L))
+            .thenReturn(List.of(stateUserId + ":new-session", legacyStateUserId + ":legacy-session"));
+        stubContext(stateUserId, "new-session", userMsg("最近对话"));
+        stubContext(legacyStateUserId, "legacy-session", userMsg("旧历史"));
+
+        PageResult<ChatSessionSummary> result = service.listSessions(AGENT_CODE, OWNER_USER_ID, 1, 20);
+
+        assertEquals(List.of("new-session", "legacy-session"), result.getList().stream()
+            .map(ChatSessionSummary::sessionId).toList());
+        assertEquals(List.of("最近对话", "旧历史"), result.getList().stream()
+            .map(ChatSessionSummary::preview).toList());
+    }
+
+    @Test
+    void getMessages_shouldFallbackToLegacyTenantScope_whenCurrentSubjectStateMissing() {
+        TenantContext.set(TENANT_ID);
+        AgentInvocationIdentityContext.set(new AgentInvocationIdentity(
+            TENANT_ID, QuotaSubjectType.ADMIN_USER, OWNER_USER_ID.toString(), true));
+        String stateUserId = AgentMemoryScope.current(AGENT_CODE).stateUserId();
+        String legacyStateUserId = WorkspaceRuntimeScope.agent(AGENT_CODE);
+        String sessionId = "legacy-session";
+        stubContext(stateUserId, sessionId);
+        stubContext(legacyStateUserId, sessionId, userMsg("旧历史"));
+        when(attachmentStore.listBySession(sessionId)).thenReturn(List.of());
+
+        List<ChatMessageVO> messages = service.getMessages(AGENT_CODE, sessionId);
+
+        assertEquals(1, messages.size());
+        assertEquals("旧历史", messages.get(0).text());
+    }
+
+    @Test
     void listSessions_shouldShortCircuit_whenTotalIsZero() {
-        when(sessionStateQueryMapper.countSessions(TENANT_ID, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(0L);
+        when(sessionStateQueryMapper.countSessions(
+            TENANT_ID, AGENT_CODE, AGENT_CODE, AGENT_CODE, OWNER_USER_ID)).thenReturn(0L);
 
         PageResult<ChatSessionSummary> result = service.listSessions(AGENT_CODE, OWNER_USER_ID, 1, 20);
 
@@ -202,7 +269,7 @@ class ChatHistoryServiceTest {
         assertTrue(result.getList().isEmpty());
         // 总数为 0 时不再查页数据
         verify(sessionStateQueryMapper, never()).pageSessionIds(
-            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(OWNER_USER_ID),
+            eq(TENANT_ID), eq(AGENT_CODE), eq(AGENT_CODE), eq(AGENT_CODE), eq(OWNER_USER_ID),
             org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/security/AdminAgentIdentityInterceptorTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/security/AdminAgentIdentityInterceptorTest.java
@@ -1,0 +1,86 @@
+package com.richard.fyoung.customeradmin.workspace.security;
+
+import cn.dev33.satoken.stp.StpUtil;
+import com.richard.fyoung.customeradmin.tenant.TenantSession;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentity;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentityContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+/** {@link AdminAgentIdentityInterceptor} 登录主体绑定与线程清理契约测试。 */
+class AdminAgentIdentityInterceptorTest {
+
+    private final AdminAgentIdentityInterceptor interceptor = new AdminAgentIdentityInterceptor();
+
+    @AfterEach
+    void tearDown() {
+        AgentInvocationIdentityContext.clear();
+    }
+
+    @Test
+    void preHandle_shouldBindAuthenticatedAdminForHistoryReads() {
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class);
+             MockedStatic<TenantSession> tenantSession = mockStatic(TenantSession.class)) {
+            stpUtil.when(StpUtil::isLogin).thenReturn(true);
+            stpUtil.when(StpUtil::getLoginIdAsString).thenReturn("42");
+            tenantSession.when(TenantSession::effectiveTenant).thenReturn("tenant-a");
+
+            assertTrue(interceptor.preHandle(request(), response(), new Object()));
+
+            AgentInvocationIdentity identity = AgentInvocationIdentityContext.get();
+            assertEquals("tenant-a", identity.tenantId());
+            assertEquals(QuotaSubjectType.ADMIN_USER, identity.subjectType());
+            assertEquals("42", identity.subjectId());
+            assertEquals(AgentInvocationIdentity.CHANNEL_ADMIN, identity.channelCode());
+        }
+    }
+
+    @Test
+    void preHandle_shouldClearStaleIdentity_whenNotLoggedIn() {
+        AgentInvocationIdentityContext.set(new AgentInvocationIdentity(
+            "stale", QuotaSubjectType.ADMIN_USER, "old", true));
+        try (MockedStatic<StpUtil> stpUtil = mockStatic(StpUtil.class)) {
+            stpUtil.when(StpUtil::isLogin).thenReturn(false);
+
+            assertTrue(interceptor.preHandle(request(), response(), new Object()));
+            assertNull(AgentInvocationIdentityContext.get());
+        }
+    }
+
+    @Test
+    void afterCompletion_shouldClearIdentity() {
+        AgentInvocationIdentityContext.set(new AgentInvocationIdentity(
+            "tenant-a", QuotaSubjectType.ADMIN_USER, "42", true));
+
+        interceptor.afterCompletion(request(), response(), new Object(), null);
+
+        assertNull(AgentInvocationIdentityContext.get());
+    }
+
+    @Test
+    void afterConcurrentHandlingStarted_shouldClearRequestThreadIdentity() {
+        AgentInvocationIdentityContext.set(new AgentInvocationIdentity(
+            "tenant-a", QuotaSubjectType.ADMIN_USER, "42", true));
+
+        interceptor.afterConcurrentHandlingStarted(request(), response(), new Object());
+
+        assertNull(AgentInvocationIdentityContext.get());
+    }
+
+    private MockHttpServletRequest request() {
+        return new MockHttpServletRequest("GET", "/api/workspace/java-assistant/chat/sessions");
+    }
+
+    private MockHttpServletResponse response() {
+        return new MockHttpServletResponse();
+    }
+}

--- a/customer-admin-web/package-lock.json
+++ b/customer-admin-web/package-lock.json
@@ -30,6 +30,7 @@
         "unplugin-auto-import": "^21.0.0",
         "unplugin-vue-components": "^32.1.0",
         "vite": "^8.1.1",
+        "vitest": "^4.1.11",
         "vue-tsc": "^3.3.5"
       }
     },
@@ -527,6 +528,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -538,10 +546,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/crypto-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmmirror.com/@types/crypto-js/-/crypto-js-4.2.2.tgz",
       "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -622,6 +648,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -870,6 +1019,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-validator": {
       "version": "4.2.5",
       "resolved": "https://registry.npmmirror.com/async-validator/-/async-validator-4.2.5.tgz",
@@ -905,6 +1064,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -945,6 +1114,13 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmmirror.com/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1094,6 +1270,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -1139,6 +1322,16 @@
       "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.1.0",
@@ -2089,6 +2282,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2111,6 +2311,20 @@
         "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -2122,6 +2336,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2139,6 +2370,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2451,6 +2692,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -2549,6 +2880,23 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zrender": {
       "version": "6.1.0",

--- a/customer-admin-web/package.json
+++ b/customer-admin-web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",
@@ -31,6 +32,7 @@
     "unplugin-auto-import": "^21.0.0",
     "unplugin-vue-components": "^32.1.0",
     "vite": "^8.1.1",
+    "vitest": "^4.1.11",
     "vue-tsc": "^3.3.5"
   }
 }

--- a/customer-admin-web/src/components/AssistantResponse.vue
+++ b/customer-admin-web/src/components/AssistantResponse.vue
@@ -1,0 +1,302 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref } from 'vue'
+import { CircleCheck, CopyDocument, Loading, WarningFilled } from '@element-plus/icons-vue'
+import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
+import TraceTimeline from '@/components/TraceTimeline.vue'
+import type { TraceNode } from '@/utils/traceTimeline'
+
+const props = withDefaults(
+  defineProps<{
+    nodes: TraceNode[]
+    text: string
+    active: boolean
+    failed?: boolean
+  }>(),
+  { failed: false },
+)
+
+const copied = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | null = null
+
+onBeforeUnmount(() => {
+  if (copiedTimer) clearTimeout(copiedTimer)
+})
+
+const resultTitle = computed(() => {
+  if (props.failed) return '本轮未完成'
+  if (props.active) return props.text ? '正在生成结果' : '正在整理结果'
+  return '最终结果'
+})
+
+async function copyResult() {
+  if (!props.text) return
+  try {
+    await navigator.clipboard.writeText(props.text)
+    copied.value = true
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => { copied.value = false }, 1600)
+  } catch {
+    ElMessage.error('复制失败，请手动选择内容复制')
+  }
+}
+</script>
+
+<template>
+  <article class="assistant-response" :class="{ 'is-active': active, 'is-failed': failed }">
+    <TraceTimeline
+      v-if="nodes.length > 0"
+      :nodes="nodes"
+      :active="active"
+      :failed="failed"
+    />
+
+    <div v-else-if="active" class="connecting-state" role="status" aria-live="polite">
+      <span class="connecting-icon" aria-hidden="true">
+        <el-icon class="is-loading"><Loading /></el-icon>
+      </span>
+      <span>
+        <strong>正在连接智能体</strong>
+        <small>即将显示完整思考与执行过程</small>
+      </span>
+    </div>
+
+    <section v-if="text || active || failed" class="result-section" aria-label="智能体回答">
+      <header class="result-header">
+        <span class="result-status" aria-hidden="true">
+          <el-icon v-if="failed"><WarningFilled /></el-icon>
+          <el-icon v-else-if="active" class="is-loading"><Loading /></el-icon>
+          <el-icon v-else><CircleCheck /></el-icon>
+        </span>
+        <strong>{{ resultTitle }}</strong>
+        <span v-if="active" class="live-label">实时输出</span>
+        <button
+          v-if="text"
+          type="button"
+          class="copy-action"
+          :aria-label="copied ? '已复制回答' : '复制回答'"
+          @click="copyResult"
+        >
+          <el-icon><CopyDocument /></el-icon>
+          <span>{{ copied ? '已复制' : '复制' }}</span>
+        </button>
+      </header>
+
+      <MarkdownRenderer v-if="text" :text="text" variant="answer" />
+      <div v-else-if="active" class="result-placeholder" role="status" aria-live="polite">
+        <span></span><span></span><span></span>
+        <small>正在生成清晰、可执行的结果</small>
+      </div>
+      <p v-else-if="failed" class="failed-empty">本轮未返回可展示的结果，请根据上方过程信息重试。</p>
+    </section>
+
+    <div class="response-extras">
+      <slot />
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.assistant-response {
+  width: min(100%, 880px);
+  min-width: 0;
+  color: var(--el-text-color-primary);
+}
+
+.connecting-state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding: 12px 14px;
+  color: var(--el-text-color-primary);
+  background: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 6%, var(--el-bg-color));
+  border: 1px solid color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 20%, var(--el-border-color-lighter));
+  border-radius: 12px;
+}
+
+.connecting-icon,
+.result-status {
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--theme-primary, var(--el-color-primary));
+}
+
+.connecting-icon {
+  width: 26px;
+  height: 26px;
+  background: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 13%, transparent);
+  border-radius: 50%;
+}
+
+.connecting-state > span:last-child {
+  display: grid;
+  gap: 2px;
+}
+
+.connecting-state strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.connecting-state small {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.result-section {
+  position: relative;
+  padding: 2px 2px 0 16px;
+}
+
+.result-section::before {
+  position: absolute;
+  top: 3px;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: linear-gradient(
+    180deg,
+    var(--theme-primary, var(--el-color-primary)),
+    color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 18%, transparent) 72%,
+    transparent
+  );
+  border-radius: 999px;
+  content: '';
+}
+
+.is-failed .result-section::before {
+  background: linear-gradient(180deg, var(--el-color-danger), transparent);
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.result-header > strong {
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.result-status {
+  color: var(--el-color-success);
+  font-size: 15px;
+}
+
+.is-active .result-status {
+  color: var(--theme-primary, var(--el-color-primary));
+}
+
+.is-failed .result-status {
+  color: var(--el-color-danger);
+}
+
+.live-label {
+  padding: 2px 7px;
+  color: var(--theme-primary, var(--el-color-primary));
+  background: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 11%, transparent);
+  border-radius: 999px;
+  font-size: 11px;
+}
+
+.copy-action {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  padding: 5px 8px;
+  gap: 5px;
+  color: var(--el-text-color-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+.copy-action:hover {
+  color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-fill-color-light);
+  border-color: var(--el-border-color-lighter);
+}
+
+.copy-action:focus-visible {
+  outline: 2px solid var(--theme-primary, var(--el-color-primary));
+  outline-offset: 2px;
+}
+
+.result-placeholder {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  gap: 4px;
+  color: var(--el-text-color-secondary);
+}
+
+.result-placeholder > span {
+  width: 5px;
+  height: 5px;
+  background: var(--theme-primary, var(--el-color-primary));
+  border-radius: 50%;
+  animation: result-pulse 1.15s ease-in-out infinite;
+}
+
+.result-placeholder > span:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.result-placeholder > span:nth-child(3) {
+  animation-delay: 0.24s;
+}
+
+.result-placeholder small {
+  margin-left: 5px;
+  font-size: 12px;
+}
+
+.failed-empty {
+  margin: 0;
+  color: var(--el-color-danger);
+  font-size: 13px;
+}
+
+.response-extras:empty {
+  display: none;
+}
+
+.response-extras:not(:empty) {
+  margin-top: 12px;
+}
+
+@keyframes result-pulse {
+  0%, 60%, 100% { opacity: 0.28; transform: translateY(0); }
+  30% { opacity: 1; transform: translateY(-2px); }
+}
+
+@media (max-width: 640px) {
+  .result-section {
+    padding-left: 12px;
+  }
+
+  .copy-action span,
+  .live-label {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .result-placeholder > span {
+    animation: none;
+    opacity: 0.7;
+  }
+
+  :deep(.is-loading) {
+    animation: none;
+  }
+}
+</style>

--- a/customer-admin-web/src/components/ChatHistorySidebar.vue
+++ b/customer-admin-web/src/components/ChatHistorySidebar.vue
@@ -9,7 +9,11 @@ const props = withDefaults(
   defineProps<{ agentCode: string; activeSessionId: string; liveSessions?: LiveSession[] }>(),
   { liveSessions: () => [] },
 )
-const emit = defineEmits<{ select: [sessionId: string] }>()
+const emit = defineEmits<{
+  select: [sessionId: string]
+  /** 首次加载完成后把排序第一的会话交给父面板决定是否恢复；手动刷新不会重复触发。 */
+  initialSession: [sessionId: string]
+}>()
 
 /** 每页条数，与后端 ChatController#sessions 的 size 默认值保持一致。 */
 const PAGE_SIZE = 20
@@ -112,7 +116,19 @@ async function loadMore() {
   }
 }
 
-onMounted(refresh)
+/**
+ * 初次挂载与用户手动刷新语义不同：只有初次挂载需要尝试恢复最近会话，后续刷新只更新列表，
+ * 避免用户已点“新建会话”时被后台历史刷新意外切走。
+ */
+async function initialize() {
+  await refresh()
+  const first = displaySessions.value[0]
+  if (first) {
+    emit('initialSession', first.sessionId)
+  }
+}
+
+onMounted(initialize)
 
 defineExpose({ refresh })
 

--- a/customer-admin-web/src/components/MarkdownRenderer.vue
+++ b/customer-admin-web/src/components/MarkdownRenderer.vue
@@ -2,18 +2,27 @@
 import { computed } from 'vue'
 import { renderMarkdown } from '@/utils/markdown'
 
-const props = defineProps<{ text: string }>()
+const props = withDefaults(defineProps<{
+  text: string
+  variant?: 'default' | 'answer'
+}>(), { variant: 'default' })
 
 const html = computed(() => renderMarkdown(props.text))
 </script>
 
 <template>
-  <div class="markdown-body" v-html="html" />
+  <div class="markdown-body" :class="`markdown-body--${variant}`" v-html="html" />
 </template>
 
 <style scoped>
 .markdown-body {
   word-break: break-word;
+}
+
+.markdown-body--answer {
+  color: var(--el-text-color-primary);
+  font-size: 14px;
+  line-height: 1.75;
 }
 
 .markdown-body :deep(p) {
@@ -25,7 +34,8 @@ const html = computed(() => renderMarkdown(props.text))
 }
 
 .markdown-body :deep(pre) {
-  background: #f6f8fa;
+  background: var(--el-fill-color-light);
+  border: 1px solid var(--el-border-color-lighter);
   border-radius: 6px;
   padding: 12px;
   overflow-x: auto;
@@ -38,7 +48,8 @@ const html = computed(() => renderMarkdown(props.text))
 }
 
 .markdown-body :deep(p code) {
-  background: rgba(27, 31, 35, 0.05);
+  color: var(--theme-primary, var(--el-color-primary));
+  background: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 9%, transparent);
   padding: 2px 4px;
   border-radius: 4px;
 }
@@ -52,13 +63,13 @@ const html = computed(() => renderMarkdown(props.text))
 
 .markdown-body :deep(th),
 .markdown-body :deep(td) {
-  border: 1px solid #dcdfe6;
+  border: 1px solid var(--el-border-color);
   padding: 6px 10px;
   text-align: left;
 }
 
 .markdown-body :deep(th) {
-  background: #f5f7fa;
+  background: var(--el-fill-color-light);
   font-weight: 600;
 }
 
@@ -71,7 +82,56 @@ const html = computed(() => renderMarkdown(props.text))
 .markdown-body :deep(blockquote) {
   margin: 8px 0;
   padding: 0 12px;
-  border-left: 3px solid #dcdfe6;
-  color: #666;
+  border-left: 3px solid var(--theme-primary, var(--el-color-primary));
+  color: var(--el-text-color-secondary);
+}
+
+.markdown-body--answer :deep(h1),
+.markdown-body--answer :deep(h2),
+.markdown-body--answer :deep(h3),
+.markdown-body--answer :deep(h4) {
+  margin: 18px 0 8px;
+  color: var(--el-text-color-primary);
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.markdown-body--answer :deep(h1:first-child),
+.markdown-body--answer :deep(h2:first-child),
+.markdown-body--answer :deep(h3:first-child) {
+  margin-top: 2px;
+}
+
+.markdown-body--answer :deep(h1) { font-size: 20px; }
+.markdown-body--answer :deep(h2) { font-size: 17px; }
+.markdown-body--answer :deep(h3) { font-size: 15px; }
+
+.markdown-body--answer :deep(a) {
+  color: var(--theme-primary, var(--el-color-primary));
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.markdown-body--answer :deep(li + li) {
+  margin-top: 3px;
+}
+
+.markdown-body--answer :deep(hr) {
+  margin: 18px 0;
+  border: 0;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+
+.markdown-body--answer :deep(pre) {
+  margin: 12px 0;
+  padding: 13px 14px;
+  border-radius: 9px;
+  line-height: 1.6;
+}
+
+.markdown-body--answer :deep(table) {
+  display: block;
+  overflow-x: auto;
+  border-radius: 8px;
 }
 </style>

--- a/customer-admin-web/src/components/TraceTimeline.vue
+++ b/customer-admin-web/src/components/TraceTimeline.vue
@@ -1,195 +1,529 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { CircleCheck, Connection, Cpu, MagicStick, Tools, VideoPause, VideoPlay } from '@element-plus/icons-vue'
-// SUBAGENT_MARKER_KIND 的唯一定义在 utils/traceTimeline.ts（<script setup> 不允许普通值导出，
-// 常量真正的“单一定义源”放在那个纯 TS 模块里，这里只是消费方）。
-import { SUBAGENT_MARKER_KIND } from '@/utils/traceTimeline'
+import { computed, ref, type Component } from 'vue'
+import {
+  ArrowRight,
+  CircleCheck,
+  Connection,
+  Cpu,
+  DocumentChecked,
+  Loading,
+  MagicStick,
+  Tools,
+  WarningFilled,
+} from '@element-plus/icons-vue'
+import {
+  SUBAGENT_MARKER_KIND,
+  parseToolResult,
+  summarizeTrace,
+  visibleTraceNodes,
+  type ParsedToolResult,
+  type TraceNode,
+} from '@/utils/traceTimeline'
 
-/** 单个子Agent 的嵌套执行时间线状态——运行中/已完成决定标题徽标样式与默认展开/折叠。 */
-export interface SubagentBlock {
-  /** 子Agent 调用链路径（如 "main/doc-writer"），同一 source 的多次调用归并进同一个面板。 */
-  source: string
-  /** 面板标题展示名。 */
-  name: string
-  /** 运行中=展开+转圈徽标；已完成（收到 SUBAGENT_RESULT）=自动折叠+对勾徽标（仍可手动展开）。 */
-  status: 'running' | 'done'
-  /** 该子Agent 内部的执行节点（含最后一条 SUBAGENT_RESULT 产出节点），复用本组件递归渲染。 */
-  nodes: TraceNode[]
-  /** 手动展开/折叠状态，由用户点击面板标题切换。 */
-  expanded: boolean
-}
+const props = withDefaults(
+  defineProps<{
+    nodes: TraceNode[]
+    active: boolean
+    failed?: boolean
+    /** 子 Agent 内部递归渲染时隐藏总标题，由外层子 Agent 标题统一控制。 */
+    hideHeader?: boolean
+  }>(),
+  { failed: false, hideHeader: false },
+)
 
-/** 与后端 ChatNodeKind 一一对应（小写下划线形式，见 SSE event 名 node:<kind>）。 */
-export interface TraceNode {
-  kind: string
-  text: string
-  /** 仅当 kind === SUBAGENT_MARKER_KIND 时有值：承载该子Agent 的嵌套执行时间线。 */
-  subagent?: SubagentBlock
-}
-
-defineProps<{
-  nodes: TraceNode[]
-  active: boolean
-  /** 子Agent 嵌套面板内部复用本组件时传 true：隐藏自带的"思考中…/思考过程"折叠头，
-   * 展开/折叠改由外层子Agent 面板标题统一控制，避免出现两层重复的折叠开关。 */
-  hideHeader?: boolean
-}>()
-
-// 默认展开，不折叠（可手动收起）——跟旧版 ThinkingBlock 默认折叠正相反。
+/** 用户要求完整思考过程保留，因此首次进入默认展开；完成后也不自动替用户收起。 */
 const expanded = ref(true)
 
-const NODE_META: Record<string, { label: string; icon: unknown; type: string }> = {
-  thinking_start: { label: '开始思考', icon: VideoPlay, type: 'primary' },
-  thinking: { label: '思考中', icon: Cpu, type: 'info' },
-  thinking_end: { label: '结束思考', icon: VideoPause, type: 'primary' },
-  model_call: { label: '调用大模型', icon: Cpu, type: 'warning' },
-  tool_skill: { label: '调用 Skill', icon: MagicStick, type: 'success' },
-  tool_mcp: { label: '调用 MCP', icon: Connection, type: 'success' },
-  tool_builtin: { label: '调用工具', icon: Tools, type: 'success' },
-  tool_result: { label: '工具返回', icon: CircleCheck, type: 'success' },
-  // 子Agent 内部复用的 kind：ANSWER 在主 Agent 走独立 message 事件不进时间线，
-  // 但子Agent 内部回答增量复用同一个 kind 值，随嵌套面板展示。
-  answer: { label: '生成回答', icon: MagicStick, type: 'success' },
-  // 子Agent 最终产出，面板内最后一条时间线项。
-  subagent_result: { label: '产出结果', icon: CircleCheck, type: 'success' },
+const displayNodes = computed(() => visibleTraceNodes(props.nodes))
+const summary = computed(() => summarizeTrace(props.nodes))
+
+const NODE_META: Record<string, { label: string; icon: Component; tone: string }> = {
+  thinking: { label: '思考中', icon: Cpu, tone: 'thinking' },
+  model_call: { label: '调用模型', icon: Cpu, tone: 'model' },
+  tool_skill: { label: '调用 Skill', icon: MagicStick, tone: 'tool' },
+  tool_mcp: { label: '调用 MCP', icon: Connection, tone: 'tool' },
+  tool_builtin: { label: '调用工具', icon: Tools, tone: 'tool' },
+  tool_result: { label: '工具返回', icon: CircleCheck, tone: 'result' },
+  answer: { label: '生成回答', icon: MagicStick, tone: 'answer' },
+  subagent_result: { label: '产出结果', icon: DocumentChecked, tone: 'result' },
 }
 
 function metaOf(kind: string) {
-  return NODE_META[kind] ?? { label: kind, icon: Cpu, type: 'info' }
+  return NODE_META[kind] ?? { label: kind, icon: Cpu, tone: 'thinking' }
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${durationMs}ms`
+  return `${(durationMs / 1000).toFixed(durationMs < 10_000 ? 1 : 0)}s`
+}
+
+const statusTitle = computed(() => {
+  if (props.failed) return '执行未完成'
+  return props.active ? '正在执行' : '分析完成'
+})
+
+const summaryText = computed(() => {
+  const parts: string[] = []
+  if (summary.value.stepCount > 0) parts.push(`${summary.value.stepCount} 个步骤`)
+  if (summary.value.toolCount > 0) parts.push(`${summary.value.toolCount} 次工具`)
+  if (summary.value.subagentCount > 0) parts.push(`${summary.value.subagentCount} 个子 Agent`)
+  if (!props.active && summary.value.durationMs != null && summary.value.durationMs > 0) {
+    parts.push(formatDuration(summary.value.durationMs))
+  }
+  if (parts.length === 0) return props.active ? '正在接收完整过程' : '完整过程已保留'
+  if (props.active) parts.push('持续更新')
+  return parts.join(' · ')
+})
+
+function isCurrentNode(index: number): boolean {
+  return props.active && index === displayNodes.value.length - 1
+}
+
+function shouldShowText(node: TraceNode): boolean {
+  return !!node.text && node.kind !== 'tool_result'
+}
+
+function toolResultOf(node: TraceNode): ParsedToolResult {
+  return parseToolResult(node.text)
+}
+
+function isLongToolResult(node: TraceNode): boolean {
+  return toolResultOf(node).output.length > 320
+}
+
+function toolResultPreview(node: TraceNode): string {
+  const output = toolResultOf(node).output
+  return output.length > 320 ? `${output.slice(0, 180)}…` : output
 }
 </script>
 
 <template>
-  <div class="trace-timeline">
-    <div v-if="!hideHeader" class="trace-header" @click="expanded = !expanded">
-      <el-icon class="chevron" :class="{ expanded }"><ArrowRight /></el-icon>
-      <span>{{ active ? '思考中…' : '思考过程' }}</span>
-    </div>
-    <el-timeline v-show="hideHeader || expanded" class="trace-body">
-      <el-timeline-item
-        v-for="(node, idx) in nodes"
-        :key="idx"
-        :type="node.kind === SUBAGENT_MARKER_KIND ? (node.subagent?.status === 'done' ? 'success' : 'primary') : (metaOf(node.kind).type as any)"
-        :icon="node.kind === SUBAGENT_MARKER_KIND ? Connection : metaOf(node.kind).icon"
-        size="normal"
-      >
-        <!-- 子Agent 嵌套面板：标题+状态徽标+内部时间线（递归复用本组件，样式与主时间线完全一致） -->
-        <template v-if="node.kind === SUBAGENT_MARKER_KIND && node.subagent">
-          <div class="subagent-card">
-            <div class="subagent-header" @click="node.subagent.expanded = !node.subagent.expanded">
-              <el-icon class="chevron" :class="{ expanded: node.subagent.expanded }"><ArrowRight /></el-icon>
-              <span class="subagent-title">子Agent · {{ node.subagent.name }}</span>
-              <el-tag size="small" :type="node.subagent.status === 'running' ? 'primary' : 'success'" class="subagent-badge">
-                <el-icon v-if="node.subagent.status === 'running'" class="is-loading"><Loading /></el-icon>
-                <el-icon v-else><CircleCheck /></el-icon>
-                {{ node.subagent.status === 'running' ? '运行中' : '已完成' }}
-              </el-tag>
+  <section
+    class="trace-timeline"
+    :class="{ 'is-active': active, 'is-failed': failed, 'is-nested': hideHeader }"
+    aria-label="思考与执行过程"
+  >
+    <button
+      v-if="!hideHeader"
+      type="button"
+      class="trace-header"
+      :aria-expanded="expanded"
+      @click="expanded = !expanded"
+    >
+      <span class="trace-status-icon" aria-hidden="true">
+        <el-icon v-if="failed"><WarningFilled /></el-icon>
+        <el-icon v-else-if="active" class="is-loading"><Loading /></el-icon>
+        <el-icon v-else><CircleCheck /></el-icon>
+      </span>
+      <span class="trace-header-copy">
+        <strong>{{ statusTitle }}</strong>
+        <span>{{ summaryText }}</span>
+      </span>
+      <span class="trace-toggle-label">{{ expanded ? '收起过程' : '展开过程' }}</span>
+      <el-icon class="trace-chevron" :class="{ expanded }"><ArrowRight /></el-icon>
+    </button>
+
+    <div v-show="hideHeader || expanded" class="trace-body">
+      <ol class="trace-list">
+        <li
+          v-for="(node, index) in displayNodes"
+          :key="index"
+          class="trace-item"
+          :class="[
+            `trace-item--${node.kind === SUBAGENT_MARKER_KIND ? 'subagent' : metaOf(node.kind).tone}`,
+            { 'is-current': isCurrentNode(index) },
+          ]"
+        >
+          <span class="trace-rail" aria-hidden="true">
+            <span class="trace-node-icon">
+              <el-icon v-if="node.kind === SUBAGENT_MARKER_KIND"><Connection /></el-icon>
+              <el-icon v-else><component :is="metaOf(node.kind).icon" /></el-icon>
+            </span>
+          </span>
+
+          <template v-if="node.kind === SUBAGENT_MARKER_KIND && node.subagent">
+            <div class="subagent-panel">
+              <button
+                type="button"
+                class="subagent-header"
+                :aria-expanded="node.subagent.expanded"
+                @click="node.subagent.expanded = !node.subagent.expanded"
+              >
+                <span class="subagent-copy">
+                  <strong>子 Agent · {{ node.subagent.name }}</strong>
+                  <span>{{ node.subagent.nodes.length }} 个内部步骤</span>
+                </span>
+                <span class="subagent-state" :class="`is-${node.subagent.status}`">
+                  <el-icon v-if="node.subagent.status === 'running'" class="is-loading"><Loading /></el-icon>
+                  <el-icon v-else><CircleCheck /></el-icon>
+                  {{ node.subagent.status === 'running' ? '运行中' : '已完成' }}
+                </span>
+                <el-icon class="trace-chevron" :class="{ expanded: node.subagent.expanded }"><ArrowRight /></el-icon>
+              </button>
+              <div v-show="node.subagent.expanded" class="subagent-body">
+                <TraceTimeline
+                  :nodes="node.subagent.nodes"
+                  :active="node.subagent.status === 'running'"
+                  hide-header
+                />
+              </div>
             </div>
-            <div v-show="node.subagent.expanded" class="subagent-body">
-              <TraceTimeline :nodes="node.subagent.nodes" :active="node.subagent.status === 'running'" hide-header />
+          </template>
+
+          <div v-else class="trace-node-content">
+            <div class="trace-node-heading">
+              <strong>{{ metaOf(node.kind).label }}</strong>
+              <span v-if="isCurrentNode(index)" class="current-label">当前</span>
+              <span v-if="node.kind === 'tool_result' && toolResultOf(node).toolName" class="tool-name">
+                {{ toolResultOf(node).toolName }}
+              </span>
             </div>
+
+            <!-- 思考增量与子 Agent 结果完整保留，不做摘要替换。 -->
+            <pre v-if="shouldShowText(node)" class="trace-text" :class="`trace-text--${metaOf(node.kind).tone}`">{{ node.text }}</pre>
+
+            <!-- 工具结果可能很长：短结果直接展示；长结果展示预览并保留可展开的完整原文。 -->
+            <template v-if="node.kind === 'tool_result'">
+              <pre class="trace-text trace-text--result">{{ toolResultPreview(node) }}</pre>
+              <details v-if="isLongToolResult(node)" class="tool-result-detail">
+                <summary>查看完整工具结果</summary>
+                <pre>{{ toolResultOf(node).output }}</pre>
+              </details>
+            </template>
           </div>
-        </template>
-        <template v-else>
-          <div class="trace-label">{{ metaOf(node.kind).label }}</div>
-          <div v-if="node.text" class="trace-text">{{ node.text }}</div>
-        </template>
-      </el-timeline-item>
-    </el-timeline>
-  </div>
+        </li>
+      </ol>
+    </div>
+  </section>
 </template>
 
 <style scoped>
 .trace-timeline {
-  margin-bottom: 6px;
-  font-size: 12px;
-  color: #909399;
+  --trace-accent: var(--theme-primary, var(--el-color-primary));
+  --trace-surface: color-mix(in srgb, var(--trace-accent) 6%, var(--el-bg-color));
+  --trace-accent-soft: color-mix(in srgb, var(--trace-accent) 14%, transparent);
+  --trace-success: var(--el-color-success);
+  --trace-line: color-mix(in srgb, var(--trace-accent) 20%, var(--el-border-color-lighter));
+  margin-bottom: 16px;
+  overflow: hidden;
+  color: var(--el-text-color-primary);
+  background: var(--trace-surface);
+  border: 1px solid var(--trace-line);
+  border-radius: 12px;
+}
+
+.trace-timeline.is-failed {
+  --trace-accent: var(--el-color-danger);
+}
+
+.trace-timeline.is-nested {
+  margin-bottom: 0;
+  overflow: visible;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+
+.trace-header,
+.subagent-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
 }
 
 .trace-header {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  cursor: pointer;
-  user-select: none;
-  margin-bottom: 4px;
+  gap: 10px;
+  padding: 12px 14px;
 }
 
-.chevron {
-  transition: transform 0.15s;
+.trace-header:focus-visible,
+.subagent-header:focus-visible {
+  outline: 2px solid var(--trace-accent);
+  outline-offset: -2px;
+}
+
+.trace-status-icon {
+  display: inline-grid;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  color: var(--trace-success);
+  background: color-mix(in srgb, var(--trace-success) 14%, transparent);
+  border-radius: 50%;
+}
+
+.is-active .trace-status-icon {
+  color: var(--trace-accent);
+  background: var(--trace-accent-soft);
+}
+
+.is-failed .trace-status-icon {
+  color: var(--el-color-danger);
+  background: var(--el-color-danger-light-9);
+}
+
+.trace-header-copy,
+.subagent-copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.trace-header-copy {
+  flex: 1;
+}
+
+.trace-header-copy strong,
+.subagent-copy strong,
+.trace-node-heading strong {
+  font-weight: 600;
+}
+
+.trace-header-copy > span,
+.subagent-copy > span {
+  overflow: hidden;
+  color: var(--el-text-color-secondary);
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trace-toggle-label {
+  flex: 0 0 auto;
+  color: var(--el-text-color-secondary);
   font-size: 12px;
 }
 
-.chevron.expanded {
+.trace-chevron {
+  flex: 0 0 auto;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  transition: transform 0.18s ease;
+}
+
+.trace-chevron.expanded {
   transform: rotate(90deg);
 }
 
 .trace-body {
-  padding: 4px 10px 0 4px;
+  padding: 0 14px 14px;
 }
 
-.trace-body :deep(.el-timeline-item__tail) {
-  border-left: 2px solid #e4e7ed;
+.is-nested > .trace-body {
+  padding: 0;
 }
 
-.trace-body :deep(.el-timeline-item__node) {
-  width: 18px;
-  height: 18px;
-  left: -3px;
+.trace-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
-.trace-body :deep(.el-timeline-item__wrapper) {
-  padding-left: 20px;
+.trace-item {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  min-width: 0;
 }
 
-.trace-label {
+.trace-rail {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.trace-item:not(:last-child) .trace-rail::after {
+  position: absolute;
+  top: 25px;
+  bottom: -3px;
+  left: 50%;
+  width: 1px;
+  background: var(--trace-line);
+  content: '';
+  transform: translateX(-50%);
+}
+
+.trace-node-icon {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 20px;
+  height: 20px;
+  margin-top: 7px;
+  place-items: center;
+  color: var(--trace-accent);
+  background: var(--el-bg-color);
+  border: 1px solid var(--trace-line);
+  border-radius: 50%;
+}
+
+.trace-node-icon :deep(.el-icon) {
   font-size: 12px;
-  font-weight: 600;
-  color: #606266;
 }
 
-.trace-text {
-  margin-top: 2px;
-  padding: 6px 8px;
-  background: #fafafa;
-  border-left: 2px solid #dcdfe6;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: #666;
+.trace-item--result .trace-node-icon,
+.trace-item--answer .trace-node-icon {
+  color: var(--trace-success);
+  border-color: color-mix(in srgb, var(--trace-success) 32%, var(--el-border-color));
 }
 
-/* 子Agent 嵌套面板：复用主时间线配色（主题色边框 + 浅底），与普通节点的 trace-text 区分层级 */
-.subagent-card {
-  border: 1px solid var(--theme-primary-lighter, #e4e7ed);
-  border-radius: 6px;
-  padding: 6px 8px;
-  background: var(--theme-page-bg, #fafcff);
+.trace-item.is-current .trace-node-icon {
+  color: var(--trace-accent);
+  background: color-mix(in srgb, var(--trace-accent) 10%, var(--el-bg-color));
+  box-shadow: 0 0 0 4px var(--trace-accent-soft);
 }
 
-.subagent-header {
+.trace-node-content,
+.subagent-panel {
+  min-width: 0;
+  margin: 3px 0 9px 6px;
+}
+
+.trace-node-content {
+  padding: 5px 8px 7px;
+}
+
+.trace-node-heading {
   display: flex;
   align-items: center;
-  gap: 6px;
+  min-width: 0;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.current-label,
+.tool-name,
+.subagent-state {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 4px;
+  border-radius: 999px;
+  font-size: 11px;
+}
+
+.current-label {
+  padding: 2px 6px;
+  color: var(--trace-accent);
+  background: var(--trace-accent-soft);
+}
+
+.tool-name {
+  overflow: hidden;
+  max-width: 220px;
+  padding: 2px 7px;
+  color: var(--el-color-primary);
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: var(--el-color-primary-light-9);
+}
+
+.trace-text,
+.tool-result-detail pre {
+  margin: 5px 0 0;
+  padding: 7px 9px;
+  color: var(--el-text-color-regular);
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: color-mix(in srgb, var(--el-bg-color) 82%, transparent);
+  border-left: 2px solid var(--trace-line);
+  border-radius: 0 6px 6px 0;
+}
+
+.trace-text--thinking {
+  color: var(--el-text-color-secondary);
+}
+
+.trace-text--result,
+.trace-text--answer {
+  border-left-color: color-mix(in srgb, var(--trace-success) 52%, var(--el-border-color));
+}
+
+.tool-result-detail {
+  margin-top: 5px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.tool-result-detail summary {
+  width: fit-content;
   cursor: pointer;
   user-select: none;
 }
 
-.subagent-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: #606266;
+.tool-result-detail pre {
+  max-height: 360px;
+  overflow: auto;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+.subagent-panel {
+  overflow: hidden;
+  background: color-mix(in srgb, var(--el-bg-color) 86%, transparent);
+  border: 1px solid var(--trace-line);
+  border-radius: 9px;
+}
+
+.subagent-header {
+  gap: 8px;
+  padding: 9px 10px;
+}
+
+.subagent-copy {
   flex: 1;
 }
 
-.subagent-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
+.subagent-copy strong {
+  font-size: 12px;
+}
+
+.subagent-state {
+  padding: 3px 7px;
+  color: var(--trace-success);
+  background: color-mix(in srgb, var(--trace-success) 12%, transparent);
+}
+
+.subagent-state.is-running {
+  color: var(--trace-accent);
+  background: var(--trace-accent-soft);
 }
 
 .subagent-body {
-  margin-top: 6px;
-  padding-left: 4px;
-  border-left: 2px dashed var(--theme-primary-lighter, #e4e7ed);
+  padding: 7px 10px 9px;
+  border-top: 1px solid var(--trace-line);
+}
+
+@media (max-width: 640px) {
+  .trace-header {
+    align-items: flex-start;
+  }
+
+  .trace-toggle-label {
+    display: none;
+  }
+
+  .tool-name {
+    max-width: 120px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trace-chevron {
+    transition: none;
+  }
+
+  :deep(.is-loading) {
+    animation: none;
+  }
 }
 </style>

--- a/customer-admin-web/src/store/chatConversations.ts
+++ b/customer-admin-web/src/store/chatConversations.ts
@@ -1,11 +1,15 @@
 import { defineStore } from 'pinia'
 import { getChatSessionMessages, interruptChat, streamChat } from '@/api/chat'
 import { generateUuid } from '@/utils/uuid'
-import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
+import {
+  ANSWER_KIND,
+  appendChatStreamNode,
+  parseChatStreamPayload,
+  type TraceNode,
+} from '@/utils/traceTimeline'
 import { createPlanCard, type PlanCard } from '@/utils/planCard'
 import { revokeAttachmentPreviews, type MessageAttachmentVM } from '@/utils/attachment'
 import { createTextChunkBatcher } from '@/utils/textChunkBatcher'
-import type { TraceNode } from '@/components/TraceTimeline.vue'
 import type { ExecutionMode, LiveSession, PlanEvent, PlanResultEvent } from '@/types/api'
 
 export interface ChatMessage {

--- a/customer-admin-web/src/store/vibeConversations.ts
+++ b/customer-admin-web/src/store/vibeConversations.ts
@@ -10,11 +10,15 @@ import {
 } from '@/api/vibecoding'
 import { getChatSessionMessages } from '@/api/chat'
 import { generateUuid } from '@/utils/uuid'
-import { ANSWER_KIND, appendChatStreamNode, parseChatStreamPayload } from '@/utils/traceTimeline'
+import {
+  ANSWER_KIND,
+  appendChatStreamNode,
+  parseChatStreamPayload,
+  type TraceNode,
+} from '@/utils/traceTimeline'
 import { createTextChunkBatcher } from '@/utils/textChunkBatcher'
 import { createPlanCard, type PlanCard } from '@/utils/planCard'
 import { revokeAttachmentPreviews, type MessageAttachmentVM } from '@/utils/attachment'
-import type { TraceNode } from '@/components/TraceTimeline.vue'
 import type { SseHandlers } from '@/utils/sse'
 import type {
   CommandOutputEvent,

--- a/customer-admin-web/src/utils/conversationRestore.test.ts
+++ b/customer-admin-web/src/utils/conversationRestore.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRestoreMostRecentSession, type RestorableConversation } from './conversationRestore'
+
+function pristineConversation(): RestorableConversation {
+  return {
+    sessionId: 'temporary-session',
+    messages: [],
+    input: '',
+    attachments: [],
+    streaming: false,
+  }
+}
+
+describe('shouldRestoreMostRecentSession', () => {
+  it('首次进入只有临时空会话时恢复最新历史', () => {
+    expect(shouldRestoreMostRecentSession(pristineConversation(), 'history-session', undefined)).toBe(true)
+  })
+
+  it('显式目标会话或当前已经是候选会话时不重复恢复', () => {
+    expect(shouldRestoreMostRecentSession(pristineConversation(), 'history-session', 'project-session')).toBe(false)
+
+    const current = pristineConversation()
+    current.sessionId = 'history-session'
+    expect(shouldRestoreMostRecentSession(current, 'history-session', undefined)).toBe(false)
+  })
+
+  it.each([
+    ['已有消息', { messages: [{}] }],
+    ['正在流式执行', { streaming: true }],
+    ['存在未发送输入', { input: '尚未发送' }],
+    ['存在待发送附件', { attachments: [{}] }],
+  ])('%s时保留当前会话', (_label, patch) => {
+    expect(shouldRestoreMostRecentSession(
+      { ...pristineConversation(), ...patch },
+      'history-session',
+      undefined,
+    )).toBe(false)
+  })
+})

--- a/customer-admin-web/src/utils/conversationRestore.ts
+++ b/customer-admin-web/src/utils/conversationRestore.ts
@@ -1,0 +1,31 @@
+/**
+ * 面板首次打开时允许被历史会话替换的最小会话结构。
+ * Chat 与 VibeCoding 的会话模型都满足该契约，避免两块面板各自维护一套恢复判断。
+ */
+export interface RestorableConversation {
+  sessionId: string
+  messages: readonly unknown[]
+  input: string
+  attachments: readonly unknown[]
+  streaming: boolean
+}
+
+/**
+ * 仅当当前会话是前端刚初始化的纯空占位时，才自动恢复最新历史会话。
+ *
+ * 显式 sessionId 优先；已有消息、流式任务、未发送输入或附件都属于用户状态，不能被历史数据覆盖。
+ */
+export function shouldRestoreMostRecentSession(
+  conversation: RestorableConversation | undefined,
+  candidateSessionId: string | undefined,
+  explicitSessionId: string | undefined,
+): candidateSessionId is string {
+  if (!conversation || !candidateSessionId || explicitSessionId) {
+    return false
+  }
+  return conversation.sessionId !== candidateSessionId
+    && conversation.messages.length === 0
+    && conversation.input.length === 0
+    && conversation.attachments.length === 0
+    && !conversation.streaming
+}

--- a/customer-admin-web/src/utils/sse.test.ts
+++ b/customer-admin-web/src/utils/sse.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseSseBlock } from './sseParser'
+
+describe('parseSseBlock', () => {
+  it('只去掉 SSE 协议分隔空格，保留正文首尾空格和多行结构', () => {
+    expect(parseSseBlock('event: message\ndata:  leading space\ndata: trailing space ')).toEqual({
+      event: 'message',
+      data: ' leading space\ntrailing space ',
+    })
+  })
+
+  it('兼容 CRLF 行尾且不吞掉思考增量空格', () => {
+    expect(parseSseBlock('event: node:thinking\r\ndata:  分析调用链 \r')).toEqual({
+      event: 'node:thinking',
+      data: ' 分析调用链 ',
+    })
+  })
+
+  it('没有 data 字段时忽略该事件块', () => {
+    expect(parseSseBlock('event: done')).toBeNull()
+  })
+})

--- a/customer-admin-web/src/utils/sse.ts
+++ b/customer-admin-web/src/utils/sse.ts
@@ -1,9 +1,7 @@
 import { useAuthStore } from '@/store/auth'
+import { parseSseBlock, type SseEvent } from '@/utils/sseParser'
 
-export interface SseEvent {
-  event: string
-  data: string
-}
+export type { SseEvent }
 
 export interface SseHandlers {
   onEvent: (event: SseEvent) => void
@@ -97,37 +95,4 @@ export function streamSse(path: string, body: unknown, handlers: SseHandlers): (
     })
 
   return () => controller.abort()
-}
-
-/**
- * 取 SSE 字段值：按规范只去掉<b>一个</b>前导空格，其余原样保留。
- *
- * <p>此前这里用的是 {@code trim()}，会把正文增量首尾的空格全吃掉——模型流是按 token 切片的，
- * 一个以空格开头的英文 token（" the"）到了页面上就与前一个词粘成 "thethe"，Markdown 的缩进
- * 也会被抹平。空格在正文里是有意义的字符，不是噪声。</p>
- *
- * <p>顺带处理行尾 {@code \r}：事件按 {@code \n\n} 切分、行按 {@code \n} 切分，若服务端用
- * {@code \r\n} 作行分隔，每行尾部会残留 {@code \r}。原先由 {@code trim()} 顺手清掉，
- * 去掉 trim 后必须显式处理，否则会把控制字符带进正文。</p>
- */
-function readSseFieldValue(rawValue: string): string {
-  const withoutCr = rawValue.endsWith('\r') ? rawValue.slice(0, -1) : rawValue
-  return withoutCr.startsWith(' ') ? withoutCr.slice(1) : withoutCr
-}
-
-function parseSseBlock(block: string): SseEvent | null {
-  let event = 'message'
-  const dataLines: string[] = []
-  for (const line of block.split('\n')) {
-    if (line.startsWith('event:')) {
-      // 事件名是协议标识而非正文，两端空白一律不保留
-      event = readSseFieldValue(line.slice('event:'.length)).trim()
-    } else if (line.startsWith('data:')) {
-      dataLines.push(readSseFieldValue(line.slice('data:'.length)))
-    }
-  }
-  if (dataLines.length === 0) {
-    return null
-  }
-  return { event, data: dataLines.join('\n') }
 }

--- a/customer-admin-web/src/utils/sseParser.ts
+++ b/customer-admin-web/src/utils/sseParser.ts
@@ -1,0 +1,34 @@
+export interface SseEvent {
+  event: string
+  data: string
+}
+
+/**
+ * 取 SSE 字段值：按规范只去掉一个协议分隔空格，其余原样保留。
+ *
+ * 此前这里用 trim()，会把正文增量首尾空格吃掉。模型流按 token 切片时，一个以空格开头的
+ * 英文 token 到页面上就会与前一个词粘连，Markdown 缩进也会丢失；正文空格属于有效数据。
+ * 同时显式移除 CRLF 留下的行尾 CR，避免把控制字符带进正文。
+ */
+function readSseFieldValue(rawValue: string): string {
+  const withoutCr = rawValue.endsWith('\r') ? rawValue.slice(0, -1) : rawValue
+  return withoutCr.startsWith(' ') ? withoutCr.slice(1) : withoutCr
+}
+
+/** 把一个完整 SSE 事件块解析为事件名和原始正文；无 data 字段的块直接忽略。 */
+export function parseSseBlock(block: string): SseEvent | null {
+  let event = 'message'
+  const dataLines: string[] = []
+  for (const line of block.split('\n')) {
+    if (line.startsWith('event:')) {
+      // 事件名是协议标识而非正文，两端空白一律不保留。
+      event = readSseFieldValue(line.slice('event:'.length)).trim()
+    } else if (line.startsWith('data:')) {
+      dataLines.push(readSseFieldValue(line.slice('data:'.length)))
+    }
+  }
+  if (dataLines.length === 0) {
+    return null
+  }
+  return { event, data: dataLines.join('\n') }
+}

--- a/customer-admin-web/src/utils/traceTimeline.test.ts
+++ b/customer-admin-web/src/utils/traceTimeline.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ANSWER_KIND,
+  SUBAGENT_MARKER_KIND,
+  appendChatStreamNode,
+  parseChatStreamPayload,
+  parseToolResult,
+  summarizeTrace,
+  visibleTraceNodes,
+  type TraceNode,
+} from './traceTimeline'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('parseChatStreamPayload', () => {
+  it('完整保留主 Agent 思考增量中的空格和换行', () => {
+    const raw = '  先确认调用链\n再检查下游契约  '
+
+    expect(parseChatStreamPayload(raw)).toEqual({
+      text: raw,
+      source: null,
+      subagentName: null,
+    })
+  })
+
+  it('解析带来源的子 Agent JSON 载荷', () => {
+    expect(parseChatStreamPayload('{"text":"分析数据库","source":"main/db","subagentName":"数据库专家"}'))
+      .toEqual({ text: '分析数据库', source: 'main/db', subagentName: '数据库专家' })
+  })
+})
+
+describe('appendChatStreamNode', () => {
+  it('合并连续思考增量并记录步骤起止时间', () => {
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(1_280)
+    const nodes: TraceNode[] = []
+
+    appendChatStreamNode(nodes, 'thinking', '先定位')
+    appendChatStreamNode(nodes, 'thinking', '，再验证')
+
+    expect(nodes).toEqual([
+      { kind: 'thinking', text: '先定位，再验证', createdAt: 1_000, updatedAt: 1_280 },
+    ])
+  })
+
+  it('把子 Agent 全部过程归入独立轨迹并保留最终产出', () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_100)
+      .mockReturnValueOnce(1_200)
+      .mockReturnValueOnce(1_300)
+      .mockReturnValueOnce(1_400)
+    const nodes: TraceNode[] = []
+
+    appendChatStreamNode(nodes, 'subagent_start', '数据库专家', 'main/db', '数据库专家')
+    appendChatStreamNode(nodes, 'thinking', '检查', 'main/db', '数据库专家')
+    appendChatStreamNode(nodes, 'thinking', '表结构', 'main/db', '数据库专家')
+    appendChatStreamNode(nodes, 'tool_builtin', 'describe_table', 'main/db', '数据库专家')
+    appendChatStreamNode(nodes, 'subagent_result', '结构一致', 'main/db', '数据库专家')
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].kind).toBe(SUBAGENT_MARKER_KIND)
+    expect(nodes[0].subagent).toMatchObject({
+      source: 'main/db',
+      name: '数据库专家',
+      status: 'done',
+      expanded: false,
+      startedAt: 1_000,
+      updatedAt: 1_400,
+      nodes: [
+        { kind: 'thinking', text: '检查表结构', createdAt: 1_100, updatedAt: 1_200 },
+        { kind: 'tool_builtin', text: 'describe_table', createdAt: 1_300, updatedAt: 1_300 },
+        { kind: 'subagent_result', text: '结构一致', createdAt: 1_400, updatedAt: 1_400 },
+      ],
+    })
+    expect(summarizeTrace(nodes)).toEqual({
+      stepCount: 4,
+      toolCount: 1,
+      subagentCount: 1,
+      durationMs: 400,
+    })
+  })
+
+  it('把子 Agent 正文作为 ANSWER 节点保留在嵌套过程里', () => {
+    const nodes: TraceNode[] = []
+
+    appendChatStreamNode(nodes, ANSWER_KIND, '第一段', 'main/writer', '文档专家')
+    appendChatStreamNode(nodes, ANSWER_KIND, '第二段', 'main/writer', '文档专家')
+
+    expect(nodes[0].subagent?.nodes).toHaveLength(1)
+    expect(nodes[0].subagent?.nodes[0].text).toBe('第一段第二段')
+  })
+})
+
+describe('轨迹展示模型', () => {
+  it('隐藏生命周期边界的重复文案，但不删除原始事件', () => {
+    const nodes: TraceNode[] = [
+      { kind: 'thinking_start', text: '开始思考', createdAt: 100, updatedAt: 100 },
+      { kind: 'thinking', text: '分析调用链', createdAt: 120, updatedAt: 220 },
+      { kind: 'thinking_end', text: '结束思考', createdAt: 240, updatedAt: 240 },
+    ]
+
+    expect(visibleTraceNodes(nodes)).toEqual([nodes[1]])
+    expect(nodes).toHaveLength(3)
+    expect(summarizeTrace(nodes)).toEqual({
+      stepCount: 1,
+      toolCount: 0,
+      subagentCount: 0,
+      durationMs: 140,
+    })
+  })
+
+  it('从稳定协议中拆出工具名，完整保留多行结果', () => {
+    expect(parseToolResult('工具「read_file」返回：第一行\n第二行')).toEqual({
+      toolName: 'read_file',
+      output: '第一行\n第二行',
+    })
+    expect(parseToolResult('旧协议原文')).toEqual({ toolName: null, output: '旧协议原文' })
+  })
+})

--- a/customer-admin-web/src/utils/traceTimeline.ts
+++ b/customer-admin-web/src/utils/traceTimeline.ts
@@ -1,28 +1,59 @@
-import type { SubagentBlock, TraceNode } from '@/components/TraceTimeline.vue'
+/**
+ * 子 Agent 的嵌套执行轨迹。状态与节点都属于对话展示模型，不泄漏到其它业务领域。
+ */
+export interface SubagentBlock {
+  source: string
+  name: string
+  status: 'running' | 'done'
+  nodes: TraceNode[]
+  expanded: boolean
+  startedAt?: number
+  updatedAt?: number
+}
+
+/** 与后端 ChatNodeKind 一一对应的小写展示节点；时间戳由前端收到 SSE 时补齐。 */
+export interface TraceNode {
+  kind: string
+  text: string
+  subagent?: SubagentBlock
+  createdAt?: number
+  updatedAt?: number
+}
+
+export interface TraceSummary {
+  stepCount: number
+  toolCount: number
+  subagentCount: number
+  durationMs: number | null
+}
+
+export interface ParsedToolResult {
+  toolName: string | null
+  output: string
+}
 
 /**
  * 前端合成的伪节点类型，仅用于在时间线里占位承载某个子Agent 的嵌套执行面板，不对应任何后端
- * ChatNodeKind——真实子Agent 事件（THINKING/ANSWER/TOOL_* 等）挂在 SubagentBlock.nodes 里，
- * 不会以这个 kind 出现。定义在这个纯 TS 模块（而非 TraceTimeline.vue 的 <script setup>）里，
- * 是因为 <script setup> 不允许普通值导出，只能在这类文件里做"单一定义源"给两边消费。
+ * ChatNodeKind——真实子Agent 事件（THINKING/ANSWER/TOOL_* 等）挂在 SubagentBlock.nodes 里。
  */
 export const SUBAGENT_MARKER_KIND = '__subagent_panel__'
 
-/**
- * 子Agent 协作场景下 SSE 新增的两个节点类型（对应后端新增 ChatNodeKind）：
- * SUBAGENT_START——子Agent 开始，text 为展示名；SUBAGENT_RESULT——子Agent 最终产出，text 为内容。
- */
+/** 子Agent 协作场景下 SSE 新增的两个节点类型（对应后端 ChatNodeKind）。 */
 export const SUBAGENT_START_KIND = 'subagent_start'
 export const SUBAGENT_RESULT_KIND = 'subagent_result'
 
-/**
- * 主 Agent 回答走独立的 message SSE 事件（不进时间线），但子Agent 内部的回答增量复用同一个
- * kind 值随嵌套面板展示——两处共用这一个常量，避免魔法值。
- */
+/** 主 Agent 回答走独立 message SSE；子Agent 回答复用这个 kind 挂进嵌套面板。 */
 export const ANSWER_KIND = 'answer'
 
-/** 同一节点需要做"增量合并"而非各占一条时间线项的 kind：连续到达时后端未去重，前端需要拼接。 */
+/** 只承担生命周期边界，不再作为两条重复的可见步骤渲染。原始事件仍保留在 nodes 中。 */
+const STRUCTURAL_KINDS: ReadonlySet<string> = new Set(['thinking_start', 'thinking_end'])
+
+const TOOL_KINDS: ReadonlySet<string> = new Set(['tool_skill', 'tool_mcp', 'tool_builtin'])
+
+/** 同一节点需要做增量合并而非各占一条时间线项的 kind。 */
 const MERGEABLE_KINDS: ReadonlySet<string> = new Set(['thinking', ANSWER_KIND])
+
+const TOOL_RESULT_PATTERN = /^工具「([^」]+)」返回：([\s\S]*)$/
 
 /** ChatStreamChunk 的 SSE data 载荷解析结果：source/subagentName 为空代表主 Agent 自身事件。 */
 export interface ChatStreamPayload {
@@ -32,10 +63,8 @@ export interface ChatStreamPayload {
 }
 
 /**
- * 解析 SSE data 载荷。协议约定：带 source 的子Agent 事件用 JSON 承载 { text, source, subagentName }；
- * 主 Agent 自身事件（source 缺省）向后兼容地保持纯文本，不强制要求后端把所有事件都改成 JSON。
- * JSON.parse 失败、或解析结果不是携带字符串 text 字段的对象，一律按纯文本兜底——保证旧协议/
- * 主 Agent 现有渲染完全不受影响。
+ * 解析 SSE data 载荷。带 source 的子Agent 事件用 JSON；主 Agent 保持纯文本。
+ * JSON 解析失败时原样回退，保证旧协议与思考增量中的空格、换行都不丢失。
  */
 export function parseChatStreamPayload(raw: string): ChatStreamPayload {
   try {
@@ -51,34 +80,74 @@ export function parseChatStreamPayload(raw: string): ChatStreamPayload {
       }
     }
   } catch {
-    // 不是 JSON，走纯文本兜底（旧协议 / 主 Agent 事件的通常形态）
+    // 非 JSON 是主 Agent/旧协议的正常形态，原样回退。
   }
   return { text: raw, source: null, subagentName: null }
 }
 
-/** 连续同 kind 的增量内容拼接进上一条，否则各占一条时间线项。 */
-function mergeInto(nodes: TraceNode[], kind: string, text: string) {
-  const last = nodes[nodes.length - 1]
-  if (last && last.kind === kind && MERGEABLE_KINDS.has(kind)) {
-    last.text += text
-  } else {
-    nodes.push({ kind, text })
+/** 结构边界节点仍保留在原始数组中，但不作为重复步骤展示。 */
+export function visibleTraceNodes(nodes: TraceNode[]): TraceNode[] {
+  return nodes.filter((node) => !STRUCTURAL_KINDS.has(node.kind))
+}
+
+/** 解析后端稳定的工具结果展示契约；不匹配时仍完整返回原文。 */
+export function parseToolResult(text: string): ParsedToolResult {
+  const match = text.match(TOOL_RESULT_PATTERN)
+  return match ? { toolName: match[1], output: match[2] } : { toolName: null, output: text }
+}
+
+/** 汇总执行轨迹标题所需的可验证事实，不猜测 token、文件数等后端未提供的数据。 */
+export function summarizeTrace(nodes: TraceNode[]): TraceSummary {
+  let stepCount = 0
+  let toolCount = 0
+  let subagentCount = 0
+  let earliest: number | null = null
+  let latest: number | null = null
+
+  const visit = (items: TraceNode[]) => {
+    for (const node of items) {
+      if (!STRUCTURAL_KINDS.has(node.kind)) stepCount += 1
+      if (TOOL_KINDS.has(node.kind)) toolCount += 1
+      if (node.kind === SUBAGENT_MARKER_KIND && node.subagent) {
+        subagentCount += 1
+        visit(node.subagent.nodes)
+      }
+      const start = node.createdAt ?? node.subagent?.startedAt
+      const end = node.updatedAt ?? node.subagent?.updatedAt ?? start
+      if (start != null) earliest = earliest == null ? start : Math.min(earliest, start)
+      if (end != null) latest = latest == null ? end : Math.max(latest, end)
+    }
+  }
+  visit(nodes)
+
+  return {
+    stepCount,
+    toolCount,
+    subagentCount,
+    durationMs: earliest != null && latest != null ? Math.max(0, latest - earliest) : null,
   }
 }
 
-/** source 缺省展示名兜底：取路径末段（如 "main/doc-writer" -> "doc-writer"）。 */
+/** 连续同 kind 的增量内容拼接进上一条，并保留该步骤的起止时间。 */
+function mergeInto(nodes: TraceNode[], kind: string, text: string, now: number) {
+  const last = nodes[nodes.length - 1]
+  if (last && last.kind === kind && MERGEABLE_KINDS.has(kind)) {
+    last.text += text
+    last.updatedAt = now
+  } else {
+    nodes.push({ kind, text, createdAt: now, updatedAt: now })
+  }
+}
+
+/** source 缺省展示名兜底：取路径末段（如 main/doc-writer -> doc-writer）。 */
 function fallbackDisplayName(source: string): string {
   const lastSegment = source.split('/').pop()
   return lastSegment || source
 }
 
 /**
- * 把一条流式事件追加进执行轨迹时间线。
- * - 无 source（主 Agent 自身事件）：按老逻辑直接追加进顶层数组，行为与改造前完全一致。
- * - 带 source（子Agent 事件）：按 source 归并进对应的嵌套面板——面板节点在该 source 首次出现时
- *   创建并插入主时间线的当前位置，之后同 source 的事件只追加进面板内部，不再改变面板在主时间线
- *   中的位置；同一子Agent 在一轮内被多次调用（重新收到 SUBAGENT_START）时复用同一个面板，
- *   状态重新翻回"运行中"。
+ * 把一条流式事件追加进执行轨迹时间线。主 Agent 直接追加；子 Agent 按 source 归入嵌套面板。
+ * 时间戳只用于本轮 UI 耗时反馈，不参与后端协议，也不会改变思考/工具文本。
  */
 export function appendChatStreamNode(
   nodes: TraceNode[],
@@ -87,28 +156,31 @@ export function appendChatStreamNode(
   source?: string | null,
   subagentName?: string | null,
 ) {
+  const now = Date.now()
   if (!source) {
-    mergeInto(nodes, kind, text)
+    mergeInto(nodes, kind, text, now)
     return
   }
 
-  // SUBAGENT_START 的 text 就是展示名（协议约定），subagentName 字段存在时优先用字段值
   const resolvedName = subagentName || (kind === SUBAGENT_START_KIND ? text : undefined)
-
   let marker = nodes.find(
-    (n): n is TraceNode & { subagent: SubagentBlock } =>
-      n.kind === SUBAGENT_MARKER_KIND && !!n.subagent && n.subagent.source === source,
+    (node): node is TraceNode & { subagent: SubagentBlock } =>
+      node.kind === SUBAGENT_MARKER_KIND && !!node.subagent && node.subagent.source === source,
   )
   if (!marker) {
     const created: TraceNode = {
       kind: SUBAGENT_MARKER_KIND,
       text: '',
+      createdAt: now,
+      updatedAt: now,
       subagent: {
         source,
         name: resolvedName || fallbackDisplayName(source),
         status: 'running',
         nodes: [],
         expanded: true,
+        startedAt: now,
+        updatedAt: now,
       },
     }
     nodes.push(created)
@@ -116,19 +188,19 @@ export function appendChatStreamNode(
   } else if (resolvedName) {
     marker.subagent.name = resolvedName
   }
+  marker.updatedAt = now
+  marker.subagent.updatedAt = now
 
   if (kind === SUBAGENT_START_KIND) {
-    // 建面板/补全标题即可，不在面板内部重复展示一条"开始"节点；
-    // 同一子Agent 被再次调用时把状态翻回运行中并重新展开
     marker.subagent.status = 'running'
     marker.subagent.expanded = true
     return
   }
   if (kind === SUBAGENT_RESULT_KIND) {
-    mergeInto(marker.subagent.nodes, kind, text)
+    mergeInto(marker.subagent.nodes, kind, text, now)
     marker.subagent.status = 'done'
     marker.subagent.expanded = false
     return
   }
-  mergeInto(marker.subagent.nodes, kind, text)
+  mergeInto(marker.subagent.nodes, kind, text, now)
 }

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { createScrollFollower } from '@/utils/scrollFollower'
+import { shouldRestoreMostRecentSession } from '@/utils/conversationRestore'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import { confirmChatPlan } from '@/api/chat'
 import AssistantResponse from '@/components/AssistantResponse.vue'
@@ -71,6 +72,16 @@ async function openSession(targetSessionId: string) {
     ElMessage.error('历史会话加载失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
     historyLoading.value = false
+  }
+}
+
+/**
+ * 页面刷新/组件重建后 store 只含临时空会话时，恢复后端按更新时间倒序返回的第一条历史。
+ * 判断集中在共享工具中，确保 Chat/VibeCoding 都不会覆盖显式跳转、草稿或进行中的会话。
+ */
+function restoreMostRecentSession(targetSessionId: string) {
+  if (shouldRestoreMostRecentSession(active.value, targetSessionId, props.initialSessionId)) {
+    openSession(targetSessionId)
   }
 }
 
@@ -241,6 +252,7 @@ defineExpose({ newSession })
         :active-session-id="activeSessionId"
         :live-sessions="liveSessions"
         @select="openSession"
+        @initial-session="restoreMostRecentSession"
       />
     </div>
   </div>

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import { WarningFilled } from '@element-plus/icons-vue'
 import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { createScrollFollower } from '@/utils/scrollFollower'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import { confirmChatPlan } from '@/api/chat'
-import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
-import TraceTimeline from '@/components/TraceTimeline.vue'
+import AssistantResponse from '@/components/AssistantResponse.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import ExecutionModeSelect from '@/components/ExecutionModeSelect.vue'
 import PlanConfirmCard from '@/components/PlanConfirmCard.vue'
@@ -82,6 +80,11 @@ const scrollFollower = createScrollFollower(() => scrollRef.value)
 
 function scrollToBottom() {
   nextTick(() => scrollFollower.follow())
+}
+
+/** 只有当前会话最后一条助手消息属于本轮 SSE，避免切历史或旧消息显示成执行中。 */
+function isStreamingMessage(index: number): boolean {
+  return !!active.value?.streaming && index === active.value.messages.length - 1
 }
 
 onBeforeUnmount(() => scrollFollower.cancel())
@@ -168,19 +171,21 @@ defineExpose({ newSession })
     <div class="chat-column">
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
         <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
-          <div class="bubble" :class="{ failed: msg.failed }">
-            <!-- 失败提示（额度用尽/后端异常）：与正常回答区分开，同一段文字看起来像"AI 说的话"
-                 还是"系统告诉你这轮没成"，差别很大 -->
-            <div v-if="msg.failed" class="failed-title">
-              <el-icon><WarningFilled /></el-icon>
-              <span>本轮对话未完成</span>
-            </div>
-            <TraceTimeline
-              v-if="msg.role === 'assistant' && msg.nodes.length > 0"
+          <div class="bubble">
+            <AssistantResponse
+              v-if="msg.role === 'assistant'"
               :nodes="msg.nodes"
-              :active="(active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1 && !msg.text"
-            />
-            <MarkdownRenderer v-if="msg.role === 'assistant'" :text="msg.text" />
+              :text="msg.text"
+              :active="isStreamingMessage(index)"
+              :failed="msg.failed"
+            >
+              <!-- Plan Mode 确认卡片（P1-1 HITL）：高风险操作待人工确认，批准/拒绝按钮 + 倒计时 -->
+              <PlanConfirmCard
+                v-if="msg.plans && msg.plans.length > 0"
+                :plans="msg.plans"
+                @decision="handlePlanDecision"
+              />
+            </AssistantResponse>
             <template v-else>{{ msg.text }}</template>
             <!-- 用户消息携带的附件：图片缩略图/文本芯片，历史消息与刚发送的消息共用同一组件 -->
             <MessageAttachments
@@ -188,13 +193,6 @@ defineExpose({ newSession })
               :agent-code="agentCode"
               :attachments="msg.attachments"
             />
-            <!-- Plan Mode 确认卡片（P1-1 HITL）：高风险操作待人工确认，批准/拒绝按钮 + 倒计时 -->
-            <PlanConfirmCard
-              v-if="msg.role === 'assistant' && msg.plans && msg.plans.length > 0"
-              :plans="msg.plans"
-              @decision="handlePlanDecision"
-            />
-            <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && (active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1">思考中…</span>
           </div>
         </div>
         <el-empty v-if="(active?.messages.length ?? 0) === 0" description="开始和智能体对话吧" />
@@ -289,30 +287,16 @@ defineExpose({ newSession })
   justify-content: flex-end;
 }
 
-.bubble.failed {
-  background: var(--el-color-danger-light-9);
-  border: 1px solid var(--el-color-danger-light-5);
-  color: var(--el-color-danger);
-}
-
-.failed-title {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-bottom: 4px;
-  font-size: 13px;
-  font-weight: 600;
-}
-
 .bubble {
-  max-width: 70%;
-  padding: 10px 14px;
-  border-radius: 8px;
+  min-width: 0;
   word-break: break-word;
 }
 
 .message-row.user .bubble {
+  max-width: 70%;
+  padding: 10px 14px;
   background: var(--theme-primary, var(--el-color-primary));
+  border-radius: 12px 12px 3px 12px;
   color: #fff;
   white-space: pre-wrap;
 }
@@ -322,14 +306,21 @@ defineExpose({ newSession })
 }
 
 .message-row.assistant .bubble {
-  background: var(--el-fill-color-light);
-  color: var(--el-text-color-primary);
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
 }
 
 .input-bar {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-top: 12px;
+}
+
+.input-bar :deep(.el-input) {
+  flex: 1;
+  min-width: 180px;
 }
 
 /* :not(.is-link) 排除"继续"链接按钮——link 按钮的文字色本就用的是同一个主题蓝（靠透明背景显色），
@@ -349,5 +340,29 @@ defineExpose({ newSession })
   min-width: 200px;
   border-left: 1px solid var(--el-border-color-lighter);
   padding-left: 16px;
+}
+
+@media (max-width: 900px) {
+  .chat-panel {
+    flex-direction: column;
+    height: auto;
+    min-height: 60vh;
+  }
+
+  .history-column {
+    min-height: 180px;
+    padding-top: 14px;
+    padding-left: 0;
+    border-top: 1px solid var(--el-border-color-lighter);
+    border-left: 0;
+  }
+
+  .message-row.user .bubble {
+    max-width: 88%;
+  }
+
+  .input-bar {
+    flex-wrap: wrap;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
 import { createScrollFollower } from '@/utils/scrollFollower'
+import { shouldRestoreMostRecentSession } from '@/utils/conversationRestore'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
 import {
   confirmVibeCodingPlan,
@@ -132,6 +133,13 @@ async function openSession(targetSessionId: string) {
     ElMessage.error('历史会话加载失败：' + (error instanceof Error ? error.message : String(error)))
   } finally {
     historyLoading.value = false
+  }
+}
+
+/** Chat 面板同语义：只用最新历史替换首次初始化的纯空占位，不覆盖用户当前状态。 */
+function restoreMostRecentSession(targetSessionId: string) {
+  if (shouldRestoreMostRecentSession(active.value, targetSessionId, props.initialSessionId)) {
+    openSession(targetSessionId)
   }
 }
 
@@ -773,6 +781,7 @@ defineExpose({ newSession })
         :active-session-id="activeSessionId"
         :live-sessions="liveSessions"
         @select="openSession"
+        @initial-session="restoreMostRecentSession"
       />
     </div>
 

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { WarningFilled } from '@element-plus/icons-vue'
 import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
 import { createScrollFollower } from '@/utils/scrollFollower'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
@@ -15,7 +14,7 @@ import {
   saveWorkspaceFileContent,
 } from '@/api/vibecoding'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
-import TraceTimeline from '@/components/TraceTimeline.vue'
+import AssistantResponse from '@/components/AssistantResponse.vue'
 import ChatHistorySidebar from '@/components/ChatHistorySidebar.vue'
 import ReviewReport from '@/components/ReviewReport.vue'
 import ExecutionModeSelect from '@/components/ExecutionModeSelect.vue'
@@ -142,6 +141,11 @@ const scrollFollower = createScrollFollower(() => scrollRef.value)
 
 function scrollToBottom() {
   nextTick(() => scrollFollower.follow())
+}
+
+/** 只有当前会话最后一条助手消息属于本轮 SSE；正文开始输出后仍保持执行中，直到流真正完成。 */
+function isStreamingMessage(index: number): boolean {
+  return !!active.value?.streaming && index === active.value.messages.length - 1
 }
 
 onBeforeUnmount(() => scrollFollower.cancel())
@@ -554,84 +558,81 @@ defineExpose({ newSession })
     <div class="chat-column">
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
         <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
-          <div class="bubble" :class="{ failed: msg.failed }">
-            <!-- 失败提示（额度用尽/后端异常）：与正常回答区分开 -->
-            <div v-if="msg.failed" class="failed-title">
-              <el-icon><WarningFilled /></el-icon>
-              <span>本轮未完成</span>
-            </div>
-            <TraceTimeline
-              v-if="msg.role === 'assistant' && msg.nodes.length > 0"
+          <div class="bubble">
+            <AssistantResponse
+              v-if="msg.role === 'assistant'"
               :nodes="msg.nodes"
-              :active="(active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1 && !msg.text"
-            />
-            <MarkdownRenderer v-if="msg.role === 'assistant'" :text="msg.text" />
-            <!-- 沙箱编译/测试报告卡片时间线（P0-3）：每轮验证一张，通过绿/失败红，可展开看失败明细 -->
-            <div
-              v-if="msg.role === 'assistant' && msg.testReports && msg.testReports.length > 0"
-              class="test-reports"
+              :text="msg.text"
+              :active="isStreamingMessage(index)"
+              :failed="msg.failed"
             >
-              <el-collapse>
-                <el-collapse-item v-for="(report, ri) in msg.testReports" :key="ri" :name="ri">
-                  <template #title>
-                    <span class="test-report-title" :class="report.success ? 'is-success' : 'is-failure'">
-                      <el-icon v-if="report.success"><SuccessFilled /></el-icon>
-                      <el-icon v-else><CircleCloseFilled /></el-icon>
-                      <span class="test-report-title-text">{{ testReportTitle(report) }}</span>
-                      <el-tag v-if="report.exhausted" type="danger" size="small" effect="dark" class="exhausted-tag">
-                        已达最大修复轮次
-                      </el-tag>
-                    </span>
-                  </template>
-                  <div v-if="report.durationMs != null" class="test-report-meta">耗时 {{ report.durationMs }} ms</div>
-                  <ul v-if="report.failureDetails.length > 0" class="test-report-failures">
-                    <li v-for="(d, di) in report.failureDetails" :key="di">{{ d }}</li>
-                  </ul>
-                  <pre v-if="report.rawOutput" class="test-report-raw">{{ report.rawOutput }}</pre>
-                  <div
-                    v-if="report.success && report.failureDetails.length === 0 && !report.rawOutput"
-                    class="test-report-ok"
-                  >
-                    验证通过 ✓
-                  </div>
-                </el-collapse-item>
-              </el-collapse>
-            </div>
-            <!-- 协作模式多角色阶段进度（P3-1）：每个角色一张卡片，展示状态标签、类型徽标与文本产物 -->
-            <div
-              v-if="msg.role === 'assistant' && msg.stages && msg.stages.length > 0"
-              class="role-stages"
-            >
+              <!-- 沙箱编译/测试报告卡片时间线（P0-3）：每轮验证一张，通过绿/失败红，可展开看失败明细 -->
               <div
-                v-for="(stage, si) in msg.stages"
-                :key="si"
-                class="role-stage-card"
-                :class="`role-stage-card--${stage.status.toLowerCase()}`"
+                v-if="msg.testReports && msg.testReports.length > 0"
+                class="test-reports"
               >
-                <div class="role-stage-header">
-                  <span class="role-stage-name">{{ stage.role }}</span>
-                  <el-tag size="small" class="role-stage-type">{{ roleStageTypeText(stage.type) }}</el-tag>
-                  <span class="role-stage-index">{{ stage.index }}/{{ stage.total }}</span>
-                  <el-tag
-                    :type="roleStageStatusTag(stage.status)"
-                    size="small"
-                    effect="dark"
-                    class="role-stage-status"
-                  >
-                    {{ roleStageStatusText(stage.status) }}
-                  </el-tag>
-                </div>
-                <div v-if="stage.output" class="role-stage-output">
-                  <MarkdownRenderer :text="stage.output" />
+                <el-collapse>
+                  <el-collapse-item v-for="(report, ri) in msg.testReports" :key="ri" :name="ri">
+                    <template #title>
+                      <span class="test-report-title" :class="report.success ? 'is-success' : 'is-failure'">
+                        <el-icon v-if="report.success"><SuccessFilled /></el-icon>
+                        <el-icon v-else><CircleCloseFilled /></el-icon>
+                        <span class="test-report-title-text">{{ testReportTitle(report) }}</span>
+                        <el-tag v-if="report.exhausted" type="danger" size="small" effect="dark" class="exhausted-tag">
+                          已达最大修复轮次
+                        </el-tag>
+                      </span>
+                    </template>
+                    <div v-if="report.durationMs != null" class="test-report-meta">耗时 {{ report.durationMs }} ms</div>
+                    <ul v-if="report.failureDetails.length > 0" class="test-report-failures">
+                      <li v-for="(d, di) in report.failureDetails" :key="di">{{ d }}</li>
+                    </ul>
+                    <pre v-if="report.rawOutput" class="test-report-raw">{{ report.rawOutput }}</pre>
+                    <div
+                      v-if="report.success && report.failureDetails.length === 0 && !report.rawOutput"
+                      class="test-report-ok"
+                    >
+                      验证通过 ✓
+                    </div>
+                  </el-collapse-item>
+                </el-collapse>
+              </div>
+              <!-- 协作模式多角色阶段进度（P3-1）：每个角色一张卡片，展示状态标签、类型徽标与文本产物 -->
+              <div
+                v-if="msg.stages && msg.stages.length > 0"
+                class="role-stages"
+              >
+                <div
+                  v-for="(stage, si) in msg.stages"
+                  :key="si"
+                  class="role-stage-card"
+                  :class="`role-stage-card--${stage.status.toLowerCase()}`"
+                >
+                  <div class="role-stage-header">
+                    <span class="role-stage-name">{{ stage.role }}</span>
+                    <el-tag size="small" class="role-stage-type">{{ roleStageTypeText(stage.type) }}</el-tag>
+                    <span class="role-stage-index">{{ stage.index }}/{{ stage.total }}</span>
+                    <el-tag
+                      :type="roleStageStatusTag(stage.status)"
+                      size="small"
+                      effect="dark"
+                      class="role-stage-status"
+                    >
+                      {{ roleStageStatusText(stage.status) }}
+                    </el-tag>
+                  </div>
+                  <div v-if="stage.output" class="role-stage-output">
+                    <MarkdownRenderer :text="stage.output" />
+                  </div>
                 </div>
               </div>
-            </div>
-            <!-- Plan Mode 确认卡片（P1-1 HITL）：高风险操作待人工确认，批准/拒绝按钮 + 倒计时 -->
-            <PlanConfirmCard
-              v-if="msg.role === 'assistant' && msg.plans && msg.plans.length > 0"
-              :plans="msg.plans"
-              @decision="handlePlanDecision"
-            />
+              <!-- Plan Mode 确认卡片（P1-1 HITL）：高风险操作待人工确认，批准/拒绝按钮 + 倒计时 -->
+              <PlanConfirmCard
+                v-if="msg.plans && msg.plans.length > 0"
+                :plans="msg.plans"
+                @decision="handlePlanDecision"
+              />
+            </AssistantResponse>
             <template v-if="msg.role === 'user'">{{ msg.text }}</template>
             <!-- 用户消息携带的附件：图片缩略图/文本芯片，历史消息与刚发送的消息共用同一组件 -->
             <MessageAttachments
@@ -639,7 +640,6 @@ defineExpose({ newSession })
               :agent-code="agentCode"
               :attachments="msg.attachments"
             />
-            <span v-if="msg.role === 'assistant' && !msg.text && msg.nodes.length === 0 && (active?.streaming ?? false) && index === (active?.messages.length ?? 0) - 1">生成中…</span>
           </div>
         </div>
         <el-empty v-if="(active?.messages.length ?? 0) === 0" description="描述你想让智能体生成/修改的代码" />
@@ -961,30 +961,16 @@ defineExpose({ newSession })
   justify-content: flex-end;
 }
 
-.bubble.failed {
-  background: var(--el-color-danger-light-9);
-  border: 1px solid var(--el-color-danger-light-5);
-  color: var(--el-color-danger);
-}
-
-.failed-title {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-bottom: 4px;
-  font-size: 13px;
-  font-weight: 600;
-}
-
 .bubble {
-  max-width: 90%;
-  padding: 10px 14px;
-  border-radius: 8px;
+  min-width: 0;
   word-break: break-word;
 }
 
 .message-row.user .bubble {
+  max-width: 88%;
+  padding: 10px 14px;
   background: var(--theme-primary, var(--el-color-primary));
+  border-radius: 12px 12px 3px 12px;
   color: #fff;
   white-space: pre-wrap;
 }
@@ -994,14 +980,21 @@ defineExpose({ newSession })
 }
 
 .message-row.assistant .bubble {
-  background: var(--el-fill-color-light);
-  color: var(--el-text-color-primary);
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
 }
 
 .input-bar {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-top: 12px;
+}
+
+.input-bar :deep(.el-input) {
+  flex: 1;
+  min-width: 180px;
 }
 
 /* :not(.is-link) 排除"继续"链接按钮——link 按钮的文字色本就用的是同一个主题蓝（靠透明背景显色），
@@ -1351,5 +1344,42 @@ defineExpose({ newSession })
 .code-editor:focus {
   border-color: var(--theme-primary, var(--el-color-primary));
   background: var(--el-bg-color);
+}
+
+@media (max-width: 1100px) {
+  .vibecoding-panel {
+    flex-wrap: wrap;
+    gap: 12px;
+    height: auto;
+    min-height: 60vh;
+  }
+
+  .history-column {
+    flex: 1 1 100%;
+    min-height: 180px;
+    padding-top: 14px;
+    padding-left: 0;
+    border-top: 1px solid var(--el-border-color-lighter);
+    border-left: 0;
+  }
+
+  .input-bar {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 760px) {
+  .chat-column,
+  .artifacts-column {
+    flex: 1 1 100%;
+    min-height: 55vh;
+  }
+
+  .artifacts-column {
+    padding-top: 14px;
+    padding-left: 0;
+    border-top: 1px solid var(--el-border-color-lighter);
+    border-left: 0;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更说明

- 重构 Java Assistant 与 VibeCoding 的智能体思考过程、工具调用和最终回答展示，使流式输出层次更清晰、状态切换更自然。
- 抽离 SSE 与轨迹数据解析逻辑，保留流式文本空白语义，并补充前端单元测试。
- 修复关闭页签或菜单后重新进入时，最近一次对话无法恢复的问题。
- 统一消息写入与历史查询的用户身份作用域，兼容读取旧版租户级历史，并增加稳定排序与异步请求上下文清理。

## 运行时验证

- 在已登录的 Java Assistant 页面连续刷新历史列表 5 次，最近对话均稳定排在第一条并恢复完整消息。
- 连续执行浏览器 F5 刷新 5 次，对话与登录状态均正常恢复。
- 关闭智能体页签后从左侧菜单重新进入，对话历史正常展示。
- 返回首页并刷新后重新进入，冷启动场景仍可恢复最近对话。
- 旧版历史记录继续可见，浏览器控制台无业务错误。

## 测试

- `customer-work-starter`：1705 tests，0 failures，0 errors，5 skipped。
- `customer-admin-server`：1428 tests，0 failures，0 errors，1 skipped。
- 定向后端测试：12 tests，全部通过。
- 前端单元测试：16 tests，全部通过。
- 前端生产构建：通过。
- `git diff --check`：通过。
