### PR TITLE
fix(admin-web): 认证结果判定改看运行结论，不再把存量豁免报成失败

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/dto/ModelCertificationVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/dto/ModelCertificationVO.java
@@ -6,12 +6,30 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-/** 模型部署认证视图，effectiveStatus 会计算过期与配置漂移。 */
+/**
+ * 模型部署认证视图。
+ *
+ * <p><b>两个状态字段语义不同，别混用</b>——前端曾拿 {@code effectiveStatus} 判「这次认证跑得怎么样」，
+ * 导致存量豁免部署每一次成功的认证都被报成失败，而检查项列表里一条失败都没有：</p>
+ * <ul>
+ *   <li>{@code status}：<b>这次运行</b>的结论，只有 PASSED / FAILED。问「这次跑得怎么样」看它，
+ *       历史列表同理——每条历史行要回答的是当时那次的结论；</li>
+ *   <li>{@code effectiveStatus}：<b>该部署当前的门禁态</b>，在运行结论之上叠加了有效期、端点 revision
+ *       与凭据版本漂移，取值还包括 STALE / EXPIRED / UNKNOWN / NOT_REQUIRED。问「现在能不能激活、
+ *       能不能被路由引用」看它。存量豁免部署（{@code certification_required=0}）恒为 NOT_REQUIRED，
+ *       与本次跑得如何无关。</li>
+ * </ul>
+ */
 @Data
 public class ModelCertificationVO {
     private Long runId;
+
+    /** 本次运行结论：PASSED / FAILED。判断「这次认证成功没有」用它。 */
     private String status;
+
+    /** 该部署当前门禁态：PASSED / FAILED / STALE / EXPIRED / UNKNOWN / NOT_REQUIRED。判断「能否激活」用它。 */
     private String effectiveStatus;
+
     private String staleReason;
     private Integer certifiedEndpointRevision;
     private Integer certifiedSecretVersion;

--- a/customer-admin-web/src/utils/certificationResult.test.ts
+++ b/customer-admin-web/src/utils/certificationResult.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelCertification } from '@/types/api'
+import {
+  canActivateByCertification,
+  certificationResultMessage,
+  isCertificationRunPassed,
+} from './certificationResult'
+
+function certification(patch: Partial<ModelCertification>): ModelCertification {
+  return {
+    runId: 1,
+    status: 'PASSED',
+    effectiveStatus: 'PASSED',
+    staleReason: null,
+    certifiedEndpointRevision: 1,
+    certifiedSecretVersion: 1,
+    validUntil: null,
+    completedAt: null,
+    passedChecks: 8,
+    failedChecks: 0,
+    latencyP95Ms: 1200,
+    verifiedContextTokens: 1000000,
+    inputPrice: null,
+    outputPrice: null,
+    currency: null,
+    failureCode: null,
+    failureMessage: null,
+    checks: [],
+    ...patch,
+  } as ModelCertification
+}
+
+describe('certificationResultMessage', () => {
+  /**
+   * 直接回归：存量豁免部署（certification_required=0）的门禁态恒为 NOT_REQUIRED。
+   * 早期实现拿 effectiveStatus 判本次结果，导致每一次成功的认证都弹「认证失败：请查看检查项」，
+   * 而检查项列表里一条失败都没有。
+   */
+  it('存量豁免部署认证通过时报成功而不是失败', () => {
+    const result = certification({ status: 'PASSED', effectiveStatus: 'NOT_REQUIRED' })
+
+    const message = certificationResultMessage(result)
+
+    expect(message.type).toBe('success')
+    expect(message.text).toContain('上线认证通过')
+    expect(message.text).toContain('存量豁免')
+  })
+
+  it('已纳入门禁且通过时提示可以激活', () => {
+    const message = certificationResultMessage(
+      certification({ status: 'PASSED', effectiveStatus: 'PASSED' }),
+    )
+
+    expect(message.type).toBe('success')
+    expect(message.text).toBe('上线认证通过，可以激活部署')
+  })
+
+  it('本次通过但结果未晋级时说明原因', () => {
+    const message = certificationResultMessage(certification({
+      status: 'PASSED',
+      effectiveStatus: 'STALE',
+      staleReason: '认证期间配置、凭据或更新认证运行已发生变化，本次结果未晋级',
+    }))
+
+    expect(message.type).toBe('success')
+    expect(message.text).toContain('未晋级')
+    expect(message.text).toContain('本次结果未晋级')
+  })
+
+  it('本次失败时报出失败原因', () => {
+    const message = certificationResultMessage(certification({
+      status: 'FAILED',
+      effectiveStatus: 'FAILED',
+      failureCode: 'TOOL_CALL',
+      failureMessage: '工具调用能力检查失败',
+    }))
+
+    expect(message.type).toBe('error')
+    expect(message.text).toBe('认证失败：工具调用能力检查失败')
+  })
+
+  it('失败但没有摘要时回落到错误码，再回落到兜底文案', () => {
+    expect(certificationResultMessage(certification({
+      status: 'FAILED', effectiveStatus: 'FAILED', failureCode: 'LATENCY', failureMessage: null,
+    })).text).toBe('认证失败：LATENCY')
+
+    expect(certificationResultMessage(certification({
+      status: 'FAILED', effectiveStatus: 'FAILED', failureCode: null, failureMessage: null,
+    })).text).toBe('认证失败：请查看检查项')
+  })
+})
+
+describe('isCertificationRunPassed', () => {
+  it('只看本次运行结论，不受门禁态影响', () => {
+    expect(isCertificationRunPassed(
+      certification({ status: 'PASSED', effectiveStatus: 'NOT_REQUIRED' }))).toBe(true)
+    expect(isCertificationRunPassed(
+      certification({ status: 'PASSED', effectiveStatus: 'STALE' }))).toBe(true)
+    expect(isCertificationRunPassed(
+      certification({ status: 'FAILED', effectiveStatus: 'NOT_REQUIRED' }))).toBe(false)
+  })
+})
+
+describe('canActivateByCertification', () => {
+  it('放行 PASSED 与存量豁免的 NOT_REQUIRED，与后端 requireCurrent 对齐', () => {
+    expect(canActivateByCertification('PASSED')).toBe(true)
+    expect(canActivateByCertification('NOT_REQUIRED')).toBe(true)
+  })
+
+  it('拦住失败、过期与配置漂移', () => {
+    expect(canActivateByCertification('FAILED')).toBe(false)
+    expect(canActivateByCertification('EXPIRED')).toBe(false)
+    expect(canActivateByCertification('STALE')).toBe(false)
+    expect(canActivateByCertification('UNKNOWN')).toBe(false)
+  })
+})

