### PR TITLE
fix(vibecoding): 会话仓库建仓时关闭 git 后台自动维护

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,18 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-08-27 git 后台维护 flaky 修复批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1705/5 skip、app-server 129、customer-channel 80、admin 1448/1 skip、gateway 1，合计 3363
+  （排除 `RedisSessionPersistenceTest`）。本批次自身加 admin **+1**（建仓时后台维护必须关闭的门禁）。
+  **CI 报"临时目录删不掉"时先看 suppressed 是不是 `NoSuchFileException`**：那是"遍历列到了它、
+  stat 时已经没了"的竞态，不是权限也不是残留，往权限方向查会全程走偏。本批次的病根在生产代码——
+  `git commit` 收尾会 fork `git maintenance run --auto --detach`，它在 `.git/objects/` 下建
+  `maintenance.lock` 再自行删除，而这个进程不在 `GitWorkspaceService#runGit` 的 waitFor 范围内。
+  **这类竞态本机与 Linux 容器都复现不出来**（macOS 500 轮、容器 900 轮重负载均 0 次：lock 在 commit
+  返回那一刻已消失，CI 是负载把它拖住的）。能拿到的确定性证据是"根因还在不在"——修复前每次 commit
+  都 fork 维护进程（200/200、300/300）、每次都产生 lock（20/20、30/30），修复后全为 0。
+  **别把"改完跑一轮绿了"当成修好**：那正是这条用例在 CI 上挂之前每天的样子。
+  上一版基线 2026-08-27 上下文窗口认证修复 + 表排序规则统一两批合入 main 后：合计 3362。）
   （2026-08-27 表排序规则统一批次实测：starter 1705 / 5 skip、app-server 129、channel 80、
   admin 1434 / 1 skip、gateway 1，**合计 3349**，BUILD SUCCESS，0 失败 0 错误，
   排除 `RedisSessionPersistenceTest`。本批次自身加 admin **+5**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitWorkspaceService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitWorkspaceService.java
