### PR TITLE
fix(aiconfig): 修正上线认证的上下文窗口判定与结果展示

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,12 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-08-27 上下文窗口认证修复批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1705/5 skip、app-server 129、customer-channel 80、admin 1442/1 skip、gateway 1，合计 3357
+  （排除 `RedisSessionPersistenceTest`）。本批次自身加 admin **+13**（窗口实测判定 9 + 建模窗口注入 4）。
+  **跑全量的同时别再跑单模块测试**——两个 Maven 进程同时写同一个 `target/`，正在跑的那个会报
+  `NoClassDefFoundError`，看起来像代码问题，实际是 class 文件被另一个进程覆盖了；本批次踩过一次。
+  上一版基线 2026-08-27 表结构快照批次：合计 3344。）
   （2026-08-27 表结构快照批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
   starter 1705/5 skip、app-server 129、customer-channel 80、admin 1429/1 skip、gateway 1，合计 3344
   （排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+1**、admin **+1**（两个库的结构快照门禁）。
@@ -184,6 +190,19 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   是各自组件的调优参数，合了会让"改 outbox 退避"意外改到死信队列。
   **`@ConfigurationProperties` 的字段默认值刻意保持字面量**：`spring-boot-configuration-processor`
   只从字面量初始化表达式提取 `defaultValue`，改成常量引用会让那 336 项默认值元数据静默消失。
+- **外部依赖返回的 0 / 空值，先分清是「未知」还是「零」**：框架 `Model#getContextWindowSize()` 走
+  `ModelContextWindows.lookup` 按模型名前缀查一张硬编码表，表里只有各厂商**官方**模型名；
+  `glm` / `deepseek` 这类走 OpenAI 兼容协议接入的第三方模型一律返回 `0`，含义是「表里没有这个名字」
+  而不是「窗口为零」。上线认证早期实现把它当能力值参与 `min` 交集（`runtime == 0 || declared == 0 ? 0`），
+  结果**所有 OpenAI 兼容第三方部署的窗口检查恒为失败**，与运营在资产里登记多大窗口无关。
+  三个既有单测全用 `StubModel` 直接返回非零值，一个都没照出来——又一次「注了 mock 就照不出真实链路」。
+  现在两侧收口：① 建模一律走 `AdminModelFactory.buildModelWithWindow` 或
+  `buildModel(..., deploymentId)`（后者自己从 `ai_model_asset.context_window` 解析注入），
+  **不要让调用方各自记得传窗口**——建模路径有主备模型/路由候选/知识库/认证探测四条，逐个要求「记得传」
+  必然漏，漏了还不报错；② 认证窗口判定改成「先声明后实测」，实测真发一次填充请求读
+  `usage.inputTokens` 作证据。`AdminModelFactoryTest` 里那条
+  `buildModel_withoutDeclaredWindow_leavesThirdPartyModelWindowUnknown` 专门钉住「框架对 glm-5.2 推断为 0」
+  这个前提，框架哪天扩了推断表它会红，那是提醒不是故障。
 - **改动"某条链路的能力"时，先列出全部同类链路再动手**。当前共 7 条：
   `chat()` / `chatStream()` / WS `/ws/user` / `/consult` 多 Agent / admin 工作台 / customer-channel / Harness。
   只在一条上验证通过 ≠ 修好了——前六次复发都是这么来的。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactory.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactory.java
@@ -2,6 +2,9 @@ package com.richard.fyoung.customeradmin.aiconfig.model.runtime;
 
 import com.richard.fyoung.customeradmin.aiconfig.model.dto.ModelTestResult;
 import com.richard.fyoung.customeradmin.common.constant.ConnectivityTestStatus;
+import com.richard.fyoung.customeradmin.aiconfig.model.entity.AiModelConfig;
+import com.richard.fyoung.customeradmin.aiconfig.model.service.ModelAssetService;
+import com.richard.fyoung.customeradmin.aiconfig.model.service.ModelConfigAccess;
 import com.richard.fyoung.customeradmin.billing.service.ModelPriceService;
 import com.richard.fyoung.customerwork.core.model.ChatModelProber;
 import com.richard.fyoung.customerwork.core.model.attribution.AttributedModel;