--- a/customer-admin-web/src/utils/certificationResult.ts
+++ b/customer-admin-web/src/utils/certificationResult.ts
@@ -1,0 +1,53 @@
+import type { ModelCertification } from '@/types/api'
+
+/**
+ * 上线认证结果的展示判定。
+ *
+ * <p>两个状态字段语义不同，混用是这里出过的缺陷：{@code status} 是<b>本次运行</b>的结论
+ * （PASSED / FAILED），{@code effectiveStatus} 是<b>该部署当前的门禁态</b>
+ * （PASSED / FAILED / STALE / EXPIRED / UNKNOWN / NOT_REQUIRED）。存量豁免部署的门禁态恒为
+ * NOT_REQUIRED，拿它判「这次跑得怎么样」会把每一次成功的认证都报成失败。</p>
+ */
+export interface CertificationResultMessage {
+  type: 'success' | 'error'
+  text: string
+}
+
+/** 本次认证运行是否通过——只看运行结论，与该部署是否纳入门禁无关。 */
+export function isCertificationRunPassed(result: ModelCertification): boolean {
+  return result.status === 'PASSED'
+}
+
+/** 认证结束后的提示：先说本次结论，再按门禁态补上「这次结果对部署意味着什么」。 */
+export function certificationResultMessage(result: ModelCertification): CertificationResultMessage {
+  if (!isCertificationRunPassed(result)) {
+    return {
+      type: 'error',
+      text: `认证失败：${result.failureMessage || result.failureCode || '请查看检查项'}`,
+    }
+  }
+  if (result.effectiveStatus === 'PASSED') {
+    return { type: 'success', text: '上线认证通过，可以激活部署' }
+  }
+  if (result.effectiveStatus === 'NOT_REQUIRED') {
+    return {
+      type: 'success',
+      text: '上线认证通过；该部署为存量豁免，尚未纳入认证门禁（改配置或轮换凭据后自动纳入）',
+    }
+  }
+  if (result.effectiveStatus === 'STALE') {
+    return {
+      type: 'success',
+      text: `上线认证通过，但本次结果未晋级：${result.staleReason || '认证期间配置或凭据已变化'}`,
+    }
+  }
+  return { type: 'success', text: `上线认证通过（当前门禁态：${result.effectiveStatus}）` }
+}
+
+/**
+ * 能否激活部署。NOT_REQUIRED 与 PASSED 都放行：后端 {@code requireCurrent} 对存量豁免部署
+ * 直接放行，前端只认 PASSED 会让存量部署停用后再也激活不回来。
+ */
+export function canActivateByCertification(effectiveStatus: string): boolean {
+  return effectiveStatus === 'PASSED' || effectiveStatus === 'NOT_REQUIRED'
+}

--- a/customer-admin-web/src/views/aiconfig/components/ModelCertificationPanel.vue
+++ b/customer-admin-web/src/views/aiconfig/components/ModelCertificationPanel.vue
@@ -6,6 +6,10 @@ import {
   listModelCertificationRuns,
   updateModel,
 } from '@/api/model'
