### PR TITLE
feat(schema): 两个业务库的全量表结构快照与漂移门禁

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# 结构快照由 scripts/export-schema-snapshot.sh 生成，每次刷新都是整份重写。
+# 标成 generated 后 GitHub 的 PR diff 默认折叠它们，避免两百多 KB 的 DDL 淹没真正要看的改动。
+# 只影响 GitHub 的展示与语言统计，不改变 git 本身的任何行为。
+mysql/schema-snapshot/*.sql linguist-generated=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,15 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-08-27 表结构快照批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1705/5 skip、app-server 129、customer-channel 80、admin 1429/1 skip、gateway 1，合计 3344
+  （排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+1**、admin **+1**（两个库的结构快照门禁）。
+  **改了会进快照文件的东西（含文件头文案）之后，必须重新生成快照再复验**——本批次就踩了一次：
+  全量跑完之后才改 header，那次全量对这两个用例的结论已经失效，得重新生成 + 单独重跑。
+  另外**快照对建库 collation 只在少数表上敏感**：MySQL 8 里建表语句写了 `DEFAULT CHARSET=utf8mb4`
+  却不写 COLLATE 时用的是字符集默认的 `utf8mb4_0900_ai_ci` 而非库的 collation，所以两个库的快照里
+  两种 collation 并存是既有状况；只有 `ENGINE=InnoDB;` 这种连 charset 都不写的表才继承建库参数。
+  上一版基线 2026-08-20 公共常量收敛批次：合计 2485。）
   （2026-08-20 公共常量收敛批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，6 skip。
   本批次自身加 starter **+2**（`SharedConstantAlignmentTest`：已收敛值不得重新声明 + 同值不得多处定义）。
   **同值不同概念别硬合**：本批次差点把 `sys_operation_log.result` 与 `ai_coding_audit_log.result`
@@ -120,7 +129,7 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   外部依赖门控测试：MySQL(root/root)、Redis(密码 123456)、Nacos(nacos/nacos:8848)，不可达自动跳过。
 - **本机跑全量的环境门控**：Redis 无密码时 `RedisSessionPersistenceTest` 必挂，需排除
   （starter 一挂会让下游模块整体 skip，`-fae` 也救不回来）：
-  `-Dtest='!RedisSessionPersistenceTest' -DfailIfNoSpecifiedTests=false`
+  `-Dtest='!RedisSessionPersistenceTest' -Dsurefire.failIfNoSpecifiedTests=false`
   MinIO 起在 9000 时 `MinioAttachmentFileStorageIntegrationTest` 可以正常跑，不必再排除；
   9000 被别的栈（如 kb-rag）占用时才需要连它一起排除。
 - 模块 A 改完给模块 B 用时，先 `mvn install -Dmaven.test.skip=true -Djacoco.skip=true`（B 解析的是本地仓库的 jar，
@@ -228,6 +237,19 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   字典序即执行序）。那个目录是 Flyway 迁移的镜像副本，供手工初始化与 **CI 建库**使用；漏同步不会影响本地
   （本地走 Flyway），但 CI 从空库灌脚本时会在依赖该表的后续脚本上炸掉——V27/V28/V36/V37/V38/V39/V41 就这么漏了 7 个，
   让 main 的 CI 从 PR #65 起连红 6 次（表现为 `Table 'customer_admin.cw_agent_call_log' doesn't exist`）。
+- **改完任何一条迁移都要跑 `./scripts/export-schema-snapshot.sh` 刷新结构快照**
+  （`mysql/schema-snapshot/{agent_scope_customer_work,customer_admin}.sql`）。这两份是「这两个库现在长什么样」
+  的直接答案，只读、不参与建库，改它们不会对任何库生效。**生成源必须是临时空库跑完迁移的产物，不是开发机的
+  长期业务库**——本机库被并行分支的迁移反复试跑过，沉积的结构与迁移产物无法区分，直接 dump 等于把污染固化。
+  漏刷新由 `CustomerWorkSchemaSnapshotTest` / `CustomerAdminSchemaSnapshotTest` 拦下：它们每次跑测试都重新
+  迁移一个临时库比对快照，不一致会指出是哪张表的第几行。**门禁与生成共用 `SchemaSnapshotExporter` 一段逻辑**，
+  不会出现「脚本生成的和门禁期望的不是一回事」。两条相关事实：
+  ① 客服端快照刻意不含框架自建的 `agentscope_sessions`（`MysqlSession` 内置 DDL 建的，没有迁移可导出它）；
+  ② 快照内容取决于 `SHOW CREATE TABLE` 的输出格式，跨 MySQL 大版本升级后需要重新生成一次，那是预期内的
+  一次性刷新而不是漂移。
+- **surefire 3.1.2 的跳过空匹配参数是 `-Dsurefire.failIfNoSpecifiedTests=false`**，不带 `surefire.` 前缀的
+  旧名已失效。只在「指定的测试类在某个模块里一个都没匹配上」时才暴露，多模块 `-Dtest=A,B` 恰好每个模块都
+  命中一个时照样通过，所以很容易一直写错而不自知。
 - **迁移脚本里不要写库名前缀**（`INSERT INTO \`customer_admin\`.\`xxx\``）：脚本执行时已经 USE 到目标库，
   写死库名会让脚本换库不可用，验证/多环境时甚至串库写到别的库去。V14 踩过。
 - **多租户（B1 起）**：隔离靠 MyBatis-Plus `TenantLineInnerInterceptor` 全局改写，租户值取自

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/schema/CustomerAdminSchemaSnapshotTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/schema/CustomerAdminSchemaSnapshotTest.java
@@ -1,0 +1,204 @@
+package com.richard.fyoung.customeradmin.schema;
+
+import com.richard.fyoung.customerwork.infra.migration.SchemaSnapshotExporter;
+import com.zaxxer.hikari.HikariDataSource;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * 后台管理库全量表结构快照的生成与漂移门禁。
+ *
+ * <p>与客服端库那一侧同构：默认新建临时库跑完 {@code classpath:db/migration} 的全部迁移，
+ * 把导出结果与仓库内快照逐字比对；带 {@code -Dschema.snapshot.write=true} 时改为覆写快照文件。
+ * 导出逻辑复用 starter 的 {@code SchemaSnapshotExporter}，两个库的归一化规则只有一处。</p>
+ *
+ * <p>本库此前没有任何全量结构文件，建新库只能按序执行 {@code mysql/02-customer-admin/} 下近百个
+ * 迁移副本。快照补上的是「当前结构长什么样」这个问题的直接答案，不替代那批副本的建库职责。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class CustomerAdminSchemaSnapshotTest {
+
+    private static final String HOST = System.getenv().getOrDefault("MYSQL_HOST", "localhost");
+    private static final int PORT = Integer.parseInt(System.getenv().getOrDefault("MYSQL_PORT", "3306"));
+    private static final String USERNAME = env("ADMIN_MYSQL_USERNAME", "root");
+    private static final String PASSWORD = env("ADMIN_MYSQL_PASSWORD", "root");
+
+    private static final String SNAPSHOT_PATH = "mysql/schema-snapshot/customer_admin.sql";
+    private static final String DATABASE_NAME = "customer_admin";
+    private static final String MIGRATION_LOCATION = "classpath:db/migration";
+    private static final int SOCKET_TIMEOUT_MS = 500;
+
+    @Test
+    void snapshotShouldStayInSyncWithMigrations() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过后台库结构快照门禁");
+        String database = "admin_snapshot_" + randomSuffix();
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过后台库结构快照门禁");
+
+        try (HikariDataSource dataSource = dataSource(database)) {
+            migrate(dataSource);
+            String exported;
+            try (Connection connection = dataSource.getConnection()) {
+                exported = SchemaSnapshotExporter.export(connection, header(connection));
+            }
+
+            Path snapshot = repositoryRoot().resolve(SNAPSHOT_PATH);
+            if (SchemaSnapshotExporter.writeModeEnabled()) {
+                Files.createDirectories(snapshot.getParent());
+                Files.writeString(snapshot, exported, StandardCharsets.UTF_8);
+                return;
+            }
+
+            assertTrue(Files.exists(snapshot),
+                "快照文件缺失：" + SNAPSHOT_PATH + "，执行 scripts/export-schema-snapshot.sh 生成");
+            String difference = SchemaSnapshotExporter.describeDifference(
+                Files.readString(snapshot, StandardCharsets.UTF_8), exported);
+            assertNull(difference,
+                "后台库结构快照与迁移产物不一致。新增或修改迁移后必须执行 "
+                    + "scripts/export-schema-snapshot.sh 重新生成快照。\n" + difference);
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    /**
+     * 构造快照文件头。
+     *
+     * <p>只放由迁移本身决定的信息：写入生成时间或机器名会让每次导出的文本都不同，门禁就永远是红的。</p>
+     */
+    private String header(Connection connection) throws Exception {
+        return "-- ----------------------------------------------------------------------------\n"
+            + "-- " + DATABASE_NAME + " 全量表结构快照（自动生成，请勿手工编辑）\n"
+            + "-- ----------------------------------------------------------------------------\n"
+            + "-- 生成方式：scripts/export-schema-snapshot.sh\n"
+            + "--           新建临时空库执行 " + MIGRATION_LOCATION + " 的全部迁移后逐表导出，\n"
+            + "--           自增当前值已抹除。\n"
+            + "-- 对应版本：Flyway V" + lastAppliedVersion(connection) + "\n"
+            + "-- 真源：customer-admin-server/src/main/resources/db/migration/\n"
+            + "--       改结构一律新增迁移，改本文件不会生效。\n"
+            + "-- 用途：结构查阅与全新建库。**不要对已有库执行**，这里没有 IF NOT EXISTS 保护。\n"
+            + "--       生产手工初始化仍按 mysql/02-customer-admin/ 的迁移副本顺序执行，\n"
+            + "--       那条路径会留下 flyway_schema_history，之后能继续增量升级。\n"
+            + "-- 建库：CREATE DATABASE `" + DATABASE_NAME + "`\n"
+            + "--         DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\n"
+            + "-- COLLATE 说明：快照里同时出现 utf8mb4_0900_ai_ci 与 utf8mb4_unicode_ci 是既有状况，\n"
+            + "--               不是导出错误。MySQL 8 的规则：建表语句写了 DEFAULT CHARSET=utf8mb4\n"
+            + "--               却没写 COLLATE 时，用的是该字符集的默认 collation(utf8mb4_0900_ai_ci)\n"
+            + "--               而非库的；显式写了 COLLATE 的按其声明；只有既不写 CHARSET 也不写\n"
+            + "--               COLLATE 的少数表才继承上面的建库参数——所以导出必须固定按上面的参数\n"
+            + "--               建库，换一套参数会让那几张表的输出跟着变。\n"
+            + "-- ----------------------------------------------------------------------------\n"
+            + "\n"
+            + "SET NAMES utf8mb4;\n";
+    }
+
+    /** 取最后执行的那条迁移的版本号：空库全量迁移时它就是当前最高版本。 */
+    private String lastAppliedVersion(Connection connection) throws Exception {
+        String sql = "SELECT `version` FROM `flyway_schema_history` "
+            + "WHERE `version` IS NOT NULL ORDER BY `installed_rank` DESC LIMIT 1";
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            return resultSet.next() ? resultSet.getString(1) : "unknown";
+        }
+    }
+
+    /**
+     * 按生产同款参数执行迁移。
+     *
+     * <p>{@code placeholderReplacement(false)} 不能省：V14 的种子数据含 {@code ${now-14d}}
+     * （SqlParamValueResolver 的动态日期语法），开着占位符替换会让 Flyway 把它当自己的占位符，
+     * 直接中断迁移。</p>
+     */
+    private void migrate(HikariDataSource dataSource) {
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations(MIGRATION_LOCATION)
+            .baselineOnMigrate(true)
+            .placeholderReplacement(false)
+            .validateMigrationNaming(true)
+            .cleanDisabled(true)
+            .load()
+            .migrate();
+    }
+
+    private Path repositoryRoot() {
+        Path workingDirectory = Path.of("").toAbsolutePath();
+        return Files.isDirectory(workingDirectory.resolve("mysql"))
+            ? workingDirectory : workingDirectory.getParent();
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), SOCKET_TIMEOUT_MS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean createDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE " + quoted(database)
+                + " DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+            return true;
+        } catch (Exception e) {
+            dropDatabase(database);
+            return false;
+        }
+    }
+
+    private void dropDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DROP DATABASE IF EXISTS " + quoted(database));
+        } catch (Exception ignored) {
+            // 清理失败不覆盖原始断言；随机库名不会影响业务库，残留可按 admin_snapshot_* 识别。
+        }
+    }
+
+    private Connection adminConnection() throws Exception {
+        return DriverManager.getConnection("jdbc:mysql://" + HOST + ":" + PORT
+            + "/?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC", USERNAME, PASSWORD);
+    }
+
+    private HikariDataSource dataSource(String database) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl("jdbc:mysql://" + HOST + ":" + PORT + "/" + database
+            + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8");
+        dataSource.setUsername(USERNAME);
+        dataSource.setPassword(PASSWORD);
+        dataSource.setMaximumPoolSize(2);
+        dataSource.setPoolName("admin-schema-snapshot");
+        return dataSource;
+    }
+
+    private static String env(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isEmpty() ? defaultValue : value;
+    }
+
+    private static String randomSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+
+    private String quoted(String identifier) {
+        if (!identifier.matches("[a-z0-9_]+")) {
+            throw new IllegalArgumentException("illegal database identifier: " + identifier);
+        }
+        return "`" + identifier + "`";
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/migration/SchemaSnapshotExporter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/migration/SchemaSnapshotExporter.java
@@ -1,0 +1,162 @@
+package com.richard.fyoung.customerwork.infra.migration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * 全量表结构快照导出器：把一个已迁移到目标版本的库导成可复现的 DDL 文本。
+ *
+ * <p>不用 mysqldump 是因为它的输出带自增当前值、工具版本注释与转储时间，同一套迁移每次导出的
+ * 结果都不同，没法拿来做漂移比对。这里逐表取 {@code SHOW CREATE TABLE} 再抹掉随数据变化的部分，
+ * 保证「同一套迁移 + 同样建库参数」在任意时刻导出的文本逐字一致——快照文件与门禁测试才能共用
+ * 同一段生成逻辑，不会各自漂移。</p>
+ *
+ * <p>导出源必须是<b>按仓库标准流程新建并跑完迁移的临时库</b>，不能是开发机上的长期业务库：后者
+ * 沉积了并行分支试跑过的结构，快照会把这些沉积物一并固化，且没有任何机制能发现。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class SchemaSnapshotExporter {
+
+    /** Flyway 自身的版本记录表：结构与业务无关，内容随执行历史变化，不进快照。 */
+    private static final String FLYWAY_HISTORY_TABLE = "flyway_schema_history";
+
+    /** 自增当前值随写入量变化，是快照里最主要的噪音来源。 */
+    private static final Pattern AUTO_INCREMENT_VALUE = Pattern.compile(" AUTO_INCREMENT=\\d+");
+
+    /** 快照固定用 LF，避免不同平台检出后 diff 全红。 */
+    private static final String LINE_SEPARATOR = "\n";
+
+    /** 建表语句前缀：用于把差异行回溯到所属表。 */
+    private static final String CREATE_TABLE_PREFIX = "CREATE TABLE `";
+
+    private static final String SECTION_RULE =
+        "-- ----------------------------------------------------------------------------";
+
+    private static final String LIST_TABLES_SQL =
+        "SELECT table_name FROM information_schema.tables "
+            + "WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' ORDER BY table_name";
+
+    /**
+     * 写入模式开关：置 true 时由生成侧覆写仓库内的快照文件，否则只做漂移比对。
+     *
+     * <p>两个库的快照测试共用这一个属性名。名字分散写会出现「脚本只刷新了一个库、另一个库悄悄留在
+     * 旧版本」，而两边都不报错。</p>
+     */
+    public static final String WRITE_MODE_PROPERTY = "schema.snapshot.write";
+
+    private SchemaSnapshotExporter() {
+    }
+
+    /** 当前是否处于快照写入模式（由 scripts/export-schema-snapshot.sh 传入）。 */
+    public static boolean writeModeEnabled() {
+        return Boolean.getBoolean(WRITE_MODE_PROPERTY);
+    }
+
+    /**
+     * 导出当前连接所指库的全量表结构。
+     *
+     * @param connection 指向已完成迁移的库的连接
+     * @param header     文件头文本，由调用方给出（不同库的说明与执行方式不同），需自带结尾换行
+     * @return 归一化后的完整快照文本
+     */
+    public static String export(Connection connection, String header) throws SQLException {
+        StringBuilder snapshot = new StringBuilder(header);
+        for (String table : listBaseTables(connection)) {
+            snapshot.append(LINE_SEPARATOR)
+                .append(SECTION_RULE).append(LINE_SEPARATOR)
+                .append("-- ").append(table).append(LINE_SEPARATOR)
+                .append(SECTION_RULE).append(LINE_SEPARATOR)
+                .append(normalize(showCreateTable(connection, table)))
+                .append(';').append(LINE_SEPARATOR);
+        }
+        return snapshot.toString();
+    }
+
+    /**
+     * 比对仓库内快照与本次导出产物，一致返回 {@code null}，否则返回定位到行的差异描述。
+     *
+     * <p>不能直接把两份全文丢给 assertEquals：快照有五万到十几万字符，断言失败时整篇打进报告里，
+     * 人根本看不出改了哪张表的哪一列，只能自己 diff 一遍。这里直接给出第一处差异的行号、所属表
+     * 与两侧内容，看一眼就知道是漏刷新了还是迁移真的变了。</p>
+     *
+     * @param expected 仓库内快照文件内容
+     * @param actual   本次从临时库导出的产物
+     */
+    public static String describeDifference(String expected, String actual) {
+        if (expected.equals(actual)) {
+            return null;
+        }
+        String[] expectedLines = expected.split(LINE_SEPARATOR, -1);
+        String[] actualLines = actual.split(LINE_SEPARATOR, -1);
+        int commonLines = Math.min(expectedLines.length, actualLines.length);
+        for (int index = 0; index < commonLines; index++) {
+            if (!expectedLines[index].equals(actualLines[index])) {
+                return "第 " + (index + 1) + " 行不一致" + tableHint(expectedLines, index) + LINE_SEPARATOR
+                    + "  快照文件：" + expectedLines[index] + LINE_SEPARATOR
+                    + "  迁移产物：" + actualLines[index];
+            }
+        }
+        boolean actualIsLonger = actualLines.length > expectedLines.length;
+        String[] extraLines = actualIsLonger ? actualLines : expectedLines;
+        String side = actualIsLonger ? "迁移产物" : "快照文件";
+        return "前 " + commonLines + " 行一致，" + side + "多出 "
+            + (extraLines.length - commonLines) + " 行" + tableHint(extraLines, commonLines) + LINE_SEPARATOR
+            + "  首行内容：" + extraLines[commonLines];
+    }
+
+    /** 从差异位置往上找最近的建表语句，把差异落到具体某张表上。 */
+    private static String tableHint(String[] lines, int index) {
+        for (int cursor = Math.min(index, lines.length - 1); cursor >= 0; cursor--) {
+            if (lines[cursor].startsWith(CREATE_TABLE_PREFIX)) {
+                String remainder = lines[cursor].substring(CREATE_TABLE_PREFIX.length());
+                int end = remainder.indexOf('`');
+                return end > 0 ? "（表 " + remainder.substring(0, end) + "）" : "";
+            }
+        }
+        return "（文件头）";
+    }
+
+    /** 列出参与快照的业务表，按表名排序保证顺序稳定。 */
+    private static List<String> listBaseTables(Connection connection) throws SQLException {
+        List<String> tables = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(LIST_TABLES_SQL);
+             ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                String table = resultSet.getString(1);
+                if (!FLYWAY_HISTORY_TABLE.equals(table)) {
+                    tables.add(table);
+                }
+            }
+        }
+        return tables;
+    }
+
+    private static String showCreateTable(Connection connection, String table) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SHOW CREATE TABLE " + quoted(table))) {
+            if (!resultSet.next()) {
+                throw new SQLException("table disappeared while exporting snapshot: " + table);
+            }
+            return resultSet.getString(2);
+        }
+    }
+
+    /** 抹掉随数据变化的部分，只保留结构本身。 */
+    private static String normalize(String ddl) {
+        return AUTO_INCREMENT_VALUE.matcher(ddl).replaceAll("");
+    }
+
+    private static String quoted(String identifier) {
+        if (!identifier.matches("[a-z0-9_]+")) {
+            throw new IllegalArgumentException("illegal database identifier: " + identifier);
+        }
+        return "`" + identifier + "`";
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/migration/CustomerWorkSchemaSnapshotTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/migration/CustomerWorkSchemaSnapshotTest.java
@@ -1,0 +1,189 @@
+package com.richard.fyoung.customerwork.infra.migration;
+
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkProperties;
+import com.richard.fyoung.customerwork.infra.config.CustomerWorkSchemaMigrator;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * 客服端业务库全量表结构快照的生成与漂移门禁。
+ *
+ * <p>默认跑门禁：新建临时库跑完全部迁移，把导出结果与仓库内快照逐字比对，不一致直接红——
+ * 加了迁移却忘了刷新快照会在这里被拦下。带 {@code -Dschema.snapshot.write=true} 时改为
+ * 覆写快照文件，供 {@code scripts/export-schema-snapshot.sh} 调用。生成与校验共用同一段导出
+ * 逻辑，不存在「脚本生成的和门禁期望的不是一回事」。</p>
+ *
+ * <p>刻意不从开发机的长期业务库导出：那个库被并行分支的迁移反复试跑过，沉积的结构无法与迁移
+ * 产物区分，快照会把它们一并固化。MySQL 不可达或账号无建库权限时自动跳过。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class CustomerWorkSchemaSnapshotTest {
+
+    private static final String HOST = System.getenv().getOrDefault("MYSQL_HOST", "localhost");
+    private static final int PORT = Integer.parseInt(System.getenv().getOrDefault("MYSQL_PORT", "3306"));
+    private static final String USERNAME = System.getenv().getOrDefault("MYSQL_USERNAME", "root");
+    private static final String PASSWORD = System.getenv().getOrDefault("MYSQL_PASSWORD", "root");
+
+    private static final String SNAPSHOT_PATH = "mysql/schema-snapshot/agent_scope_customer_work.sql";
+    private static final String DATABASE_NAME = "agent_scope_customer_work";
+    private static final int SOCKET_TIMEOUT_MS = 500;
+
+    @Test
+    void snapshotShouldStayInSyncWithMigrations() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过客服端库结构快照门禁");
+        String database = "cw_snapshot_" + randomSuffix();
+        assumeTrue(createDatabase(database), "MySQL 测试账号无建库权限，跳过客服端库结构快照门禁");
+
+        try (HikariDataSource dataSource = dataSource(database)) {
+            migrate(dataSource, database);
+            String exported;
+            try (Connection connection = dataSource.getConnection()) {
+                exported = SchemaSnapshotExporter.export(connection, header(connection));
+            }
+
+            Path snapshot = repositoryRoot().resolve(SNAPSHOT_PATH);
+            if (SchemaSnapshotExporter.writeModeEnabled()) {
+                Files.createDirectories(snapshot.getParent());
+                Files.writeString(snapshot, exported, StandardCharsets.UTF_8);
+                return;
+            }
+
+            assertTrue(Files.exists(snapshot),
+                "快照文件缺失：" + SNAPSHOT_PATH + "，执行 scripts/export-schema-snapshot.sh 生成");
+            String difference = SchemaSnapshotExporter.describeDifference(
+                Files.readString(snapshot, StandardCharsets.UTF_8), exported);
+            assertNull(difference,
+                "客服端库结构快照与迁移产物不一致。新增或修改迁移后必须执行 "
+                    + "scripts/export-schema-snapshot.sh 重新生成快照。\n" + difference);
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    /**
+     * 构造快照文件头。
+     *
+     * <p>只放由迁移本身决定的信息：写入生成时间或机器名会让每次导出的文本都不同，门禁就永远是红的。</p>
+     */
+    private String header(Connection connection) throws Exception {
+        return "-- ----------------------------------------------------------------------------\n"
+            + "-- " + DATABASE_NAME + " 全量表结构快照（自动生成，请勿手工编辑）\n"
+            + "-- ----------------------------------------------------------------------------\n"
+            + "-- 生成方式：scripts/export-schema-snapshot.sh\n"
+            + "--           新建临时空库执行 classpath:db/customerwork/migration 的全部迁移\n"
+            + "--           （含 V2/V9 两个 Java 迁移）后逐表导出，自增当前值已抹除。\n"
+            + "-- 对应版本：Flyway V" + lastAppliedVersion(connection) + "\n"
+            + "-- 真源：customer-work-starter/src/main/resources/db/customerwork/migration/\n"
+            + "--       + com.richard.fyoung.customerwork.infra.migration 下的 Java 迁移。\n"
+            + "--       改结构一律新增迁移，改本文件不会生效。\n"
+            + "-- 用途：结构查阅与全新建库。**不要对已有库执行**，这里没有 IF NOT EXISTS 保护。\n"
+            + "-- 缺表说明：框架会话表 agentscope_sessions 不在本快照内——它由 AgentScope 的\n"
+            + "--           MysqlSession 在首次连接时按内置 DDL 自建，不归 Flyway 管，因此也没有\n"
+            + "--           迁移可以导出它。用本快照建库后由框架自行补上，不是遗漏。\n"
+            + "-- 建库：CREATE DATABASE `" + DATABASE_NAME + "`\n"
+            + "--         DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\n"
+            + "-- COLLATE 说明：快照里同时出现 utf8mb4_0900_ai_ci 与 utf8mb4_unicode_ci 是既有状况，\n"
+            + "--               不是导出错误。MySQL 8 的规则：建表语句写了 DEFAULT CHARSET=utf8mb4\n"
+            + "--               却没写 COLLATE 时，用的是该字符集的默认 collation(utf8mb4_0900_ai_ci)\n"
+            + "--               而非库的；显式写了 COLLATE 的按其声明；只有既不写 CHARSET 也不写\n"
+            + "--               COLLATE 的少数表才继承上面的建库参数——所以导出必须固定按上面的参数\n"
+            + "--               建库，换一套参数会让那几张表的输出跟着变。\n"
+            + "-- ----------------------------------------------------------------------------\n"
+            + "\n"
+            + "SET NAMES utf8mb4;\n";
+    }
+
+    /** 取最后执行的那条迁移的版本号：空库全量迁移时它就是当前最高版本。 */
+    private String lastAppliedVersion(Connection connection) throws Exception {
+        String sql = "SELECT `version` FROM `flyway_schema_history` "
+            + "WHERE `version` IS NOT NULL ORDER BY `installed_rank` DESC LIMIT 1";
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            return resultSet.next() ? resultSet.getString(1) : "unknown";
+        }
+    }
+
+    private void migrate(HikariDataSource dataSource, String database) {
+        CustomerWorkProperties properties = new CustomerWorkProperties();
+        properties.getSession().getMysql().setDatabase(database);
+        properties.getSession().getMysql().setMigrationEnabled(true);
+        new CustomerWorkSchemaMigrator(dataSource, properties).afterPropertiesSet();
+    }
+
+    private Path repositoryRoot() {
+        Path workingDirectory = Path.of("").toAbsolutePath();
+        return Files.isDirectory(workingDirectory.resolve("mysql"))
+            ? workingDirectory : workingDirectory.getParent();
+    }
+
+    private boolean reachable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), SOCKET_TIMEOUT_MS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean createDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE " + quoted(database)
+                + " DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+            return true;
+        } catch (Exception e) {
+            dropDatabase(database);
+            return false;
+        }
+    }
+
+    private void dropDatabase(String database) {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DROP DATABASE IF EXISTS " + quoted(database));
+        } catch (Exception ignored) {
+            // 清理失败不覆盖原始断言；随机库名不会影响业务库，残留可按 cw_snapshot_* 识别。
+        }
+    }
+
+    private Connection adminConnection() throws Exception {
+        return DriverManager.getConnection("jdbc:mysql://" + HOST + ":" + PORT
+            + "/?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC", USERNAME, PASSWORD);
+    }
+
+    private HikariDataSource dataSource(String database) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl("jdbc:mysql://" + HOST + ":" + PORT + "/" + database
+            + "?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8");
+        dataSource.setUsername(USERNAME);
+        dataSource.setPassword(PASSWORD);
+        dataSource.setMaximumPoolSize(2);
+        dataSource.setPoolName("cw-schema-snapshot");
+        return dataSource;
+    }
+
+    private static String randomSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+
+    private String quoted(String identifier) {
+        if (!identifier.matches("[a-z0-9_]+")) {
+            throw new IllegalArgumentException("illegal database identifier: " + identifier);
+        }
+        return "`" + identifier + "`";
+    }
+}

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -2314,6 +2314,7 @@ customer_work/                                  # 父 pom（packaging=pom，聚�
 ├── mysql/01-agent-scope-customer-work/         # 客服主业务库建库脚本（customer-work-schema.sql）
 ├── mysql/02-customer-admin/                    # customer-admin-server 建库脚本（V1~V20 有序副本，独立库）
 ├── mysql/03-xxl-job/                           # XXL-JOB 调度中心库（可选）