@@ -36,6 +39,8 @@ public class AdminModelFactory {
     private final ChatModelProber prober;
     private final ModelEndpointPolicy endpointPolicy;
     private final ModelPriceService modelPriceService;
+    private final ModelConfigAccess modelConfigAccess;
+    private final ModelAssetService modelAssetService;
 
     public AdminModelFactory() {
         this(new ModelEndpointPolicy(List::of), null);
@@ -45,9 +50,19 @@ public class AdminModelFactory {
         this(endpointPolicy, null);
     }
 
-    @Autowired
     public AdminModelFactory(ModelEndpointPolicy endpointPolicy, ModelPriceService modelPriceService) {
-        this(new ChatModelProber(endpointPolicy), endpointPolicy, modelPriceService);
+        this(new ChatModelProber(endpointPolicy), endpointPolicy, modelPriceService, null, null);
+    }
+
+    /**
+     * 生产装配构造。{@code modelConfigAccess} 与 {@code modelAssetService} 用于按部署 ID 解析
+     * 资产登记的上下文窗口——见 {@link #resolveDeclaredContextWindow}。
+     */
+    @Autowired
+    public AdminModelFactory(ModelEndpointPolicy endpointPolicy, ModelPriceService modelPriceService,
+                             ModelConfigAccess modelConfigAccess, ModelAssetService modelAssetService) {
+        this(new ChatModelProber(endpointPolicy), endpointPolicy, modelPriceService,
+            modelConfigAccess, modelAssetService);
     }
 
     /** 包内可见，供单测注入短超时，避免真实等待默认 8s（生产走策略注入构造）。 */
@@ -56,24 +71,32 @@ public class AdminModelFactory {
     }
 
     private AdminModelFactory(Duration testTimeout, ModelEndpointPolicy endpointPolicy) {
-        this(new ChatModelProber(testTimeout, endpointPolicy), endpointPolicy, null);
+        this(new ChatModelProber(testTimeout, endpointPolicy), endpointPolicy, null, null, null);
     }
 
     /** 包内测试构造：薄壳测试只验证委托与结果翻译。 */
     AdminModelFactory(ChatModelProber prober) {
-        this(prober, new ModelEndpointPolicy(List::of), null);
+        this(prober, new ModelEndpointPolicy(List::of), null, null, null);
     }
 
     /** 包内测试构造：为模型构建注入确定性的端点策略与 DNS 结果。 */
     AdminModelFactory(ChatModelProber prober, ModelEndpointPolicy endpointPolicy) {
-        this(prober, endpointPolicy, null);
+        this(prober, endpointPolicy, null, null, null);
     }
 
     AdminModelFactory(ChatModelProber prober, ModelEndpointPolicy endpointPolicy,
                       ModelPriceService modelPriceService) {
+        this(prober, endpointPolicy, modelPriceService, null, null);
+    }
+
+    AdminModelFactory(ChatModelProber prober, ModelEndpointPolicy endpointPolicy,
+                      ModelPriceService modelPriceService, ModelConfigAccess modelConfigAccess,
+                      ModelAssetService modelAssetService) {
         this.prober = prober;
         this.endpointPolicy = endpointPolicy;
         this.modelPriceService = modelPriceService;
+        this.modelConfigAccess = modelConfigAccess;
+        this.modelAssetService = modelAssetService;
     }
 
     /**
@@ -98,18 +121,53 @@ public class AdminModelFactory {
      * baseUrl，阻断已发布配置绕过保存期校验；该校验不替代厂商 SDK 自身连接阶段的 DNS 与重定向控制。</p>
      */
     public Model buildModel(String provider, String baseUrl, String apiKey, String modelName) {
+        return buildModelWithWindow(provider, baseUrl, apiKey, modelName, null);
+    }
+
+    /**
+     * 同上，并把权威上下文窗口注入运行时，覆盖框架的模型名推断。
+     *
+     * <p>框架的推断表只收录各厂商官方模型名；{@code glm} / {@code deepseek} 这类第三方模型走
+     * OpenAI 兼容协议接入时一律推断为 0，而下游会把 0 当成「窗口为零」而不是「未知」——
+     * 路由按各档取 min 上报能力、上线认证按窗口判门槛，都会因此失真。已经持有资产对象的调用方
+     * 直接传声明值；只有部署 ID 的调用方走 {@link #buildModel(String, String, String, String, Long)}，
+     * 由本类自行解析。</p>
+     *
+     * @param contextWindowSize 权威上下文窗口（可空；空或非正数则回落框架推断）
+     */
+    public Model buildModelWithWindow(String provider, String baseUrl, String apiKey, String modelName,
+                                      Integer contextWindowSize) {
         ModelProvider p = ModelProvider.of(provider);
         String validatedBaseUrl = endpointPolicy.validateAndNormalizeBaseUrl(baseUrl);
         return ChatModelFactory.build(p.getCode(), modelName, apiKey, validatedBaseUrl, true,
-            GenerateOptions.builder().build(), null, null);
+            GenerateOptions.builder().build(), null, null, contextWindowSize);
     }
 
+    /**
+     * 按部署建模：在计费归因之外，同时把该部署对应资产登记的上下文窗口注入运行时。
+     *
+     * <p>窗口在这里解析而不是让调用方各传各的——建模路径不止一条（主备模型、路由策略候选、
+     * 知识库、认证探测），逐个要求「记得传窗口」必然漏，漏了还不报错，只表现为运行时能力上报为 0。</p>
+     */
     public Model buildModel(String provider, String baseUrl, String apiKey,
                             String modelName, Long deploymentId) {
-        Model model = buildModel(provider, baseUrl, apiKey, modelName);
+        Model model = buildModelWithWindow(provider, baseUrl, apiKey, modelName,
+            resolveDeclaredContextWindow(deploymentId));
         ModelCallAttribution attribution = modelPriceService == null
             ? ModelCallAttribution.unpriced(provider, deploymentId, modelName)
             : modelPriceService.attribution(provider, deploymentId, modelName);
         return new AttributedModel(model, attribution);
+    }
+
+    /**
+     * 按部署 ID 解析资产登记的上下文窗口；依赖未装配、部署不可见或资产未登记窗口时返回 {@code null}，
+     * 由调用方回落框架推断。窗口只是能力元信息，解析不到不该阻断建模。
+     */
+    public Integer resolveDeclaredContextWindow(Long deploymentId) {
+        if (deploymentId == null || modelConfigAccess == null || modelAssetService == null) {
+            return null;
+        }
+        AiModelConfig deployment = modelConfigAccess.findVisibleAnyStateById(deploymentId);
+        return deployment == null ? null : modelAssetService.findDeclaredContextWindow(deployment);
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AgentScopeModelCertificationProbe.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AgentScopeModelCertificationProbe.java
@@ -43,6 +43,24 @@ public class AgentScopeModelCertificationProbe implements ModelCertificationProb
     private static final Duration CAPABILITY_TIMEOUT = Duration.ofSeconds(20);
     private static final String TOOL_NAME = "certification_echo";
 
+    /**
+     * 上下文窗口实测的填充上限。门槛可能声明到百万级，真按那个量填充既慢又费；
+     * 超过上限的部分退回资产声明，并在证据摘要里写明实测只覆盖到哪。
+     */
+    private static final int MAX_PROBE_CONTEXT_TOKENS = 32_768;
+
+    /** 实测请求要发大段输入，超时单独放宽，不跟能力探测共用 20s。 */
+    private static final Duration CONTEXT_PROBE_TIMEOUT = Duration.ofSeconds(60);
+
+    /** 实测请求只要模型开口即可，输出压到最小，避免为验证输入长度付出输出成本。 */
+    private static final int CONTEXT_PROBE_MAX_TOKENS = 8;
+
+    /** 填充文本的字符/token 估算比。各家 tokenizer 差异大，首次按它估，不够再按端点回报的真实比率补一次。 */
+    private static final int CHARS_PER_TOKEN = 3;
+
+    /** 补填的字符数上限（相对目标 token 数）。防止端点回报异常时把填充撑到不可控的量。 */
+    private static final int MAX_FILLER_CHARS_PER_TOKEN = 12;
+
     private final AdminModelFactory modelFactory;
     private final ObjectMapper objectMapper;
 
@@ -72,8 +90,9 @@ public class AgentScopeModelCertificationProbe implements ModelCertificationProb
 
         Model model;
         try {
-            model = modelFactory.buildModel(protocol(deployment), deployment.getBaseUrl(), secretValue,
-                deployment.getModel());
+            // 资产登记窗口是这个部署窗口能力的权威声明，建模时就注入，别让框架去猜模型名
+            model = modelFactory.buildModelWithWindow(protocol(deployment), deployment.getBaseUrl(),
+                secretValue, deployment.getModel(), declaredContext(asset));
         } catch (Exception e) {
             addUnavailableCapabilityChecks(checks, request);
             checks.add(failed("CONTEXT_WINDOW", "上下文窗口", null,
@@ -84,12 +103,121 @@ public class AgentScopeModelCertificationProbe implements ModelCertificationProb
         checks.add(probeStreaming(model, request.streamingRequired()));
         checks.add(probeToolCall(model, request.toolCallRequired()));
         checks.add(probeStructuredOutput(model, request.structuredOutputRequired()));
-        int verifiedContext = verifiedContext(model, asset);
-        checks.add(check("CONTEXT_WINDOW", "上下文窗口",
-            verifiedContext >= request.requiredContextTokens(), String.valueOf(verifiedContext),
-            "≥ " + request.requiredContextTokens(), verifiedContext >= request.requiredContextTokens()
-                ? "运行时能力与资产声明满足窗口要求" : "运行时能力或资产声明低于窗口要求"));
-        return new ProbeResult(checks, p95, verifiedContext > 0 ? verifiedContext : null);
+        ContextWindowEvidence context = probeContextWindow(model, asset, request.requiredContextTokens());
+        checks.add(context.check());
+        return new ProbeResult(checks, p95, context.verifiedTokens());
+    }
+
+    /**
+     * 上下文窗口实测：真发一次填充到门槛量级的请求，用端点自己回报的输入 token 数作为证据。
+     *
+     * <p>不再拿框架的 {@code getContextWindowSize()} 当运行时证据——那个值是按模型名前缀查硬编码表得来的，
+     * 表里只有各厂商官方模型名，第三方模型（glm / deepseek / 自建网关）一律查不到返回 0，
+     * 而 0 被当成「窗口为零」会让这类部署永远认证不过。</p>
+     *
+     * <p>判定顺序是先声明后实测：资产没登记窗口、或登记值本身低于门槛时直接判失败，
+     * 省掉一次注定无意义的大请求。</p>
+     */
+    private ContextWindowEvidence probeContextWindow(Model model, AiModelAsset asset, int required) {
+        String threshold = "≥ " + required;
+        Integer declaredValue = declaredContext(asset);
+        if (declaredValue == null) {
+            return new ContextWindowEvidence(failed("CONTEXT_WINDOW", "上下文窗口", null, threshold,
+                "模型资产未登记上下文窗口，无据可验"), null);
+        }
+        int declared = declaredValue;
+        if (declared < required) {
+            return new ContextWindowEvidence(failed("CONTEXT_WINDOW", "上下文窗口",
+                String.valueOf(declared), threshold, "资产登记的上下文窗口低于门槛"), declared);
+        }
+
+        int target = Math.min(required, MAX_PROBE_CONTEXT_TOKENS);
+        Integer measured;
+        try {
+            measured = measureAcceptedInputTokens(model, target);
+        } catch (Exception e) {
+            return new ContextWindowEvidence(failed("CONTEXT_WINDOW", "上下文窗口", null, threshold,
+                "上下文窗口实测请求失败，端点未能接受 " + target + " token 输入"), null);
+        }
+
+        // 不回 usage 的兼容网关拿不到真实输入量，只能按发送量估算，实测值上标注出来
+        boolean approximated = measured == null;
+        int evidence = approximated ? target : measured;
+        String measuredValue = evidence + (approximated ? " tokens (估算)" : " tokens");
+        if (!approximated && measured < target) {
+            // 填充补过一轮仍达不到目标：证据不足以支撑门槛，判失败而不是拿这个数字虚过
+            return new ContextWindowEvidence(failed("CONTEXT_WINDOW", "上下文窗口", measuredValue,
+                threshold, "实测输入仅 " + measured + " token，不足以证明满足 " + target + " token 门槛"),
+                null);
+        }
+        String message = required > MAX_PROBE_CONTEXT_TOKENS
+            ? "实测接受 " + evidence + " token 输入（实测上限 " + MAX_PROBE_CONTEXT_TOKENS
+                + "），超出部分依据资产登记的 " + declared
+            : "实测接受 " + evidence + " token 输入，满足窗口门槛";
+        return new ContextWindowEvidence(
+            passed("CONTEXT_WINDOW", "上下文窗口", measuredValue, threshold, message), declared);
+    }
+
+    /**
+     * 发一次填充到目标量级的请求，返回端点回报的输入 token 数；端点不回 usage 时返回 {@code null}。
+     * 请求被拒（输入超出真实窗口）时抛出，由调用方判失败。
+     *
+     * <p>各家 tokenizer 的字符/token 比差异很大，首轮按估算比填充可能不到目标量。
+     * 这种情况下用端点自己回报的真实比率补填一次——拿一个偏低的实测值当证据就是虚过，
+     * 而认证是门禁，虚过等于门禁失效。</p>
+     */
+    private Integer measureAcceptedInputTokens(Model model, int targetTokens) {
+        String text = filler(targetTokens * CHARS_PER_TOKEN);
+        Integer measured = sendContextProbe(model, text);
+        if (measured == null || measured >= targetTokens) {
+            return measured;
+        }
+        long adjustedChars = Math.min((long) text.length() * targetTokens / measured,
+            (long) targetTokens * MAX_FILLER_CHARS_PER_TOKEN);
+        if (adjustedChars <= text.length()) {
+            return measured;
+        }
+        return sendContextProbe(model, filler((int) adjustedChars));
+    }
+
+    private Integer sendContextProbe(Model model, String text) {
+        Msg prompt = Msg.builder().role(MsgRole.USER).textContent(text).build();
+        List<ChatResponse> responses = model.stream(List.of(prompt), List.of(),
+                GenerateOptions.builder().stream(false).maxTokens(CONTEXT_PROBE_MAX_TOKENS).build())
+            .collectList().block(CONTEXT_PROBE_TIMEOUT);
+        if (CollectionUtils.isEmpty(responses)) {
+            throw new IllegalStateException("empty context probe response");
+        }
+        int inputTokens = responses.stream()
+            .filter(response -> response.getUsage() != null)
+            .mapToInt(response -> response.getUsage().getInputTokens())
+            .max().orElse(0);
+        return inputTokens > 0 ? inputTokens : null;
+    }
+
+    /**
+     * 构造指定字符数的填充文本。刻意用递增编号而不是重复字符——重复字符会被 BPE 合并成极少 token，
+     * 那样发出去的实际输入远小于目标，实测就成了假阳性。
+     */
+    private String filler(int targetChars) {
+        StringBuilder text = new StringBuilder(targetChars + 64);
+        text.append("以下为上线认证的上下文窗口实测填充内容，请只回复 ok。");
+        int index = 0;
+        while (text.length() < targetChars) {
+            text.append("seg").append(index++).append(' ');
+        }
+        return text.toString();
+    }
+
+    private Integer declaredContext(AiModelAsset asset) {
+        if (asset == null || asset.getContextWindow() == null || asset.getContextWindow() <= 0) {
+            return null;
+        }
+        return asset.getContextWindow();
+    }
+
+    /** 检查项与落库的窗口结论；后者取通过校验的声明窗口，实测证据在检查项的实测值里。 */
+    private record ContextWindowEvidence(ModelCertificationCheckVO check, Integer verifiedTokens) {
     }
 
     private boolean probeConnectivity(AiModelConfig deployment, String secretValue,
@@ -209,12 +337,6 @@ public class AgentScopeModelCertificationProbe implements ModelCertificationProb
         } catch (Exception e) {
             return false;
         }
-    }
-
-    private int verifiedContext(Model model, AiModelAsset asset) {
-        int runtime = Math.max(0, model.getContextWindowSize());
-        int declared = asset.getContextWindow() == null ? 0 : Math.max(0, asset.getContextWindow());
-        return runtime == 0 || declared == 0 ? 0 : Math.min(runtime, declared);
     }
 
     private void addUnavailableCapabilityChecks(List<ModelCertificationCheckVO> checks,

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelAssetService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelAssetService.java
@@ -98,6 +98,24 @@ public class ModelAssetService {
             (left, right) -> left));
     }
 
+    /**
+     * 解析部署背后资产登记的上下文窗口，供运行时建模注入框架。
+     *
+     * <p>查不到资产或资产未登记窗口时返回 {@code null}，由调用方回落框架推断——窗口只是能力元信息，
+     * 缺了不该阻断建模；真正需要 fail 的场景（上线认证）由认证自己判定，不在这里代劳。</p>
+     */
+    public Integer findDeclaredContextWindow(AiModelConfig model) {
+        if (model == null || model.getAssetId() == null) {
+            return null;
+        }
+        AiModelAsset asset = CrossTenantOperations.execute(() -> assetMapper.selectOne(
+            new QueryWrapper<AiModelAsset>().eq("id", model.getAssetId())));
+        if (asset == null || asset.getContextWindow() == null || asset.getContextWindow() <= 0) {
+            return null;
+        }
+        return asset.getContextWindow();
+    }
+
     public AiModelAsset requireVisible(Long id, String currentTenant, boolean tenantEnabled) {
         QueryWrapper<AiModelAsset> wrapper = new QueryWrapper<AiModelAsset>().eq("id", id);
         if (tenantEnabled) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelCertificationService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelCertificationService.java
@@ -46,6 +46,9 @@ public class ModelCertificationService {
     private static final int HISTORY_LIMIT = 20;
     private static final int MAX_MESSAGE_LENGTH = 500;
 
+    /** 缺价时的摘要要指得出下一步落点：单价按 (provider, model) 精确匹配，改名或换厂商都要重新维护。 */
+    private static final String PRICE_MISSING = "未配置生效模型单价，请在计费管理维护该模型单价后重试";
+
     private final ModelConfigAccess modelConfigAccess;
     private final ModelAssetService modelAssetService;
     private final SecretRefService secretRefService;
@@ -199,8 +202,8 @@ public class ModelCertificationService {
     private void appendCostChecks(List<ModelCertificationCheckVO> checks, AiModelPrice price,
                                   ModelCertificationRequest request) {
         if (price == null) {
-            checks.add(failedCost("INPUT_COST", "输入成本", null, request.maxInputPrice(), "未配置生效模型单价"));
-            checks.add(failedCost("OUTPUT_COST", "输出成本", null, request.maxOutputPrice(), "未配置生效模型单价"));
+            checks.add(failedCost("INPUT_COST", "输入成本", null, request.maxInputPrice(), PRICE_MISSING));
+            checks.add(failedCost("OUTPUT_COST", "输出成本", null, request.maxOutputPrice(), PRICE_MISSING));
             return;
         }
         checks.add(costCheck("INPUT_COST", "输入成本", price.getInputPrice(), request.maxInputPrice()));

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/knowledge/service/KnowledgeService.java
@@ -351,8 +351,10 @@ public class KnowledgeService {
             throw new BizException(ResultCode.RESOURCE_NOT_FOUND, "未配置可用的对话模型用于知识库问答");
         }
         AiModelConfig config = candidates.get(0);
-        return modelFactory.buildModel(config.getProvider(), config.getBaseUrl(),
-            cryptoUtil.decrypt(config.getApiKey()), config.getModel());
+        // 窗口取资产登记值而不是让框架按模型名猜：第三方模型猜不出来会返回 0（未知），下游会当成「窗口为零」
+        return modelFactory.buildModelWithWindow(config.getProvider(), config.getBaseUrl(),
+            cryptoUtil.decrypt(config.getApiKey()), config.getModel(),
+            modelFactory.resolveDeclaredContextWindow(config.getId()));
     }
 
     /** 一次性模型调用（与 GitAssistantService/CollaborativeCodingService 同手法），带知识库问答系统提示词。 */

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactoryTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AdminModelFactoryTest.java
@@ -153,6 +153,49 @@ class AdminModelFactoryTest {
         assertInstanceOf(OpenAIChatModel.class, model);
     }
 
+    // ==================== 上下文窗口注入 ====================
+
+    /**
+     * 钉住本次修复的前提事实：框架按模型名前缀查硬编码表推断窗口，表里只有各厂商官方模型名。
+     * glm / deepseek 这类走 OpenAI 兼容协议接入的第三方模型推断为 0——0 是「未知」不是「窗口为零」。
+     * 框架哪天扩了推断表，这条会红，那是提醒而不是故障。
+     */
+    @Test
+    void buildModel_withoutDeclaredWindow_leavesThirdPartyModelWindowUnknown() {
+        Model model = publicEndpointFactory().buildModel(
+            "openai", "https://api.openai.com/v1", "sk-test", "glm-5.2");
+
+        assertEquals(0, model.getContextWindowSize());
+    }
+
+    @Test
+    void buildModelWithWindow_shouldOverrideFrameworkInference() {
+        Model model = publicEndpointFactory().buildModelWithWindow(
+            "openai", "https://api.openai.com/v1", "sk-test", "glm-5.2", 1_000_000);
+
+        assertEquals(1_000_000, model.getContextWindowSize());
+    }
+
+    /** 声明缺失或非法时回落框架推断，不能把 0 / 负数当窗口写进运行时。 */
+    @Test
+    void buildModelWithWindow_shouldFallBackToInferenceOnInvalidDeclaration() {
+        AdminModelFactory factory = publicEndpointFactory();
+
+        assertEquals(128_000, factory.buildModelWithWindow(
+            "openai", "https://api.openai.com/v1", "sk-test", "gpt-4o-mini", null)
+            .getContextWindowSize());
+        assertEquals(128_000, factory.buildModelWithWindow(
+            "openai", "https://api.openai.com/v1", "sk-test", "gpt-4o-mini", 0)
+            .getContextWindowSize());
+    }
+
+    /** 依赖未装配（单测与旧构造）时解析返回 null，不能因此抛异常阻断建模。 */
+    @Test
+    void resolveDeclaredContextWindow_withoutDependencies_shouldReturnNull() {
+        assertNull(publicEndpointFactory().resolveDeclaredContextWindow(1L));
+        assertNull(publicEndpointFactory().resolveDeclaredContextWindow(null));
+    }
+
     private AdminModelFactory publicEndpointFactory() {
         ModelEndpointPolicy endpointPolicy = new ModelEndpointPolicy(List::of,
             host -> new InetAddress[] {InetAddress.getByName("8.8.8.8")});

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AgentScopeModelCertificationProbeTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/AgentScopeModelCertificationProbeTest.java
@@ -13,6 +13,7 @@ import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
@@ -22,6 +23,7 @@ import reactor.core.publisher.Flux;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,7 +31,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -69,7 +74,8 @@ class AgentScopeModelCertificationProbeTest {
         assertNull(result.verifiedContextTokens());
         verify(modelFactory, times(1)).testConnectivity(
             "anthropic", "https://model.example/v1", SECRET_VALUE, "model-v1");
-        verify(modelFactory, never()).buildModel(anyString(), anyString(), anyString(), anyString());
+        verify(modelFactory, never()).buildModelWithWindow(
+            anyString(), anyString(), anyString(), anyString(), any());
         assertSensitiveTextAbsent(result);
     }
 
@@ -82,14 +88,17 @@ class AgentScopeModelCertificationProbeTest {
                 response(TextBlock.builder().text("chunk-2").build())),
             Flux.just(response(new ToolUseBlock(
                 "call-1", "certification_echo", Map.of("value", "ok")))),
-            Flux.just(response(TextBlock.builder().text("{\"status\":\"ok\"}").build()))));
-        when(modelFactory.buildModel(anyString(), anyString(), anyString(), anyString())).thenReturn(model);
+            Flux.just(response(TextBlock.builder().text("{\"status\":\"ok\"}").build())),
+            Flux.just(usageResponse(8_400))));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
 
         ModelCertificationProbe.ProbeResult result = probe.probe(
             deployment(), asset(32_000), SECRET_VALUE, request(8_192));
 
-        assertEquals(3, model.calls());
-        assertEquals(16_000, result.verifiedContextTokens());
+        assertEquals(4, model.calls());
+        assertEquals(32_000, result.verifiedContextTokens());
+        assertEquals("8400 tokens", check(result, "CONTEXT_WINDOW").measuredValue());
         assertEquals(ModelCertificationCheckStatus.PASSED.name(), check(result, "CONNECTIVITY").status());
         assertEquals(ModelCertificationCheckStatus.PASSED.name(), check(result, "LATENCY").status());
         assertEquals(ModelCertificationCheckStatus.PASSED.name(), check(result, "STREAMING").status());
@@ -98,8 +107,8 @@ class AgentScopeModelCertificationProbeTest {
         assertEquals(ModelCertificationCheckStatus.PASSED.name(), check(result, "CONTEXT_WINDOW").status());
         verify(modelFactory, times(3)).testConnectivity(
             "anthropic", "https://model.example/v1", SECRET_VALUE, "model-v1");
-        verify(modelFactory).buildModel(
-            "anthropic", "https://model.example/v1", SECRET_VALUE, "model-v1");
+        verify(modelFactory).buildModelWithWindow(
+            "anthropic", "https://model.example/v1", SECRET_VALUE, "model-v1", 32_000);
         assertSensitiveTextAbsent(result);
     }
 
@@ -110,8 +119,10 @@ class AgentScopeModelCertificationProbeTest {
         StubModel model = new StubModel(4_096, true, List.of(
             Flux.just(response(TextBlock.builder().text(THIRD_PARTY_BODY).build())),
             Flux.just(response(new ToolUseBlock("call-1", "wrong_tool", Map.of()))),
-            Flux.just(response(TextBlock.builder().text(THIRD_PARTY_BODY).build()))));
-        when(modelFactory.buildModel(anyString(), anyString(), anyString(), anyString())).thenReturn(model);
+            Flux.just(response(TextBlock.builder().text(THIRD_PARTY_BODY).build())),
+            Flux.error(new IllegalStateException(THIRD_PARTY_BODY))));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
 
         ModelCertificationProbe.ProbeResult result = probe.probe(
             deployment(), asset(32_000), SECRET_VALUE, request(8_192));
@@ -121,8 +132,187 @@ class AgentScopeModelCertificationProbeTest {
         assertEquals(ModelCertificationCheckStatus.FAILED.name(), check(result, "TOOL_CALL").status());
         assertEquals(ModelCertificationCheckStatus.FAILED.name(), check(result, "STRUCTURED_OUTPUT").status());
         assertEquals(ModelCertificationCheckStatus.FAILED.name(), check(result, "CONTEXT_WINDOW").status());
-        assertEquals(4_096, result.verifiedContextTokens());
+        assertNull(result.verifiedContextTokens());
         assertSensitiveTextAbsent(result);
+    }
+
+    /**
+     * 本次修复的直接回归：框架按模型名前缀推断窗口，推断表只有各厂商官方模型名，
+     * glm / deepseek 这类走 OpenAI 兼容协议接入的第三方模型一律推断为 0。
+     * 0 是「未知」不是「窗口为零」，不能据此判失败。
+     */
+    @Test
+    void runtimeWindowUnknown_shouldStillPassOnDeclaredAssetAndRealProbe() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0, Flux.just(usageResponse(8_500)));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(1_000_000), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.PASSED.name(), window.status());
+        assertEquals("8500 tokens", window.measuredValue());
+        assertEquals(1_000_000, result.verifiedContextTokens());
+    }
+
+    /** 资产声明才是窗口的权威来源；没登记就没有可校验的依据，此时才该判失败。 */
+    @Test
+    void assetWithoutDeclaredWindow_shouldFailWithoutSpendingProbeRequest() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0);
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(null), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.FAILED.name(), window.status());
+        assertTrue(window.message().contains("未登记"));
+        assertNull(result.verifiedContextTokens());
+        assertEquals(3, model.calls());
+        verify(modelFactory).buildModelWithWindow(
+            "anthropic", "https://model.example/v1", SECRET_VALUE, "model-v1", null);
+    }
+
+    /** 声明值本身就低于门槛时不必再发大请求，直接判失败并如实报出声明值。 */
+    @Test
+    void declaredWindowBelowThreshold_shouldFailWithoutSpendingProbeRequest() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0);
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(4_096), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.FAILED.name(), window.status());
+        assertEquals("4096", window.measuredValue());
+        assertEquals(4_096, result.verifiedContextTokens());
+        assertEquals(3, model.calls());
+    }
+
+    /** 实测请求被端点拒绝（输入超出真实窗口）即为不通过，且不得回显第三方响应体。 */
+    @Test
+    void rejectedContextProbe_shouldFailWithoutLeakingProviderBody() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0, Flux.error(new IllegalStateException(THIRD_PARTY_BODY)));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(1_000_000), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.FAILED.name(), window.status());
+        assertNull(result.verifiedContextTokens());
+        assertSensitiveTextAbsent(result);
+    }
+
+    /** 兼容网关可能不回 usage：请求成功即视为接受了这段输入，但实测值要标注成估算。 */
+    @Test
+    void endpointWithoutUsage_shouldPassAndMarkMeasurementApproximated() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0,
+            Flux.just(response(TextBlock.builder().text("ok").build())));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(1_000_000), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.PASSED.name(), window.status());
+        assertEquals("8192 tokens (估算)", window.measuredValue());
+    }
+
+    /** 门槛高于实测上限时只填充到上限，摘要必须写明实测覆盖到哪、其余依据什么。 */
+    @Test
+    void thresholdAboveProbeCeiling_shouldStateProbeCoverageInEvidence() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0, Flux.just(usageResponse(33_000)));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(1_000_000), SECRET_VALUE, request(200_000));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.PASSED.name(), window.status());
+        assertTrue(window.message().contains("实测上限 32768"));
+        assertTrue(window.message().contains("1000000"));
+        // 填充按实测上限而不是门槛构造，否则一次认证要发 20 万 token
+        assertTrue(model.lastPromptLength() < 200_000);
+        assertTrue(model.lastPromptLength() > 32_768);
+    }
+
+    /**
+     * 各家 tokenizer 的字符/token 比不同，首轮填充可能不到目标量。
+     * 这时要按端点回报的真实比率补填一次，而不是拿偏低的实测值当证据。
+     */
+    @Test
+    void shortFirstMeasurement_shouldRefillByReportedRatioAndPass() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0,
+            Flux.just(usageResponse(4_000)), Flux.just(usageResponse(8_400)));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(1_000_000), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.PASSED.name(), window.status());
+        assertEquals("8400 tokens", window.measuredValue());
+        // 三次能力探测 + 两次上下文实测
+        assertEquals(5, model.calls());
+    }
+
+    /** 补填一轮后仍达不到目标：证据不足以支撑门槛，判失败而不是拿这个数字虚过。 */
+    @Test
+    void persistentlyShortMeasurement_shouldFailInsteadOfPassingOnWeakEvidence() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0,
+            Flux.just(usageResponse(3_000)), Flux.just(usageResponse(3_100)));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        ModelCertificationProbe.ProbeResult result = probe.probe(
+            deployment(), asset(1_000_000), SECRET_VALUE, request(8_192));
+
+        ModelCertificationCheckVO window = check(result, "CONTEXT_WINDOW");
+        assertEquals(ModelCertificationCheckStatus.FAILED.name(), window.status());
+        assertEquals("3100 tokens", window.measuredValue());
+        assertTrue(window.message().contains("不足以证明"));
+        assertNull(result.verifiedContextTokens());
+    }
+
+    /** 填充不能靠重复字符：BPE 会把它压成极少 token，实际发送量远低于目标，实测就成了假阳性。 */
+    @Test
+    void contextProbeFiller_shouldVaryContentInsteadOfRepeatingOneCharacter() {
+        when(modelFactory.testConnectivity(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(successfulConnectivity());
+        StubModel model = capableModel(0, Flux.just(usageResponse(8_500)));
+        when(modelFactory.buildModelWithWindow(anyString(), anyString(), anyString(), anyString(), any()))
+            .thenReturn(model);
+
+        probe.probe(deployment(), asset(1_000_000), SECRET_VALUE, request(8_192));
+
+        String filler = model.lastPrompt();
+        assertTrue(filler.contains("seg0 "));
+        assertTrue(filler.contains("seg1000 "));
+        assertFalse(containsSensitiveText(filler));
     }
 
     private ModelTestResult successfulConnectivity() {
@@ -138,10 +328,26 @@ class AgentScopeModelCertificationProbeTest {
         return deployment;
     }
 
-    private AiModelAsset asset(int contextWindow) {
+    private AiModelAsset asset(Integer contextWindow) {
         AiModelAsset asset = new AiModelAsset();
         asset.setContextWindow(contextWindow);
         return asset;
+    }
+
+    /** 三项能力探测一律通过的 stub，后接调用方给定的上下文实测响应（可给多轮，覆盖补填）。 */
+    @SafeVarargs
+    private StubModel capableModel(int runtimeWindow, Flux<ChatResponse>... contextProbes) {
+        List<Flux<ChatResponse>> responses = new ArrayList<>(capabilityResponses());
+        responses.addAll(List.of(contextProbes));
+        return new StubModel(runtimeWindow, true, responses);
+    }
+
+    private List<Flux<ChatResponse>> capabilityResponses() {
+        return List.of(
+            Flux.just(response(TextBlock.builder().text("chunk-1").build()),
+                response(TextBlock.builder().text("chunk-2").build())),
+            Flux.just(response(new ToolUseBlock("call-1", "certification_echo", Map.of("value", "ok")))),
+            Flux.just(response(TextBlock.builder().text("{\"status\":\"ok\"}").build())));
     }
 
     private ModelCertificationRequest request(int requiredContextTokens) {
@@ -172,12 +378,19 @@ class AgentScopeModelCertificationProbeTest {
         return new ChatResponse("response", List.of(content), null, null, "stop");
     }
 
+    /** 端点回报输入 token 数的响应——上下文窗口实测的权威证据就取自这里。 */
+    private ChatResponse usageResponse(int inputTokens) {
+        return new ChatResponse("response", List.of(TextBlock.builder().text("ok").build()),
+            new ChatUsage(inputTokens, 2, 0, 0.1d), null, "stop");
+    }
+
     private static final class StubModel implements Model {
 
         private final int contextWindow;
         private final boolean structuredOutput;
         private final List<Flux<ChatResponse>> responses;
         private final AtomicInteger calls = new AtomicInteger();
+        private volatile String lastPrompt = "";
 
         private StubModel(int contextWindow, boolean structuredOutput,
                           List<Flux<ChatResponse>> responses) {
@@ -189,6 +402,7 @@ class AgentScopeModelCertificationProbeTest {
         @Override
         public Flux<ChatResponse> stream(List<Msg> messages, List<ToolSchema> tools,
                                          GenerateOptions options) {
+            lastPrompt = messages.isEmpty() ? "" : messages.get(0).getTextContent();
             int index = calls.getAndIncrement();
             return index < responses.size()
                 ? responses.get(index)
@@ -212,6 +426,14 @@ class AgentScopeModelCertificationProbeTest {
 
         private int calls() {
             return calls.get();
+        }
+
+        private String lastPrompt() {
+            return lastPrompt;
+        }
+
+        private int lastPromptLength() {
+            return lastPrompt.length();
         }
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ChatModelFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ChatModelFactory.java
@@ -30,25 +30,51 @@ public final class ChatModelFactory {
     }
 
     /**
-     * 按厂商构建模型。stream 开关与高级生成参数对各厂商统一应用；{@code baseUrl} 有值才覆盖（否则用厂商默认端点）。
+     * 按厂商构建模型，上下文窗口交给框架按模型名前缀推断。
      *
-     * @param provider       厂商标识（大小写不敏感，空则 dashscope）
-     * @param modelName      模型名
-     * @param apiKey         鉴权密钥（ollama 本地私有化不需要）
-     * @param baseUrl        自定义端点（可空）
-     * @param stream         是否流式
-     * @param options        高级生成参数（温度 / topP / maxTokens / 推理强度）
-     * @param enableSearch   DashScope 联网搜索（仅 dashscope 生效，可空）
-     * @param enableThinking DashScope 深度思考（仅 dashscope 生效，可空）
+     * <p>框架的推断表只收录各厂商官方模型名（{@code gpt-4o} / {@code qwen-plus} 等），
+     * 第三方模型走 OpenAI 兼容协议接入时推断不出来、{@code getContextWindowSize()} 返回 0。
+     * 有权威声明值的场景请改用 {@link #build(String, String, String, String, boolean,
+     * GenerateOptions, Boolean, Boolean, Integer)}。</p>
      */
     public static Model build(String provider, String modelName, String apiKey, String baseUrl,
                               boolean stream, GenerateOptions options,
                               Boolean enableSearch, Boolean enableThinking) {
+        return build(provider, modelName, apiKey, baseUrl, stream, options,
+            enableSearch, enableThinking, null);
+    }
+
+    /**
+     * 按厂商构建模型。stream 开关与高级生成参数对各厂商统一应用；{@code baseUrl} 有值才覆盖（否则用厂商默认端点）。
+     *
+     * <p>{@code contextWindowSize} 传入时覆盖框架的模型名推断。框架推断表只认各厂商官方模型名，
+     * 第三方模型（glm / deepseek / 自建网关）走 OpenAI 兼容协议时一律推断为 0，而 0 会被下游
+     * 当成「窗口为零」而非「未知」——路由按各档取 min 上报能力、上线认证按窗口判定门槛，都会因此失真。
+     * 调用方拿得到权威声明（如模型资产登记的窗口）时必须传进来。</p>
+     *
+     * @param provider          厂商标识（大小写不敏感，空则 dashscope）
+     * @param modelName         模型名
+     * @param apiKey            鉴权密钥（ollama 本地私有化不需要）
+     * @param baseUrl           自定义端点（可空）
+     * @param stream            是否流式
+     * @param options           高级生成参数（温度 / topP / maxTokens / 推理强度）
+     * @param enableSearch      DashScope 联网搜索（仅 dashscope 生效，可空）
+     * @param enableThinking    DashScope 深度思考（仅 dashscope 生效，可空）
+     * @param contextWindowSize 权威上下文窗口（可空；空或非正数则回落框架推断）
+     */
+    public static Model build(String provider, String modelName, String apiKey, String baseUrl,
+                              boolean stream, GenerateOptions options,
+                              Boolean enableSearch, Boolean enableThinking,
+                              Integer contextWindowSize) {
         String p = provider == null ? ModelProviders.DASHSCOPE : provider.toLowerCase();
+        boolean declaredWindow = contextWindowSize != null && contextWindowSize > 0;
         switch (p) {
             case ModelProviders.OPENAI: {
                 OpenAIChatModel.Builder b = OpenAIChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).stream(stream).generateOptions(options);
+                if (declaredWindow) {
+                    b.contextWindowSize(contextWindowSize);
+                }
                 if (StringUtils.hasText(baseUrl)) {
                     b.baseUrl(baseUrl);
                 }
@@ -57,6 +83,9 @@ public final class ChatModelFactory {
             case ModelProviders.ANTHROPIC: {
                 AnthropicChatModel.Builder b = AnthropicChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).stream(stream).defaultOptions(options);
+                if (declaredWindow) {
+                    b.contextWindowSize(contextWindowSize);
+                }
                 if (StringUtils.hasText(baseUrl)) {
                     b.baseUrl(baseUrl);
                 }
@@ -66,6 +95,9 @@ public final class ChatModelFactory {
                 // 注意：Gemini 需额外引入 google-genai 依赖
                 GeminiChatModel.Builder b = GeminiChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).streamEnabled(stream).defaultOptions(options);
+                if (declaredWindow) {
+                    b.contextWindowSize(contextWindowSize);
+                }
                 if (StringUtils.hasText(baseUrl)) {
                     b.baseUrl(baseUrl);
                 }
@@ -74,6 +106,9 @@ public final class ChatModelFactory {
             case ModelProviders.OLLAMA: {
                 // Ollama 本地私有化：使用 OllamaOptions（生成参数另行配置），默认 localhost:11434
                 OllamaChatModel.Builder b = OllamaChatModel.builder().modelName(modelName);
+                if (declaredWindow) {
+                    b.contextWindowSize(contextWindowSize);
+                }
                 if (StringUtils.hasText(baseUrl)) {
                     b.baseUrl(baseUrl);
                 }
@@ -82,6 +117,9 @@ public final class ChatModelFactory {
             default: {
                 DashScopeChatModel.Builder b = DashScopeChatModel.builder()
                     .apiKey(apiKey).modelName(modelName).stream(stream).defaultOptions(options);
+                if (declaredWindow) {
+                    b.contextWindowSize(contextWindowSize);
+                }
                 if (StringUtils.hasText(baseUrl)) {
                     b.baseUrl(baseUrl);
                 }

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -1080,6 +1080,20 @@ lineage 与不可变版本。
 `AdminModelFactory.buildModel -> ChatModelFactory.build` 使用 AgentScope 厂商 SDK；本轮没有证明这些请求固定解析结果
 或关闭重定向，不能把连通性探测链路保障泛化为全部模型调用。
 
+**上线认证的上下文窗口判定**：窗口的权威来源是 `ai_model_asset.context_window`，不是框架。
+框架的 `Model#getContextWindowSize()` 走 `ModelContextWindows.lookup` 按模型名前缀查一张硬编码表，
+表里只有各厂商**官方**模型名（`gpt-4o` / `qwen-plus` / `claude-3-5` 等）；`glm` / `deepseek` 这类
+走 OpenAI 兼容协议接入的第三方模型一律查不到、返回 `0`。**`0` 的语义是「未知」而不是「窗口为零」**，
+早期实现把它当成能力值参与 `min` 交集，导致所有 OpenAI 兼容第三方部署的窗口检查恒为失败。
+
+现在两侧收口：① `AdminModelFactory.buildModelWithWindow` / `buildModel(..., deploymentId)` 建模时
+把资产登记窗口注入框架 builder，运行时能力上报（`PolicyRoutingModel` 等按各档取 min）不再失真；
+② 认证按**先声明后实测**判定——资产未登记窗口或登记值低于门槛直接失败（省掉一次注定无意义的大请求），
+否则真发一次填充到门槛量级的请求，用端点回报的 `usage.inputTokens` 作为实测证据。填充刻意用递增编号
+而非重复字符（重复字符会被 BPE 压成极少 token，实际发送量远低于目标，实测就成了假阳性）；
+实测上限 32768 token，门槛高于上限时只填到上限，超出部分依据资产声明并在证据摘要里写明覆盖范围；
+兼容网关不回 `usage` 时按发送量估算并在实测值上标注「估算」。
+
 **调用统计的 token 口径（V43 起补齐缓存量）**：框架 `ChatUsage` 一共只给四个原始量——
 `inputTokens` / `outputTokens` / `cachedTokens` / `time`（`totalTokens` 是派生的 input+output），
 没有 reasoning tokens、没有价格信息。此前只落了前两个和 total，**缓存量与模型自报耗时采到了却被丢弃**，


### PR DESCRIPTION
## 问题

后台「模型治理 → 执行认证 → 运行上线认证」对 OpenAI 兼容协议接入的第三方模型**必然失败**，
且与运营在资产里登记多大上下文窗口无关：

| 检查项 | 结果 | 实测 | 门槛 |
|---|---|---|---|
| 上下文窗口 | FAILED | **0** | ≥ 8192 |

## 根因

`AgentScopeModelCertificationProbe#verifiedContext` 拿框架的 `Model#getContextWindowSize()`
当运行时证据，与资产声明取 `min` 交集：

```java
return runtime == 0 || declared == 0 ? 0 : Math.min(runtime, declared);
```

而那个值来自 `ModelContextWindows.lookup(modelName, OPENAI)` —— 一张只收录**厂商官方模型名**
的硬编码表（`gpt-4.1` / `gpt-4o` / `o1` / `o3` / `o4-mini`）。`glm-5.2`、`deepseek-v4-pro`、
`qwen3.7-plus` 这类走 OpenAI 兼容协议接入的模型前缀全部匹配不上，返回 `0`。

**`0` 的语义是「表里没有这个名字」，不是「窗口为零」**。把未知当成零，让这类部署的窗口检查恒为失败；
`PolicyRoutingModel` / `TieredRoutingModel` 按各档取 `min` 上报的窗口能力同样恒为 0。

三个既有单测全部用 `StubModel` 直接返回 16000 / 4096，从没覆盖框架返回 0 的真实场景，所以一直没被照出来。

## 修复

**建模侧** —— 让权威声明进入运行时，而不是让框架猜模型名：
- `ChatModelFactory.build` 增加 `contextWindowSize` 重载，五家厂商 builder 统一注入（它们都有
  `contextWindowSize(int)`，只是从未被调用过）
- `AdminModelFactory` 新增 `buildModelWithWindow`；带 `deploymentId` 的重载**自行**从
  `ai_model_asset.context_window` 解析注入 —— 不让调用方「记得传」。建模路径有主备模型、路由候选、
  VibeCoding、实验评估、知识库、认证探测六条，逐个要求记得传必然漏，漏了还不报错

**认证侧** —— 窗口判定改为「先声明后实测」：
- 资产未登记窗口 / 登记值低于门槛 → 直接失败，省掉一次注定无意义的大请求，摘要分别写明是哪一侧不足
- 否则真发一次填充到门槛量级的请求，用端点回报的 `usage.inputTokens` 作为实测证据
- 填充用递增编号而非重复字符（重复字符会被 BPE 压成极少 token，实际发送量远低于目标，
  实测就成了假阳性）
- 首轮 token 数不足目标时按端点回报的真实比率补填一次；仍不足则**判失败**而不是拿偏低值虚过 ——
  认证是门禁，虚过等于门禁失效
- 实测上限 32768 token（门槛可声明到百万级，真按那个量填既慢又费），门槛更高时超出部分依据
  资产声明，并在证据摘要里写明实测覆盖到哪
- 兼容网关不回 `usage` 时按发送量估算，实测值上标注「估算」

**顺带**：缺价的成本检查摘要补上落点指引（原文案只说「未配置生效模型单价」，运营不知道去哪配）。

## 测试

admin +13，全模块 BUILD SUCCESS：starter 1705/5skip、app-server 129、customer-channel 80、
admin 1442/1skip、gateway 1，合计 3357（排除 `RedisSessionPersistenceTest`）。

新增覆盖：框架推断为 0 时仍能通过（本次缺陷的直接回归）、资产未登记、声明低于门槛、
实测被拒、网关不回 usage、门槛超实测上限、填充内容不重复、按真实比率补填、补填后仍不足判失败。
`AdminModelFactoryTest` 用真实 `OpenAIChatModel` 钉住「`glm-5.2` 推断为 0」这个前提 ——
框架哪天扩了推断表它会红，那是提醒而不是故障。

有效性做过反向验证：把判定退回旧行为，12 条用例里 7 条立刻变红。