+import {
+  canActivateByCertification,
+  certificationResultMessage,
+} from '@/utils/certificationResult'
 import type {
   ModelCertification,
   ModelCertificationRequest,
@@ -39,7 +43,7 @@ const form = reactive<ModelCertificationRequest>({
 })
 
 const effectiveStatus = computed(() => current.value?.effectiveStatus ?? 'UNKNOWN')
-const canActivate = computed(() => effectiveStatus.value === 'PASSED'
+const canActivate = computed(() => canActivateByCertification(effectiveStatus.value)
   && (props.model?.status !== 1 || props.model?.lifecycleStatus !== 'ACTIVE'))
 
 watch(() => props.modelId, (id) => {
@@ -70,11 +74,8 @@ async function certify() {
   certifying.value = true
   try {
     current.value = await certifyModel(props.modelId, { ...form })
-    ElMessage[current.value.effectiveStatus === 'PASSED' ? 'success' : 'error'](
-      current.value.effectiveStatus === 'PASSED'
-        ? '上线认证通过，可以激活部署'
-        : `认证失败：${current.value.failureMessage || current.value.failureCode || '请查看检查项'}`,
-    )
+    const message = certificationResultMessage(current.value)
+    ElMessage[message.type](message.text)
     await load()
     emit('updated')
   } finally {
@@ -152,7 +153,12 @@ function formatTime(value: string | null | undefined) {
     <section class="cert-hero" :class="`is-${effectiveStatus.toLowerCase()}`">
       <div>
         <span>当前上线认证</span>
-        <strong>{{ effectiveStatus }}</strong>
+        <strong>
+          {{ effectiveStatus }}
+          <el-tag v-if="current?.runId" :type="checkType(current.status)" size="small" effect="plain">
+            最近一次运行 {{ current.status }}
+          </el-tag>
+        </strong>
         <small v-if="current?.staleReason">{{ current.staleReason }}</small>
         <small v-else>有效至 {{ formatTime(current?.validUntil) }}</small>
       </div>
@@ -221,8 +227,10 @@ function formatTime(value: string | null | undefined) {
       <h3>认证历史</h3>
       <el-table :data="history" max-height="260" empty-text="暂无历史">
         <el-table-column prop="runId" label="Run" width="80" />
+        <!-- 历史要回答的是「那次跑得怎么样」，所以取 status；effectiveStatus 是按当前配置算的
+             门禁态，对每条历史行都算成同一个值，看不出哪次通过哪次失败 -->
         <el-table-column label="状态" width="110">
-          <template #default="{ row }"><el-tag :type="statusType(row.effectiveStatus)">{{ row.effectiveStatus }}</el-tag></template>
+          <template #default="{ row }"><el-tag :type="statusType(row.status)">{{ row.status }}</el-tag></template>
         </el-table-column>
         <el-table-column prop="latencyP95Ms" label="P95(ms)" width="100" />
         <el-table-column label="完成时间" min-width="170">


### PR DESCRIPTION
接 #154（已合并）。首轮修复上线后实测发现的第二个缺陷，同一功能域、独立成因。

## 现象

8 项检查 6 通过 2 跳过、`ai_model_certification_run.status = PASSED`、`failure_code` 为空，
前端仍弹 **「认证失败：请查看检查项」**，而检查项列表里一条失败都没有。

```
run 2092850194686464002  status=PASSED  failure_code=NULL
run 2092849975265644546  status=PASSED  failure_code=NULL
```

## 根因

`ModelCertificationPanel` 拿 `effectiveStatus` 判「本次认证跑得怎么样」。两个字段语义不同：

| 字段 | 回答的问题 | 取值 |
|---|---|---|
| `status` | **这次运行**的结论 | PASSED / FAILED |
| `effectiveStatus` | **该部署当前的门禁态** | PASSED / FAILED / STALE / EXPIRED / UNKNOWN / **NOT_REQUIRED** |

存量部署（`certification_required=0`，迁移时刻意保持兼容）的门禁态恒为 `NOT_REQUIRED`，
前端把非 PASSED 一律当失败，`failureMessage` / `failureCode` 又都是 null，于是落到兜底文案。
**这类部署无论跑得多完美都提示认证失败，且运营完全无从判断问题在哪。**

## 同源的另外两处

- **认证历史列表**同样显示 `effectiveStatus` —— 后端对每条历史行都按当前配置重算，
  存量部署的所有历史行都是 NOT_REQUIRED，看不出哪次通过哪次失败。改为显示那次运行的 `status`
- **`canActivate` 只认 PASSED**，比后端 `requireCurrent` 严（后端对存量豁免直接放行），
  存量部署一旦停用就再也激活不回来。改为放行 PASSED 与 NOT_REQUIRED

## 修复

判定逻辑抽到 `utils/certificationResult.ts`（前端没有组件测试基础设施，但这部分是纯函数，
抽出来就能按现有 utils 测试风格覆盖），配 8 条用例；hero 区补「最近一次运行」标签，
让门禁态与运行结论同时可见，不再出现「大字 NOT_REQUIRED + 检查项全绿 + 弹窗说失败」的三方矛盾；
`ModelCertificationVO` 给这两个字段补上区分说明。

## 验证

前端 vitest 24 通过、`vue-tsc -b && vite build` 通过；admin 1447 通过（含 #155 新增的 5 条）。
反向验证：把判定退回 `effectiveStatus`，8 条里 4 条立刻变红。