+├── mysql/schema-snapshot/                      # 两个业务库的全量表结构快照（只读，由 scripts/export-schema-snapshot.sh 生成）
 ├── Dockerfile / docker-compose.yml             # 多模块构建 + 一键起依赖
 └── .github/workflows/ci.yml                    # CI（Redis/MySQL/Nacos 服务容器）
 ```

--- a/docs/新人必读.md
+++ b/docs/新人必读.md
@@ -155,6 +155,7 @@ HTTP 请求
 **给 customer-admin 加一个后台菜单/页面**：
 - 后端：`customer-admin-server` 加 Controller（Sa-Token `@SaCheckPermission` 权限点 + `@OperationLog` + `Result<T>` 包装），需要 starter 能力时在自己的 `@Configuration` 里显式 new（admin 排除了 starter 自动装配）。
 - 迁移：新增 `db/migration/Vxx__*.sql` 登记菜单/权限（含中文务必 utf8mb4 方式执行，见 CLAUDE.local.md 字符集坑），同步副本到 `mysql/02-customer-admin/`（加两位序号前缀）。
+- 结构快照：改了任何一条迁移都要跑 `./scripts/export-schema-snapshot.sh` 刷新 `mysql/schema-snapshot/`，漏刷新会被快照门禁测试拦下。
 - 前端：`customer-admin-web` 加页面 + 在 `router/component-map.ts` 注册组件映射，按钮用 `v-permission` 指令控显隐。
 
 > 想作为**库**用在你自己的工程里？只引入 `customer-work-starter` 依赖即可（见 [功能与配置全量参考 §9.1](功能与配置全量参考.md)），

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -7,6 +7,7 @@
 | 01 | `01-agent-scope-customer-work/` | `agent_scope_customer_work` | customer-work-app-server（8080，客服/工单/订单业务库） |
 | 02 | `02-customer-admin/` | `customer_admin` | customer-admin-server（8082，后台管理库） |
 | 03 | `03-xxl-job/` | `xxl_job` | XXL-JOB 调度中心（可选，未部署调度中心可跳过） |
+| — | `schema-snapshot/` | 两个业务库 | **只读结构快照，不参与建库流程**，见下方专节 |
 
 ## 执行方式
 
@@ -33,10 +34,45 @@ mysql -uroot -p --default-character-set=utf8mb4 xxl_job < 03-xxl-job/xxl-job-sch
 
 | 本目录文件 | 真源 | 同步时机 |
 |---|---|---|
-| `01-agent-scope-customer-work/customer-work-schema.sql` | starter `src/main/resources/customerwork/schema/customer-work-schema.sql`（SchemaInitializer 启动自动建表用） | 每次改业务表结构 |
+| `01-agent-scope-customer-work/customer-work-schema.sql` | starter `src/main/resources/db/customerwork/migration/` 的 Flyway 迁移 + `infra/migration` 下的 V2/V9 两个 Java 迁移 | 每次改业务表结构 |
 | `02-customer-admin/NN-V*.sql` | customer-admin-server `src/main/resources/db/migration/V*.sql`（Flyway，dev 环境自动执行） | 每新增一个迁移，复制过来并加两位序号前缀 |
 | `03-xxl-job/xxl-job-schema.sql` | XXL-JOB 官方发行包 | 升级调度中心版本时 |
 
 - `customer_admin` 库不再维护合并版 schema（历史的 `admin-schema.sql` 已删除——它欠账 V12~V18，
   内容不完整且易误导）；需要全新建库就按序执行 20 个迁移副本。
 - 已有环境增量升级：只执行比当前库版本号大的迁移（Flyway 环境看 `flyway_schema_history` 表）。
+
+## `schema-snapshot/` — 全量表结构快照
+
+回答「这两个库现在长什么样」的直接答案。**只读，不参与任何建库流程**：
+
+| 文件 | 内容 |
+|---|---|
+| `agent_scope_customer_work.sql` | 客服端业务库 47 张表（框架自建的 `agentscope_sessions` 不在内，见文件头说明） |
+| `customer_admin.sql` | 后台管理库 88 张表 |
+
+- **不要手工编辑**，改结构一律新增迁移；改快照文件不会对任何库生效。
+- **不要对已有库执行**：里面是裸 `CREATE TABLE`，没有 `IF NOT EXISTS` 保护。
+- 生产建库仍走 `01-`/`02-` 那两条路径——快照里没有种子数据，`02-` 那条还会留下
+  `flyway_schema_history` 以便后续增量升级。
+
+### 怎么刷新
+
+```bash
+./scripts/export-schema-snapshot.sh
+```
+
+各起一个带随机后缀的临时空库跑完全部迁移后逐表导出，最后删库。**刻意不从开发机的长期业务库导出**：
+那个库被并行分支的迁移反复试跑过，沉积的结构与迁移产物无法区分，直接 dump 会把它们一并固化下来。
+
+### 漏刷新会被拦下
+
+`CustomerWorkSchemaSnapshotTest` / `CustomerAdminSchemaSnapshotTest` 每次跑测试都会重新迁移一个临时库、
+把产物与快照逐字比对，不一致直接红并指出是哪张表的第几行。生成与校验共用同一段导出逻辑
+（`SchemaSnapshotExporter`），不存在「脚本生成的和门禁期望的不是一回事」。
+
+CI 跑全量 `mvn clean test`，因此这两个门禁在 PR 上自动生效，无需额外配置。MySQL 不可达时自动跳过。
+
+> 快照内容取决于 MySQL 的 `SHOW CREATE TABLE` 输出格式。跨大版本（8.0 → 8.4）升级 MySQL 后
+> 需要重新生成一次，属预期内的一次性刷新，不是漂移。
+

--- a/mysql/schema-snapshot/agent_scope_customer_work.sql
+++ b/mysql/schema-snapshot/agent_scope_customer_work.sql
@@ -1,0 +1,1004 @@
+-- ----------------------------------------------------------------------------
+-- agent_scope_customer_work 全量表结构快照（自动生成，请勿手工编辑）
+-- ----------------------------------------------------------------------------
+-- 生成方式：scripts/export-schema-snapshot.sh
+--           新建临时空库执行 classpath:db/customerwork/migration 的全部迁移
+--           （含 V2/V9 两个 Java 迁移）后逐表导出，自增当前值已抹除。
+-- 对应版本：Flyway V21
+-- 真源：customer-work-starter/src/main/resources/db/customerwork/migration/
+--       + com.richard.fyoung.customerwork.infra.migration 下的 Java 迁移。
+--       改结构一律新增迁移，改本文件不会生效。
+-- 用途：结构查阅与全新建库。**不要对已有库执行**，这里没有 IF NOT EXISTS 保护。
+-- 缺表说明：框架会话表 agentscope_sessions 不在本快照内——它由 AgentScope 的
+--           MysqlSession 在首次连接时按内置 DDL 自建，不归 Flyway 管，因此也没有
+--           迁移可以导出它。用本快照建库后由框架自行补上，不是遗漏。
+-- 建库：CREATE DATABASE `agent_scope_customer_work`
+--         DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+-- COLLATE 说明：快照里同时出现 utf8mb4_0900_ai_ci 与 utf8mb4_unicode_ci 是既有状况，
+--               不是导出错误。MySQL 8 的规则：建表语句写了 DEFAULT CHARSET=utf8mb4
+--               却没写 COLLATE 时，用的是该字符集的默认 collation(utf8mb4_0900_ai_ci)
+--               而非库的；显式写了 COLLATE 的按其声明；只有既不写 CHARSET 也不写
+--               COLLATE 的少数表才继承上面的建库参数——所以导出必须固定按上面的参数
+--               建库，换一套参数会让那几张表的输出跟着变。
+-- ----------------------------------------------------------------------------
+
+SET NAMES utf8mb4;
+
+-- ----------------------------------------------------------------------------
+-- cw_agent_call_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_agent_call_log` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `request_id` varchar(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
+  `user_id` varchar(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
+  `username` varchar(128) NOT NULL DEFAULT '' COMMENT '用户名',
+  `agent_code` varchar(128) NOT NULL DEFAULT '' COMMENT '智能体编码',
+  `agent_name` varchar(255) NOT NULL DEFAULT '' COMMENT '智能体名称',
+  `session_id` varchar(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+  `session_type` varchar(32) NOT NULL DEFAULT 'CHAT' COMMENT '会话类型 CHAT/VIBE_CODING',
+  `question` mediumtext COMMENT '用户问题',
+  `answer` mediumtext COMMENT '智能体回答',
+  `start_time` bigint NOT NULL COMMENT '调用开始时间戳（毫秒）',
+  `end_time` bigint NOT NULL COMMENT '调用结束时间戳（毫秒）',
+  `duration_ms` bigint NOT NULL DEFAULT '0' COMMENT '总耗时（毫秒）',
+  `model_ms` bigint NOT NULL DEFAULT '0' COMMENT 'MODEL段耗时合计（毫秒）',
+  `tool_ms` bigint NOT NULL DEFAULT '0' COMMENT 'TOOL段耗时合计（毫秒）',
+  `mcp_ms` bigint NOT NULL DEFAULT '0' COMMENT 'MCP段耗时合计（毫秒）',
+  `skill_ms` bigint NOT NULL DEFAULT '0' COMMENT 'SKILL段耗时合计（毫秒）',
+  `segment_count` int NOT NULL DEFAULT '0' COMMENT '分段总数',
+  `input_tokens` bigint DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）',
+  `output_tokens` bigint DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）',
+  `total_tokens` bigint DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）',
+  `cached_tokens` bigint DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）',
+  `model_reported_ms` bigint DEFAULT NULL COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销',
+  `model_cost_amount` decimal(30,14) DEFAULT NULL COMMENT '本次调用已结算模型金额',
+  `model_cost_currency` varchar(16) DEFAULT NULL COMMENT '单币种结算币种',
+  `model_cost_status` varchar(24) NOT NULL DEFAULT 'NO_MODEL' COMMENT 'COMPLETE/PARTIAL/UNAVAILABLE/MULTI_CURRENCY/NO_MODEL',
+  `model_segment_count` int NOT NULL DEFAULT '0' COMMENT '模型分段数',
+  `settled_cost_segment_count` int NOT NULL DEFAULT '0' COMMENT '已结算模型分段数',
+  `unsettled_cost_segment_count` int NOT NULL DEFAULT '0' COMMENT '未结算模型分段数',
+  `trace_id` varchar(32) DEFAULT NULL COMMENT 'W3C trace-id，关联 OTel/Tempo',
+  `runtime_revision` varchar(64) DEFAULT NULL COMMENT '实例实际应用的运行配置发布修订',
+  `runtime_content_hash` char(64) DEFAULT NULL COMMENT '运行配置内容摘要，关联发布任务与实例ACK',
+  `version_binding_json` json DEFAULT NULL COMMENT '模型/提示词/Agent/知识库/工具版本绑定（不含密钥）',
+  `replay_snapshot_json` json DEFAULT NULL COMMENT '脱敏模型参数、RAG与工具重放事实',
+  `experiment_id` bigint DEFAULT NULL COMMENT '在线实验ID',
+  `experiment_revision` int DEFAULT NULL COMMENT '不可变实验修订号',
+  `experiment_arm` varchar(16) DEFAULT NULL COMMENT 'CONTROL/TREATMENT',
+  `experiment_deployment_id` bigint DEFAULT NULL COMMENT '实际命中的模型部署ID',
+  `experiment_bucket` int DEFAULT NULL COMMENT '稳定分桶0..9999；无可信主体时为空',
+  `success` tinyint(1) NOT NULL DEFAULT '1' COMMENT '整次调用是否成功',
+  `error_msg` varchar(1024) DEFAULT NULL COMMENT '失败原因',
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_call_request` (`request_id`),
+  KEY `idx_call_username` (`username`),
+  KEY `idx_call_agent_code` (`agent_code`),
+  KEY `idx_call_session` (`session_id`),
+  KEY `idx_call_start` (`start_time`),
+  KEY `idx_agent_call_log_tenant` (`tenant_id`),
+  KEY `idx_call_trace_id` (`trace_id`),
+  KEY `idx_call_runtime_revision` (`runtime_revision`),
+  KEY `idx_call_experiment_arm` (`experiment_id`,`experiment_revision`,`experiment_arm`,`start_time`),
+  KEY `idx_agent_call_cost_window` (`tenant_id`,`start_time`,`model_cost_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='智能体调用主记录（分段耗时统计）';
+
+-- ----------------------------------------------------------------------------
+-- cw_agent_call_segment
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_agent_call_segment` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `call_log_id` bigint NOT NULL COMMENT '所属主记录ID',
+  `seq` int NOT NULL COMMENT '调用内分段序号（从1起）',
+  `kind` varchar(16) NOT NULL COMMENT '分段类别 MODEL/TOOL/MCP/SKILL',
+  `name` varchar(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
+  `start_time` bigint NOT NULL COMMENT '分段开始时间戳（毫秒）',
+  `duration_ms` bigint NOT NULL DEFAULT '0' COMMENT '分段耗时（毫秒）',
+  `input_tokens` bigint DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）',
+  `output_tokens` bigint DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）',
+  `cached_tokens` bigint DEFAULT NULL COMMENT '命中缓存的输入token（仅MODEL段）',
+  `model_reported_ms` bigint DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
+  `provider` varchar(64) DEFAULT NULL COMMENT '实际模型供应商',
+  `deployment_id` bigint DEFAULT NULL COMMENT '实际模型部署ID',
+  `model_name` varchar(191) DEFAULT NULL COMMENT '实际模型名',
+  `price_id` bigint DEFAULT NULL COMMENT '调用时冻结的价目ID',
+  `currency` varchar(16) DEFAULT NULL COMMENT '调用时冻结的币种',
+  `input_unit_price` decimal(20,8) DEFAULT NULL COMMENT '调用时输入单价（每百万token）',
+  `output_unit_price` decimal(20,8) DEFAULT NULL COMMENT '调用时输出单价（每百万token）',
+  `cached_unit_price` decimal(20,8) DEFAULT NULL COMMENT '调用时缓存输入单价（每百万token）',
+  `pricing_status` varchar(16) NOT NULL DEFAULT 'UNPRICED' COMMENT 'PRICED/UNPRICED',
+  `cost_amount` decimal(30,14) DEFAULT NULL COMMENT '按冻结价目结算的模型金额',
+  `cost_currency` varchar(16) DEFAULT NULL COMMENT '结算币种',
+  `cost_status` varchar(24) NOT NULL DEFAULT 'NOT_APPLICABLE' COMMENT 'SETTLED/UNPRICED/USAGE_MISSING/USAGE_INVALID/NOT_APPLICABLE',
+  `success` tinyint(1) NOT NULL DEFAULT '1' COMMENT '分段是否成功',
+  `error_msg` varchar(1024) DEFAULT NULL COMMENT '失败原因',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_segment_call_log` (`call_log_id`,`seq`),
+  KEY `idx_agent_call_segment_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='智能体调用分段明细';
+
+-- ----------------------------------------------------------------------------
+-- cw_approval
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_approval` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '审批单号',
+  `type` varchar(32) NOT NULL COMMENT '审批类型：REFUND 等',
+  `session_id` varchar(128) DEFAULT NULL COMMENT '关联会话',
+  `order_id` varchar(64) DEFAULT NULL COMMENT '关联订单号',
+  `amount` varchar(32) DEFAULT NULL COMMENT '涉及金额',
+  `reason` text COMMENT '诉求原因',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  `status` varchar(16) NOT NULL COMMENT 'PENDING/APPROVED/DENIED',
+  `operator` varchar(64) DEFAULT NULL COMMENT '决策操作员',
+  `decision_note` text COMMENT '决策备注',
+  `decided_at_ms` bigint DEFAULT '0' COMMENT '决策时间戳（毫秒）',
+  `execution_status` varchar(24) DEFAULT 'NOT_APPLICABLE' COMMENT '下游执行状态',
+  `execution_failure_reason` text COMMENT '下游执行失败原因',
+  `execution_attempts` int DEFAULT '0' COMMENT '下游执行尝试次数',
+  PRIMARY KEY (`id`),
+  KEY `idx_approval_status` (`status`),
+  KEY `idx_approval_created` (`created_at_ms`),
+  KEY `idx_approval_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='人工审批工单（退款放行等资金动作）';
+
+-- ----------------------------------------------------------------------------
+-- cw_audit_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_audit_log` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `event_type` varchar(64) NOT NULL COMMENT '事件类型: tool-call / final-answer / error',
+  `agent_name` varchar(128) DEFAULT '' COMMENT 'Agent 名称',
+  `event_data` text COMMENT '结构化事件字段 JSON',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP COMMENT '记录时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_audit_type` (`event_type`),
+  KEY `idx_audit_created` (`created_at`),
+  KEY `idx_audit_agent` (`agent_name`),
+  KEY `idx_audit_log_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='合规审计轨迹（结构化存储）';
+
+-- ----------------------------------------------------------------------------
+-- cw_badcase
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_badcase` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT 'badcase ID（应用赋值的UUID）',
+  `source` varchar(24) NOT NULL COMMENT '来源：NEGATIVE_FEEDBACK 用户点踩 / QUALITY_FAILURE 质检不过',
+  `session_id` varchar(128) DEFAULT NULL COMMENT '所属会话',
+  `message_id` varchar(64) DEFAULT NULL COMMENT '被反馈的消息ID（质检来源为空，质检针对一批回复）',
+  `user_input` text COMMENT '用户问了什么（从聊天留痕回查）',
+  `agent_reply` text COMMENT 'AI答了什么（从聊天留痕回查）',
+  `signal_hash` char(64) DEFAULT NULL COMMENT '归一化用户问题SHA-256，供上线复发观测',
+  `detail` text COMMENT '原始信号明细：点踩存用户留言，质检存得分与扣分项',
+  `status` varchar(16) NOT NULL DEFAULT 'PENDING' COMMENT '状态：PENDING 待筛/RESOLVED 已处理/IGNORED 已忽略',
+  `adopted_knowledge_id` bigint DEFAULT NULL COMMENT '已回流成的知识条目ID（cw_knowledge.id）',
+  `adopted_eval_case_id` varchar(64) DEFAULT NULL COMMENT '已回流成的评测用例编号（cw_eval_case.case_id）',
+  `handled_by` varchar(64) DEFAULT NULL COMMENT '处理人',
+  `handled_at_ms` bigint DEFAULT NULL COMMENT '处理时间戳（毫秒）',
+  `ignore_reason` varchar(500) DEFAULT NULL COMMENT '忽略原因（仅 IGNORED 时有值）',
+  `created_at_ms` bigint NOT NULL COMMENT '登记时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_badcase_status` (`tenant_id`,`status`,`created_at_ms`),
+  KEY `idx_badcase_session` (`session_id`),
+  KEY `idx_badcase_signal` (`tenant_id`,`signal_hash`,`created_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='badcase 待筛队列（回流知识库/评测用例）';
+
+-- ----------------------------------------------------------------------------
+-- cw_chat_attachment
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_chat_attachment` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '附件ID(UUID)',
+  `session_id` varchar(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+  `message_id` varchar(64) NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）',
+  `uploader` varchar(128) NOT NULL DEFAULT '' COMMENT '上传者标识',
+  `channel` varchar(32) NOT NULL DEFAULT '' COMMENT '来源渠道:user_chat/admin_chat/vibecoding',
+  `file_name` varchar(255) NOT NULL COMMENT '原始文件名',
+  `extension` varchar(16) NOT NULL DEFAULT '' COMMENT '扩展名',
+  `mime_type` varchar(128) NOT NULL DEFAULT '' COMMENT 'MIME类型',
+  `file_size` bigint NOT NULL DEFAULT '0' COMMENT '文件字节数',
+  `storage_path` varchar(512) NOT NULL DEFAULT '' COMMENT '落盘相对路径',
+  `parse_status` varchar(16) NOT NULL DEFAULT 'SUCCESS' COMMENT '解析状态:SUCCESS/FAILED',
+  `parsed_text` mediumtext COMMENT '解析出的文本',
+  `error_message` varchar(512) DEFAULT NULL COMMENT '解析失败原因',
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_cw_attachment_session` (`session_id`),
+  KEY `idx_cw_attachment_created` (`created_at`),
+  KEY `idx_chat_attachment_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='对话附件';
+
+-- ----------------------------------------------------------------------------
+-- cw_chat_message
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_chat_message` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键（游标翻页）',
+  `message_id` varchar(64) NOT NULL COMMENT '业务消息号 MSG-<uuid>',
+  `session_id` varchar(128) NOT NULL COMMENT '所属会话',
+  `ticket_id` varchar(64) DEFAULT NULL COMMENT '关联工单号（可空）',
+  `sender_type` varchar(16) NOT NULL COMMENT '发送方类型 USER/BOT/AGENT/SYSTEM',
+  `sender_id` varchar(64) DEFAULT NULL COMMENT '发送方标识（可空）',
+  `content` text NOT NULL COMMENT '消息内容',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_chat_message_id` (`message_id`),
+  KEY `idx_chat_session` (`session_id`,`id`),
+  KEY `idx_chat_ticket` (`ticket_id`,`id`),
+  KEY `idx_chat_message_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='会话/工单聊天消息留痕';
+
+-- ----------------------------------------------------------------------------
+-- cw_complaint
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_complaint` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `complaint_no` varchar(64) NOT NULL COMMENT '投诉工单号',
+  `order_id` varchar(32) DEFAULT NULL COMMENT '关联订单号（可空）',
+  `content` text COMMENT '投诉内容',
+  `status` varchar(16) NOT NULL COMMENT '状态：PROCESSING/RESOLVED',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`complaint_no`),
+  KEY `idx_complaint_order` (`order_id`,`created_at_ms`),
+  KEY `idx_complaint_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='投诉工单（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_csat_survey
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_csat_survey` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `session_id` varchar(128) NOT NULL COMMENT '会话ID（自然主键：一次会话只该有一次整体评价）',
+  `scope_id` varchar(128) NOT NULL DEFAULT 'default' COMMENT '运营统计分区键 = 租户码（OpsScopeResolver 取当前租户上下文）',
+  `score` tinyint DEFAULT NULL COMMENT '评分 1-5；NULL 表示已邀请未评价（回收率的分母靠它区分）',
+  `comment` text COMMENT '文字说明',
+  `invited_at_ms` bigint NOT NULL COMMENT '发出邀请时间戳（毫秒）——统计窗口以它为准',
+  `submitted_at_ms` bigint NOT NULL DEFAULT '0' COMMENT '提交评分时间戳（毫秒）；未评价为 0',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`session_id`),
+  KEY `idx_csat_window` (`tenant_id`,`scope_id`,`invited_at_ms`),
+  KEY `idx_csat_score` (`tenant_id`,`score`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='会话级满意度调查（CSAT）';
+
+-- ----------------------------------------------------------------------------
+-- cw_dead_letter
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_dead_letter` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '死信ID（应用赋值的UUID）',
+  `type` varchar(64) NOT NULL COMMENT '死信类型：决定由哪个 DeadLetterHandler 重投',
+  `payload` text NOT NULL COMMENT '重投所需的完整载荷（JSON）',
+  `biz_key` varchar(128) DEFAULT NULL COMMENT '关联业务标识（订单号/会话号），供运营检索',
+  `status` varchar(16) NOT NULL DEFAULT 'PENDING' COMMENT '状态：PENDING 待重投/SUCCEEDED 已成功/ABANDONED 已放弃',
+  `attempts` int NOT NULL DEFAULT '0' COMMENT '已重试次数',
+  `last_error` text COMMENT '最近一次失败原因',
+  `next_retry_at_ms` bigint NOT NULL COMMENT '下次重投时刻（毫秒）',
+  `lease_owner` varchar(128) DEFAULT NULL COMMENT '当前租约持有实例',
+  `lease_until_ms` bigint NOT NULL DEFAULT '0' COMMENT '租约到期时间',
+  `created_at_ms` bigint NOT NULL COMMENT '失败发生时刻（毫秒）',
+  `finished_at_ms` bigint NOT NULL DEFAULT '0' COMMENT '终态时刻（成功或放弃）；未终结为 0',
+  PRIMARY KEY (`id`),
+  KEY `idx_dead_letter_due` (`tenant_id`,`status`,`next_retry_at_ms`),
+  KEY `idx_dead_letter_biz` (`tenant_id`,`biz_key`),
+  KEY `idx_dead_letter_lease` (`tenant_id`,`status`,`lease_until_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='死信队列（失败操作的兜底重投）';
+
+-- ----------------------------------------------------------------------------
+-- cw_dialog_stage
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_dialog_stage` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `session_id` varchar(191) NOT NULL COMMENT '会话 ID',
+  `stage` varchar(24) NOT NULL COMMENT '当前对话阶段：GREETING/COLLECTING/PROCESSING/CONFIRMING/ESCALATED',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`session_id`),
+  KEY `idx_dialog_stage_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='对话阶段状态机（多实例共享）';
+
+-- ----------------------------------------------------------------------------
+-- cw_dict_item
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_dict_item` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `dict_type` varchar(64) NOT NULL COMMENT '所属字典类型编码',
+  `item_key` varchar(128) NOT NULL COMMENT '字典项键（业务值）',
+  `item_label` varchar(128) NOT NULL COMMENT '字典项标签（展示文案）',
+  `sort` int NOT NULL DEFAULT '0' COMMENT '排序号，越小越靠前',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `remark` varchar(255) DEFAULT NULL COMMENT '备注说明',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_dict_item` (`tenant_id`,`dict_type`,`item_key`),
+  KEY `idx_dict_item_type` (`dict_type`),
+  KEY `idx_dict_item_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='字典项表';
+
+-- ----------------------------------------------------------------------------
+-- cw_dict_type
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_dict_type` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `dict_type` varchar(64) NOT NULL COMMENT '字典类型编码（如 order_status）',
+  `type_name` varchar(64) NOT NULL COMMENT '类型名称（展示用）',
+  `remark` varchar(255) DEFAULT NULL COMMENT '备注说明',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_dict_type` (`tenant_id`,`dict_type`),
+  KEY `idx_dict_type_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='字典类型表';
+
+-- ----------------------------------------------------------------------------
+-- cw_eval_case
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_eval_case` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `eval_type` varchar(16) NOT NULL COMMENT '评测类型：INTENT 意图路由 / QUALITY 回复质量',
+  `case_id` varchar(64) NOT NULL COMMENT '用例编号（同类型内唯一；与种子同号即覆盖种子）',
+  `input` varchar(1024) NOT NULL COMMENT '用户输入',
+  `expected` varchar(1024) DEFAULT NULL COMMENT 'INTENT=期望意图（空=期望快车道不命中，交LLM）；QUALITY=期望要点',
+  `category` varchar(64) DEFAULT NULL COMMENT '归类标签',
+  `source` varchar(16) NOT NULL DEFAULT 'MANUAL' COMMENT '来源：SEED 种子/BADCASE 回流/MANUAL 手工',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否参与评测：0 可屏蔽同号种子用例',
+  `origin_ref` varchar(64) DEFAULT NULL COMMENT '溯源引用：来自 badcase 时记 badcase ID，便于回看原始会话',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_eval_case` (`tenant_id`,`eval_type`,`case_id`),
+  KEY `idx_eval_case_tenant` (`tenant_id`,`eval_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='评测用例（种子之外的增量与修正）';
+
+-- ----------------------------------------------------------------------------
+-- cw_eval_dataset_release
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_eval_dataset_release` (
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `release_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '命名版本ID（应用生成UUID）',
+  `eval_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'INTENT/QUALITY',
+  `version_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户内、类型内唯一的人类可读版本名',
+  `snapshot_version_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '不可变内容快照 cw_eval_dataset_version.version_id',
+  `content_hash` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '快照内容SHA-256，跨库绑定时用于校验漂移',
+  `case_count` int NOT NULL COMMENT '版本包含的用例数',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'DRAFT' COMMENT 'DRAFT/APPROVED/REJECTED',
+  `review_comment` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '审核意见',
+  `created_by` bigint DEFAULT NULL COMMENT '创建人',
+  `reviewed_by` bigint DEFAULT NULL COMMENT '审核人',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  `reviewed_at_ms` bigint DEFAULT NULL COMMENT '审核时间戳（毫秒）',
+  PRIMARY KEY (`release_id`),
+  UNIQUE KEY `uk_eval_dataset_release_name` (`tenant_id`,`eval_type`,`version_name`),
+  KEY `idx_eval_dataset_release_status` (`tenant_id`,`eval_type`,`status`,`created_at_ms`),
+  KEY `idx_eval_dataset_release_snapshot` (`tenant_id`,`snapshot_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='评测数据集命名版本与审核';
+
+-- ----------------------------------------------------------------------------
+-- cw_eval_dataset_version
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_eval_dataset_version` (
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `version_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '数据集版本ID（应用生成UUID）',
+  `eval_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'INTENT/QUALITY',
+  `content_hash` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '规范化用例JSON的SHA-256',
+  `case_count` int NOT NULL COMMENT '快照用例数',
+  `cases_json` longtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '本次实际执行的完整用例JSON',
+  `created_at_ms` bigint NOT NULL COMMENT '首次创建时间戳（毫秒）',
+  PRIMARY KEY (`version_id`),
+  UNIQUE KEY `uk_eval_dataset_content` (`tenant_id`,`eval_type`,`content_hash`),
+  KEY `idx_eval_dataset_tenant_time` (`tenant_id`,`eval_type`,`created_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='评测数据集不可变版本';
+
+-- ----------------------------------------------------------------------------
+-- cw_eval_run
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_eval_run` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `run_id` varchar(64) NOT NULL COMMENT '运行ID（应用赋值的UUID）',
+  `seq` bigint NOT NULL AUTO_INCREMENT COMMENT '写入顺序号（同毫秒也不丢序）',
+  `eval_type` varchar(16) NOT NULL COMMENT '评测类型：INTENT 意图路由 / QUALITY 回复质量',
+  `total` int NOT NULL DEFAULT '0' COMMENT '用例总数',
+  `passed` int NOT NULL DEFAULT '0' COMMENT '通过数',
+  `primary_metric` double NOT NULL DEFAULT '0' COMMENT '主指标(0-1)：INTENT=准确率 / QUALITY=平均分/5',
+  `secondary_metric` double NOT NULL DEFAULT '0' COMMENT '次指标(0-1)：INTENT=快车道覆盖率 / QUALITY=通过率',
+  `failed_case_ids_json` text COMMENT '失败用例ID的JSON数组（版本间回归识别的依据，不从明细里反解）',
+  `failures_json` text COMMENT '失败明细的JSON数组（人读）',
+  `metrics_json` text COMMENT '该类型完整原始指标的JSON字典（归一化不丢信息）',
+  `trigger_source` varchar(16) NOT NULL DEFAULT 'MANUAL' COMMENT '触发来源：MANUAL/SCHEDULED/API',
+  `dataset_size` int NOT NULL DEFAULT '0' COMMENT '评测集规模（用例增删后两次指标不可直接比）',
+  `dataset_version_id` varchar(64) DEFAULT NULL COMMENT '本次实际执行的数据集版本',
+  `dataset_fingerprint` varchar(64) DEFAULT NULL COMMENT '数据集内容SHA-256',
+  `version_binding_json` text COMMENT '模型/提示词/Agent/知识/工具/Judge/rubric版本绑定JSON',
+  `prompt_fingerprint` varchar(32) DEFAULT NULL COMMENT '本次运行时生效的提示词指纹（cw_prompt_version.fingerprint）',
+  `remark` varchar(500) DEFAULT NULL COMMENT '备注（如"换 qwen-max 后重跑"）',
+  `created_at_ms` bigint NOT NULL COMMENT '运行时间戳（毫秒）',
+  PRIMARY KEY (`run_id`),
+  UNIQUE KEY `seq` (`seq`),
+  KEY `idx_eval_run_type_time` (`tenant_id`,`eval_type`,`created_at_ms`),
+  KEY `idx_eval_run_dataset_version` (`tenant_id`,`eval_type`,`dataset_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='评测运行记录（只追加，供版本对比）';
+
+-- ----------------------------------------------------------------------------
+-- cw_fact_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_fact_log` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键（即写入顺序）',
+  `scope_id` varchar(128) NOT NULL DEFAULT 'default' COMMENT '记忆分区键（TenantResolver 由 sessionId 解析）',
+  `fact` text NOT NULL COMMENT '事实内容',
+  `ts` bigint NOT NULL COMMENT '事实时间戳（毫秒）',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_fact_log_scope` (`tenant_id`,`scope_id`,`id`),
+  KEY `idx_fact_log_ts` (`tenant_id`,`scope_id`,`ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='事实日志（L3，append-only 审计流水，永不改写）';
+
+-- ----------------------------------------------------------------------------
+-- cw_handoff_ticket
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_handoff_ticket` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '工单号',
+  `session_id` varchar(128) DEFAULT NULL COMMENT '关联会话',
+  `reason` text COMMENT '转人工原因',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  `status` varchar(16) NOT NULL COMMENT 'PENDING/CLAIMED/RESOLVED',
+  `claimed_by` varchar(64) DEFAULT NULL COMMENT '接单坐席',
+  `claimed_at_ms` bigint DEFAULT '0' COMMENT '接单时间戳（毫秒）',
+  `resolution_note` text COMMENT '处理结果备注',
+  `resolved_at_ms` bigint DEFAULT '0' COMMENT '结案时间戳（毫秒）',
+  `category` varchar(64) DEFAULT NULL COMMENT '工单分类（LLM 分类，可空）',
+  `required_skill` varchar(64) DEFAULT NULL COMMENT '所需坐席技能标签（LLM 分类，可空）',
+  `priority` varchar(16) DEFAULT NULL COMMENT '优先级 LOW/MEDIUM/HIGH/URGENT（LLM 分类，可空）',
+  `emotion` varchar(32) DEFAULT NULL COMMENT '用户情绪（LLM 分类，可空）',
+  `suggested_assignees` text COMMENT '推荐坐席列表 JSON（HITL 推荐，人工点选非自动派单，可空）',
+  PRIMARY KEY (`id`),
+  KEY `idx_handoff_status` (`status`),
+  KEY `idx_handoff_created` (`created_at_ms`),
+  KEY `idx_handoff_ticket_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='人机切换工单（AI 转人工闭环 + 智能分配增强）';
+
+-- ----------------------------------------------------------------------------
+-- cw_harness_memory
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_harness_memory` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `scope_id` varchar(512) NOT NULL COMMENT '记忆归属（workspace 目录路径）',
+  `scope_hash` varchar(64) NOT NULL COMMENT 'scope_id 的 SHA-256（唯一键用，规避 512 字节索引长度限制）',
+  `content` mediumtext NOT NULL COMMENT 'MEMORY.md 全文',
+  `updated_at_ms` bigint NOT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_harness_memory_scope` (`tenant_id`,`scope_hash`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Harness 分层记忆（MEMORY.md 权威副本）';
+
+-- ----------------------------------------------------------------------------
+-- cw_invoice_request
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_invoice_request` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '发票申请自增主键',
+  `order_id` varchar(32) NOT NULL COMMENT '关联订单号',
+  `invoice_title` varchar(255) NOT NULL COMMENT '发票抬头',
+  `status` varchar(16) NOT NULL DEFAULT 'PENDING' COMMENT '状态：PENDING/ISSUED',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_invoice_order` (`order_id`,`created_at_ms`),
+  KEY `idx_invoice_request_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='发票申请（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_knowledge
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_knowledge` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '知识条目自增主键',
+  `keyword` varchar(255) NOT NULL COMMENT '命中关键词（逗号分隔）',
+  `title` varchar(255) NOT NULL COMMENT '条目标题',
+  `content` text NOT NULL COMMENT '条目内容',
+  `source` varchar(255) DEFAULT NULL COMMENT '来源标注',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_knowledge_title` (`tenant_id`,`title`),
+  KEY `idx_knowledge_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='知识库 FAQ（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_knowledge_gap
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_knowledge_gap` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `question_hash` varchar(64) NOT NULL COMMENT '问题原文的 SHA-256',
+  `question` varchar(512) NOT NULL COMMENT '问题原文（截断保存）——运营要看的就是这个',
+  `scope_id` varchar(128) NOT NULL DEFAULT 'default' COMMENT '运营统计分区键 = 租户码（OpsScopeResolver 取当前租户上下文）',
+  `miss_count` bigint NOT NULL DEFAULT '1' COMMENT '累计未命中次数：排行依据，越大越该优先补',
+  `first_seen_at_ms` bigint NOT NULL COMMENT '首次出现时间戳（毫秒）——这个问题何时开始查不到',
+  `last_seen_at_ms` bigint NOT NULL COMMENT '最近出现时间戳（毫秒）',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_knowledge_gap` (`tenant_id`,`scope_id`,`question_hash`),
+  KEY `idx_knowledge_gap_rank` (`tenant_id`,`scope_id`,`miss_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='知识盲区（反复检索不到的问题，计数表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_long_term_memory
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_long_term_memory` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `scope_id` varchar(128) NOT NULL DEFAULT 'default' COMMENT '记忆分区键（TenantResolver 由 sessionId 解析）',
+  `fact` text NOT NULL COMMENT '事实内容',
+  `scope_hash` varchar(64) NOT NULL COMMENT 'scope_id + fact 的 SHA-256（去重键，TEXT 无法建唯一索引）',
+  `created_at_ms` bigint NOT NULL COMMENT '写入时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ltm_scope_fact` (`tenant_id`,`scope_hash`),
+  KEY `idx_ltm_scope` (`tenant_id`,`scope_id`,`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='长期记忆事实（L2，跨会话语义召回）';
+
+-- ----------------------------------------------------------------------------
+-- cw_member
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_member` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `member_id` varchar(64) NOT NULL COMMENT '会员ID（对应用户ID）',
+  `level` varchar(32) NOT NULL COMMENT '会员等级',
+  `points` int NOT NULL DEFAULT '0' COMMENT '当前积分',
+  `points_expiring` int NOT NULL DEFAULT '0' COMMENT '本月底到期积分',
+  `benefits` varchar(255) DEFAULT NULL COMMENT '等级权益',
+  `next_level` varchar(32) DEFAULT NULL COMMENT '下一等级',
+  `upgrade_gap` decimal(10,2) DEFAULT '0.00' COMMENT '升级所需再消费金额',
+  `phone` varchar(32) DEFAULT NULL COMMENT '注册手机号',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`member_id`),
+  KEY `idx_member_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='会员（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_member_account_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_member_account_log` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '处理日志自增主键',
+  `issue` varchar(255) NOT NULL COMMENT '账户问题描述',
+  `handling` varchar(500) DEFAULT NULL COMMENT '处置话术',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_account_log_created` (`created_at_ms`),
+  KEY `idx_member_account_log_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='会员账户问题处理日志（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_memory_consent
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_memory_consent` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `subject_type` varchar(32) NOT NULL COMMENT '主体类型: USER/SESSION/SERVICE_ACCOUNT',
+  `subject_id` varchar(128) NOT NULL COMMENT '租户内主体ID',
+  `agent_id` varchar(128) NOT NULL COMMENT 'Agent稳定标识',
+  `scope_id` varchar(68) NOT NULL COMMENT '四维主体键SHA-256分区',
+  `status` varchar(16) NOT NULL COMMENT 'GRANTED/WITHDRAWN',
+  `consent_version` varchar(64) NOT NULL COMMENT '用户同意的隐私条款版本',
+  `granted_at_ms` bigint DEFAULT NULL COMMENT '授权时间戳（毫秒）',
+  `withdrawn_at_ms` bigint DEFAULT NULL COMMENT '撤回时间戳（毫秒）',
+  `updated_at_ms` bigint NOT NULL COMMENT '最后更新时间戳（毫秒）',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_memory_consent_subject` (`tenant_id`,`subject_type`,`subject_id`,`agent_id`),
+  UNIQUE KEY `uk_memory_consent_scope` (`tenant_id`,`scope_id`),
+  KEY `idx_memory_consent_status` (`tenant_id`,`status`,`updated_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='长期记忆主体同意记录';
+
+-- ----------------------------------------------------------------------------
+-- cw_message_feedback
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_message_feedback` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `message_id` varchar(64) NOT NULL COMMENT '被反馈的消息ID',
+  `session_id` varchar(128) DEFAULT NULL COMMENT '所属会话',
+  `type` varchar(8) NOT NULL COMMENT 'UP/DOWN',
+  `comment` text COMMENT '文字说明',
+  `created_at_ms` bigint NOT NULL COMMENT '提交时间戳（毫秒，重复提交取最新）',
+  PRIMARY KEY (`message_id`),
+  KEY `idx_feedback_session` (`session_id`),
+  KEY `idx_feedback_type` (`type`),
+  KEY `idx_message_feedback_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='消息级用户反馈（点赞/点踩）';
+
+-- ----------------------------------------------------------------------------
+-- cw_order
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_order` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `order_id` varchar(32) NOT NULL COMMENT '订单号',
+  `user_id` varchar(64) NOT NULL COMMENT '下单用户',
+  `product_id` varchar(32) NOT NULL COMMENT '商品ID',
+  `product_name` varchar(128) DEFAULT NULL COMMENT '商品名称',
+  `amount` decimal(10,2) NOT NULL COMMENT '订单金额',
+  `status` varchar(32) NOT NULL COMMENT '订单状态',
+  `receiver_addr` varchar(255) DEFAULT NULL COMMENT '收货地址',
+  `logistics_trace` text COMMENT '物流轨迹',
+  `created_at_ms` bigint NOT NULL COMMENT '下单时间戳（毫秒）',
+  PRIMARY KEY (`order_id`),
+  KEY `idx_order_user` (`user_id`,`created_at_ms`),
+  KEY `idx_order_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='订单（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_outbox_message
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_outbox_message` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '消息ID，也是下游幂等键',
+  `type` varchar(64) NOT NULL COMMENT 'Handler 类型',
+  `aggregate_id` varchar(128) NOT NULL COMMENT '聚合根业务标识',
+  `payload` mediumtext NOT NULL COMMENT '自包含 JSON 载荷',
+  `status` varchar(16) NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING/PROCESSING/SUCCEEDED/ABANDONED',
+  `attempts` int NOT NULL DEFAULT '0' COMMENT '投递失败次数',
+  `next_attempt_at_ms` bigint NOT NULL COMMENT '下次投递时间',
+  `lease_owner` varchar(128) DEFAULT NULL COMMENT '当前租约持有实例',
+  `lease_until_ms` bigint NOT NULL DEFAULT '0' COMMENT '租约到期时间',
+  `last_error` text COMMENT '最近一次投递错误',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间',
+  `finished_at_ms` bigint NOT NULL DEFAULT '0' COMMENT '终态时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_outbox_due` (`tenant_id`,`status`,`next_attempt_at_ms`),
+  KEY `idx_outbox_lease` (`tenant_id`,`status`,`lease_until_ms`),
+  KEY `idx_outbox_aggregate` (`tenant_id`,`aggregate_id`,`created_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='同库事务 Outbox';
+
+-- ----------------------------------------------------------------------------
+-- cw_product
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_product` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `product_id` varchar(32) NOT NULL COMMENT '商品ID',
+  `name` varchar(128) NOT NULL COMMENT '商品名称',
+  `category` varchar(64) DEFAULT NULL COMMENT '品类',
+  `price` decimal(10,2) NOT NULL COMMENT '价格',
+  `stock` int NOT NULL DEFAULT '0' COMMENT '库存',
+  `description` varchar(500) DEFAULT NULL COMMENT '商品描述',
+  `promotion` varchar(255) DEFAULT NULL COMMENT '优惠活动',
+  `status` varchar(16) NOT NULL DEFAULT 'ON_SALE' COMMENT 'ON_SALE/OFF_SALE',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`product_id`),
+  KEY `idx_product_category` (`category`),
+  KEY `idx_product_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='商品（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_prompt_version
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_prompt_version` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `fingerprint` varchar(32) NOT NULL COMMENT '内容指纹（SHA-256 十六进制前16位）',
+  `content` mediumtext NOT NULL COMMENT '提示词全文（归因时比对两版差异）',
+  `length` int NOT NULL DEFAULT '0' COMMENT '全文字符数（列表页展示，避免每行拖全文）',
+  `captured_at_ms` bigint NOT NULL COMMENT '首次观测到该版本的时间戳（毫秒）',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`fingerprint`),
+  KEY `idx_prompt_version_time` (`tenant_id`,`captured_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='提示词版本（运行时实际生效的那份）';
+
+-- ----------------------------------------------------------------------------
+-- cw_rate_limit_rule
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_rate_limit_rule` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `rule_name` varchar(64) NOT NULL COMMENT '规则名（运营可读）',
+  `path_prefix` varchar(128) NOT NULL COMMENT '匹配的请求路径前缀',
+  `dimension` varchar(16) NOT NULL COMMENT '计数维度: API_KEY/IP/GLOBAL',
+  `limit_count` int NOT NULL COMMENT '窗口内允许的最大请求数',
+  `algorithm` varchar(32) NOT NULL COMMENT '算法: FIXED_WINDOW/SLIDING_WINDOW',
+  `window_seconds` int NOT NULL DEFAULT '60' COMMENT '时间窗（秒）',
+  `priority` int NOT NULL DEFAULT '0' COMMENT '优先级，越小越先匹配（首匹配即止）',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_rate_limit_rule_name` (`tenant_id`,`rule_name`),
+  KEY `idx_rate_limit_priority` (`priority`),
+  KEY `idx_rate_limit_rule_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='限流规则表（接入层限流规则层）';
+
+-- ----------------------------------------------------------------------------
+-- cw_refund
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_refund` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `refund_no` varchar(64) NOT NULL COMMENT '售后工单号',
+  `order_id` varchar(32) NOT NULL COMMENT '关联订单号',
+  `type` varchar(16) NOT NULL COMMENT '类型：REFUND/RETURN/EXCHANGE',
+  `status` varchar(16) NOT NULL COMMENT '状态：PENDING/APPROVED/DENIED',
+  `amount` decimal(10,2) DEFAULT NULL COMMENT '退款金额（退货/换货可空）',
+  `reason` varchar(500) DEFAULT NULL COMMENT '诉求原因',
+  `new_spec` varchar(128) DEFAULT NULL COMMENT '换货目标规格',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`refund_no`),
+  KEY `idx_refund_order` (`order_id`,`created_at_ms`),
+  KEY `idx_refund_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='售后工单（JDBC 后端演示表）';
+
+-- ----------------------------------------------------------------------------
+-- cw_seat_agent
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_seat_agent` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '坐席ID',
+  `name` varchar(64) NOT NULL COMMENT '坐席名',
+  `skills` varchar(512) DEFAULT NULL COMMENT '技能标签（逗号分隔，如 refund,invoice）',
+  `max_load` int NOT NULL DEFAULT '0' COMMENT '最大并发工单数',
+  `current_load` int NOT NULL DEFAULT '0' COMMENT '当前在处理工单数',
+  `online` tinyint(1) NOT NULL DEFAULT '0' COMMENT '是否在线: 1在线/0离线',
+  `seat_group` varchar(64) DEFAULT NULL COMMENT '坐席分组',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_seat_online` (`online`),
+  KEY `idx_seat_agent_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='坐席库（智能分配候选坐席池）';
+
+-- ----------------------------------------------------------------------------
+-- cw_semantic_cache
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_semantic_cache` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离，拦截器自动改写）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `scope_id` varchar(128) NOT NULL DEFAULT 'default' COMMENT '缓存分区键',
+  `config_generation` varchar(64) NOT NULL DEFAULT 'bootstrap' COMMENT '写入时运行配置 contentHash；bootstrap 表示尚未接入热配置',
+  `intent` varchar(32) NOT NULL COMMENT '意图分类，命中时先按它缩小候选集（关键剪枝）',
+  `question` varchar(512) NOT NULL COMMENT '原始问题（人读，排查"为什么这条命中了"要看）',
+  `question_vector` mediumtext NOT NULL COMMENT '问题向量，逗号分隔浮点数',
+  `answer` text NOT NULL COMMENT '当时的回答',
+  `hit_count` bigint NOT NULL DEFAULT '0' COMMENT '命中次数（容量淘汰时保留高频条目）',
+  `created_at_ms` bigint NOT NULL COMMENT '写入时间戳（毫秒），TTL 以此为准',
+  `last_hit_at_ms` bigint NOT NULL COMMENT '最近命中时间戳（毫秒），LRU 淘汰以此为准',
+  PRIMARY KEY (`id`),
+  KEY `idx_semcache_lookup` (`tenant_id`,`config_generation`,`scope_id`,`intent`,`last_hit_at_ms`),
+  KEY `idx_semcache_created` (`tenant_id`,`config_generation`,`scope_id`,`created_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='语义缓存（仅通用问答，默认关闭）';
+
+-- ----------------------------------------------------------------------------
+-- cw_sensitive_word
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_sensitive_word` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `word` varchar(128) NOT NULL COMMENT '敏感词原词面',
+  `category` varchar(32) NOT NULL COMMENT '类目: POLITICS/PORN/ABUSE/COMPETITOR/CUSTOM',
+  `action` varchar(16) NOT NULL COMMENT '处置动作: BLOCK/MASK/REVIEW',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sensitive_word` (`tenant_id`,`word`),
+  KEY `idx_sensitive_word_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='敏感词表（一次拦截词库）';
+
+-- ----------------------------------------------------------------------------
+-- cw_sensitive_word_hit_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_sensitive_word_hit_log` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `direction` varchar(16) NOT NULL COMMENT '命中方向: INBOUND用户输入/OUTBOUND模型输出',
+  `action` varchar(16) NOT NULL COMMENT '整体决策: BLOCK/MASK/REVIEW',
+  `words` varchar(512) DEFAULT NULL COMMENT '命中词面，逗号分隔',
+  `categories` varchar(128) DEFAULT NULL COMMENT '命中类目，逗号分隔已去重',
+  `hit_count` int NOT NULL DEFAULT '0' COMMENT '命中词个数',
+  `agent_name` varchar(128) DEFAULT NULL COMMENT '智能体名',
+  `session_id` varchar(128) DEFAULT NULL COMMENT '会话ID',
+  `user_id` varchar(128) DEFAULT NULL COMMENT '用户ID',
+  `snippet` varchar(512) DEFAULT NULL COMMENT '原文片段（已按配置截断）',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '命中时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_hit_created` (`created_at_ms`),
+  KEY `idx_hit_action` (`action`),
+  KEY `idx_hit_session` (`session_id`),
+  KEY `idx_sensitive_word_hit_log_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='敏感词命中日志（后台看板数据源）';
+
+-- ----------------------------------------------------------------------------
+-- cw_skill
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_skill` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `skill_code` varchar(64) NOT NULL COMMENT '技能编码（= 落盘目录名）',
+  `skill_name` varchar(64) NOT NULL COMMENT '技能名称',
+  `content` mediumtext NOT NULL COMMENT 'SKILL.md 正文',
+  `description` varchar(255) DEFAULT NULL COMMENT '技能描述',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_cw_skill_code` (`tenant_id`,`skill_code`),
+  KEY `idx_cw_skill_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='技能库（SKILL.md 正文）';
+
+-- ----------------------------------------------------------------------------
+-- cw_skill_file
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_skill_file` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `skill_id` bigint NOT NULL COMMENT '所属技能（cw_skill.id）',
+  `file_path` varchar(512) NOT NULL COMMENT '相对 SKILL.md 所在目录的路径，如 references/api.md',
+  `file_size` bigint NOT NULL DEFAULT '0' COMMENT '文件字节数',
+  `content` longblob COMMENT '文件内容（文本/二进制统一按字节存）',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_cw_skill_file_skill` (`skill_id`),
+  KEY `idx_cw_skill_file_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='技能附属文件';
+
+-- ----------------------------------------------------------------------------
+-- cw_slot_filling_progress
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_slot_filling_progress` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `progress_key` varchar(191) NOT NULL COMMENT '收集进度键：sessionId:formName',
+  `asking` varchar(64) DEFAULT NULL COMMENT '当前追问的槽位名',
+  `collected_json` text COMMENT '已收集槽位值（JSON）',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '记录最后修改时间',
+  PRIMARY KEY (`progress_key`),
+  KEY `idx_slot_filling_progress_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='多轮槽位收集进度（如退款表单信息采集）';
+
+-- ----------------------------------------------------------------------------
+-- cw_subject_quota_hit
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_subject_quota_hit` (
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `subject_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '主体类型: USER/IP/API_KEY',
+  `subject_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '主体标识（API Key 已做 SHA-256 指纹，不含明文）',
+  `level_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '判定所依据的等级',
+  `limit_kind` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '触顶维度: TOKEN/REQUEST',
+  `used` bigint NOT NULL DEFAULT '0' COMMENT '触顶时已用量',
+  `limit_value` bigint NOT NULL DEFAULT '0' COMMENT '触顶时的上限',
+  `window_seconds` int NOT NULL DEFAULT '0' COMMENT '滚动窗口长度（秒）',
+  `action` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'BLOCK' COMMENT '当时处置: BLOCK 真拦了 / WARN 只记录',
+  `resource` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '触发位置（HTTP 路径或 ws:chat）',
+  `created_at_ms` bigint NOT NULL COMMENT '命中时刻（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_squota_hit_tenant_time` (`tenant_id`,`created_at_ms`),
+  KEY `idx_squota_hit_subject` (`tenant_id`,`subject_type`,`subject_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='主体配额超限命中记录';
+
+-- ----------------------------------------------------------------------------
+-- cw_subject_quota_level
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_subject_quota_level` (
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `level_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '等级编码，如 free/vip/anonymous',
+  `level_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '等级名称（运营可读）',
+  `subject_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'USER' COMMENT '适用主体: USER 登录用户 / IP 匿名 / API_KEY 接入方',
+  `window_seconds` int NOT NULL DEFAULT '1800' COMMENT '滚动窗口长度（秒），1800=30分钟',
+  `token_limit` bigint NOT NULL DEFAULT '0' COMMENT '窗口内 token 上限，0=不限',
+  `request_limit` int NOT NULL DEFAULT '0' COMMENT '窗口内请求次数上限，0=不限',
+  `exceed_action` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'BLOCK' COMMENT '超限处置: BLOCK 拦截 / WARN 仅记录',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_squota_level` (`tenant_id`,`level_code`),
+  KEY `idx_squota_level_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='主体配额等级（每租户每档一条）';
+
+-- ----------------------------------------------------------------------------
+-- cw_tenant_quota
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_tenant_quota` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `period` varchar(16) NOT NULL COMMENT '周期: DAILY 日 / MONTHLY 月',
+  `token_limit` bigint NOT NULL DEFAULT '0' COMMENT 'token 上限，0=不限',
+  `amount_limit` decimal(16,4) NOT NULL DEFAULT '0.0000' COMMENT '金额上限（元），0=不限；实时链路只拦 token，金额走 T+1 账单告警',
+  `exceed_action` varchar(16) NOT NULL DEFAULT 'BLOCK' COMMENT '超额处置: BLOCK 拦截 / DEGRADE 降级备用模型 / WARN 仅告警',
+  `warn_percent` int NOT NULL DEFAULT '80' COMMENT '预警阈值（用量百分比），达到即告警但不拦',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用: 1启用/0停用',
+  `remark` varchar(255) DEFAULT NULL COMMENT '备注',
+  `created_at_ms` bigint DEFAULT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint DEFAULT NULL COMMENT '更新时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_tenant_quota` (`tenant_id`,`period`),
+  KEY `idx_tenant_quota_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='租户配额（每租户每周期一条）';
+
+-- ----------------------------------------------------------------------------
+-- cw_ticket
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_ticket` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '工单号',
+  `session_id` varchar(128) NOT NULL COMMENT '关联会话',
+  `user_id` varchar(64) NOT NULL COMMENT '发起用户',
+  `title` varchar(255) DEFAULT NULL COMMENT '工单标题',
+  `category` varchar(32) NOT NULL DEFAULT 'OTHER' COMMENT '分类',
+  `priority` varchar(16) NOT NULL DEFAULT 'NORMAL' COMMENT '优先级',
+  `status` varchar(32) NOT NULL COMMENT '状态机状态',
+  `assignee` varchar(64) DEFAULT NULL COMMENT '当前处理坐席',
+  `handoff_reason` varchar(255) DEFAULT NULL COMMENT '转人工原因',
+  `resolve_note` text COMMENT '处理结论/备注',
+  `routing_category` varchar(64) DEFAULT NULL COMMENT '智能路由分类原文',
+  `required_skill` varchar(64) DEFAULT NULL COMMENT '所需坐席技能',
+  `routing_priority` varchar(16) DEFAULT NULL COMMENT '智能路由优先级原文',
+  `emotion` varchar(32) DEFAULT NULL COMMENT '用户情绪',
+  `suggested_assignees` text COMMENT '推荐坐席列表 JSON',
+  `reopen_count` int NOT NULL DEFAULT '0' COMMENT '重开次数',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  `updated_at_ms` bigint NOT NULL COMMENT '更新时间戳（毫秒）',
+  `handoff_at_ms` bigint DEFAULT '0' COMMENT '最近转人工时间戳（毫秒）',
+  `claimed_at_ms` bigint DEFAULT '0' COMMENT '接单时间戳（毫秒）',
+  `resolved_at_ms` bigint DEFAULT '0' COMMENT '解决时间戳（毫秒）',
+  `closed_at_ms` bigint DEFAULT '0' COMMENT '关闭时间戳（毫秒）',
+  `last_user_active_at_ms` bigint DEFAULT '0' COMMENT '用户最后活跃时间戳（毫秒，空闲超时巡检基准）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ticket_session` (`session_id`),
+  KEY `idx_ticket_user` (`user_id`,`created_at_ms`),
+  KEY `idx_ticket_status` (`status`,`updated_at_ms`),
+  KEY `idx_ticket_assignee` (`assignee`,`status`),
+  KEY `idx_ticket_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='客服工单（完整生命周期状态机）';
+
+-- ----------------------------------------------------------------------------
+-- cw_ticket_event
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_ticket_event` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '事件自增主键',
+  `ticket_id` varchar(64) NOT NULL COMMENT '所属工单号',
+  `event_type` varchar(32) NOT NULL COMMENT '事件类型',
+  `from_status` varchar(32) DEFAULT NULL COMMENT '流转前状态',
+  `to_status` varchar(32) DEFAULT NULL COMMENT '流转后状态',
+  `actor_type` varchar(16) NOT NULL COMMENT '动作发起方类型',
+  `actor_id` varchar(64) DEFAULT NULL COMMENT '动作发起方标识',
+  `note` varchar(500) DEFAULT NULL COMMENT '备注',
+  `created_at_ms` bigint NOT NULL COMMENT '事件时间戳（毫秒）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ticket_event` (`ticket_id`,`id`),
+  KEY `idx_ticket_event_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='工单事件轨迹（不可变审计）';
+
+-- ----------------------------------------------------------------------------
+-- cw_user
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_user` (
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `id` varchar(64) NOT NULL COMMENT '用户ID',
+  `username` varchar(64) NOT NULL COMMENT '用户名',
+  `password_hash` varchar(100) NOT NULL COMMENT 'BCrypt 密码哈希',
+  `nickname` varchar(64) DEFAULT NULL COMMENT '昵称',
+  `phone` varchar(32) DEFAULT NULL COMMENT '手机号',
+  `status` varchar(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/DISABLED',
+  `created_at_ms` bigint NOT NULL COMMENT '创建时间戳（毫秒）',
+  `avatar_url` varchar(255) DEFAULT NULL COMMENT '头像访问URL（相对路径，可为空）',
+  `level_code` varchar(64) DEFAULT NULL COMMENT '配额等级编码（空=默认档）',
+  `session_epoch` bigint NOT NULL DEFAULT '0' COMMENT '用户会话撤销版本',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_user_username` (`tenant_id`,`username`),
+  KEY `idx_user_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='客服系统终端用户账户';

--- a/mysql/schema-snapshot/customer_admin.sql
+++ b/mysql/schema-snapshot/customer_admin.sql
@@ -1,0 +1,2199 @@
+-- ----------------------------------------------------------------------------
+-- customer_admin 全量表结构快照（自动生成，请勿手工编辑）
+-- ----------------------------------------------------------------------------
+-- 生成方式：scripts/export-schema-snapshot.sh
+--           新建临时空库执行 classpath:db/migration 的全部迁移后逐表导出，
+--           自增当前值已抹除。
+-- 对应版本：Flyway V99
+-- 真源：customer-admin-server/src/main/resources/db/migration/
+--       改结构一律新增迁移，改本文件不会生效。
+-- 用途：结构查阅与全新建库。**不要对已有库执行**，这里没有 IF NOT EXISTS 保护。
+--       生产手工初始化仍按 mysql/02-customer-admin/ 的迁移副本顺序执行，
+--       那条路径会留下 flyway_schema_history，之后能继续增量升级。
+-- 建库：CREATE DATABASE `customer_admin`
+--         DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+-- COLLATE 说明：快照里同时出现 utf8mb4_0900_ai_ci 与 utf8mb4_unicode_ci 是既有状况，
+--               不是导出错误。MySQL 8 的规则：建表语句写了 DEFAULT CHARSET=utf8mb4
+--               却没写 COLLATE 时，用的是该字符集的默认 collation(utf8mb4_0900_ai_ci)
+--               而非库的；显式写了 COLLATE 的按其声明；只有既不写 CHARSET 也不写
+--               COLLATE 的少数表才继承上面的建库参数——所以导出必须固定按上面的参数
+--               建库，换一套参数会让那几张表的输出跟着变。
+-- ----------------------------------------------------------------------------
+
+SET NAMES utf8mb4;
+
+-- ----------------------------------------------------------------------------
+-- ai_agent
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '智能体名称',
+  `agent_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '智能体编码（用于动态菜单路由，[a-z0-9-]+）',
+  `model_id` bigint NOT NULL COMMENT '关联模型ID（必填）',
+  `model_route_policy_id` bigint DEFAULT NULL COMMENT '绑定的 ai_model_route_policy.id；空=沿用主备模型链',
+  `system_prompt` text COLLATE utf8mb4_unicode_ci COMMENT '系统提示词',
+  `capabilities` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'chat' COMMENT '能力标识（逗号分隔：chat,vibecoding）',
+  `icon` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '菜单图标',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0停用 / 1启用',
+  `runtime_revision` bigint NOT NULL DEFAULT '0' COMMENT '运行时实例配置修订号',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除（会话历史归档保留）',
+  `max_iters` int DEFAULT NULL COMMENT 'ReAct 最大迭代轮数（null=默认10）',
+  `tool_timeout_seconds` int DEFAULT NULL COMMENT '工具执行超时秒数（null=框架默认5分钟）',
+  `tool_max_attempts` int DEFAULT NULL COMMENT '工具执行最大尝试次数（null=框架默认1次）',
+  `compress_trigger_msgs` int DEFAULT NULL COMMENT '上下文压缩触发消息数（null=不启用压缩）',
+  `compress_keep_msgs` int DEFAULT NULL COMMENT '压缩后保留最近消息数（null=默认10）',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_agent_code` (`agent_code`),
+  KEY `idx_ai_agent_model` (`model_id`),
+  KEY `idx_ai_agent_tenant` (`tenant_id`),
+  KEY `idx_ai_agent_route_policy` (`tenant_id`,`model_route_policy_id`,`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体配置';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_backup_model
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_backup_model` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_id` bigint NOT NULL COMMENT '智能体ID',
+  `model_id` bigint NOT NULL COMMENT '备用模型ID',
+  `sort_order` int NOT NULL DEFAULT '0' COMMENT '容错切换顺序（升序，越小越先尝试）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_agent_backup` (`agent_id`,`model_id`),
+  KEY `idx_backup_model` (`model_id`),
+  KEY `idx_ai_agent_backup_model_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-备用模型关联';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_improvement_case
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_improvement_case` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `source_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'KNOWLEDGE_GAP/BADCASE',
+  `source_key` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'questionHash或badcaseId',
+  `signal_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '同类问题复发观测键',
+  `source_signal_count` bigint NOT NULL DEFAULT '0' COMMENT '认领时累计信号数',
+  `owner_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sla_due_at_ms` bigint NOT NULL,
+  `status` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `agent_id` bigint DEFAULT NULL,
+  `agent_code` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `artifact_type` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `artifact_version` char(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '精确候选版本指纹',
+  `candidate_versions_json` json DEFAULT NULL COMMENT '非密钥九维版本绑定',
+  `eval_type` varchar(16) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `eval_case_id` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `eval_run_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `reevaluation_status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NOT_RUN',
+  `reevaluation_verdict` varchar(24) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `reevaluation_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `publish_task_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `publish_revision` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `publish_status` varchar(24) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `published_at_ms` bigint DEFAULT NULL COMMENT 'Worker观测到全目标APPLIED的时间',
+  `baseline_signal_count` bigint DEFAULT NULL,
+  `observation_started_at_ms` bigint DEFAULT NULL,
+  `observation_ends_at_ms` bigint DEFAULT NULL,
+  `min_exposure_calls` int DEFAULT NULL,
+  `max_recurrence_signals` int DEFAULT NULL,
+  `observed_calls` bigint NOT NULL DEFAULT '0',
+  `observed_signals` bigint NOT NULL DEFAULT '0',
+  `effect_status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NOT_STARTED',
+  `last_observed_at_ms` bigint DEFAULT NULL,
+  `next_action_at_ms` bigint NOT NULL,
+  `lease_owner` varchar(160) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `lease_until_ms` bigint NOT NULL DEFAULT '0',
+  `automation_failures` int NOT NULL DEFAULT '0',
+  `last_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at_ms` bigint NOT NULL,
+  `updated_at_ms` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_improvement_source` (`tenant_id`,`source_type`,`source_key`),
+  KEY `idx_improvement_owner_sla` (`tenant_id`,`owner_id`,`status`,`sla_due_at_ms`),
+  KEY `idx_improvement_due` (`status`,`next_action_at_ms`,`lease_until_ms`),
+  KEY `idx_improvement_publish` (`tenant_id`,`publish_task_id`),
+  CONSTRAINT `chk_improvement_source_type` CHECK ((`source_type` in (_utf8mb4'KNOWLEDGE_GAP',_utf8mb4'BADCASE'))),
+  CONSTRAINT `chk_improvement_status` CHECK ((`status` in (_utf8mb4'OWNED',_utf8mb4'READY_FOR_REEVALUATION',_utf8mb4'REEVALUATING',_utf8mb4'REEVALUATION_FAILED',_utf8mb4'READY_TO_PUBLISH',_utf8mb4'PUBLISHING',_utf8mb4'PUBLISH_FAILED',_utf8mb4'OBSERVING',_utf8mb4'VERIFIED',_utf8mb4'INEFFECTIVE',_utf8mb4'INCONCLUSIVE',_utf8mb4'CANCELLED')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体问题从认领到线上效果验证的治理闭环';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_knowledge_base
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_knowledge_base` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_id` bigint NOT NULL COMMENT '智能体ID',
+  `knowledge_base_id` bigint NOT NULL COMMENT '知识库ID',
+  `knowledge_base_version_id` bigint NOT NULL COMMENT 'Agent 冻结的知识库版本ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_agent_kb` (`agent_id`,`knowledge_base_id`),
+  KEY `idx_ai_agent_kb_base` (`knowledge_base_id`),
+  KEY `idx_ai_agent_knowledge_base_tenant` (`tenant_id`),
+  KEY `idx_ai_agent_kb_version` (`tenant_id`,`knowledge_base_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-知识库关联';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_mcp
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_mcp` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_id` bigint NOT NULL COMMENT '智能体ID',
+  `mcp_id` bigint NOT NULL COMMENT 'MCP ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_agent_mcp` (`agent_id`,`mcp_id`),
+  KEY `idx_ai_agent_mcp_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-MCP关联';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_memory
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_memory` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '智能体与可信调用主体分区键',
+  `content` longtext COLLATE utf8mb4_unicode_ci COMMENT '长期记忆内容（MEMORY.md 全文）',
+  `version` bigint NOT NULL DEFAULT '1' COMMENT '乐观锁版本',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_agent_code` (`agent_code`),
+  KEY `idx_ai_agent_memory_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体跨会话长期记忆（MEMORY.md 权威存储）';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_skill
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_skill` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_id` bigint NOT NULL COMMENT '智能体ID',
+  `skill_id` bigint NOT NULL COMMENT 'Skill ID',
+  `skill_version_id` bigint NOT NULL COMMENT 'Agent 冻结的 Skill 版本ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_agent_skill` (`agent_id`,`skill_id`),
+  KEY `idx_ai_agent_skill_tenant` (`tenant_id`),
+  KEY `idx_ai_agent_skill_version` (`tenant_id`,`skill_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-Skill关联';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_sub_agent
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_sub_agent` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_id` bigint NOT NULL COMMENT '父智能体ID',
+  `sub_agent_id` bigint NOT NULL COMMENT '子智能体ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_agent_sub_agent` (`agent_id`,`sub_agent_id`),
+  KEY `idx_ai_agent_sub_agent_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-子智能体关联';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_system_tool
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_system_tool` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `agent_id` bigint NOT NULL COMMENT '智能体ID',
+  `system_tool_id` bigint NOT NULL COMMENT '系统工具ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_agent_system_tool_agent` (`agent_id`),
+  KEY `idx_ai_agent_system_tool_tool` (`system_tool_id`),
+  KEY `idx_ai_agent_system_tool_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体-系统工具关联（纯关系表）';
+
+-- ----------------------------------------------------------------------------
+-- ai_agent_task
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_agent_task` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `task_id` varchar(64) COLLATE utf8mb4_general_ci NOT NULL COMMENT '框架任务ID（agent_spawn 返回给模型的那个，全局唯一）',
+  `parent_agent_code` varchar(64) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '发起任务的父智能体编码',
+  `sub_agent_id` varchar(128) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '执行任务的子智能体标识',
+  `parent_session_id` varchar(128) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '父会话ID（任务归属的对话）',
+  `status` varchar(16) COLLATE utf8mb4_general_ci NOT NULL COMMENT '状态：PENDING/RUNNING/COMPLETED/FAILED/CANCELLED',
+  `result` mediumtext COLLATE utf8mb4_general_ci COMMENT '任务成功时的结果文本',
+  `error_message` text COLLATE utf8mb4_general_ci COMMENT '任务失败时的错误信息',
+  `cancel_requested` tinyint(1) NOT NULL DEFAULT '0' COMMENT '是否已请求取消（1=是）',
+  `owner_id` varchar(128) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '当前执行所有者（Pod/进程唯一ID）',
+  `lease_until` datetime(3) DEFAULT NULL COMMENT '所有权租约到期时间',
+  `heartbeat_at` datetime(3) DEFAULT NULL COMMENT '当前所有者最近心跳',
+  `attempt_count` int NOT NULL DEFAULT '0' COMMENT '领取执行次数',
+  `replayable` tinyint(1) NOT NULL DEFAULT '0' COMMENT '是否具备可重放执行输入',
+  `task_input` mediumtext COLLATE utf8mb4_general_ci COMMENT '子智能体原始任务提示词',
+  `child_session_id` varchar(128) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '恢复执行的稳定子会话ID',
+  `runtime_user_id` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT 'RuntimeContext userId',
+  `subject_type` varchar(32) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '可信调用主体类型',
+  `subject_id` varchar(128) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '可信调用主体ID或指纹',
+  `subject_authenticated` tinyint(1) DEFAULT NULL COMMENT '主体是否已认证',
+  `access_epoch` bigint DEFAULT NULL COMMENT '租户访问版本快照',
+  `channel_code` varchar(32) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '服务端确认的调用渠道',
+  `created_at` datetime NOT NULL COMMENT '任务创建时间',
+  `started_at` datetime DEFAULT NULL COMMENT '开始执行时间（进入 RUNNING）',
+  `finished_at` datetime DEFAULT NULL COMMENT '结束时间（进入任一终态）',
+  `updated_at` datetime NOT NULL COMMENT '最后更新时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_task_id` (`task_id`),
+  KEY `idx_session` (`parent_session_id`),
+  KEY `idx_agent_status` (`parent_agent_code`,`status`),
+  KEY `idx_created` (`created_at`),
+  KEY `idx_ai_agent_task_tenant` (`tenant_id`),
+  KEY `idx_task_lease_recovery` (`status`,`replayable`,`lease_until`,`attempt_count`),
+  KEY `idx_task_owner_status` (`owner_id`,`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='智能体后台委派任务';
+
+-- ----------------------------------------------------------------------------
+-- ai_channel_binding
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_channel_binding` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `channel_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '渠道编码（唯一，如 default/wechat/web）',
+  `agent_id` bigint NOT NULL COMMENT '绑定的智能体ID（其配置作为客服机器人运行时配置）',
+  `status` int NOT NULL DEFAULT '1' COMMENT '0停用 / 1启用（停用则不参与自动发布）',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` int NOT NULL DEFAULT '0' COMMENT '逻辑删除 0否/1是',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_channel_code` (`channel_code`,`deleted`),
+  KEY `idx_agent_id` (`agent_id`),
+  KEY `idx_ai_channel_binding_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='渠道-客服机器人运行配置绑定';
+
+-- ----------------------------------------------------------------------------
+-- ai_channel_robot
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_channel_robot` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `channel_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '渠道类型：dingtalk（预留 wecom/wechat）',
+  `robot_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '机器人名称',
+  `app_key` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '渠道 AppKey / ClientId',
+  `app_secret_cipher` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'AppSecret（AES-GCM 密文，永不明文返回列表）',
+  `robot_code` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '机器人编码（钉钉 robotCode 等，选填）',
+  `callback_mode` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'plaintext' COMMENT '微信回调模式：plaintext 明文 / safe AES 安全模式',
+  `encoding_aes_key_cipher` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '微信 EncodingAESKey（AES-GCM 密文）',
+  `agent_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '绑定的智能体编码（ai_agent.agent_code）',
+  `session_mode` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'continuous' COMMENT '会话模式：continuous 持续会话 / per_message 单次问答',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0停用 / 1启用',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_channel_appkey` (`channel_type`,`app_key`),
+  KEY `idx_ai_channel_robot_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='渠道机器人';
+
+-- ----------------------------------------------------------------------------
+-- ai_channel_session
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_channel_session` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `channel_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '渠道类型：dingtalk（预留 wecom/wechat）',
+  `app_key` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '渠道 AppKey / ClientId',
+  `external_user_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '渠道侧外部用户唯一标识（钉钉 senderStaffId 等）',
+  `session_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '映射到的工作区会话 ID（ch-<uuid>）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_channel_user` (`channel_type`,`app_key`,`external_user_id`),
+  KEY `idx_ai_channel_session_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='渠道外部用户与工作区会话映射';
+
+-- ----------------------------------------------------------------------------
+-- ai_chat_attachment
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_chat_attachment` (
+  `id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '附件ID(UUID)',
+  `session_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '会话ID',
+  `message_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '绑定的用户消息ID（框架Msg.id，空=未绑定）',
+  `agent_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '智能体编码（一次上传归属的智能体）',
+  `uploader` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '上传者标识（当前登录管理员ID）',
+  `channel` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '来源渠道：admin_chat/vibecoding',
+  `file_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '原始文件名',
+  `extension` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '扩展名',
+  `mime_type` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT 'MIME类型',
+  `file_size` bigint NOT NULL DEFAULT '0' COMMENT '文件字节数',
+  `storage_path` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '落盘相对路径',
+  `parse_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'SUCCESS' COMMENT '解析状态：SUCCESS/FAILED',
+  `parsed_text` mediumtext COLLATE utf8mb4_unicode_ci COMMENT '解析出的文本（FAILED 为空）',
+  `error_message` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '解析失败原因（SUCCESS 为空）',
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_by` bigint DEFAULT NULL COMMENT '上传人（后台用户ID）；NULL=存量数据，租户内共享',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_attachment_session` (`session_id`),
+  KEY `idx_ai_attachment_agent` (`agent_code`),
+  KEY `idx_ai_attachment_created` (`created_at`),
+  KEY `idx_ai_chat_attachment_tenant` (`tenant_id`),
+  KEY `idx_ai_chat_attachment_create_by` (`create_by`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='对话附件（多格式解析落库）';
+
+-- ----------------------------------------------------------------------------
+-- ai_chat_session_state
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_chat_session_state` (
+  `session_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `state_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `item_index` int NOT NULL DEFAULT '0',
+  `state_data` longtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`session_id`,`state_key`,`item_index`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='智能体对话状态持久化（AgentStateStore，含短期记忆/对话历史）';
+
+-- ----------------------------------------------------------------------------
+-- ai_code_knowledge_chunk
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_code_knowledge_chunk` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `index_id` bigint NOT NULL COMMENT '所属索引ID',
+  `source_path` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '来源文件相对路径',
+  `chunk_index` int NOT NULL COMMENT '同一文件内的分块序号（0起）',
+  `symbol` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分块对应的符号（类/方法名等，可空）',
+  `lang` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '语言标识（java/xml/...）',
+  `content` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '分块文本内容',
+  `embedding` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '向量（JSON 浮点数组）',
+  `dimensions` int NOT NULL COMMENT '向量维度',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_code_knowledge_chunk_index` (`index_id`),
+  KEY `idx_ai_code_knowledge_chunk_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='代码知识库分块与向量';
+
+-- ----------------------------------------------------------------------------
+-- ai_code_knowledge_index
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_code_knowledge_index` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `index_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '索引名（唯一，用户可读标识）',
+  `source_path` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '被索引的源码目录/文件路径',
+  `embedding_model` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'Embedding 模型名（如 text-embedding-v3）',
+  `dimensions` int DEFAULT NULL COMMENT '向量维度',
+  `chunk_count` int NOT NULL DEFAULT '0' COMMENT '已入库分块数（构建进度）',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '状态：BUILDING 构建中 / READY 就绪 / FAILED 失败',
+  `message` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '状态说明（失败原因等）',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人用户ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人用户ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_code_knowledge_index_name` (`index_name`),
+  KEY `idx_ai_code_knowledge_index_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='代码知识库索引';
+
+-- ----------------------------------------------------------------------------
+-- ai_code_review_task
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_code_review_task` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `agent_code` varchar(64) NOT NULL COMMENT '智能体编码',
+  `session_id` varchar(64) NOT NULL COMMENT '会话 id',
+  `user_id` bigint NOT NULL COMMENT '提交人（admin 用户 id）',
+  `status` varchar(20) NOT NULL COMMENT '状态：RUNNING/SUCCESS/FAILED',
+  `result_json` mediumtext COMMENT '审查结果 JSON（SUCCESS 才有）',
+  `error_msg` varchar(1000) DEFAULT NULL COMMENT '失败原因（FAILED 才有）',
+  `create_time` datetime NOT NULL COMMENT '创建时间',
+  `update_time` datetime NOT NULL COMMENT '更新时间',
+  `finish_time` datetime DEFAULT NULL COMMENT '完成时间（SUCCESS/FAILED 时写入）',
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_user` (`user_id`),
+  KEY `idx_session` (`session_id`),
+  KEY `idx_ai_code_review_task_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='AI 代码审查异步任务';
+
+-- ----------------------------------------------------------------------------
+-- ai_coding_audit_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_coding_audit_log` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint DEFAULT NULL COMMENT '操作人用户ID',
+  `username` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '操作人账号（冗余存储，用户改名/删除后历史仍可读）',
+  `agent_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '智能体编码',
+  `session_id` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '会话ID',
+  `operation` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '操作类型：CHAT_STREAM/FILE_SAVE/GIT_DIFF_SUMMARY/COMMIT_MESSAGE/PR_DESCRIPTION',
+  `changed_files` text COLLATE utf8mb4_unicode_ci COMMENT '本次操作产生变更的文件清单（JSON数组），只读操作/无变更为空',
+  `input_tokens` int DEFAULT NULL COMMENT '模型输入token数（未发生模型调用或框架未返回用量时为空）',
+  `output_tokens` int DEFAULT NULL COMMENT '模型输出token数',
+  `total_tokens` int DEFAULT NULL COMMENT '模型总token数',
+  `cached_tokens` bigint DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total_tokens）',
+  `duration_ms` bigint DEFAULT NULL COMMENT '操作耗时（毫秒）',
+  `result` tinyint NOT NULL COMMENT '结果：1成功 / 0失败',
+  `error_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '失败错误码（ResultCode枚举名或流终止信号），成功为空',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '操作时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_coding_audit_agent_session` (`agent_code`,`session_id`),
+  KEY `idx_ai_coding_audit_user` (`user_id`),
+  KEY `idx_ai_coding_audit_time` (`create_time`),
+  KEY `idx_ai_coding_audit_log_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI编码操作审计日志';
+
+-- ----------------------------------------------------------------------------
+-- ai_config_version
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_config_version` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `config_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '配置类型：AGENT 智能体运行时配置 / MODEL 模型配置',
+  `target_code` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '目标业务编码（如 agentCode / channelCode），人可读、跨环境稳定',
+  `target_id` bigint DEFAULT NULL COMMENT '目标主键（可空：跨环境迁移后主键会变，故以 target_code 为准）',
+  `version` int NOT NULL COMMENT '该目标下的版本序号，从 1 开始',
+  `content` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '下发内容的完整快照（JSON），回滚即取此内容重发',
+  `content_hash` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '内容摘要，用于跳过"内容没变却重复发布"',
+  `publish_scope` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'FULL' COMMENT '发布范围：FULL 全量 / GRAY 灰度',
+  `gray_tenants` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '灰度租户编码列表（JSON 数组），publish_scope=GRAY 时有效',
+  `data_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '实际发布到的 Nacos dataId',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'PUBLISHED' COMMENT '状态：PUBLISHED 已发布 / SUPERSEDED 已被后续版本取代 / FAILED 发布失败',
+  `source_version` int DEFAULT NULL COMMENT '回滚来源版本号；非回滚产生的版本为空',
+  `remark` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '发布说明',
+  `create_by` bigint DEFAULT NULL COMMENT '发布人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '发布时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_config_version_tenant` (`tenant_id`,`config_type`,`target_code`,`version`),
+  KEY `idx_config_version_target` (`config_type`,`target_code`,`create_time`),
+  KEY `idx_config_version_status` (`status`),
+  KEY `idx_ai_config_version_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='配置发布版本快照（支持对比与回滚）';
+
+-- ----------------------------------------------------------------------------
+-- ai_cost_alert
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_cost_alert` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `period` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '周期：DAILY/MONTHLY',
+  `period_key` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '自然周期键，如 2026-08 或 2026-08-21',
+  `alert_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'BUDGET_WARNING/BUDGET_EXCEEDED/FORECAST_EXCEEDED',
+  `used_amount` decimal(16,4) NOT NULL DEFAULT '0.0000' COMMENT '首次触发时已结算金额（元）',
+  `limit_amount` decimal(16,4) NOT NULL DEFAULT '0.0000' COMMENT '触发时金额预算（元）',
+  `forecast_amount` decimal(16,4) NOT NULL DEFAULT '0.0000' COMMENT '触发时周期预测金额（元）',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'OPEN' COMMENT 'OPEN/ACKED',
+  `first_seen_at` datetime(3) NOT NULL COMMENT '首次触发时间',
+  `ack_by` bigint DEFAULT NULL COMMENT '确认人ID',
+  `ack_at` datetime(3) DEFAULT NULL COMMENT '确认时间',
+  `create_time` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+  `update_time` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_cost_alert_business` (`tenant_id`,`period`,`period_key`,`alert_type`),
+  KEY `idx_cost_alert_tenant_status` (`tenant_id`,`status`,`first_seen_at`),
+  KEY `idx_cost_alert_status_time` (`status`,`first_seen_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='金额预算告警事实';
+
+-- ----------------------------------------------------------------------------
+-- ai_eval_release_gate_override
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_eval_release_gate_override` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `task_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '可靠发布任务ID',
+  `candidate_content_hash` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '豁免对应的候选内容哈希',
+  `operator_id` bigint NOT NULL COMMENT '豁免操作人',
+  `reason` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '紧急豁免原因',
+  `previous_decision_json` longtext COLLATE utf8mb4_unicode_ci COMMENT '豁免前的完整门禁判定',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_eval_gate_override_task` (`tenant_id`,`task_id`),
+  KEY `idx_eval_gate_override_operator` (`tenant_id`,`operator_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='评测发布门禁紧急豁免审计';
+
+-- ----------------------------------------------------------------------------
+-- ai_eval_release_gate_policy
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_eval_release_gate_policy` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `eval_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'INTENT/QUALITY',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否参与发布门禁',
+  `min_primary_metric` double DEFAULT NULL COMMENT '主指标绝对下限',
+  `min_secondary_metric` double DEFAULT NULL COMMENT '次指标绝对下限',
+  `max_primary_regression` double DEFAULT NULL COMMENT '相对基线允许的主指标最大下降',
+  `max_secondary_regression` double DEFAULT NULL COMMENT '相对基线允许的次指标最大下降',
+  `critical_case_ids_json` text COLLATE utf8mb4_unicode_ci COMMENT '零容忍关键用例ID数组',
+  `judge_error_policy` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'BLOCK' COMMENT 'BLOCK/ALLOW',
+  `require_artifact_match` tinyint NOT NULL DEFAULT '1' COMMENT '评测版本是否必须匹配发布候选',
+  `create_by` bigint DEFAULT NULL,
+  `create_time` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `update_by` bigint DEFAULT NULL,
+  `update_time` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_eval_gate_policy_tenant_type` (`tenant_id`,`eval_type`),
+  KEY `idx_eval_gate_policy_enabled` (`tenant_id`,`enabled`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='评测发布门禁策略';
+
+-- ----------------------------------------------------------------------------
+-- ai_governance_audit_event
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_governance_audit_event` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `request_id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '审批请求ID',
+  `sequence_no` int NOT NULL COMMENT '请求内单调事件序号',
+  `event_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'SUBMITTED/APPROVED/EXECUTED/REJECTED/FAILED/EXPIRED',
+  `actor_id` bigint DEFAULT NULL COMMENT '操作人；系统事件为空',
+  `actor_name` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '操作人账号快照',
+  `payload_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '审批载荷 SHA-256',
+  `detail` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '不含敏感数据的审计摘要',
+  `previous_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '前一事件哈希',
+  `event_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '当前事件哈希',
+  `retention_until` datetime NOT NULL COMMENT '最短留存截止时间',
+  `create_time` datetime(3) NOT NULL COMMENT '事件时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_governance_audit_request_seq` (`tenant_id`,`request_id`,`sequence_no`),
+  UNIQUE KEY `uk_governance_audit_event_hash` (`event_hash`),
+  KEY `idx_governance_audit_retention` (`retention_until`),
+  KEY `idx_governance_audit_request` (`tenant_id`,`request_id`,`create_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='追加写治理审计哈希链';
+
+-- ----------------------------------------------------------------------------
+-- ai_governed_change_request
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_governed_change_request` (
+  `id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '审批请求ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `change_type` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '类型化高风险变更',
+  `target_key` varchar(160) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '稳定目标键',
+  `payload_json` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '服务端类型化执行载荷，不含凭据',
+  `payload_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '执行载荷 SHA-256',
+  `maker_id` bigint NOT NULL COMMENT '发起人',
+  `maker_name` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '发起人账号快照',
+  `checker_id` bigint DEFAULT NULL COMMENT '复核人',
+  `checker_name` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '复核人账号快照',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'PENDING/EXECUTING/EXECUTED/REJECTED/FAILED/EXPIRED',
+  `decision_reason` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '复核理由',
+  `result_json` mediumtext COLLATE utf8mb4_unicode_ci COMMENT '脱敏执行结果',
+  `failure_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '稳定失败码，不保存异常明文',
+  `expires_at` datetime(3) NOT NULL COMMENT '审批到期时间',
+  `decided_at` datetime(3) DEFAULT NULL COMMENT '复核时间',
+  `executed_at` datetime(3) DEFAULT NULL COMMENT '执行终止时间',
+  `create_time` datetime(3) NOT NULL COMMENT '创建时间',
+  `update_time` datetime(3) NOT NULL COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_governed_change_tenant_status` (`tenant_id`,`status`,`create_time` DESC),
+  KEY `idx_governed_change_expiry` (`status`,`expires_at`),
+  KEY `idx_governed_change_execution_recovery` (`status`,`update_time`),
+  KEY `idx_governed_change_target` (`tenant_id`,`change_type`,`target_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='maker-checker 高风险变更请求';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_base
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_base` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `kb_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '知识库名称（唯一标识，供智能体表单展示）',
+  `base_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'RAG 服务基址（不含 /api/v1/knowledge/search 路径）',
+  `app_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '知识库应用ID（请求体 app_id）',
+  `api_key` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'AppKey（AES/GCM 加密存储，请求头 Authorization: Bearer）',
+  `content_type` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'application/json' COMMENT '请求 Content-Type',
+  `extra_headers` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '自定义请求头（JSON 对象字符串，空=无）',
+  `top_n` int NOT NULL DEFAULT '5' COMMENT '单次检索返回条数（请求体 top_n）',
+  `score_threshold` decimal(6,4) NOT NULL DEFAULT '0.0000' COMMENT '相关度阈值：低于该值的召回丢弃，0=不过滤（rerank 分数量级仅 0.1x）',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0禁用 / 1启用',
+  `test_status` tinyint NOT NULL DEFAULT '0' COMMENT '最近测试结果：0未测试 / 1成功 / 2失败',
+  `test_time` datetime DEFAULT NULL COMMENT '最近测试时间',
+  `remark` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `current_version_id` bigint DEFAULT NULL COMMENT '当前不可变版本ID',
+  `latest_version_no` int NOT NULL DEFAULT '0' COMMENT '最新版本号',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_name` (`kb_name`),
+  KEY `idx_ai_knowledge_base_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='RAG 知识库配置';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_base_version
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_base_version` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `knowledge_base_id` bigint NOT NULL COMMENT '稳定知识库ID',
+  `version_no` int NOT NULL COMMENT '版本号',
+  `base_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本冻结 RAG 服务基址',
+  `app_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本冻结应用ID',
+  `api_key` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本冻结密文 AppKey',
+  `content_type` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'application/json' COMMENT '版本冻结 Content-Type',
+  `extra_headers` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '版本冻结请求头',
+  `top_n` int NOT NULL DEFAULT '5' COMMENT '版本冻结召回数',
+  `score_threshold` decimal(8,6) NOT NULL DEFAULT '0.000000' COMMENT '版本冻结相关度阈值',
+  `checkpoint` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '文档快照 checkpoint',
+  `snapshot_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '配置与文档成员指纹',
+  `document_count` int NOT NULL DEFAULT '0' COMMENT '快照文档数',
+  `quality_score` decimal(8,6) NOT NULL DEFAULT '1.000000' COMMENT '快照质量分',
+  `quality_status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'PASSED' COMMENT 'UNKNOWN/PASSED/FAILED',
+  `change_note` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '变更说明',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_version_no` (`tenant_id`,`knowledge_base_id`,`version_no`),
+  KEY `idx_ai_kb_version_base` (`tenant_id`,`knowledge_base_id`,`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识库不可变版本';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_base_version_document
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_base_version_document` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `knowledge_base_version_id` bigint NOT NULL COMMENT '知识库版本ID',
+  `document_revision_id` bigint NOT NULL COMMENT '文档修订ID',
+  `source_id` bigint NOT NULL COMMENT '文档源ID',
+  `external_id` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '文档稳定外部ID',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_version_document` (`knowledge_base_version_id`,`source_id`,`external_id`),
+  KEY `idx_ai_kb_version_revision` (`tenant_id`,`document_revision_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识库版本文档成员';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_document
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_document` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `knowledge_base_id` bigint NOT NULL COMMENT '知识库ID',
+  `source_id` bigint NOT NULL COMMENT '文档源ID',
+  `external_id` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '上游文档稳定ID',
+  `current_revision_id` bigint DEFAULT NULL COMMENT '当前修订ID',
+  `source_version` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '上游版本',
+  `content_hash` char(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '当前正文指纹',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '同步删除标记',
+  `source_updated_at` datetime(6) DEFAULT NULL COMMENT '上游更新时间',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  `update_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_document_external` (`tenant_id`,`source_id`,`external_id`),
+  KEY `idx_ai_kb_document_active` (`tenant_id`,`knowledge_base_id`,`deleted`,`source_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识文档稳定身份';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_document_chunk
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_document_chunk` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `document_revision_id` bigint NOT NULL COMMENT '文档修订ID',
+  `chunk_index` int NOT NULL COMMENT '分块序号',
+  `content` longtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '分块正文',
+  `embedding` longtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '向量 JSON',
+  `dimensions` int NOT NULL COMMENT '向量维度',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_chunk_index` (`document_revision_id`,`chunk_index`),
+  KEY `idx_ai_kb_chunk_tenant_revision` (`tenant_id`,`document_revision_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识文档向量分块';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_document_revision
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_document_revision` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `document_id` bigint NOT NULL COMMENT '文档稳定ID',
+  `source_id` bigint NOT NULL COMMENT '文档源ID',
+  `parent_revision_id` bigint DEFAULT NULL COMMENT '父修订ID',
+  `operation` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'UPSERT/DELETE',
+  `source_version` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '上游版本',
+  `title` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '标题',
+  `source_uri` varchar(2048) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '来源地址',
+  `content` longtext COLLATE utf8mb4_unicode_ci COMMENT '不可变正文；DELETE 修订为空',
+  `content_hash` char(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '正文指纹',
+  `acl_mode` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'PUBLIC' COMMENT 'PUBLIC/RESTRICTED',
+  `allowed_subject_types` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '允许主体类型',
+  `allowed_subject_ids` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '允许主体ID JSON数组',
+  `allowed_channels` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '允许渠道 JSON数组',
+  `source_updated_at` datetime(6) DEFAULT NULL COMMENT '上游更新时间',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_kb_revision_document` (`tenant_id`,`document_id`,`id`),
+  KEY `idx_ai_kb_revision_source` (`tenant_id`,`source_id`,`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识文档不可变修订';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_source
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_source` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `knowledge_base_id` bigint NOT NULL COMMENT '知识库ID',
+  `source_code` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '文档源稳定编码',
+  `source_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '文档源名称',
+  `source_type` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'PUSH' COMMENT '接入类型',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '0禁用/1启用',
+  `freshness_sla_minutes` int NOT NULL DEFAULT '1440' COMMENT '新鲜度 SLA 分钟',
+  `quality_threshold` decimal(8,6) NOT NULL DEFAULT '0.800000' COMMENT '最低质量分',
+  `default_acl_json` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '默认文档 ACL',
+  `current_checkpoint` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近成功 checkpoint',
+  `last_sync_at` datetime(6) DEFAULT NULL COMMENT '最近同步时间',
+  `last_successful_sync_at` datetime(6) DEFAULT NULL COMMENT '最近成功同步时间',
+  `last_sync_status` varchar(24) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'PROCESSING/SUCCEEDED/FAILED/QUALITY_FAILED',
+  `last_sync_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近同步错误',
+  `active_document_count` int NOT NULL DEFAULT '0' COMMENT '有效文档数',
+  `quality_score` decimal(8,6) DEFAULT NULL COMMENT '最近质量分',
+  `quality_status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'UNKNOWN' COMMENT 'UNKNOWN/PASSED/FAILED',
+  `revision` int NOT NULL DEFAULT '1' COMMENT '配置修订号',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_source_code` (`tenant_id`,`knowledge_base_id`,`source_code`),
+  KEY `idx_ai_kb_source_base` (`tenant_id`,`knowledge_base_id`,`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识库文档源';
+
+-- ----------------------------------------------------------------------------
+-- ai_knowledge_sync_run
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_knowledge_sync_run` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `knowledge_base_id` bigint NOT NULL COMMENT '知识库ID',
+  `source_id` bigint NOT NULL COMMENT '文档源ID',
+  `request_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '上游幂等请求ID',
+  `request_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '请求内容指纹',
+  `sync_mode` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'FULL/INCREMENTAL',
+  `checkpoint_before` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '提交前 checkpoint',
+  `checkpoint_after` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '目标 checkpoint',
+  `status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'PROCESSING/SUCCEEDED/FAILED/QUALITY_FAILED',
+  `received_count` int NOT NULL DEFAULT '0' COMMENT '接收变更数',
+  `upserted_count` int DEFAULT NULL COMMENT '写入数',
+  `deleted_count` int DEFAULT NULL COMMENT '删除数',
+  `unchanged_count` int DEFAULT NULL COMMENT '未变化数',
+  `active_document_count` int DEFAULT NULL COMMENT '提交后有效文档数',
+  `duplicate_content_count` int DEFAULT NULL COMMENT '重复正文数',
+  `quality_score` decimal(8,6) DEFAULT NULL COMMENT '质量分',
+  `quality_status` varchar(24) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'UNKNOWN/PASSED/FAILED',
+  `knowledge_base_version_id` bigint DEFAULT NULL COMMENT '成功发布的知识库版本ID',
+  `snapshot_hash` char(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '成功快照指纹',
+  `error_message` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '失败摘要',
+  `started_at` datetime(6) NOT NULL COMMENT '开始时间',
+  `finished_at` datetime(6) DEFAULT NULL COMMENT '结束时间',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_kb_sync_request` (`tenant_id`,`source_id`,`request_id`),
+  KEY `idx_ai_kb_sync_runs` (`tenant_id`,`source_id`,`id`),
+  KEY `idx_ai_kb_sync_status` (`tenant_id`,`status`,`started_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='知识文档源同步运行';
+
+-- ----------------------------------------------------------------------------
+-- ai_mcp
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_mcp` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `mcp_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'MCP 名称',
+  `mcp_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '类型（stdio / sse）',
+  `config` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'MCP 连接配置（命令/URL/参数等，JSON）',
+  `secret_ref_id` bigint DEFAULT NULL COMMENT 'MCP 敏感配置 SecretRef',
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '描述',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0禁用 / 1启用',
+  `test_status` tinyint NOT NULL DEFAULT '0' COMMENT '连通性测试：0未测试 / 1成功 / 2失败',
+  `test_time` datetime DEFAULT NULL COMMENT '最近一次测试时间',
+  `allowed_subject_types` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'USER,ADMIN_USER,API_KEY' COMMENT '允许调用主体类型，逗号分隔：USER/ADMIN_USER/IP/API_KEY',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_mcp_tenant` (`tenant_id`),
+  KEY `idx_ai_mcp_secret_ref` (`secret_ref_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='MCP 配置';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_asset
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_asset` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `asset_code` varchar(96) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户内稳定资产编码',
+  `asset_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '资产名称',
+  `vendor` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CUSTOM' COMMENT '模型厂商，不等同于接入协议',
+  `model_key` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '厂商模型标识',
+  `family` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '模型家族',
+  `asset_version` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '模型版本',
+  `modality` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'TEXT' COMMENT '能力模态，逗号分隔',
+  `context_window` int DEFAULT NULL COMMENT '上下文窗口 token 数',
+  `max_output_tokens` int DEFAULT NULL COMMENT '最大输出 token 数',
+  `supports_stream` tinyint NOT NULL DEFAULT '1' COMMENT '是否支持流式输出',
+  `supports_tool` tinyint NOT NULL DEFAULT '1' COMMENT '是否支持工具调用',
+  `supports_json_schema` tinyint NOT NULL DEFAULT '0' COMMENT '是否支持 JSON Schema',
+  `supports_multimodal` tinyint NOT NULL DEFAULT '0' COMMENT '是否支持多模态',
+  `capability_hash` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '能力声明摘要',
+  `lifecycle_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE' COMMENT 'DRAFT/ACTIVE/DEPRECATED/RETIRED',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '修改人',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_model_asset_tenant_code` (`tenant_id`,`asset_code`,`deleted`),
+  KEY `idx_model_asset_tenant_model` (`tenant_id`,`vendor`,`model_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型目录资产';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_certification
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_certification` (
+  `model_config_id` bigint NOT NULL COMMENT '模型部署ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'UNKNOWN' COMMENT 'UNKNOWN/PASSED/FAILED',
+  `current_run_id` bigint DEFAULT NULL COMMENT '当前认证运行ID',
+  `certified_endpoint_revision` int DEFAULT NULL COMMENT '通过认证的端点修订号',
+  `certified_secret_version` int DEFAULT NULL COMMENT '通过认证的 SecretRef 版本',
+  `valid_until` datetime DEFAULT NULL COMMENT '认证到期时间',
+  `completed_at` datetime DEFAULT NULL COMMENT '最近完成时间',
+  `passed_checks` int NOT NULL DEFAULT '0' COMMENT '通过检查数',
+  `failed_checks` int NOT NULL DEFAULT '0' COMMENT '失败检查数',
+  `latency_p95_ms` bigint DEFAULT NULL COMMENT '最近基础 P95 延迟',
+  `verified_context_tokens` int DEFAULT NULL COMMENT '最近确认上下文窗口',
+  `failure_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近失败编码',
+  `failure_message` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近脱敏失败摘要',
+  `revision` int NOT NULL DEFAULT '1' COMMENT '快照修订号',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`model_config_id`),
+  KEY `idx_model_certification_tenant_status` (`tenant_id`,`status`,`valid_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型部署认证快照';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_certification_run
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_certification_run` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `model_config_id` bigint NOT NULL COMMENT '模型部署ID',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'PASSED/FAILED',
+  `endpoint_revision` int NOT NULL COMMENT '认证时端点修订号',
+  `secret_version` int DEFAULT NULL COMMENT '认证时 SecretRef 版本；不保存凭据',
+  `required_context_tokens` int NOT NULL COMMENT '要求的上下文窗口 token 数',
+  `max_latency_ms` bigint NOT NULL COMMENT '基础延迟门槛',
+  `max_input_price` decimal(16,6) NOT NULL COMMENT '输入单价上限/百万 token',
+  `max_output_price` decimal(16,6) NOT NULL COMMENT '输出单价上限/百万 token',
+  `latency_p95_ms` bigint DEFAULT NULL COMMENT '基础探测 P95 延迟',
+  `verified_context_tokens` int DEFAULT NULL COMMENT '运行时与资产声明共同确认的窗口',
+  `input_price` decimal(16,6) DEFAULT NULL COMMENT '认证时生效输入单价',
+  `output_price` decimal(16,6) DEFAULT NULL COMMENT '认证时生效输出单价',
+  `currency` varchar(8) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '单价币种',
+  `checks_json` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '完整检查项与证据 JSON，不含凭据',
+  `failure_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '首个失败检查编码',
+  `failure_message` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '脱敏失败摘要',
+  `triggered_by` bigint DEFAULT NULL COMMENT '触发人',
+  `started_at` datetime NOT NULL COMMENT '开始时间',
+  `completed_at` datetime NOT NULL COMMENT '完成时间',
+  `valid_until` datetime DEFAULT NULL COMMENT 'PASSED 认证有效期',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '写入时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_model_cert_run_tenant_model` (`tenant_id`,`model_config_id`,`completed_at` DESC),
+  KEY `idx_model_cert_run_status` (`tenant_id`,`status`,`valid_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型部署认证不可变运行记录';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_config
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_config` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `model_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '模型名称（自定义标识）',
+  `deployment_code` varchar(96) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '租户内稳定部署编码',
+  `provider` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'openai' COMMENT '提供方（当前固定 openai，预留扩展）',
+  `protocol_adapter` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '运行时接入协议',
+  `api_key` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'AppKey（AES/GCM 加密存储）',
+  `secret_ref_id` bigint DEFAULT NULL COMMENT '凭据引用ID',
+  `base_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '接口 URL',
+  `region` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '部署地域',
+  `environment` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'PRODUCTION' COMMENT '部署环境',
+  `endpoint_revision` int NOT NULL DEFAULT '1' COMMENT '端点配置修订号',
+  `lifecycle_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/DEPRECATED/RETIRED',
+  `certification_required` tinyint NOT NULL DEFAULT '0' COMMENT '0=存量兼容免认证/1=上线前必须通过认证',
+  `model` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '模型名（如 gpt-4o）',
+  `is_default` tinyint NOT NULL DEFAULT '0' COMMENT '是否默认模型：0否 / 1是',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0禁用 / 1启用',
+  `test_status` tinyint NOT NULL DEFAULT '0' COMMENT '最近测试结果：0未测试 / 1成功 / 2失败',
+  `test_time` datetime DEFAULT NULL COMMENT '最近测试时间',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `asset_id` bigint DEFAULT NULL COMMENT '模型目录资产ID',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_model_deployment_tenant_code` (`tenant_id`,`deployment_code`,`deleted`),
+  KEY `idx_ai_model_config_tenant` (`tenant_id`),
+  KEY `idx_model_config_asset` (`tenant_id`,`asset_id`),
+  KEY `idx_model_config_secret` (`tenant_id`,`secret_ref_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI 模型配置';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_experiment
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_experiment` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `experiment_code` varchar(96) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户内稳定实验编码',
+  `experiment_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '实验名称',
+  `agent_id` bigint NOT NULL COMMENT '实验智能体ID',
+  `control_deployment_id` bigint NOT NULL COMMENT '对照组模型部署ID',
+  `control_model_ref` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '创建时对照组模型标识快照',
+  `control_endpoint_revision` int NOT NULL COMMENT '创建时对照组端点修订号',
+  `treatment_deployment_id` bigint NOT NULL COMMENT '实验组模型部署ID',
+  `treatment_model_ref` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '创建时实验组模型标识快照',
+  `treatment_endpoint_revision` int NOT NULL COMMENT '创建时实验组端点修订号',
+  `dataset_release_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '审核通过的数据集命名版本ID',
+  `dataset_version_name` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '创建时的数据集版本名快照',
+  `dataset_snapshot_version_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '不可变数据集内容快照ID',
+  `dataset_content_hash` char(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '数据集内容SHA-256',
+  `judge_deployment_id` bigint DEFAULT NULL COMMENT '创建时冻结的Judge部署ID',
+  `judge_model_ref` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '创建时Judge模型标识快照',
+  `judge_endpoint_revision` int DEFAULT NULL COMMENT '创建时Judge端点修订号',
+  `offline_eval_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NOT_STARTED' COMMENT 'NOT_STARTED/RUNNING/PASSED/FAILED',
+  `offline_eval_started_at` datetime(6) DEFAULT NULL COMMENT '离线评测开始时间',
+  `offline_eval_completed_at` datetime(6) DEFAULT NULL COMMENT '离线评测完成时间',
+  `offline_eval_error` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '门禁失败摘要',
+  `revision` int NOT NULL DEFAULT '1' COMMENT '不可变实验修订号',
+  `assignment_salt` char(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '不可变确定性分桶盐值',
+  `treatment_bps` int NOT NULL COMMENT '实验组流量，基点制1..9999',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'DRAFT' COMMENT 'DRAFT/RUNNING/STOPPED/COMPLETED',
+  `activation_task_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'ACTIVATE可靠发布任务ID',
+  `deactivation_task_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'DEACTIVATE可靠发布任务ID',
+  `min_sample` bigint NOT NULL COMMENT '触发护栏判断的最小样本数',
+  `max_error_rate` decimal(8,7) NOT NULL COMMENT '错误率护栏0..1',
+  `max_p95_latency_ms` bigint NOT NULL COMMENT 'P95延迟护栏毫秒',
+  `expires_at` datetime NOT NULL COMMENT '实验硬截止时间',
+  `started_at` datetime DEFAULT NULL COMMENT '启动时间',
+  `stopped_at` datetime DEFAULT NULL COMMENT '停止时间',
+  `completed_at` datetime DEFAULT NULL COMMENT '正常到期完成时间',
+  `stop_reason` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '停止、自动停止或到期原因',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '修改人',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `running_agent_id` bigint GENERATED ALWAYS AS ((case when (`status` = _utf8mb4'RUNNING') then `agent_id` else NULL end)) STORED COMMENT '仅RUNNING态参与唯一约束',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_model_experiment_tenant_code` (`tenant_id`,`experiment_code`),
+  UNIQUE KEY `uk_model_experiment_one_running_agent` (`tenant_id`,`running_agent_id`),
+  KEY `idx_model_experiment_tenant_status` (`tenant_id`,`status`,`create_time` DESC),
+  KEY `idx_model_experiment_expiry` (`status`,`expires_at`),
+  KEY `idx_model_experiment_activation_task` (`tenant_id`,`activation_task_id`),
+  KEY `idx_model_experiment_deactivation_task` (`tenant_id`,`deactivation_task_id`),
+  CONSTRAINT `chk_model_experiment_distinct_arms` CHECK ((`control_deployment_id` <> `treatment_deployment_id`)),
+  CONSTRAINT `chk_model_experiment_error_rate` CHECK ((`max_error_rate` between 0 and 1)),
+  CONSTRAINT `chk_model_experiment_min_sample` CHECK ((`min_sample` >= 1)),
+  CONSTRAINT `chk_model_experiment_p95` CHECK ((`max_p95_latency_ms` >= 1)),
+  CONSTRAINT `chk_model_experiment_revision` CHECK ((`revision` >= 1)),
+  CONSTRAINT `chk_model_experiment_status` CHECK ((`status` in (_utf8mb4'DRAFT',_utf8mb4'RUNNING',_utf8mb4'STOPPED',_utf8mb4'COMPLETED'))),
+  CONSTRAINT `chk_model_experiment_treatment_bps` CHECK ((`treatment_bps` between 1 and 9999))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='在线模型双臂实验定义';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_experiment_arm_eval
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_experiment_arm_eval` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `experiment_id` bigint NOT NULL COMMENT '模型实验ID',
+  `arm` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'CONTROL/TREATMENT',
+  `attempt_no` int NOT NULL COMMENT '该臂评测尝试序号',
+  `deployment_id` bigint NOT NULL COMMENT '被测部署ID',
+  `endpoint_revision` int NOT NULL COMMENT '被测端点修订号',
+  `dataset_release_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '数据集命名版本ID',
+  `dataset_snapshot_version_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '不可变数据集快照ID',
+  `dataset_content_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '数据集内容SHA-256',
+  `judge_deployment_id` bigint NOT NULL COMMENT 'Judge部署ID',
+  `judge_endpoint_revision` int NOT NULL COMMENT 'Judge端点修订号',
+  `rubric_version` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '评分rubric指纹',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'RUNNING/PASSED/FAILED/ERROR',
+  `total` int DEFAULT NULL COMMENT '用例总数',
+  `judged` int DEFAULT NULL COMMENT '成功评分数',
+  `passed` int DEFAULT NULL COMMENT '通过用例数',
+  `avg_score` decimal(8,6) DEFAULT NULL COMMENT '平均分1到5',
+  `pass_rate` decimal(8,6) DEFAULT NULL COMMENT '通过率0到1',
+  `failed_case_ids_json` text COLLATE utf8mb4_unicode_ci COMMENT '低分用例ID数组',
+  `error_case_ids_json` text COLLATE utf8mb4_unicode_ci COMMENT '评分错误用例ID数组',
+  `error_message` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '执行错误摘要',
+  `started_at` datetime(6) NOT NULL COMMENT '开始时间',
+  `completed_at` datetime(6) DEFAULT NULL COMMENT '完成时间',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '写入时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_model_experiment_arm_attempt` (`tenant_id`,`experiment_id`,`arm`,`attempt_no`),
+  KEY `idx_model_experiment_arm_eval` (`tenant_id`,`experiment_id`,`attempt_no` DESC),
+  CONSTRAINT `chk_model_experiment_arm` CHECK ((`arm` in (_utf8mb4'CONTROL',_utf8mb4'TREATMENT'))),
+  CONSTRAINT `chk_model_experiment_arm_eval_status` CHECK ((`status` in (_utf8mb4'RUNNING',_utf8mb4'PASSED',_utf8mb4'FAILED',_utf8mb4'ERROR')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型实验control/treatment离线评测事实';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_experiment_event
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_experiment_event` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `experiment_id` bigint NOT NULL COMMENT '实验ID',
+  `event_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'START/STOP/AUTO_STOP/EXPIRED',
+  `from_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '变更前状态',
+  `to_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '变更后状态',
+  `reason` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '停止或系统判断原因',
+  `actor_id` bigint DEFAULT NULL COMMENT '人工操作人；系统事件为空',
+  `occurred_at` datetime NOT NULL COMMENT '事件发生时间',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '写入时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_model_experiment_event_tenant_experiment` (`tenant_id`,`experiment_id`,`occurred_at` DESC),
+  CONSTRAINT `chk_model_experiment_event_from_status` CHECK ((`from_status` in (_utf8mb4'DRAFT',_utf8mb4'RUNNING',_utf8mb4'STOPPED',_utf8mb4'COMPLETED'))),
+  CONSTRAINT `chk_model_experiment_event_to_status` CHECK ((`to_status` in (_utf8mb4'DRAFT',_utf8mb4'RUNNING',_utf8mb4'STOPPED',_utf8mb4'COMPLETED'))),
+  CONSTRAINT `chk_model_experiment_event_type` CHECK ((`event_type` in (_utf8mb4'START',_utf8mb4'STOP',_utf8mb4'AUTO_STOP',_utf8mb4'EXPIRED')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='在线模型实验追加式生命周期事件';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_health_event
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_health_event` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `model_config_id` bigint NOT NULL COMMENT '模型部署ID',
+  `event_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'PROBE' COMMENT 'PROBE/STATE_TRANSITION/STALE_PROBE/OVERRIDE_*',
+  `source` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'MANUAL/SCHEDULED/RUNTIME/MIGRATION',
+  `probe_kind` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CONNECTIVITY' COMMENT 'CONNECTIVITY/AUTH/CAPABILITY',
+  `previous_health_status` varchar(16) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '事件前原始健康状态',
+  `health_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '本次探测后的健康状态',
+  `effective_health_status` varchar(16) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '覆盖后的有效健康状态',
+  `override_mode` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'AUTO' COMMENT '事件对应覆盖模式',
+  `operator_id` bigint DEFAULT NULL COMMENT '人工覆盖操作人',
+  `operator_name` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '人工覆盖账号快照',
+  `test_status` tinyint DEFAULT NULL COMMENT '探测事件为0/1/2，覆盖事件为空',
+  `latency_ms` bigint DEFAULT NULL COMMENT '探测耗时',
+  `error_category` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'AUTH/RATE_LIMIT/TIMEOUT/CONTRACT/UNKNOWN',
+  `message` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '脱敏后的结果摘要',
+  `occurred_at` datetime(6) NOT NULL COMMENT '探测实际开始时间（微秒）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '写入时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_model_health_event_tenant_model` (`tenant_id`,`model_config_id`,`occurred_at` DESC),
+  KEY `idx_model_health_event_category` (`tenant_id`,`error_category`,`occurred_at` DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型部署健康事件';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_health_snapshot
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_health_snapshot` (
+  `model_config_id` bigint NOT NULL COMMENT '模型部署ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `health_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'UNKNOWN' COMMENT 'UNKNOWN/HEALTHY/DEGRADED/UNHEALTHY/RECOVERING',
+  `auth_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'UNKNOWN' COMMENT 'UNKNOWN/PASSED/FAILED',
+  `capability_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'UNKNOWN' COMMENT 'UNKNOWN/PASSED/FAILED',
+  `consecutive_failures` int NOT NULL DEFAULT '0' COMMENT '连续失败次数',
+  `consecutive_successes` int NOT NULL DEFAULT '0' COMMENT '连续成功次数',
+  `last_latency_ms` bigint DEFAULT NULL COMMENT '最近探测耗时',
+  `last_error_category` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'AUTH/RATE_LIMIT/TIMEOUT/CONTRACT/UNKNOWN',
+  `last_message` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '脱敏后的最近结果摘要',
+  `last_probe_at` datetime(6) DEFAULT NULL COMMENT '最近探测实际开始时间（微秒）',
+  `last_success_at` datetime DEFAULT NULL COMMENT '最近成功时间',
+  `last_failure_at` datetime DEFAULT NULL COMMENT '最近失败时间',
+  `next_probe_at` datetime DEFAULT NULL COMMENT '下次计划探测时间',
+  `cooldown_until` datetime(6) DEFAULT NULL COMMENT 'UNHEALTHY 冷却截止时间',
+  `override_mode` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'AUTO' COMMENT 'AUTO/FORCE_HEALTHY/FORCE_UNHEALTHY',
+  `override_reason` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '人工覆盖理由',
+  `override_operator_id` bigint DEFAULT NULL COMMENT '覆盖操作人',
+  `override_operator_name` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '覆盖操作人账号快照',
+  `override_until` datetime(6) DEFAULT NULL COMMENT '人工覆盖到期时间',
+  `revision` int NOT NULL DEFAULT '1' COMMENT '快照修订号',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`model_config_id`),
+  KEY `idx_model_health_tenant_status` (`tenant_id`,`health_status`,`next_probe_at`),
+  KEY `idx_model_health_override_expiry` (`override_mode`,`override_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型部署健康快照';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_price
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_price` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `provider` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '模型厂商，如 dashscope/openai',
+  `model_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '模型名，如 qwen-max',
+  `input_price` decimal(16,6) NOT NULL DEFAULT '0.000000' COMMENT '输入单价（元/百万 token）',
+  `output_price` decimal(16,6) NOT NULL DEFAULT '0.000000' COMMENT '输出单价（元/百万 token）',
+  `cached_price` decimal(16,6) NOT NULL DEFAULT '0.000000' COMMENT '缓存命中输入单价（元/百万 token）',
+  `currency` varchar(8) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'CNY' COMMENT '币种',
+  `effective_from` datetime NOT NULL COMMENT '生效时间；调价不改旧行而是插新行，历史账单才算得回去',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  PRIMARY KEY (`id`),
+  KEY `idx_model_price_lookup` (`provider`,`model_name`,`effective_from`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型单价（按生效时间留历史，供账单回溯）';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_route_policy
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_route_policy` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `policy_code` varchar(96) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户内稳定策略编码',
+  `policy_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '策略名称',
+  `description` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '策略说明',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'DRAFT' COMMENT 'DRAFT/ACTIVE/DISABLED',
+  `current_version_id` bigint DEFAULT NULL COMMENT '当前生效的不可变版本ID',
+  `current_version_no` int DEFAULT NULL COMMENT '当前生效版本号',
+  `latest_version_no` int NOT NULL DEFAULT '0' COMMENT '已创建的最新版本号',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '修改人',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_model_route_policy_tenant_code` (`tenant_id`,`policy_code`,`deleted`),
+  KEY `idx_model_route_policy_tenant_status` (`tenant_id`,`status`,`update_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型路由策略身份';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_route_policy_version
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_route_policy_version` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `policy_id` bigint NOT NULL COMMENT '路由策略ID',
+  `version_no` int NOT NULL COMMENT '租户策略内单调递增版本号',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'DRAFT' COMMENT 'DRAFT/ACTIVE/RETIRED',
+  `content_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '规则规范化内容 SHA-256',
+  `change_note` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '版本变更说明',
+  `activated_by` bigint DEFAULT NULL COMMENT '激活人',
+  `activated_at` datetime DEFAULT NULL COMMENT '激活时间',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_model_route_policy_version` (`tenant_id`,`policy_id`,`version_no`),
+  KEY `idx_model_route_version_policy_status` (`tenant_id`,`policy_id`,`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型路由策略不可变版本';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_route_rule
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_model_route_rule` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `policy_version_id` bigint NOT NULL COMMENT '不可变策略版本ID',
+  `purpose` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'DEFAULT/ECONOMY/COMPLEX_REASONING/FALLBACK',
+  `deployment_id` bigint NOT NULL COMMENT 'ai_model_config.id，仅引用部署，不复制凭据',
+  `priority` int NOT NULL COMMENT '数值越小优先级越高',
+  `condition_json` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '类型化条件 JSON；空对象表示无条件',
+  `condition_summary` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '供审计和命中解释的条件摘要',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_model_route_rule_version_priority` (`tenant_id`,`policy_version_id`,`priority`),
+  KEY `idx_model_route_rule_deployment` (`tenant_id`,`deployment_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型路由版本规则';
+
+-- ----------------------------------------------------------------------------
+-- ai_plan_confirmation
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_plan_confirmation` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `agent_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '智能体编码',
+  `session_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '会话ID',
+  `plan_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '计划ID',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'PENDING/APPROVED/REJECTED/TIMEOUT/CANCELLED',
+  `expire_at` datetime NOT NULL COMMENT '确认截止时间',
+  `resolved_at` datetime DEFAULT NULL COMMENT '终态时间',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_plan_confirmation_scope` (`tenant_id`,`agent_code`,`session_id`,`plan_id`),
+  KEY `idx_plan_confirmation_pending` (`tenant_id`,`status`,`expire_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Plan/HITL 跨 Pod 挂起态';
+
+-- ----------------------------------------------------------------------------
+-- ai_project
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_project` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `project_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '项目名称',
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '描述',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_project_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='会话项目分组（跨智能体自由归类会话）';
+
+-- ----------------------------------------------------------------------------
+-- ai_project_session
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_project_session` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `project_id` bigint NOT NULL COMMENT '项目ID',
+  `agent_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '会话所属智能体编码',
+  `session_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '会话ID（AgentStateStore 里的逻辑 key，非本表自增主键）',
+  `create_by` bigint DEFAULT NULL COMMENT '添加人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '添加时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_project_session` (`project_id`,`agent_code`,`session_id`),
+  KEY `idx_ai_project_session_project` (`project_id`),
+  KEY `idx_ai_project_session_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='项目-会话关联';
+
+-- ----------------------------------------------------------------------------
+-- ai_runtime_config_ack
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_runtime_config_ack` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `revision` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content_hash` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `instance_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `reason` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `applied_at_ms` bigint NOT NULL,
+  `created_at_ms` bigint NOT NULL,
+  `updated_at_ms` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_runtime_ack_tenant_revision_instance` (`tenant_id`,`revision`,`instance_id`),
+  KEY `idx_runtime_ack_revision_status` (`tenant_id`,`revision`,`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='运行时配置实例应用回执';
+
+-- ----------------------------------------------------------------------------
+-- ai_runtime_publish_task
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_runtime_publish_task` (
+  `id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `seq` bigint NOT NULL AUTO_INCREMENT COMMENT '严格写入顺序，避免同毫秒任务排序不确定',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `target_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `target_id` bigint NOT NULL,
+  `experiment_id` bigint DEFAULT NULL COMMENT '在线实验ID；通用发布任务为空',
+  `experiment_publish_action` varchar(16) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'ACTIVATE/DEACTIVATE；通用发布任务为空',
+  `operation_id` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '一次回滚/灰度操作ID；灰度多任务共用',
+  `publish_intent` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NORMAL' COMMENT 'NORMAL/SAFE_ROLLBACK/SAFE_GRAY',
+  `source_config_version_id` bigint DEFAULT NULL COMMENT '白名单补丁来源配置版本主键',
+  `source_content_hash` char(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '来源完整快照SHA-256，仅作完整性审计',
+  `rollback_patch_json` json DEFAULT NULL COMMENT '仅允许systemPrompt/maxIters，不含模型、凭据、MCP、路由与实验',
+  `channel_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `data_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `group_name` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `revision` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content_hash` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `ack_targets_json` text COLLATE utf8mb4_unicode_ci COMMENT '入队时冻结的目标实例ID JSON',
+  `publish_scope` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'FULL',
+  `gray_tenants` text COLLATE utf8mb4_unicode_ci,
+  `source_version` int DEFAULT NULL,
+  `remark` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `attempts` int NOT NULL DEFAULT '0',
+  `next_attempt_at_ms` bigint NOT NULL,
+  `lease_owner` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `lease_until_ms` bigint NOT NULL DEFAULT '0',
+  `last_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `candidate_versions_json` text COLLATE utf8mb4_unicode_ci COMMENT '待发布候选的可比版本绑定JSON',
+  `gate_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NOT_REQUIRED' COMMENT 'NOT_REQUIRED/PENDING/PASSED/BLOCKED/OVERRIDDEN',
+  `gate_eval_run_ids_json` text COLLATE utf8mb4_unicode_ci COMMENT '本次判定使用的EvalRun ID数组',
+  `gate_decision_json` longtext COLLATE utf8mb4_unicode_ci COMMENT '完整门禁判定JSON',
+  `gate_evaluated_at_ms` bigint DEFAULT NULL COMMENT '门禁判定时间戳',
+  `gate_override_id` bigint DEFAULT NULL COMMENT '紧急豁免审计ID',
+  `created_at_ms` bigint NOT NULL,
+  `updated_at_ms` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_runtime_publish_seq` (`seq`),
+  UNIQUE KEY `uk_runtime_publish_tenant_revision` (`tenant_id`,`revision`),
+  KEY `idx_runtime_publish_due` (`status`,`next_attempt_at_ms`,`lease_until_ms`),
+  KEY `idx_runtime_publish_target` (`tenant_id`,`target_id`,`seq`),
+  KEY `idx_runtime_publish_gate` (`tenant_id`,`gate_status`,`seq`),
+  KEY `idx_runtime_publish_experiment` (`tenant_id`,`experiment_id`,`seq`),
+  KEY `idx_runtime_publish_operation` (`tenant_id`,`operation_id`,`seq`),
+  KEY `idx_runtime_publish_source_version` (`tenant_id`,`source_config_version_id`,`seq`),
+  KEY `idx_runtime_publish_nacos_key` (`tenant_id`,`data_id`,`group_name`,`seq`,`status`),
+  CONSTRAINT `chk_runtime_publish_experiment_intent` CHECK ((((`experiment_id` is null) and (`experiment_publish_action` is null)) or ((`experiment_id` is not null) and (`experiment_publish_action` in (_utf8mb4'ACTIVATE',_utf8mb4'DEACTIVATE'))))),
+  CONSTRAINT `chk_runtime_publish_safe_intent` CHECK ((((`publish_intent` = _utf8mb4'NORMAL') and (`source_config_version_id` is null) and (`source_content_hash` is null) and (`rollback_patch_json` is null)) or ((`publish_intent` in (_utf8mb4'SAFE_ROLLBACK',_utf8mb4'SAFE_GRAY')) and (`operation_id` is not null) and (`source_config_version_id` is not null) and (`source_content_hash` is not null) and (`rollback_patch_json` is not null))))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='运行时配置可靠发布任务';
+
+-- ----------------------------------------------------------------------------
+-- ai_scheduled_task
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_scheduled_task` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `task_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '任务编码（= XXL-JOB JobHandler 调用时的业务标识，全局唯一）',
+  `task_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '任务名称',
+  `agent_id` bigint NOT NULL COMMENT '关联智能体ID（逻辑关联 ai_agent.id）',
+  `prompt` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '每次触发时传给 Agent 的用户消息内容',
+  `cron` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'cron 表达式（内置动态调度器按此周期执行；为空则不参与内置周期调度，仅可手动/外部触发）',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否允许执行：0禁用 / 1启用',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_scheduled_task_code` (`task_code`),
+  KEY `idx_ai_scheduled_task_agent` (`agent_id`),
+  KEY `idx_ai_scheduled_task_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='定时任务定义';
+
+-- ----------------------------------------------------------------------------
+-- ai_scheduled_task_claim
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_scheduled_task_claim` (
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '任务所属租户',
+  `task_id` bigint NOT NULL COMMENT '定时任务ID',
+  `task_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '任务编码快照',
+  `fire_time` datetime(3) NOT NULL COMMENT 'Cron 计算出的计划触发时刻',
+  `owner_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '成功认领的 Admin 实例ID',
+  `claim_time` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '认领时间',
+  PRIMARY KEY (`tenant_id`,`task_id`,`fire_time`),
+  KEY `idx_scheduled_task_claim_time` (`claim_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='内置定时任务多Pod触发认领';
+
+-- ----------------------------------------------------------------------------
+-- ai_scheduled_task_run
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_scheduled_task_run` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `task_id` bigint NOT NULL COMMENT '任务ID',
+  `task_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '任务编码（冗余，任务被删除后历史记录仍可读）',
+  `trigger_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '触发方式：XXL_JOB / MANUAL',
+  `start_time` datetime NOT NULL COMMENT '开始执行时间',
+  `end_time` datetime DEFAULT NULL COMMENT '结束时间',
+  `cost_ms` bigint DEFAULT NULL COMMENT '耗时（毫秒）',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '执行结果：SUCCESS / FAILED',
+  `output` text COLLATE utf8mb4_unicode_ci COMMENT 'Agent 回复内容（落库前截断到 8000 字符）',
+  `error_message` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '失败原因',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_scheduled_task_run_task_time` (`task_id`,`start_time` DESC),
+  KEY `idx_ai_scheduled_task_run_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='定时任务执行历史（只追加，不做逻辑删除）';
+
+-- ----------------------------------------------------------------------------
+-- ai_secret_material
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_secret_material` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `secret_ref_id` bigint NOT NULL COMMENT 'ai_secret_ref.id',
+  `version` int NOT NULL COMMENT '不可变密钥版本',
+  `cipher_text` varchar(2048) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'LOCAL_AES 密文，禁止通过接口返回',
+  `key_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'admin-aes-gcm' COMMENT '加密主密钥标识',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/SUPERSEDED/REVOKED',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_secret_material_version` (`secret_ref_id`,`version`),
+  KEY `idx_secret_material_tenant_ref` (`tenant_id`,`secret_ref_id`,`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='本地加密密钥版本';
+
+-- ----------------------------------------------------------------------------
+-- ai_secret_ref
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_secret_ref` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `ref_code` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户内稳定凭据引用编码',
+  `ref_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '凭据名称',
+  `provider_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'LOCAL_AES' COMMENT 'LOCAL_AES/VAULT/AWS_SM/AZURE_KV/GCP_SM/ENV',
+  `external_ref` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '外部密钥管理器引用，不保存密钥值',
+  `current_version` int NOT NULL DEFAULT '1' COMMENT '当前版本',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/EXPIRED/DISABLED/ERROR',
+  `expires_at` datetime DEFAULT NULL COMMENT '凭据过期时间',
+  `last_rotated_at` datetime DEFAULT NULL COMMENT '最近轮换时间',
+  `last_rotated_by` bigint DEFAULT NULL COMMENT '最近轮换人',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '修改人',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_secret_ref_tenant_code` (`tenant_id`,`ref_code`,`deleted`),
+  KEY `idx_secret_ref_tenant_status` (`tenant_id`,`status`,`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='密钥引用元数据';
+
+-- ----------------------------------------------------------------------------
+-- ai_site_message
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_site_message` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `user_id` bigint NOT NULL COMMENT '接收人（admin 用户 id）',
+  `title` varchar(200) NOT NULL COMMENT '消息标题',
+  `content` varchar(2000) DEFAULT NULL COMMENT '消息正文',
+  `biz_type` varchar(50) NOT NULL COMMENT '业务类型（如 CODE_REVIEW）',
+  `biz_id` varchar(64) DEFAULT NULL COMMENT '业务主键',
+  `link` varchar(500) DEFAULT NULL COMMENT '前端跳转路由（可空）',
+  `read_flag` tinyint NOT NULL DEFAULT '0' COMMENT '已读标记：0未读/1已读',
+  `read_time` datetime DEFAULT NULL COMMENT '标记已读时间',
+  `create_time` datetime NOT NULL COMMENT '创建时间',
+  `update_time` datetime NOT NULL COMMENT '更新时间',
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_user_read` (`user_id`,`read_flag`),
+  KEY `idx_ai_site_message_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='通用站内消息';
+
+-- ----------------------------------------------------------------------------
+-- ai_skill
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_skill` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `skill_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '技能名称',
+  `skill_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '技能编码',
+  `content` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '技能内容/定义（SKILL.md 内容）',
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '描述',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0禁用 / 1启用',
+  `current_version_id` bigint DEFAULT NULL COMMENT '当前不可变版本ID',
+  `latest_version_no` int NOT NULL DEFAULT '0' COMMENT '最新版本号',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `storage_targets` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'local' COMMENT '存储目标，逗号分隔：local,nacos,sftp',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_skill_code` (`skill_code`),
+  KEY `idx_ai_skill_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Skill 配置';
+
+-- ----------------------------------------------------------------------------
+-- ai_skill_file
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_skill_file` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `skill_id` bigint NOT NULL COMMENT '所属 Skill（ai_skill.id）',
+  `file_path` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '相对 SKILL.md 所在目录的路径，如 references/api.md',
+  `file_size` bigint NOT NULL DEFAULT '0' COMMENT '文件字节数',
+  `content` longblob COMMENT '文件内容（文本/二进制统一按字节存）',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_ai_skill_file_skill` (`skill_id`),
+  KEY `idx_ai_skill_file_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Skill 附属文件（zip 上传的 references/scripts 等）';
+
+-- ----------------------------------------------------------------------------
+-- ai_skill_version
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_skill_version` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `skill_id` bigint NOT NULL COMMENT '稳定 Skill ID',
+  `version_no` int NOT NULL COMMENT '版本号',
+  `skill_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本冻结名称',
+  `skill_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本冻结编码',
+  `content` longtext COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本冻结 SKILL.md',
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '版本冻结描述',
+  `content_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '版本内容指纹',
+  `change_note` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '变更说明',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_skill_version_no` (`tenant_id`,`skill_id`,`version_no`),
+  KEY `idx_ai_skill_version_skill` (`tenant_id`,`skill_id`,`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Skill 不可变版本';
+
+-- ----------------------------------------------------------------------------
+-- ai_skill_version_file
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_skill_version_file` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID',
+  `skill_version_id` bigint NOT NULL COMMENT 'Skill 版本ID',
+  `file_path` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '相对文件路径',
+  `file_size` bigint NOT NULL DEFAULT '0' COMMENT '文件字节数',
+  `content` longblob COMMENT '文件内容',
+  `content_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '文件内容指纹',
+  `create_time` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_skill_version_file` (`skill_version_id`,`file_path`),
+  KEY `idx_ai_skill_version_file_tenant` (`tenant_id`,`skill_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Skill 版本附属文件';
+
+-- ----------------------------------------------------------------------------
+-- ai_slo_alert
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_slo_alert` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `policy_id` bigint NOT NULL COMMENT 'SLO策略ID',
+  `window_end_minute` bigint NOT NULL COMMENT '评估时刻UTC分钟桶',
+  `alert_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'MULTI_WINDOW_BURN',
+  `active_policy_id` bigint DEFAULT NULL COMMENT '活跃告警策略ID，恢复后置空',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'OPEN' COMMENT 'OPEN/ACKED/RESOLVED',
+  `short_burn_rate` decimal(12,6) NOT NULL COMMENT '短窗口燃烧率',
+  `long_burn_rate` decimal(12,6) NOT NULL COMMENT '长窗口燃烧率',
+  `first_seen_at` datetime NOT NULL COMMENT '首次发现时间',
+  `last_seen_at` datetime DEFAULT NULL COMMENT '最近燃烧或恢复观测时间',
+  `ack_by` bigint DEFAULT NULL COMMENT '确认人',
+  `ack_at` datetime DEFAULT NULL COMMENT '确认时间',
+  `resolved_at` datetime DEFAULT NULL COMMENT '恢复时间',
+  `update_time` datetime DEFAULT NULL COMMENT '状态更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_slo_alert_active` (`tenant_id`,`active_policy_id`),
+  KEY `idx_slo_alert_tenant_time` (`tenant_id`,`first_seen_at` DESC),
+  KEY `idx_slo_alert_tenant_status` (`tenant_id`,`status`,`last_seen_at`),
+  CONSTRAINT `chk_slo_alert_type` CHECK ((`alert_type` = _utf8mb4'MULTI_WINDOW_BURN'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SLO错误预算告警事实';
+
+-- ----------------------------------------------------------------------------
+-- ai_slo_alert_event
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_slo_alert_event` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `alert_id` bigint NOT NULL,
+  `policy_id` bigint NOT NULL,
+  `event_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'OPENED/ACKED/RESOLVED',
+  `actor_user_id` bigint DEFAULT NULL,
+  `short_burn_rate` decimal(12,6) NOT NULL,
+  `long_burn_rate` decimal(12,6) NOT NULL,
+  `occurred_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_slo_alert_event_once` (`alert_id`,`event_type`),
+  KEY `idx_slo_alert_event_tenant_time` (`tenant_id`,`occurred_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SLO告警状态迁移事件';
+
+-- ----------------------------------------------------------------------------
+-- ai_slo_notification_task
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_slo_notification_task` (
+  `id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` bigint NOT NULL,
+  `alert_id` bigint NOT NULL,
+  `policy_id` bigint NOT NULL,
+  `event_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `title` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'PENDING/PROCESSING/DELIVERED',
+  `attempts` int NOT NULL DEFAULT '0',
+  `next_attempt_at_ms` bigint NOT NULL,
+  `lease_owner` varchar(160) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `lease_until_ms` bigint NOT NULL DEFAULT '0',
+  `last_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `recipient_count` int NOT NULL DEFAULT '0',
+  `created_at_ms` bigint NOT NULL,
+  `updated_at_ms` bigint NOT NULL,
+  `delivered_at_ms` bigint DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_slo_notification_event` (`event_id`),
+  KEY `idx_slo_notification_due` (`status`,`next_attempt_at_ms`,`lease_until_ms`),
+  KEY `idx_slo_notification_tenant` (`tenant_id`,`created_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SLO告警可靠通知任务';
+
+-- ----------------------------------------------------------------------------
+-- ai_slo_policy
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_slo_policy` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `policy_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '策略名称',
+  `scope_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'TENANT/AGENT/CHANNEL',
+  `scope_key` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'Agent编码或渠道编码；租户范围为空',
+  `availability_target` decimal(8,7) NOT NULL COMMENT '成功率目标0..1',
+  `latency_target` decimal(8,7) NOT NULL COMMENT '阈值内完成比例目标0..1',
+  `latency_threshold_ms` bigint NOT NULL COMMENT '延迟阈值毫秒',
+  `short_window_minutes` int NOT NULL COMMENT '短窗口分钟',
+  `long_window_minutes` int NOT NULL COMMENT '长窗口分钟',
+  `minimum_sample_count` int NOT NULL DEFAULT '100' COMMENT '短长窗口各自触发评估所需的最低调用样本数',
+  `burn_rate_threshold` decimal(12,6) NOT NULL COMMENT '短长窗口共同触发的燃烧率阈值',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1' COMMENT '是否启用',
+  `next_evaluation_at_ms` bigint NOT NULL DEFAULT '0' COMMENT '下次周期评估时间',
+  `evaluation_lease_owner` varchar(160) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '周期评估租约持有者',
+  `evaluation_lease_until_ms` bigint NOT NULL DEFAULT '0' COMMENT '周期评估租约截止时间',
+  `evaluation_failures` int NOT NULL DEFAULT '0' COMMENT '连续评估失败次数',
+  `last_evaluated_at` datetime DEFAULT NULL COMMENT '最近评估时间',
+  `last_evaluation_status` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近评估状态',
+  `last_evaluation_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近评估错误',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_slo_policy_tenant_name` (`tenant_id`,`policy_name`),
+  KEY `idx_slo_policy_tenant_scope` (`tenant_id`,`scope_type`,`scope_key`,`enabled`),
+  KEY `idx_slo_policy_evaluation_due` (`enabled`,`next_evaluation_at_ms`,`evaluation_lease_until_ms`),
+  CONSTRAINT `chk_slo_policy_availability` CHECK (((`availability_target` > 0) and (`availability_target` < 1))),
+  CONSTRAINT `chk_slo_policy_burn` CHECK ((`burn_rate_threshold` > 0)),
+  CONSTRAINT `chk_slo_policy_latency` CHECK (((`latency_target` > 0) and (`latency_target` < 1))),
+  CONSTRAINT `chk_slo_policy_latency_ms` CHECK ((`latency_threshold_ms` > 0)),
+  CONSTRAINT `chk_slo_policy_minimum_samples` CHECK ((`minimum_sample_count` > 0)),
+  CONSTRAINT `chk_slo_policy_scope` CHECK ((`scope_type` in (_utf8mb4'TENANT',_utf8mb4'AGENT',_utf8mb4'CHANNEL'))),
+  CONSTRAINT `chk_slo_policy_windows` CHECK (((`short_window_minutes` > 0) and (`long_window_minutes` > `short_window_minutes`)))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户SLO策略';
+
+-- ----------------------------------------------------------------------------
+-- ai_system_tool
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_system_tool` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tool_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '工具编码（唯一，运行时按此值取同名 Spring Bean，不可修改）',
+  `tool_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '工具展示名称',
+  `description` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '工具描述',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否启用：0禁用 / 1启用',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_ai_system_tool_code` (`tool_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='系统工具目录（代码定义，库存启停状态）';
+
+-- ----------------------------------------------------------------------------
+-- ai_workspace_session
+-- ----------------------------------------------------------------------------
+CREATE TABLE `ai_workspace_session` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `agent_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `session_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `owner_user_id` bigint NOT NULL,
+  `created_at_ms` bigint NOT NULL,
+  `updated_at_ms` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_workspace_session_tenant_agent_session` (`tenant_id`,`agent_code`,`session_id`),
+  KEY `idx_workspace_session_tenant_owner` (`tenant_id`,`owner_user_id`,`updated_at_ms`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='工作区会话租户与用户归属';
+
+-- ----------------------------------------------------------------------------
+-- cw_agent_call_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_agent_call_log` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `request_id` varchar(64) NOT NULL DEFAULT '' COMMENT '请求ID（全链路关联）',
+  `user_id` varchar(128) NOT NULL DEFAULT '' COMMENT '用户ID（ctx.userId）',
+  `username` varchar(128) NOT NULL DEFAULT '' COMMENT '用户名',
+  `agent_code` varchar(128) NOT NULL DEFAULT '' COMMENT '智能体编码',
+  `agent_name` varchar(255) NOT NULL DEFAULT '' COMMENT '智能体名称',
+  `session_id` varchar(128) NOT NULL DEFAULT '' COMMENT '会话ID',
+  `session_type` varchar(32) NOT NULL DEFAULT 'CHAT' COMMENT '会话类型 CHAT/VIBE_CODING',
+  `question` mediumtext COMMENT '用户问题',
+  `answer` mediumtext COMMENT '智能体回答',
+  `start_time` bigint NOT NULL COMMENT '调用开始时间戳（毫秒）',
+  `end_time` bigint NOT NULL COMMENT '调用结束时间戳（毫秒）',
+  `duration_ms` bigint NOT NULL DEFAULT '0' COMMENT '总耗时（毫秒）',
+  `model_ms` bigint NOT NULL DEFAULT '0' COMMENT 'MODEL段耗时合计（毫秒）',
+  `tool_ms` bigint NOT NULL DEFAULT '0' COMMENT 'TOOL段耗时合计（毫秒）',
+  `mcp_ms` bigint NOT NULL DEFAULT '0' COMMENT 'MCP段耗时合计（毫秒）',
+  `skill_ms` bigint NOT NULL DEFAULT '0' COMMENT 'SKILL段耗时合计（毫秒）',
+  `segment_count` int NOT NULL DEFAULT '0' COMMENT '分段总数',
+  `input_tokens` bigint DEFAULT NULL COMMENT '请求级输入token合计（缺失为NULL）',
+  `output_tokens` bigint DEFAULT NULL COMMENT '请求级输出token合计（缺失为NULL）',
+  `total_tokens` bigint DEFAULT NULL COMMENT '请求级总token合计（缺失为NULL）',
+  `cached_tokens` bigint DEFAULT NULL COMMENT '命中缓存的输入token（input_tokens的子集，不计入total）',
+  `model_reported_ms` bigint DEFAULT NULL COMMENT '模型自报耗时合计（毫秒），与model_ms之差=网络/排队开销',
+  `model_cost_amount` decimal(30,14) DEFAULT NULL COMMENT '本次调用已结算模型金额',
+  `model_cost_currency` varchar(16) DEFAULT NULL COMMENT '单币种结算币种',
+  `model_cost_status` varchar(24) NOT NULL DEFAULT 'NO_MODEL' COMMENT 'COMPLETE/PARTIAL/UNAVAILABLE/MULTI_CURRENCY/NO_MODEL',
+  `model_segment_count` int NOT NULL DEFAULT '0' COMMENT '模型分段数',
+  `settled_cost_segment_count` int NOT NULL DEFAULT '0' COMMENT '已结算模型分段数',
+  `unsettled_cost_segment_count` int NOT NULL DEFAULT '0' COMMENT '未结算模型分段数',
+  `trace_id` varchar(32) DEFAULT NULL COMMENT 'W3C trace-id，关联 OTel/Tempo',
+  `runtime_revision` varchar(64) DEFAULT NULL COMMENT '实例实际应用的运行配置发布修订',
+  `runtime_content_hash` char(64) DEFAULT NULL COMMENT '运行配置内容摘要，关联发布任务与实例ACK',
+  `version_binding_json` json DEFAULT NULL COMMENT '模型/提示词/Agent/知识库/工具版本绑定（不含密钥）',
+  `replay_snapshot_json` json DEFAULT NULL COMMENT '脱敏模型参数、RAG与工具重放事实',
+  `experiment_id` bigint DEFAULT NULL COMMENT '在线实验ID',
+  `experiment_revision` int DEFAULT NULL COMMENT '不可变实验修订号',
+  `experiment_arm` varchar(16) DEFAULT NULL COMMENT 'CONTROL/TREATMENT',
+  `experiment_deployment_id` bigint DEFAULT NULL COMMENT '实际命中的模型部署ID',
+  `experiment_bucket` int DEFAULT NULL COMMENT '稳定分桶0..9999；无可信主体时为空',
+  `success` tinyint(1) NOT NULL DEFAULT '1' COMMENT '整次调用是否成功',
+  `error_msg` varchar(1024) DEFAULT NULL COMMENT '失败原因',
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '落库时间',
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_call_request` (`request_id`),
+  KEY `idx_call_username` (`username`),
+  KEY `idx_call_agent_code` (`agent_code`),
+  KEY `idx_call_session` (`session_id`),
+  KEY `idx_call_start` (`start_time`),
+  KEY `idx_cw_agent_call_log_tenant` (`tenant_id`),
+  KEY `idx_call_trace_id` (`trace_id`),
+  KEY `idx_call_runtime_revision` (`runtime_revision`),
+  KEY `idx_call_experiment_arm` (`experiment_id`,`experiment_revision`,`experiment_arm`,`start_time`),
+  KEY `idx_agent_call_cost_window` (`tenant_id`,`start_time`,`model_cost_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='智能体调用主记录（分段耗时统计）';
+
+-- ----------------------------------------------------------------------------
+-- cw_agent_call_segment
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_agent_call_segment` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `call_log_id` bigint NOT NULL COMMENT '所属主记录ID',
+  `seq` int NOT NULL COMMENT '调用内分段序号（从1起）',
+  `kind` varchar(16) NOT NULL COMMENT '分段类别 MODEL/TOOL/MCP/SKILL',
+  `name` varchar(255) NOT NULL DEFAULT '' COMMENT '分段名称（模型名/工具名）',
+  `start_time` bigint NOT NULL COMMENT '分段开始时间戳（毫秒）',
+  `duration_ms` bigint NOT NULL DEFAULT '0' COMMENT '分段耗时（毫秒）',
+  `input_tokens` bigint DEFAULT NULL COMMENT '输入token（仅MODEL段，缺失为NULL）',
+  `output_tokens` bigint DEFAULT NULL COMMENT '输出token（仅MODEL段，缺失为NULL）',
+  `cached_tokens` bigint DEFAULT NULL COMMENT '命中缓存的输入token（仅MODEL段）',
+  `model_reported_ms` bigint DEFAULT NULL COMMENT '模型自报耗时（毫秒，仅MODEL段）',
+  `provider` varchar(64) DEFAULT NULL COMMENT '实际模型供应商',
+  `deployment_id` bigint DEFAULT NULL COMMENT '实际模型部署ID',
+  `model_name` varchar(191) DEFAULT NULL COMMENT '实际模型名',
+  `price_id` bigint DEFAULT NULL COMMENT '调用时冻结的价目ID',
+  `currency` varchar(16) DEFAULT NULL COMMENT '调用时冻结的币种',
+  `input_unit_price` decimal(20,8) DEFAULT NULL COMMENT '调用时输入单价（每百万token）',
+  `output_unit_price` decimal(20,8) DEFAULT NULL COMMENT '调用时输出单价（每百万token）',
+  `cached_unit_price` decimal(20,8) DEFAULT NULL COMMENT '调用时缓存输入单价（每百万token）',
+  `pricing_status` varchar(16) NOT NULL DEFAULT 'UNPRICED' COMMENT 'PRICED/UNPRICED',
+  `cost_amount` decimal(30,14) DEFAULT NULL COMMENT '按冻结价目结算的模型金额',
+  `cost_currency` varchar(16) DEFAULT NULL COMMENT '结算币种',
+  `cost_status` varchar(24) NOT NULL DEFAULT 'NOT_APPLICABLE' COMMENT 'SETTLED/UNPRICED/USAGE_MISSING/USAGE_INVALID/NOT_APPLICABLE',
+  `success` tinyint(1) NOT NULL DEFAULT '1' COMMENT '分段是否成功',
+  `error_msg` varchar(1024) DEFAULT NULL COMMENT '失败原因',
+  `tenant_id` varchar(64) NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_segment_call_log` (`call_log_id`,`seq`),
+  KEY `idx_cw_agent_call_segment_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='智能体调用分段明细';
+
+-- ----------------------------------------------------------------------------
+-- cw_tenant_usage_daily
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_tenant_usage_daily` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户ID',
+  `stat_date` date NOT NULL COMMENT '统计日期（自然日）',
+  `provider` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '模型厂商',
+  `model_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '模型名',
+  `call_count` bigint NOT NULL DEFAULT '0' COMMENT '调用次数',
+  `input_tokens` bigint NOT NULL DEFAULT '0' COMMENT '输入 token',
+  `output_tokens` bigint NOT NULL DEFAULT '0' COMMENT '输出 token',
+  `cached_tokens` bigint NOT NULL DEFAULT '0' COMMENT '缓存命中输入 token（input 的子集）',
+  `total_tokens` bigint NOT NULL DEFAULT '0' COMMENT '总 token',
+  `model_segment_count` bigint NOT NULL DEFAULT '0' COMMENT '模型分段数',
+  `settled_segment_count` bigint NOT NULL DEFAULT '0' COMMENT '已结算模型分段数',
+  `unsettled_segment_count` bigint NOT NULL DEFAULT '0' COMMENT '未结算模型分段数',
+  `amount` decimal(30,14) NOT NULL DEFAULT '0.00000000000000' COMMENT '已结算模型金额（由调用事实精确求和）',
+  `currency` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '币种；不同币种禁止相加',
+  `source_max_call_log_id` bigint NOT NULL DEFAULT '0' COMMENT '本次归集冻结的客服端调用日志上界',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_tenant_usage_daily` (`tenant_id`,`stat_date`,`provider`,`model_name`,`currency`),
+  KEY `idx_usage_daily_date` (`stat_date`),
+  KEY `idx_usage_daily_tenant` (`tenant_id`,`stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户日用量归集（账单与报表数据源）';
+
+-- ----------------------------------------------------------------------------
+-- cw_usage_aggregation_lock
+-- ----------------------------------------------------------------------------
+CREATE TABLE `cw_usage_aggregation_lock` (
+  `stat_date` date NOT NULL COMMENT '归集日期',
+  `update_time` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '最后一次领取时间',
+  PRIMARY KEY (`stat_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='日账单归集数据库串行锁';
+
+-- ----------------------------------------------------------------------------
+-- login_carousel_image
+-- ----------------------------------------------------------------------------
+CREATE TABLE `login_carousel_image` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `image_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '上传时的原始文件名（管理页展示用）',
+  `image_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '对外访问相对URL：/api/login-images/{uuid}.{ext}',
+  `sort_order` int NOT NULL DEFAULT '0' COMMENT '轮播顺序，小的在前',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否启用：0禁用 / 1启用',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  PRIMARY KEY (`id`),
+  KEY `idx_login_carousel_sort` (`sort_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='登录页轮播背景图';
+
+-- ----------------------------------------------------------------------------
+-- sql_datasource
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sql_datasource` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '数据源名称（唯一，供 SQL 定义下拉选择）',
+  `jdbc_url` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'JDBC 连接串',
+  `username` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '连接用户名',
+  `password` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '连接密码（AES-GCM 密文，永不明文返回）',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否启用：0禁用 / 1启用',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sql_datasource_name` (`name`),
+  KEY `idx_sql_datasource_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SQL 配置外部数据源';
+
+-- ----------------------------------------------------------------------------
+-- sql_define
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sql_define` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `define_key` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '定义编码（唯一，通用查询接口按此 key 执行）',
+  `datasource_id` bigint NOT NULL COMMENT '关联数据源ID（逻辑关联 sql_datasource.id）',
+  `sql_describe` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'SQL 用途描述',
+  `query_sql` text COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '查询 SQL（命名参数 :paramName，强制只读 SELECT/WITH）',
+  `count_sql` text COLLATE utf8mb4_unicode_ci COMMENT '总数 SQL（可空；为空则前端只有上/下一页无总数）',
+  `auto_load` tinyint NOT NULL DEFAULT '0' COMMENT '打开页面是否自动执行：0否 / 1是',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否启用：0禁用 / 1启用',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sql_define_key` (`define_key`),
+  KEY `idx_sql_define_datasource` (`datasource_id`),
+  KEY `idx_sql_define_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SQL 查询定义';
+
+-- ----------------------------------------------------------------------------
+-- sql_define_param
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sql_define_param` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `define_id` bigint NOT NULL COMMENT '所属 SQL 定义ID',
+  `param_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '参数名（对应 SQL 里的 :paramName）',
+  `param_desc` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '参数说明（前端表单 label）',
+  `param_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '参数类型：STRING / INTEGER / DATETIME',
+  `date_format` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '日期格式（仅 DATETIME 类型生效，如 yyyy-MM-dd HH:mm:ss / yyyy-MM-dd；空默认 yyyy-MM-dd HH:mm:ss）',
+  `required` tinyint NOT NULL DEFAULT '0' COMMENT '是否必填：0否 / 1是',
+  `default_value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '默认值（支持 ${now}/${now-14d}/${now-2h} 时间表达式）',
+  `drop_down` text COLLATE utf8mb4_unicode_ci COMMENT '下拉选项（JSON 对象 {"值":"显示名"}，可空）',
+  `is_page_num` tinyint NOT NULL DEFAULT '0' COMMENT '是否分页页码参数：其值换算为 offset 绑定',
+  `is_page_size` tinyint NOT NULL DEFAULT '0' COMMENT '是否分页页大小参数：绑定 pageSize 本身',
+  `sort` int NOT NULL DEFAULT '0' COMMENT '表单排序（升序）',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_sql_define_param_define` (`define_id`),
+  KEY `idx_sql_define_param_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SQL 查询参数元数据';
+
+-- ----------------------------------------------------------------------------
+-- sql_field_transform
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sql_field_transform` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `define_id` bigint NOT NULL COMMENT '所属 SQL 定义ID',
+  `field_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '匹配的结果列名',
+  `transform_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '转换类型：DATE_FORMAT / VALUE_MAP',
+  `transform_config` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '转换配置（DATE_FORMAT 为格式串 / VALUE_MAP 为 JSON 映射）',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  KEY `idx_sql_field_transform_define` (`define_id`),
+  KEY `idx_sql_field_transform_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='SQL 结果列转换器';
+
+-- ----------------------------------------------------------------------------
+-- sys_menu_change_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_menu_change_log` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `menu_id` bigint NOT NULL COMMENT '被操作的菜单节点ID（删除后节点已不存在，此处仍保留历史指向）',
+  `action` varchar(16) NOT NULL COMMENT '操作类型：CREATE/UPDATE/DELETE/MOVE',
+  `before_snapshot` text COMMENT '变更前节点 JSON（CREATE 时为空）',
+  `after_snapshot` text COMMENT '变更后节点 JSON（DELETE 时为空）',
+  `operator_id` bigint DEFAULT NULL COMMENT '操作人用户ID',
+  `operator_name` varchar(64) DEFAULT NULL COMMENT '操作人昵称（冗余存储，用户改名/删除后历史记录仍可读）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_menu_change_log_menu` (`menu_id`),
+  KEY `idx_menu_change_log_time` (`create_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='菜单变更审计流水（排查用，不支持回滚）';
+
+-- ----------------------------------------------------------------------------
+-- sys_operation_log
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_operation_log` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint DEFAULT NULL COMMENT '操作人ID（登录失败等未认证场景可为空）',
+  `username` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '操作人账号',
+  `operation` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '操作类型（登录/登出/新增/修改/删除/测试等）',
+  `method` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '请求方法/接口',
+  `target` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '操作对象（模块+资源标识）',
+  `params` text COLLATE utf8mb4_unicode_ci COMMENT '请求参数（脱敏后）',
+  `result` tinyint NOT NULL COMMENT '结果：1成功 / 0失败',
+  `error_msg` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '失败原因',
+  `ip` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '操作IP',
+  `event_id` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '一次操作的稳定审计事件ID',
+  `audit_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'COMPLETED' COMMENT 'STARTED/COMPLETED',
+  `retention_until` datetime DEFAULT NULL COMMENT '最短留存截止时间',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '操作时间',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_operation_log_event` (`event_id`),
+  KEY `idx_sys_operation_log_user` (`user_id`),
+  KEY `idx_sys_operation_log_time` (`create_time`),
+  KEY `idx_sys_operation_log_tenant` (`tenant_id`),
+  KEY `idx_sys_operation_log_retention` (`audit_status`,`retention_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='操作日志（含登录/登出日志）';
+
+-- ----------------------------------------------------------------------------
+-- sys_permission
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_permission` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `parent_id` bigint NOT NULL DEFAULT '0' COMMENT '父权限ID（支持菜单树，0=根节点）',
+  `perm_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '权限/菜单名称',
+  `perm_code` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '权限标识（如 mcp:add / skill:delete）',
+  `type` tinyint NOT NULL COMMENT '类型：1菜单 / 2按钮 / 3接口',
+  `path` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '前端路由 / 接口路径',
+  `icon` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '图标库图标名或上传图片URL（按 icon_type 区分）',
+  `icon_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'library' COMMENT '图标类型：library=图标库图标名，image=上传图片URL',
+  `sort` int NOT NULL DEFAULT '0' COMMENT '排序',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_permission_code` (`perm_code`),
+  KEY `idx_sys_permission_parent` (`parent_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='权限/菜单（树形）';
+
+-- ----------------------------------------------------------------------------
+-- sys_role
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_role` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `role_name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '角色名称',
+  `role_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '角色编码（唯一，如 super_admin）',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0禁用 / 1启用',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `data_scope` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'SELF' COMMENT '数据范围：ALL全部租户 / TENANT本租户全部 / SELF仅本人创建',
+  `control_plane` tinyint NOT NULL DEFAULT '0' COMMENT '是否控制面角色：0否 / 1是',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_role_tenant_code` (`tenant_id`,`role_code`),
+  KEY `idx_sys_role_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='角色';
+
+-- ----------------------------------------------------------------------------
+-- sys_role_permission
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_role_permission` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `role_id` bigint NOT NULL COMMENT '角色ID',
+  `permission_id` bigint NOT NULL COMMENT '权限ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_role_permission` (`role_id`,`permission_id`),
+  KEY `idx_sys_role_permission_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='角色-权限关联';
+
+-- ----------------------------------------------------------------------------
+-- sys_tenant
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_tenant` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `tenant_code` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户编码（业务主键，出现在 API Key 映射/日志/指标标签里）',
+  `tenant_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '租户名称',
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE' COMMENT '状态：ACTIVE正常 / SUSPENDED冻结 / TERMINATED退租',
+  `contact_name` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '联系人',
+  `contact_phone` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '联系电话',
+  `contact_email` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '联系邮箱',
+  `remark` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `expire_time` datetime DEFAULT NULL COMMENT '到期时间（空=不限期）',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `access_epoch` bigint NOT NULL DEFAULT '0' COMMENT '访问版本；冻结、恢复、退租或主动撤权时递增',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_tenant_code` (`tenant_code`),
+  KEY `idx_sys_tenant_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户主数据';
+
+-- ----------------------------------------------------------------------------
+-- sys_tenant_access_publish_task
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_tenant_access_publish_task` (
+  `id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `seq` bigint NOT NULL AUTO_INCREMENT COMMENT '严格写入顺序',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tenant_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `access_epoch` bigint NOT NULL,
+  `operation` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'PROVISION/EXPIRY_CHANGE/STATUS_CHANGE/SESSION_REVOKE/OFFBOARD',
+  `session_revocation_status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'NOT_REQUIRED/EPOCH_ENFORCED',
+  `channel_disable_status` varchar(24) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'NOT_REQUIRED/COMPLETED',
+  `channels_disabled_count` int NOT NULL DEFAULT '0',
+  `expire_time` datetime DEFAULT NULL,
+  `data_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `group_name` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `attempts` int NOT NULL DEFAULT '0',
+  `next_attempt_at_ms` bigint NOT NULL,
+  `active_lease_key` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '处理中写租户ID；唯一键保证同租户仅一个发布者',
+  `lease_owner` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `lease_until_ms` bigint NOT NULL DEFAULT '0',
+  `last_error` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `published_at_ms` bigint DEFAULT NULL,
+  `created_at_ms` bigint NOT NULL,
+  `updated_at_ms` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_tenant_access_publish_seq` (`seq`),
+  UNIQUE KEY `uk_tenant_access_publish_epoch` (`tenant_id`,`access_epoch`),
+  UNIQUE KEY `uk_tenant_access_publish_active_lease` (`active_lease_key`),
+  KEY `idx_tenant_access_publish_due` (`status`,`next_attempt_at_ms`,`lease_until_ms`),
+  KEY `idx_tenant_access_publish_tenant` (`tenant_id`,`seq`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户访问快照可靠发布任务';
+
+-- ----------------------------------------------------------------------------
+-- sys_user
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_user` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `username` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '登录账号',
+  `password` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '密码（BCrypt 加密存储，LDAP 账号为 NULL）',
+  `nickname` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '昵称',
+  `login_type` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'LOCAL' COMMENT '账号来源：LOCAL本地账号 / LDAP域账号(OA单点登录)',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：0禁用 / 1启用',
+  `approval_status` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'APPROVED' COMMENT '注册审核状态：PENDING/APPROVED/REJECTED',
+  `approval_by` bigint DEFAULT NULL COMMENT '最近一次审核人 sys_user.id',
+  `approval_time` datetime DEFAULT NULL COMMENT '最近一次审核时间',
+  `approval_remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最近一次审核说明或拒绝原因',
+  `last_login_time` datetime DEFAULT NULL COMMENT '最后登录时间',
+  `last_login_ip` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '最后登录 IP',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `level_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '配额等级编码（空=默认档），见客服端库 cw_subject_quota_level',
+  `auth_epoch` bigint NOT NULL DEFAULT '0' COMMENT '认证版本；禁用、删号、改密或角色变化时递增',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_user_username` (`username`),
+  KEY `idx_sys_user_tenant` (`tenant_id`),
+  KEY `idx_sys_user_approval` (`tenant_id`,`approval_status`,`deleted`,`create_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='后台用户';
+
+-- ----------------------------------------------------------------------------
+-- sys_user_role
+-- ----------------------------------------------------------------------------
+CREATE TABLE `sys_user_role` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL COMMENT '用户ID',
+  `role_id` bigint NOT NULL COMMENT '角色ID',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_sys_user_role` (`user_id`,`role_id`),
+  KEY `idx_sys_user_role_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户-角色关联';
+
+-- ----------------------------------------------------------------------------
+-- workbench_site
+-- ----------------------------------------------------------------------------
+CREATE TABLE `workbench_site` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '系统名称',
+  `category` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '分类：如 git/jenkins/oa',
+  `url` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '访问地址',
+  `account` varchar(128) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '登录账号',
+  `password` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '登录密码（AES-GCM 密文，永不明文返回）',
+  `remark` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '备注',
+  `enabled` tinyint NOT NULL DEFAULT '1' COMMENT '是否启用：0禁用 / 1启用',
+  `username_selector` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '用户名输入框 CSS 选择器，留空用启发式',
+  `password_selector` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '密码输入框 CSS 选择器，留空用 input[type=password]',
+  `submit_selector` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '登录按钮 CSS 选择器，留空用启发式',
+  `fill_mode` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'auto' COMMENT '填充模式：auto=原生setter一次性 / typing=逐字模拟（顽固React如Kibana）',
+  `submit_mode` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'click' COMMENT '提交方式：click=点按钮 / formSubmit=表单提交',
+  `init_delay_ms` int NOT NULL DEFAULT '500' COMMENT '进页面后开始查找元素的延迟毫秒',
+  `submit_delay_ms` int NOT NULL DEFAULT '300' COMMENT '填完到点击提交的延迟毫秒',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_workbench_site_name` (`name`),
+  KEY `idx_workbench_site_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='内网工作台系统账号本';
+
+-- ----------------------------------------------------------------------------
+-- workbench_token
+-- ----------------------------------------------------------------------------
+CREATE TABLE `workbench_token` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL COMMENT '令牌所属用户ID',
+  `name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '令牌用途备注',
+  `token_hash` char(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '令牌明文的 SHA-256 十六进制，明文只在创建时返回一次',
+  `token_prefix` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '令牌前缀（如 wbt_ab12cd34），列表展示用',
+  `expire_time` datetime DEFAULT NULL COMMENT '过期时间，NULL 表示永不过期',
+  `last_used_time` datetime DEFAULT NULL COMMENT '最近一次使用时间',
+  `revoked` tinyint NOT NULL DEFAULT '0' COMMENT '是否已吊销：0否 / 1是',
+  `create_by` bigint DEFAULT NULL COMMENT '创建人ID',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_by` bigint DEFAULT NULL COMMENT '更新人ID',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint NOT NULL DEFAULT '0' COMMENT '逻辑删除：0正常 / 1删除',
+  `tenant_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'default' COMMENT '租户ID（多租户行级隔离）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_workbench_token_hash` (`token_hash`),
+  KEY `idx_workbench_token_user` (`user_id`),
+  KEY `idx_workbench_token_tenant` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='内网工作台个人访问令牌';

--- a/scripts/export-schema-snapshot.sh
+++ b/scripts/export-schema-snapshot.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# =============================================================================
+# 重新生成两个业务库的全量表结构快照。
+#
+#   mysql/schema-snapshot/agent_scope_customer_work.sql   客服端业务库
+#   mysql/schema-snapshot/customer_admin.sql              后台管理库
+#
+# 做法：各起一个带随机后缀的临时空库，跑完该库的全部 Flyway 迁移后逐表导出，最后删库。
+# 不从开发机的长期业务库导出——那个库被并行分支的迁移反复试跑过，沉积的结构与迁移产物无法区分。
+#
+# 与门禁同源：生成走的就是 CustomerWorkSchemaSnapshotTest / CustomerAdminSchemaSnapshotTest
+# 这两个测试的写入模式，日常跑测试时它们会把快照与迁移产物逐字比对，漏刷新会直接红。
+# =============================================================================
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+# shell 默认 java 常年是 1.8，必须显式切 17
+if [ -z "${JAVA_HOME:-}" ] || ! "${JAVA_HOME}/bin/java" -version 2>&1 | grep -q '"17'; then
+  export JAVA_HOME="$(/usr/libexec/java_home -v 17)"
+fi
+echo "JAVA_HOME=${JAVA_HOME}"
+
+# scripts/ 下那份写死了本机 localRepository，换台机器会直接报 Could not create local repository；
+# 此时回落到仓库根的同名文件（走默认 ~/.m2/repository）。
+SETTINGS="${REPO_ROOT}/scripts/settings-central-direct.xml"
+LOCAL_REPO="$(sed -n 's:.*<localRepository>\(.*\)</localRepository>.*:\1:p' "${SETTINGS}" | head -1)"
+if [ -n "${LOCAL_REPO}" ] && [ ! -d "${LOCAL_REPO}" ]; then
+  SETTINGS="${REPO_ROOT}/settings-central-direct.xml"
+  echo "本机无 ${LOCAL_REPO}，改用 ${SETTINGS}"
+fi
+
+MYSQL_HOST="${MYSQL_HOST:-localhost}"
+MYSQL_PORT="${MYSQL_PORT:-3306}"
+
+# MySQL 不可达时两个测试都会 assumeTrue 跳过，脚本会「成功」退出而快照一个字没变——
+# 这种静默失效比直接报错难查得多，所以先探一次。
+if ! (exec 3<>"/dev/tcp/${MYSQL_HOST}/${MYSQL_PORT}") 2>/dev/null; then
+  echo "错误：MySQL ${MYSQL_HOST}:${MYSQL_PORT} 不可达，无法生成快照。" >&2
+  echo "      本机可用 docker start mysql_db_low_case 启动。" >&2
+  exit 1
+fi
+echo "MySQL ${MYSQL_HOST}:${MYSQL_PORT} 可达"
+
+# admin 侧测试账号口径与 run-admin-server-dev.sh 保持一致
+export ADMIN_MYSQL_PASSWORD="${ADMIN_MYSQL_PASSWORD:-root}"
+
+mvn -gs "${SETTINGS}" -s "${SETTINGS}" \
+  -pl customer-work-starter,customer-admin-server -am \
+  test \
+  -Dtest='CustomerWorkSchemaSnapshotTest,CustomerAdminSchemaSnapshotTest' \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dschema.snapshot.write=true \
+  -Djacoco.skip=true
+
+SNAPSHOTS=(
+  "mysql/schema-snapshot/agent_scope_customer_work.sql"
+  "mysql/schema-snapshot/customer_admin.sql"
+)
+for snapshot in "${SNAPSHOTS[@]}"; do
+  if [ ! -s "${REPO_ROOT}/${snapshot}" ]; then
+    echo "错误：${snapshot} 未生成或为空，请检查上面的测试输出。" >&2
+    exit 1
+  fi
+done
+
+echo ""
+echo "快照已刷新："
+for snapshot in "${SNAPSHOTS[@]}"; do
+  printf '  %-52s %s 张表\n' "${snapshot}" \
+    "$(grep -c '^CREATE TABLE ' "${REPO_ROOT}/${snapshot}")"
+done
+echo ""
+git -C "${REPO_ROOT}" --no-pager diff --stat -- mysql/schema-snapshot/ || true


### PR DESCRIPTION
## 背景

「这两个库现在长什么样」此前没有直接答案：

- 客服端库只有一份混着种子数据的建库脚本，且 `mysql/README.md` 标注的真源（starter 的
  `customerwork/schema/customer-work-schema.sql` + `SchemaInitializer`）**早已随代码一起删除**，
  这份文件实际处于无主手工维护状态。
- 后台库连全量结构都没有，要看结构只能按序读近百个迁移文件。

## 改动

| 产物 | 说明 |
|---|---|
| `mysql/schema-snapshot/agent_scope_customer_work.sql` | 客服端库 47 张表 |
| `mysql/schema-snapshot/customer_admin.sql` | 后台库 88 张表 |
| `scripts/export-schema-snapshot.sh` | 一条命令重新生成 |
| `SchemaSnapshotExporter` | 导出与归一化逻辑（生成与门禁共用） |
| 两个门禁测试 | 漏刷新直接红，并指出是哪张表的第几行 |

## 三个关键设计

**1. 导出源是临时空库，不是开发机的业务库。** 本机开发库被并行分支的迁移反复试跑过，
沉积的结构与迁移产物无法区分，直接 `mysqldump` 等于把污染固化进快照，且没有任何机制能发现。
脚本各起一个带随机后缀的临时库跑完全部迁移后导出，最后删库。

**2. 生成与校验共用同一段逻辑。** 两个测试默认跑门禁（比对），带 `-Dschema.snapshot.write=true`
时改为写文件——脚本走的就是后者。不存在「脚本生成的和门禁期望的不是一回事」。

**3. 输出必须可复现。** 抹掉随数据变化的 `AUTO_INCREMENT=n`、排除 `flyway_schema_history`、
表名排序；文件头只放由迁移本身决定的信息（含 Flyway 版本号），不写生成时间或机器名——
写了门禁就永远是红的。

## 验证

- 连续三次独立导出（各自新建临时库）结果逐字一致。
- 故意制造两类漂移，门禁均变红且定位准确：
  - 少一列 → `第 312 行不一致（表 cw_dict_item）`，并列出两侧内容
  - 缺整张表 → `第 2127 行不一致（表 sys_user）`
- 全模块 `mvn clean test` BUILD SUCCESS，0 失败 0 错误
  （starter 1705 / app-server 129 / customer-channel 80 / admin 1429 / gateway 1，
  排除 `RedisSessionPersistenceTest`）。
- CI 跑的就是全量 `mvn clean test`，因此这两个门禁在 PR 上自动生效，未改 `ci.yml`。

## 顺带修掉的两处

- `mysql/README.md` 里失效的真源标注 → 改为指向 Flyway 迁移 + V2/V9 两个 Java 迁移。
- `CLAUDE.md` 里 surefire 的旧参数名 → 3.1.2 起是 `-Dsurefire.failIfNoSpecifiedTests=false`。
  旧名只在「指定测试在某个模块一个都没匹配上」时才暴露，多模块恰好各命中一个时照样通过，
  很容易一直写错而不自知。

## 两条需要知道的事实

- **客服端快照刻意不含 `agentscope_sessions`**：它由 AgentScope 的 `MysqlSession` 按内置 DDL
  自建，不归 Flyway 管，没有迁移可以导出它。文件头已写明，不是遗漏。
- **快照里两种 collation 并存是既有状况**：MySQL 8 里建表语句写了 `DEFAULT CHARSET=utf8mb4`
  却不写 COLLATE 时用的是字符集默认的 `utf8mb4_0900_ai_ci` 而非库的 collation。只有
  `ENGINE=InnoDB;` 这类连 charset 都不写的少数表才继承建库参数——所以导出固定按
  `utf8mb4 / utf8mb4_unicode_ci` 建库。