### PR TITLE
fix(admin-web): 折叠命中看板重复命中词

### DIFF
--- a/customer-admin-web/src/utils/sensitiveHitWords.test.ts
+++ b/customer-admin-web/src/utils/sensitiveHitWords.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeSensitiveHitWords } from './sensitiveHitWords'
+
+describe('summarizeSensitiveHitWords', () => {
+  it('按首次出现顺序折叠重复词，并把重复次数显示为额外命中数', () => {
+    expect(summarizeSensitiveHitWords(['梅西', '阿根廷', '梅西', '阿根廷', '阿根廷']))
+      .toEqual([
+        { word: '梅西', extraCount: 1 },
+        { word: '阿根廷', extraCount: 2 },
+      ])
+  })
+
+  it('只命中一次的词保留且额外次数为零', () => {
+    expect(summarizeSensitiveHitWords(['梅西', '阿根廷'])).toEqual([
+      { word: '梅西', extraCount: 0 },
+      { word: '阿根廷', extraCount: 0 },
+    ])
+  })
+
+  it('空命中词列表返回空结果', () => {
+    expect(summarizeSensitiveHitWords([])).toEqual([])
+  })
+})

--- a/customer-admin-web/src/utils/sensitiveHitWords.ts
+++ b/customer-admin-web/src/utils/sensitiveHitWords.ts
@@ -1,0 +1,23 @@
+export interface SensitiveHitWordSummary {
+  word: string
+  /** 除首次命中外的重复次数；0 表示只命中一次。 */
+  extraCount: number
+}
+
+/**
+ * 按首次出现顺序汇总同一条明细内的命中词。
+ *
+ * 后端保留每一次实际命中用于 hitCount 与统计，前端只在展示层折叠重复标签。
+ */
+export function summarizeSensitiveHitWords(words: readonly string[]): SensitiveHitWordSummary[] {
+  const summaries = new Map<string, SensitiveHitWordSummary>()
+  for (const word of words) {
+    const existing = summaries.get(word)
+    if (existing) {
+      existing.extraCount += 1
+    } else {
+      summaries.set(word, { word, extraCount: 0 })
+    }
+  }
+  return [...summaries.values()]
+}

--- a/customer-admin-web/src/views/contentguard/SensitiveHitLogBoard.vue
+++ b/customer-admin-web/src/views/contentguard/SensitiveHitLogBoard.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, reactive, ref } from 'vue'
 import ContentGuardTrendChart from '@/components/ContentGuardTrendChart.vue'
 import { fetchHitLogStats, pageHitLogs } from '@/api/contentGuard'
+import { summarizeSensitiveHitWords } from '@/utils/sensitiveHitWords'
 import type {
   ContentGuardCountVO,
   SensitiveWordHitLogPageQuery,
@@ -178,7 +179,14 @@ onMounted(handleSearch)
         </el-table-column>
         <el-table-column label="命中词" min-width="180">
           <template #default="{ row }">
-            <el-tag v-for="word in row.words" :key="word" size="small" class="word-tag">{{ word }}</el-tag>
+            <el-tag
+              v-for="item in summarizeSensitiveHitWords(row.words)"
+              :key="item.word"
+              size="small"
+              class="word-tag"
+            >
+              {{ item.word }}<span v-if="item.extraCount > 0" class="word-extra-count">+{{ item.extraCount }}</span>
+            </el-tag>
           </template>
         </el-table-column>
         <el-table-column prop="agentName" label="智能体" width="140" show-overflow-tooltip />
@@ -293,5 +301,10 @@ onMounted(handleSearch)
 
 .word-tag {
   margin-right: 4px;
+}
+
+.word-extra-count {
+  margin-left: 4px;
+  font-weight: 600;
 }
 </style>


### PR DESCRIPTION
## 变更

- 命中看板明细按首次出现顺序折叠重复命中词
- 在唯一标签后展示额外命中次数，如 `梅西 +1`、`阿根廷 +2`
- 保持后端 `words`、`hitCount` 和统计口径不变

## 验证

- `npm test`：5 个测试文件、27 个用例通过
- `npm run build`：通过
- Maven 全模块：3363 个用例，0 失败、0 错误、6 跳过，`BUILD SUCCESS`
- Headless Chrome DOM：重复词折叠及 `+N` 展示通过，控制台 0 错误