@@ -36,13 +36,38 @@ public class GitWorkspaceService {
     static final String GIT_DIR_NAME = ".git";
     /** baseline 是会话内唯一提交，故 HEAD 恒等于 baseline，回滚以 HEAD 为恢复基准。 */
     private static final String HEAD_REF = "HEAD";
+    /** git 后台自动维护的开关配置项；建仓时置 {@link #MAINTENANCE_AUTO_OFF}，原因见 {@link #ensureRepo}。 */
+    static final String MAINTENANCE_AUTO_KEY = "maintenance.auto";
+    /** {@link #MAINTENANCE_AUTO_KEY} 的取值：关闭。 */
+    static final String MAINTENANCE_AUTO_OFF = "false";
 
-    /** 幂等：{@code .git} 已存在则直接返回；否则 init + 建立空基线提交，作为后续 diff 的对比基准。 */
+    /**
+     * 幂等：{@code .git} 已存在则直接返回；否则 init + 建立空基线提交，作为后续 diff 的对比基准。
+     *
+     * <p><b>建仓即关掉 git 的后台自动维护</b>：git 2.30 起 {@code commit} 收尾时会 fork 一个
+     * {@code git maintenance run --auto}（新版还带 {@code --detach} 直接 daemonize），它先在
+     * {@code .git/objects/} 下建 {@code maintenance.lock} 再干活，结束时自行删除——也就是
+     * <b>{@link #runGit} 已经 waitFor 到我们启的那个 git 进程了，git 却还有个后台进程在动这个目录</b>。
+     * 会话仓库是一次性快照仓库（只有一个 baseline 提交、随会话销毁），没有任何需要维护的对象，
+     * 这个后台进程带来的只有与调用方的竞态：遍历 workspace 时列到了 lock 文件，轮到删除时它已被后台
+     * 进程删掉（CI 上 {@code GitWorkspaceServiceTest} 的 {@code @TempDir} 清理即因此间歇性报
+     * {@code NoSuchFileException: .git/objects/maintenance.lock}）。从源头不产生它，而不是让调用方
+     * 去容忍这个文件的时有时无。</p>
+     *
+     * <p>只有 {@code commit} 会触发自动维护，故配置必须写在 baseline 提交之前；已有 {@code .git}
+     * 的老仓库走上面的早退分支，它们此后不再产生新提交，也就不会再 fork 维护进程。</p>
+     *
+     * <p>配置写进仓库、而不是每次调用都带 {@code -c}：同一个 workspace 目录还会被沙箱
+     * （{@code SandboxCommandService} 就在这个目录里执行智能体给出的命令，其中可能有 git）
+     * 和会话打包（{@code SessionWorkspaceStorage} 遍历整棵树、{@code .git} 也在内）读写，
+     * 只有落到仓库 config 上才能一并约束那些不经过 {@link #runGit} 的 git 调用。</p>
+     */
     public void ensureRepo(Path workspace) {
         if (Files.isDirectory(workspace.resolve(".git"))) {
             return;
         }
         runGit(workspace, "init", "-q");
+        runGit(workspace, "config", MAINTENANCE_AUTO_KEY, MAINTENANCE_AUTO_OFF);
         runGit(workspace, "config", "user.email", "vibecoding@customer-work.local");
         runGit(workspace, "config", "user.name", "VibeCoding");
         runGit(workspace, "add", "-A");

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitWorkspaceServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitWorkspaceServiceTest.java
@@ -8,9 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -22,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author owlzhangfq@gmail.com
  */
 class GitWorkspaceServiceTest {
+
+    /** 断言用的只读 git 调用超时，与被测类的执行超时无关，取值只需覆盖一次本地 config 读取。 */
+    private static final long GIT_READ_TIMEOUT_SECONDS = 15;
 
     private final GitWorkspaceService service = new GitWorkspaceService();
 
@@ -40,6 +45,36 @@ class GitWorkspaceServiceTest {
         // 第二次调用不应报错（.git 已存在，直接跳过）
         service.ensureRepo(workspace);
         assertTrue(Files.isDirectory(workspace.resolve(".git")));
+    }
+
+    /**
+     * 本类曾在 CI 上间歇性失败：{@code @TempDir} 清理报
+     * {@code NoSuchFileException: .git/objects/maintenance.lock}——不是"删不掉"，是"列到了它、删的时候
+     * 已经没了"。病根在 {@code commit} 收尾时 fork 的后台 {@code git maintenance run --auto}：
+     * 它建这个 lock 再自行删除，而这个进程不在 {@code runGit} 的 waitFor 范围内，与调用方遍历 workspace
+     * 天然竞态。会话仓库不需要任何维护，故建仓时就把它关掉，让这个文件根本不会出现。
+     *
+     * <p>删掉那行 config 这里就会红——竞态本身在本机复现不出来（窗口只有几毫秒，只有 CI 的负载
+     * 才拉得开），所以能守住的只有"后台维护是关的"这个事实。</p>
+     */
+    @Test
+    void ensureRepo_shouldDisableBackgroundMaintenance() throws Exception {
+        service.ensureRepo(workspace);
+
+        assertEquals(GitWorkspaceService.MAINTENANCE_AUTO_OFF,
+            readRepoConfig(GitWorkspaceService.MAINTENANCE_AUTO_KEY),
+            "会话仓库必须关闭 git 后台自动维护，否则 commit 之后仍有后台进程在动 .git/objects/");
+    }
+
+    /** 读取 workspace 自身 git 仓库的一项配置（读不到时返回空串）。 */
+    private String readRepoConfig(String key) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder("git", "config", "--get", key)
+            .directory(workspace.toFile())
+            .redirectErrorStream(true)
+            .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        process.waitFor(GIT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        return output.trim();
     }
 
     @Test


### PR DESCRIPTION
## 问题

`GitWorkspaceServiceTest.ensureRepo_shouldBeIdempotent` 在 CI 上间歇性失败，本地不复现。既有 flaky，非某个 PR 引入：

- main run [32969766741](https://github.com/liulangjietou/customer_work/actions/runs/32969766741)（2026-08-26 合 #152）
- PR #155 run [33042714981](https://github.com/liulangjietou/customer_work/actions/runs/33042714981)（2026-08-27）

```
java.io.IOException: Failed to delete temp directory /tmp/junit11484004010798304577.
The following paths could not be deleted: .git/objects/maintenance.lock
  Suppressed: java.nio.file.NoSuchFileException: .../.git/objects/maintenance.lock
    at java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:220)
```

第一个异常抛在 `FileTreeWalker.getAttributes`——readdir 已经列到这个条目、随后 stat 时文件已消失。**是竞态，不是权限或残留**；JUnit 的 `visitFileFailed` 把它当权限问题去 `resetPermissionsAndTryToDeleteAgain`，再删一次仍是 `NoSuchFileException`，于是收进 failures 报成"删不掉"。

## 病根在生产代码

git 2.30 起 `commit` 收尾会 fork 一个 `git maintenance run --auto`（新版还带 `--detach` 直接 daemonize）。它先在 `.git/objects/` 下建 `maintenance.lock` 再干活、结束时自行删除。

这个进程**不在 `GitWorkspaceService#runGit` 的 waitFor 范围内**——我们启的那个 git 进程已经返回，git 却还有个后台进程在动这个目录。会话仓库只有一个 baseline 提交、随会话销毁，没有任何需要维护的对象，这个后台进程带来的只有与调用方的竞态。

这也解释了**为什么偏偏是 `ensureRepo_shouldBeIdempotent`**：它是全类唯一「commit 之后立刻结束方法」的用例，`@TempDir` 清理紧跟在两个 `assertTrue` 后面；其余用例在 `ensureRepo` 之后还要跑 diff/rollback（又是几个 git 进程、几十毫秒），足够让后台维护先跑完。

## 改动

建仓时 `git config maintenance.auto false`，从源头不产生这个 lock，而不是让调用方去容忍它的时有时无。

- **必须写在 baseline 提交之前**：只有 `commit` 触发自动维护。
- **落到仓库 config 而非命令行 `-c`**：同一个 workspace 目录还会被沙箱（`SandboxCommandService` 就在这个目录里执行智能体给出的命令，其中可能有 git）和会话打包（`SessionWorkspaceStorage` 遍历整棵树、`.git` 也在内）读写，只有落到仓库 config 才能一并约束那些不经过 `runGit` 的 git 调用。
- 已有 `.git` 的老仓库走 `ensureRepo` 的早退分支，它们此后不再产生新提交，也就不会再 fork 维护进程。

顺带消除一个同源的生产风险：`SessionWorkspaceStorage#archive` 打包整棵树时，若在 walker 取得属性之后、`Files.copy` 之前该文件消失，异常会从 `visitFile` 直接冒出去（`visitFileFailed` 只兜 walker 自身读属性失败），整次归档失败。

未采用「测试内显式清理并容忍 NoSuchFileException」的兜底方案——那掩盖竞态而非消除它，且放着生产代码里同样的 fork 行为不管。

## 验证

竞态本身**在本机与 Linux 容器都没能自然复现**（macOS 500 轮、容器 900 轮重负载均 0 次）：lock 在 commit 返回那一刻就已消失，CI 是负载把它拖住的。所以拿的是「根因还在不在」的确定性证据，两个环境 git 均为 2.54：

| 观测项 | 环境 | 修复前 | 修复后 |
|---|---|---|---|
| 每次 commit 是否 fork 维护进程 | macOS，200 轮建仓 | 200 / 200 | **0 / 200** |
| 同上 | Linux 容器（2 CPU），300 轮 | 300 / 300 | **0 / 300** |
| 是否产生 `maintenance.lock` | macOS，20 轮建仓（并行轮询） | 20 / 20 | **0 / 20** |
| 同上 | Linux 容器，30 轮（纳秒级窗口测量） | 30 / 30 | **0 / 30** |

- 新增 `ensureRepo_shouldDisableBackgroundMaintenance` 守住这个事实：临时撤掉那行 config 后该用例立刻红（`expected: <false> but was: <>`），还原即绿。
- 全模块 `BUILD SUCCESS`，0 失败 0 错误：starter 1705/5 skip、app-server 129、customer-channel 80、admin 1448/1 skip、gateway 1，合计 3363（排除 `RedisSessionPersistenceTest`，本机 Redis 无密码）。
