### PR TITLE
feat(admin-web): 优化智能体工作区布局与交互

### DIFF
--- a/customer-admin-web/src/components/AssistantResponse.vue
+++ b/customer-admin-web/src/components/AssistantResponse.vue
@@ -97,9 +97,47 @@ async function copyResult() {
 
 <style scoped>
 .assistant-response {
+  --response-accent: var(--theme-primary, var(--el-color-primary));
+  position: relative;
   width: min(100%, 880px);
   min-width: 0;
+  box-sizing: border-box;
+  padding: 0 0 2px 22px;
   color: var(--el-text-color-primary);
+}
+
+.assistant-response::before {
+  position: absolute;
+  top: 2px;
+  bottom: 0;
+  left: 3px;
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    var(--response-accent),
+    color-mix(in srgb, var(--response-accent) 22%, transparent) 78%,
+    transparent
+  );
+  border-radius: 999px;
+  content: '';
+}
+
+.assistant-response::after {
+  position: absolute;
+  top: 5px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  box-sizing: border-box;
+  background: var(--el-bg-color);
+  border: 2px solid var(--response-accent);
+  border-radius: 50%;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--response-accent) 10%, transparent);
+  content: '';
+}
+
+.assistant-response.is-failed {
+  --response-accent: var(--el-color-danger);
 }
 
 .connecting-state {
@@ -145,28 +183,7 @@ async function copyResult() {
 }
 
 .result-section {
-  position: relative;
-  padding: 2px 2px 0 16px;
-}
-
-.result-section::before {
-  position: absolute;
-  top: 3px;
-  bottom: 0;
-  left: 0;
-  width: 3px;
-  background: linear-gradient(
-    180deg,
-    var(--theme-primary, var(--el-color-primary)),
-    color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 18%, transparent) 72%,
-    transparent
-  );
-  border-radius: 999px;
-  content: '';
-}
-
-.is-failed .result-section::before {
-  background: linear-gradient(180deg, var(--el-color-danger), transparent);
+  padding: 2px 2px 0 0;
 }
 
 .result-header {
@@ -279,8 +296,8 @@ async function copyResult() {
 }
 
 @media (max-width: 640px) {
-  .result-section {
-    padding-left: 12px;
+  .assistant-response {
+    padding-left: 18px;
   }
 
   .copy-action span,

--- a/customer-admin-web/src/components/ChatHistorySidebar.vue
+++ b/customer-admin-web/src/components/ChatHistorySidebar.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onActivated, onBeforeUnmount, onMounted, ref } from 'vue'
 import { listChatSessions } from '@/api/chat'
+import {
+  filterLoadedChatSessions,
+  formatChatHistoryTime,
+  groupChatHistorySessions,
+} from '@/utils/chatHistoryPresentation'
 import AddToProjectDialog from './AddToProjectDialog.vue'
 import type { ChatSessionSummary, LiveSession } from '@/types/api'
 
@@ -13,6 +18,8 @@ const emit = defineEmits<{
   select: [sessionId: string]
   /** 首次加载完成后把排序第一的会话交给父面板决定是否恢复；手动刷新不会重复触发。 */
   initialSession: [sessionId: string]
+  /** 只通知父面板视觉收起；组件自身保持挂载，避免丢失列表与分页状态。 */
+  collapse: []
 }>()
 
 /** 每页条数，与后端 ChatController#sessions 的 size 默认值保持一致。 */
@@ -23,6 +30,9 @@ const page = ref(0)
 const total = ref(0)
 const loading = ref(false) // 首页加载
 const loadingMore = ref(false) // 滚动追加下一页
+const searchQuery = ref('')
+const currentDate = ref(new Date())
+let midnightRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
 // 以"已消费页数"判断到底，而非累积条数——空上下文会话在后端被跳过，累积条数可能永远够不到 total。
 const noMore = computed(() => page.value > 0 && page.value * PAGE_SIZE >= total.value)
@@ -71,6 +81,23 @@ const displaySessions = computed<DisplaySession[]>(() => {
   // 进行中置顶；同为进行中/同为非进行中时维持既有顺序（后端已按时间倒序，内存补充项排其后）
   return list.sort((a, b) => Number(b.streaming) - Number(a.streaming))
 })
+
+/** 搜索严格限定在已加载的合并列表，不触发请求、不改变分页游标。 */
+const hasSearchQuery = computed(() => searchQuery.value.trim().length > 0)
+const filteredSessions = computed(() => filterLoadedChatSessions(displaySessions.value, searchQuery.value))
+const groupedSessions = computed(() => groupChatHistorySessions(filteredSessions.value, currentDate.value))
+
+/** keep-alive 页面跨午夜后重新计算“今天”分组；定时器按下一个本地午夜重排，兼容夏令时。 */
+function scheduleMidnightRefresh() {
+  if (midnightRefreshTimer) {
+    clearTimeout(midnightRefreshTimer)
+  }
+  const now = new Date()
+  currentDate.value = now
+  const nextMidnight = new Date(now)
+  nextMidnight.setHours(24, 0, 0, 0)
+  midnightRefreshTimer = setTimeout(scheduleMidnightRefresh, Math.max(1000, nextMidnight.getTime() - now.getTime()))
+}
 
 /** 拉取指定页并去重合并到累积列表（同 sessionId 以已有为准，防加载间隙新会话导致的页间重复）。 */
 async function loadPage(target: number) {
@@ -128,7 +155,17 @@ async function initialize() {
   }
 }
 
-onMounted(initialize)
+onMounted(() => {
+  scheduleMidnightRefresh()
+  initialize()
+})
+onActivated(scheduleMidnightRefresh)
+onBeforeUnmount(() => {
+  if (midnightRefreshTimer) {
+    clearTimeout(midnightRefreshTimer)
+    midnightRefreshTimer = null
+  }
+})
 
 defineExpose({ refresh })
 
@@ -144,51 +181,111 @@ function openAddToProject(sessionId: string) {
 <template>
   <div class="history-sidebar">
     <div class="history-header">
-      <span>历史对话</span>
-      <el-button link type="primary" :loading="loading" @click="refresh">刷新</el-button>
+      <div class="history-title">
+        <h2>历史会话</h2>
+        <span :title="`已加载 ${displaySessions.length} 条会话`">{{ displaySessions.length }}</span>
+      </div>
+      <div class="history-actions">
+        <button
+          type="button"
+          class="mini-action"
+          :disabled="loading"
+          title="刷新历史会话"
+          aria-label="刷新历史会话"
+          @click="refresh"
+        >
+          <el-icon :class="{ 'is-loading': loading }"><RefreshRight /></el-icon>
+        </button>
+        <button
+          type="button"
+          class="mini-action"
+          title="收起历史会话"
+          aria-label="收起历史会话"
+          @click="emit('collapse')"
+        >
+          <el-icon><ArrowLeft /></el-icon>
+        </button>
+      </div>
     </div>
-    <el-empty v-if="!loading && displaySessions.length === 0" description="暂无历史对话" :image-size="50" />
+
+    <label class="history-search">
+      <el-icon aria-hidden="true"><Search /></el-icon>
+      <input
+        v-model="searchQuery"
+        type="search"
+        placeholder="搜索已加载会话"
+        aria-label="搜索已加载会话"
+        autocomplete="off"
+      />
+    </label>
+
+    <el-empty v-if="!loading && displaySessions.length === 0" description="暂无历史会话" :image-size="48" />
     <div
       v-else
       class="session-scroll"
       v-infinite-scroll="loadMore"
-      :infinite-scroll-disabled="loading || loadingMore || noMore"
+      :infinite-scroll-disabled="loading || loadingMore || noMore || hasSearchQuery"
       :infinite-scroll-immediate="false"
       :infinite-scroll-distance="10"
     >
-      <ul class="session-list">
-        <li
-          v-for="session in displaySessions"
-          :key="session.sessionId"
-          class="session-item"
-          :class="{ active: session.sessionId === activeSessionId }"
-          @click="emit('select', session.sessionId)"
-        >
-          <div class="session-row">
-            <div class="session-main">
-              <div class="session-preview">
-                <span v-if="session.streaming" class="streaming-dot" />
-                {{ session.preview || '（空会话）' }}
-              </div>
-              <div class="session-meta">
-                <el-tag v-if="session.streaming" type="warning" size="small" effect="light" class="streaming-tag">进行中</el-tag>
-                <span>{{ session.messageCount }} 条</span>
-                <span v-if="session.lastMessageTime">{{ session.lastMessageTime }}</span>
-              </div>
-            </div>
-            <el-dropdown trigger="click" @command="openAddToProject(session.sessionId)" @click.stop>
-              <el-icon class="session-more" @click.stop><MoreFilled /></el-icon>
-              <template #dropdown>
-                <el-dropdown-menu>
-                  <el-dropdown-item command="add-to-project">加入 Project</el-dropdown-item>
-                </el-dropdown-menu>
-              </template>
-            </el-dropdown>
-          </div>
-        </li>
-      </ul>
-      <div v-if="loadingMore" class="load-status">加载中…</div>
-      <div v-else-if="noMore && displaySessions.length > 0" class="load-status">没有更多了</div>
+      <div v-if="loading && displaySessions.length === 0" class="load-status">加载中…</div>
+      <div v-else-if="groupedSessions.length === 0" class="search-empty">
+        <span>当前已加载的会话中无匹配结果</span>
+        <button type="button" @click="searchQuery = ''">清空搜索</button>
+      </div>
+      <template v-else>
+        <section v-for="group in groupedSessions" :key="group.key" class="session-group">
+          <h3 class="date-label">{{ group.label }}</h3>
+          <ul class="session-list">
+            <li
+              v-for="session in group.sessions"
+              :key="session.sessionId"
+              class="session-item"
+              :class="{ active: session.sessionId === activeSessionId }"
+            >
+              <button
+                type="button"
+                class="session-select"
+                :aria-current="session.sessionId === activeSessionId ? 'true' : undefined"
+                @click="emit('select', session.sessionId)"
+              >
+                <span class="session-main">
+                  <span class="session-preview">
+                    <span v-if="session.streaming" class="streaming-dot" />
+                    {{ session.preview || '（空会话）' }}
+                  </span>
+                  <span class="session-meta">
+                    <el-tag v-if="session.streaming" type="warning" size="small" effect="light" class="streaming-tag">进行中</el-tag>
+                    <span>{{ session.messageCount }} 条</span>
+                    <span v-if="session.lastMessageTime">{{ formatChatHistoryTime(session.lastMessageTime) }}</span>
+                  </span>
+                </span>
+              </button>
+              <el-dropdown trigger="click" @command="openAddToProject(session.sessionId)" @click.stop>
+                <button
+                  type="button"
+                  class="session-more"
+                  :aria-label="`打开“${session.preview || '空会话'}”的更多操作`"
+                  title="更多操作"
+                  @click.stop
+                >
+                  <el-icon><MoreFilled /></el-icon>
+                </button>
+                <template #dropdown>
+                  <el-dropdown-menu>
+                    <el-dropdown-item command="add-to-project">加入 Project</el-dropdown-item>
+                  </el-dropdown-menu>
+                </template>
+              </el-dropdown>
+            </li>
+          </ul>
+        </section>
+      </template>
+      <div v-if="hasSearchQuery" class="search-scope">仅搜索已加载的 {{ displaySessions.length }} 条会话</div>
+      <template v-else>
+        <div v-if="loadingMore" class="load-status">加载中…</div>
+        <div v-else-if="noMore && displaySessions.length > 0" class="load-status">没有更多了</div>
+      </template>
     </div>
 
     <AddToProjectDialog v-model="addToProjectVisible" :agent-code="agentCode" :session-id="addToProjectSessionId" />
@@ -201,15 +298,126 @@ function openAddToProject(sessionId: string) {
   flex-direction: column;
   height: 100%;
   min-width: 0;
+  overflow: hidden;
+  color: var(--el-text-color-primary);
+  background: var(--el-bg-color);
 }
 
 .history-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
-  font-weight: 600;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 12px 8px 16px;
+}
+
+.history-title {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.history-title h2 {
+  margin: 0;
+  overflow: hidden;
   font-size: 13px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-title span {
+  color: var(--el-text-color-placeholder);
+  font-size: 10px;
+}
+
+.history-actions {
+  display: flex;
+  flex: none;
+  gap: 2px;
+}
+
+.mini-action {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+  color: var(--el-text-color-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.mini-action:hover:not(:disabled) {
+  color: var(--el-text-color-primary);
+  background: var(--el-fill-color-light);
+}
+
+.mini-action:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.mini-action:focus-visible,
+.session-select:focus-visible,
+.session-more:focus-visible,
+.search-empty button:focus-visible {
+  outline: 0;
+  box-shadow:
+    0 0 0 2px var(--el-bg-color),
+    0 0 0 4px var(--el-text-color-primary);
+}
+
+.mini-action .el-icon {
+  font-size: 15px;
+}
+
+.mini-action .is-loading {
+  animation: history-rotate 1s linear infinite;
+}
+
+.history-search {
+  position: relative;
+  display: block;
+  flex: none;
+  margin: 0 14px 8px;
+}
+
+.history-search .el-icon {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  z-index: 1;
+  color: var(--el-text-color-placeholder);
+  font-size: 14px;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.history-search input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 32px;
+  padding: 0 10px 0 31px;
+  color: var(--el-text-color-primary);
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color);
+  border-radius: 9px;
+  outline: 0;
+  font: inherit;
+  font-size: 11px;
+}
+
+.history-search input::placeholder {
+  color: var(--el-text-color-placeholder);
+}
+
+.history-search input:focus {
+  border-color: var(--el-text-color-primary);
+  box-shadow: 0 0 0 1px var(--el-text-color-primary);
 }
 
 /* 用普通 overflow 容器承接 v-infinite-scroll（指令监听宿主元素自身滚动，el-scrollbar 的内部滚动它监听不到） */
@@ -217,7 +425,9 @@ function openAddToProject(sessionId: string) {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  padding: 2px 10px 14px;
   scrollbar-width: thin;
+  scrollbar-color: var(--el-border-color-darker) transparent;
 }
 
 .session-scroll::-webkit-scrollbar {
@@ -225,8 +435,21 @@ function openAddToProject(sessionId: string) {
 }
 
 .session-scroll::-webkit-scrollbar-thumb {
-  background: #dcdfe6;
+  background: var(--el-border-color-darker);
   border-radius: 3px;
+}
+
+.session-group {
+  margin: 0;
+}
+
+.date-label {
+  margin: 0;
+  padding: 10px 6px 5px;
+  color: var(--el-text-color-placeholder);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
 }
 
 .session-list {
@@ -238,68 +461,112 @@ function openAddToProject(sessionId: string) {
 .load-status {
   text-align: center;
   font-size: 12px;
-  color: #999;
-  padding: 8px 0;
+  color: var(--el-text-color-placeholder);
+  padding: 12px 0;
 }
 
 .session-item {
-  padding: 8px;
-  border-radius: 6px;
-  cursor: pointer;
-  margin-bottom: 4px;
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+  margin: 2px 0;
+  padding: 9px 7px 8px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  transition: background-color 140ms ease, border-color 140ms ease;
 }
 
 .session-item:hover {
-  background: #f5f7fa;
+  background: var(--el-fill-color-light);
 }
 
 .session-item.active {
-  background: #ecf5ff;
+  background: var(--el-color-primary-light-9);
+  border-color: var(--el-color-primary-light-7);
 }
 
-.session-row {
+.session-item.active::before {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: -1px;
+  width: 3px;
+  background: var(--el-color-primary);
+  border-radius: 0 3px 3px 0;
+  content: '';
+}
+
+.session-select {
   display: flex;
-  align-items: flex-start;
-  gap: 4px;
+  min-width: 0;
+  padding: 0;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
 }
 
 .session-main {
-  flex: 1;
+  display: block;
   min-width: 0;
 }
 
 .session-more {
-  flex-shrink: 0;
-  margin-top: 2px;
-  padding: 2px;
-  border-radius: 4px;
-  color: #909399;
+  display: grid;
+  width: 24px;
+  height: 24px;
+  margin: -3px -2px 0 0;
+  padding: 0;
+  place-items: center;
+  color: var(--el-text-color-placeholder);
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
 }
 
 .session-more:hover {
-  background: #e4e7ed;
-  color: #409eff;
+  color: var(--el-text-color-primary);
+  background: var(--el-fill-color);
 }
 
 .session-preview {
-  font-size: 13px;
-  color: #333;
+  display: block;
+  min-width: 0;
   overflow: hidden;
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-item.active .session-preview {
+  color: var(--el-text-color-primary);
+  font-weight: 650;
 }
 
 .session-meta {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
-  color: #999;
-  margin-top: 2px;
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+  white-space: nowrap;
 }
 
 .streaming-tag {
-  margin-right: 2px;
+  flex: none;
+  height: 18px;
+  margin-right: 1px;
+  padding: 0 5px;
+  font-size: 10px;
 }
 
 /* 进行中会话标题前的闪烁小圆点，配合「进行中」tag 强化辨识 */
@@ -313,8 +580,52 @@ function openAddToProject(sessionId: string) {
   animation: streaming-blink 1s ease-in-out infinite;
 }
 
+.search-empty {
+  display: grid;
+  min-height: 120px;
+  padding: 24px 10px;
+  place-content: center;
+  gap: 10px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  text-align: center;
+}
+
+.search-empty button {
+  justify-self: center;
+  padding: 2px 4px;
+  color: var(--el-color-primary);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.search-scope {
+  padding: 10px 6px 2px;
+  color: var(--el-text-color-placeholder);
+  font-size: 10px;
+  text-align: center;
+}
+
+@keyframes history-rotate {
+  to { transform: rotate(360deg); }
+}
+
 @keyframes streaming-blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-item {
+    transition: none;
+  }
+
+  .mini-action .is-loading,
+  .streaming-dot {
+    animation: none;
+  }
 }
 </style>

--- a/customer-admin-web/src/components/FooterCopyright.vue
+++ b/customer-admin-web/src/components/FooterCopyright.vue
@@ -15,8 +15,11 @@ defineProps<{
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 16px;
+  width: 100%;
+  height: 100%;
+  padding: 0 16px;
   font-size: 12px;
+  line-height: 1;
   color: var(--el-text-color-secondary);
 }
 

--- a/customer-admin-web/src/components/ThemeToolbar.vue
+++ b/customer-admin-web/src/components/ThemeToolbar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useThemeStore, PRESET_COLORS } from '@/store/theme'
+import { chooseButtonTextColor } from '@/utils/themeContrast'
 
 const props = defineProps<{
   onNewSession: () => void
@@ -8,35 +9,107 @@ const props = defineProps<{
 
 const themeStore = useThemeStore()
 const showPicker = ref(false)
+const toolbarRef = ref<HTMLElement>()
+const themeButtonRef = ref<HTMLButtonElement>()
+
+/** 为实心主题色按钮选择满足普通文字对比度的黑/白文字。 */
+const primaryTextColor = computed(() => chooseButtonTextColor(themeStore.primaryColor))
+
+function togglePicker() {
+  showPicker.value = !showPicker.value
+}
+
+function closePicker(restoreFocus = false) {
+  if (!showPicker.value) return
+  showPicker.value = false
+  if (restoreFocus) {
+    nextTick(() => themeButtonRef.value?.focus())
+  }
+}
+
+function selectColor(color: string) {
+  themeStore.setPrimaryColor(color)
+  closePicker(true)
+}
+
+function handleDocumentPointerDown(event: PointerEvent) {
+  if (showPicker.value && !toolbarRef.value?.contains(event.target as Node)) {
+    closePicker()
+  }
+}
+
+function handleEscape(event: KeyboardEvent) {
+  if (!showPicker.value) return
+  event.stopPropagation()
+  event.preventDefault()
+  closePicker(true)
+}
+
+function handleFocusOut(event: FocusEvent) {
+  const nextTarget = event.relatedTarget as Node | null
+  if (showPicker.value && (!nextTarget || !toolbarRef.value?.contains(nextTarget))) {
+    closePicker()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleDocumentPointerDown)
+  document.addEventListener('keydown', handleEscape)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleDocumentPointerDown)
+  document.removeEventListener('keydown', handleEscape)
+})
 </script>
 
 <template>
-  <div class="theme-toolbar">
-    <!-- 主题色选择 -->
-    <div class="theme-picker" @mouseenter="showPicker = true" @mouseleave="showPicker = false">
-      <button type="button" class="theme-btn" title="切换主题色">
+  <div ref="toolbarRef" class="theme-toolbar" @focusout="handleFocusOut">
+    <div class="theme-picker">
+      <button
+        ref="themeButtonRef"
+        type="button"
+        class="theme-btn"
+        title="切换主题色"
+        aria-label="切换主题色"
+        :aria-expanded="showPicker"
+        aria-controls="theme-color-palette"
+        @click="togglePicker"
+      >
         <span class="color-dot" :style="{ backgroundColor: themeStore.primaryColor }" />
-        <span class="color-label">主题色</span>
-        <el-icon class="arrow" :class="{ open: showPicker }"><ArrowDown /></el-icon>
       </button>
-      <transition name="fade">
-        <div v-show="showPicker" class="color-popover">
-          <div
+      <transition name="theme-popover">
+        <div
+          v-show="showPicker"
+          id="theme-color-palette"
+          class="color-popover"
+          role="group"
+          aria-label="选择主题色"
+        >
+          <button
             v-for="color in PRESET_COLORS"
             :key="color"
+            type="button"
             class="color-option"
             :class="{ active: themeStore.primaryColor === color }"
             :style="{ backgroundColor: color }"
-            :title="color"
-            @click="themeStore.setPrimaryColor(color)"
-          />
+            :title="`使用主题色 ${color}`"
+            :aria-label="`使用主题色 ${color}`"
+            :aria-pressed="themeStore.primaryColor === color"
+            @click="selectColor(color)"
+          >
+            <el-icon v-if="themeStore.primaryColor === color" class="check-mark" aria-hidden="true"><Check /></el-icon>
+          </button>
         </div>
       </transition>
     </div>
 
-    <!-- 新建会话 -->
-    <button type="button" class="new-session-btn" @click="props.onNewSession">
-      <el-icon><Plus /></el-icon>
+    <button
+      type="button"
+      class="new-session-btn"
+      :style="{ color: primaryTextColor }"
+      @click="props.onNewSession"
+    >
+      <el-icon aria-hidden="true"><Plus /></el-icon>
       新建会话
     </button>
   </div>
@@ -53,51 +126,34 @@ const showPicker = ref(false)
   position: relative;
 }
 
-/* 主题色胶囊按钮：浅黄底，规格与代码知识库/新建会话一致（34px 高/17px 圆角/0 18px 内距） */
 .theme-btn {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  height: 34px;
-  padding: 0 18px;
-  border-radius: 17px;
-  border: none;
-  background: #fdf0cd;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  color: var(--el-text-color-regular);
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color);
+  border-radius: 10px;
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
+  box-shadow: 0 1px 2px rgb(16 24 40 / 3%);
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
 }
 
 .theme-btn:hover {
-  filter: brightness(1.03);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  border-color: var(--theme-primary, var(--el-color-primary));
+  box-shadow: 0 4px 10px rgb(16 24 40 / 8%);
   transform: translateY(-1px);
 }
 
 .color-dot {
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
-  border: 2px solid var(--el-bg-color);
-  box-shadow: 0 0 0 1px var(--el-border-color), 0 1px 3px rgba(0, 0, 0, 0.15);
-}
-
-.color-label {
-  /* 浅黄底上固定深棕字保证可读性，不随明暗模式切换 */
-  color: #8a6116;
-  font-weight: 500;
-}
-
-.arrow {
-  font-size: 12px;
-  color: #8a6116;
-  transition: transform 0.2s;
-}
-
-.arrow.open {
-  transform: rotate(180deg);
+  border: 3px solid var(--el-bg-color);
+  box-shadow: 0 0 0 1px var(--el-border-color), 0 1px 3px rgb(16 24 40 / 18%);
 }
 
 .color-popover {
@@ -110,52 +166,62 @@ const showPicker = ref(false)
   gap: 10px;
   padding: 12px;
   background: var(--el-bg-color);
-  border-radius: 10px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
-  border: 1px solid var(--el-border-color-lighter);
-  width: 172px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgb(16 24 40 / 14%);
+  width: 170px;
 }
 
 .color-option {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 24px;
   height: 24px;
+  padding: 0;
   border-radius: 50%;
-  cursor: pointer;
-  transition: transform 0.15s, box-shadow 0.15s;
   border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
 .color-option:hover {
-  transform: scale(1.18);
+  transform: scale(1.12);
 }
 
 .color-option.active {
   border-color: var(--el-bg-color);
-  box-shadow: 0 0 0 2px var(--theme-primary, var(--el-color-primary));
+  box-shadow: 0 0 0 2px var(--el-text-color-primary);
 }
 
-/* 新建会话：白底细边框胶囊，规格与代码知识库/主题色按钮一致；悬浮时描主题色边 */
+.check-mark {
+  color: #fff;
+  font-size: 13px;
+  filter: drop-shadow(0 1px 2px rgb(0 0 0 / 45%));
+}
+
 .new-session-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  height: 34px;
-  padding: 0 18px;
-  border: 1px solid var(--el-border-color);
-  border-radius: 17px;
-  background: var(--el-bg-color);
-  color: var(--el-text-color-regular);
-  font-size: 13px;
-  font-weight: 500;
+  min-width: 106px;
+  height: 36px;
+  padding: 0 14px;
+  background: var(--theme-primary, var(--el-color-primary));
+  border: 1px solid var(--theme-primary, var(--el-color-primary));
+  border-radius: 10px;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 25%, transparent);
+  transition: filter 160ms ease, transform 160ms ease, box-shadow 160ms ease;
 }
 
 .new-session-btn:hover {
-  border-color: var(--theme-primary, var(--el-color-primary));
-  color: var(--theme-primary, var(--el-color-primary));
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  filter: brightness(0.96);
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 32%, transparent);
   transform: translateY(-1px);
 }
 
@@ -164,14 +230,39 @@ const showPicker = ref(false)
   filter: brightness(0.96);
 }
 
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s, transform 0.2s;
+.theme-btn:focus-visible,
+.new-session-btn:focus-visible,
+.color-option:focus-visible {
+  outline: 0;
+  box-shadow:
+    0 0 0 2px var(--el-bg-color),
+    0 0 0 4px var(--el-text-color-primary);
 }
 
-.fade-enter-from,
-.fade-leave-to {
+.theme-popover-enter-active,
+.theme-popover-leave-active {
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.theme-popover-enter-from,
+.theme-popover-leave-to {
   opacity: 0;
   transform: translateY(-4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-btn,
+  .new-session-btn,
+  .color-option,
+  .theme-popover-enter-active,
+  .theme-popover-leave-active {
+    transition: none;
+  }
+
+  .theme-btn:hover,
+  .new-session-btn:hover,
+  .color-option:hover {
+    transform: none;
+  }
 }
 </style>

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -24,6 +24,8 @@ const themeStore = useThemeStore()
 // 与菜单节点 node.path 里存的 /sql/query?defineKey=xxx 完整链接对齐，其它页面维持原样按 path 高亮。
 const activePath = computed(() => (route.path === '/sql/query' ? route.fullPath : route.path))
 const asideWidth = computed(() => menuStore.collapsed ? '64px' : '220px')
+// 工作区需要接管 el-main 的剩余高度来承载内部滚动；只按精确路由名收口，避免表格、表单页受影响。
+const isWorkspaceRoute = computed(() => route.name === 'Workspace')
 
 // MainLayout 只在 Layout 的子路由下挂载（登录页/改密页在其外层），路由一变化就落一个标签，
 // 已存在的标签只切激活态、不重复追加。
@@ -56,7 +58,7 @@ async function handleLogout() {
         <MenuTree :nodes="menuStore.tree" :collapsed="menuStore.collapsed" />
       </el-menu>
     </el-aside>
-    <el-container>
+    <el-container class="layout-content">
       <el-header class="layout-header">
         <div class="header-left">
           <el-button
@@ -90,7 +92,13 @@ async function handleLogout() {
       </el-header>
       <TabsBar v-if="auth.isApproved" />
       <AppBreadcrumb v-if="auth.isApproved" />
-      <el-main class="layout-main" :class="{ 'layout-main--home': route.name === 'Home' }">
+      <el-main
+        class="layout-main"
+        :class="{
+          'layout-main--home': route.name === 'Home',
+          'layout-main--workspace': isWorkspaceRoute,
+        }"
+      >
         <!-- 只精确缓存 WorkspaceView：TabsBar 让"已打开的标签"在视觉上常驻，但底下的路由组件此前没配
              keep-alive，标签切走再切回其实是整个组件重新 mount——WorkspaceView 里的对话/VibeCoding
              面板state 全在组件本地 ref，一销毁就清空，进行中的 SSE 流也被 onUnmounted 里的 abortStream
@@ -113,6 +121,11 @@ async function handleLogout() {
 <style scoped>
 .layout {
   height: 100%;
+}
+
+.layout-content {
+  min-width: 0;
+  min-height: 0;
 }
 
 .layout-aside {
@@ -209,12 +222,26 @@ async function handleLogout() {
 }
 
 .layout-main {
+  min-width: 0;
+  min-height: 0;
   background: var(--el-bg-color-page);
 }
 
 .layout-main--home {
   padding: 0;
   overflow: hidden;
+}
+
+.layout-main--workspace {
+  padding: 14px 18px 18px;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 13% 0%,
+      color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 5%, transparent),
+      transparent 24%
+    ),
+    var(--el-bg-color-page);
 }
 
 .layout-footer {
@@ -224,5 +251,18 @@ async function handleLogout() {
   background: var(--el-bg-color);
   border-top: 1px solid var(--el-border-color-lighter);
   padding: 0;
+}
+
+@media (max-width: 900px) {
+  .layout-main--workspace {
+    padding: 8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .layout-aside,
+  .logo-text {
+    transition: none;
+  }
 }
 </style>

--- a/customer-admin-web/src/styles/workspace-conversation.css
+++ b/customer-admin-web/src/styles/workspace-conversation.css
@@ -1,0 +1,261 @@
+/** Chat 与 VibeCoding 共用的对话视觉骨架；各面板仅保留列结构与容器断点。 */
+.workspace-conversation {
+  --conversation-messages-padding: 28px 32px 36px;
+  --conversation-composer-padding: 10px 24px 14px;
+  --conversation-user-bubble-max-width: 72%;
+  --conversation-toolbar-wrap: nowrap;
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--el-bg-color);
+  transition: grid-template-columns 0.2s ease;
+}
+
+.workspace-conversation .chat-column {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background-color: var(--el-bg-color);
+}
+
+.workspace-conversation .messages {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--conversation-messages-padding);
+  background-color: var(--el-bg-color);
+  background-image: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 31px,
+    color-mix(in srgb, var(--el-border-color-lighter) 24%, transparent) 32px
+  );
+  scrollbar-color: var(--el-border-color) transparent;
+  scrollbar-width: thin;
+}
+
+.workspace-conversation .messages::-webkit-scrollbar {
+  width: 6px;
+}
+
+.workspace-conversation .messages::-webkit-scrollbar-thumb {
+  background: var(--el-border-color);
+  border-radius: 999px;
+}
+
+.workspace-conversation .attachment-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 7px;
+  padding-bottom: 7px;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.workspace-conversation .message-row {
+  display: flex;
+  width: min(880px, 100%);
+  margin: 0 auto 22px;
+}
+
+.workspace-conversation .message-row.user {
+  justify-content: flex-end;
+}
+
+.workspace-conversation .bubble {
+  min-width: 0;
+  word-break: break-word;
+}
+
+.workspace-conversation .message-row.user .bubble {
+  max-width: var(--conversation-user-bubble-max-width);
+  padding: 10px 14px;
+  color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 38%, var(--el-text-color-primary));
+  background: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 13%, var(--el-bg-color));
+  border: 1px solid color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 28%, var(--el-border-color-lighter));
+  border-radius: 14px 14px 4px 14px;
+  box-shadow: 0 2px 5px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 8%, transparent);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.workspace-conversation .message-row.user .bubble:hover {
+  background: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 17%, var(--el-bg-color));
+}
+
+.workspace-conversation .message-row.assistant .bubble {
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
+}
+
+.workspace-conversation .input-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.workspace-conversation .input-bar .el-input {
+  flex: 1;
+  min-width: 180px;
+}
+
+.workspace-conversation .input-bar .el-input__wrapper {
+  padding: 0 4px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.workspace-conversation .input-bar .el-input__inner {
+  height: 36px;
+  line-height: 36px;
+}
+
+.workspace-conversation .composer-wrap {
+  position: relative;
+  z-index: 2;
+  flex: 0 0 auto;
+  padding: var(--conversation-composer-padding);
+  background: linear-gradient(transparent, color-mix(in srgb, var(--el-bg-color) 96%, transparent) 24%);
+}
+
+.workspace-conversation .composer-shell {
+  width: min(880px, 100%);
+  margin: 0 auto;
+  padding: 9px 10px 8px 12px;
+  background: var(--el-bg-color-overlay, var(--el-bg-color));
+  border: 1px solid var(--el-border-color);
+  border-radius: 14px;
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--el-text-color-primary) 9%, transparent);
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.workspace-conversation .composer-shell:focus-within {
+  border-color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 58%, var(--el-border-color));
+  box-shadow:
+    0 10px 30px color-mix(in srgb, var(--el-text-color-primary) 10%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 10%, transparent);
+}
+
+.workspace-conversation .composer-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: var(--conversation-toolbar-wrap);
+  min-width: 0;
+  gap: 6px;
+  margin-top: 5px;
+}
+
+.workspace-conversation .composer-toolbar .el-button {
+  height: 28px;
+  padding: 0 9px;
+  color: var(--el-text-color-secondary);
+  background: var(--el-fill-color-light);
+  border-color: var(--el-border-color-lighter);
+  border-radius: 8px;
+}
+
+.workspace-conversation .composer-toolbar .el-button:hover {
+  color: var(--theme-primary, var(--el-color-primary));
+  border-color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 34%, var(--el-border-color));
+}
+
+.workspace-conversation .composer-send {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.workspace-conversation .composer-send .el-button + .el-button {
+  margin-left: 0;
+}
+
+.workspace-conversation .composer-send .el-button:not(.is-link) {
+  min-width: 64px;
+  border-radius: 9px;
+}
+
+/* link“继续”靠透明背景显示主题文字，不能与实心主按钮共用背景覆盖。 */
+.workspace-conversation .input-bar .el-button--primary:not(.is-link) {
+  background-color: var(--theme-primary, var(--el-color-primary));
+  border-color: var(--theme-primary, var(--el-color-primary));
+}
+
+.workspace-conversation .input-bar .el-button--primary:not(.is-link):hover {
+  background-color: var(--theme-primary-light, #79bbff);
+  border-color: var(--theme-primary-light, #79bbff);
+}
+
+.workspace-conversation .history-column {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  padding: 15px 14px 12px 16px;
+  background: color-mix(in srgb, var(--el-fill-color-lighter) 58%, var(--el-bg-color));
+  border-left: 1px solid var(--el-border-color-lighter);
+  opacity: 1;
+  transition: opacity 0.16s ease, padding 0.2s ease;
+}
+
+.workspace-conversation.is-history-collapsed .history-column {
+  visibility: hidden;
+  padding-right: 0;
+  padding-left: 0;
+  border-left-color: transparent;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.workspace-conversation .history-restore {
+  position: absolute;
+  z-index: 5;
+  top: 14px;
+  right: 12px;
+  color: var(--theme-primary, var(--el-color-primary));
+  background: var(--el-bg-color-overlay, var(--el-bg-color));
+  border-color: var(--el-border-color);
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--el-text-color-primary) 10%, transparent);
+}
+
+@container workspace-panel (max-width: 1040px) {
+  .workspace-conversation.vibecoding-panel .history-column {
+    padding: 14px 16px;
+    border-top: 1px solid var(--el-border-color-lighter);
+    border-left: 0;
+  }
+
+  .workspace-conversation.vibecoding-panel.is-history-collapsed .history-column {
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top-color: transparent;
+  }
+}
+
+@container workspace-panel (max-width: 900px) {
+  .workspace-conversation.chat-panel .history-column {
+    padding: 14px 16px;
+    border-top: 1px solid var(--el-border-color-lighter);
+    border-left: 0;
+  }
+
+  .workspace-conversation.chat-panel.is-history-collapsed .history-column {
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top-color: transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-conversation,
+  .workspace-conversation .history-column,
+  .workspace-conversation .composer-shell {
+    transition-duration: 0.01ms;
+  }
+}

--- a/customer-admin-web/src/utils/chatHistoryPresentation.test.ts
+++ b/customer-admin-web/src/utils/chatHistoryPresentation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterLoadedChatSessions,
+  formatChatHistoryTime,
+  groupChatHistorySessions,
+  type ChatHistoryPresentableSession,
+} from './chatHistoryPresentation'
+
+function session(
+  sessionId: string,
+  preview: string,
+  lastMessageTime: string | null,
+  streaming = false,
+): ChatHistoryPresentableSession {
+  return { sessionId, preview, lastMessageTime, streaming }
+}
+
+describe('filterLoadedChatSessions', () => {
+  it('只在已加载会话中按标题筛选，且不改写原数组', () => {
+    const loaded = [
+      session('session-1', 'Java 8 CompletableFuture 异常处理', '2026-08-28 08:21:00.000'),
+      session('session-2', '查询本周考勤', '2026-08-26 16:48:17.856'),
+    ]
+
+    const filtered = filterLoadedChatSessions(loaded, '  completablefuture ')
+
+    expect(filtered.map((item) => item.sessionId)).toEqual(['session-1'])
+    expect(loaded.map((item) => item.sessionId)).toEqual(['session-1', 'session-2'])
+    expect(filterLoadedChatSessions(loaded, '')).not.toBe(loaded)
+  })
+})
+
+describe('groupChatHistorySessions', () => {
+  it('按进行中、今天、具体日期和无时间分组并维持组内顺序', () => {
+    const now = new Date(2026, 7, 28, 12, 0, 0)
+    const loaded = [
+      session('streaming-1', '生成代码', null, true),
+      session('today-1', '今天第一条', '2026-08-28 08:34:29.409'),
+      session('today-2', '今天第二条', '2026-08-28 08:21:00.000'),
+      session('older-1', '前天', '2026-08-26 20:23:36.200'),
+      session('undated-1', '尚未落库', null),
+    ]
+
+    const groups = groupChatHistorySessions(loaded, now)
+
+    expect(groups.map((group) => ({
+      key: group.key,
+      label: group.label,
+      sessionIds: group.sessions.map((item) => item.sessionId),
+    }))).toEqual([
+      { key: 'streaming', label: '进行中', sessionIds: ['streaming-1'] },
+      { key: '2026-08-28', label: '今天', sessionIds: ['today-1', 'today-2'] },
+      { key: '2026-08-26', label: '8 月 26 日', sessionIds: ['older-1'] },
+      { key: 'undated', label: '未记录时间', sessionIds: ['undated-1'] },
+    ])
+  })
+
+  it('跨年日期包含年份，now 由调用方显式传入', () => {
+    const groups = groupChatHistorySessions(
+      [session('last-year', '去年会话', '2025-12-31 23:59:59.999')],
+      new Date(2026, 0, 1, 0, 1, 0),
+    )
+
+    expect(groups[0]?.label).toBe('2025 年 12 月 31 日')
+  })
+})
+
+describe('formatChatHistoryTime', () => {
+  it('本地 LocalDateTime 去掉秒和毫秒，只保留时分', () => {
+    expect(formatChatHistoryTime('2026-08-28 08:34:29.409')).toBe('08:34')
+    expect(formatChatHistoryTime('2026-08-28T16:07:03')).toBe('16:07')
+  })
+
+  it('空值不展示，无法解析时也不泄漏毫秒精度', () => {
+    expect(formatChatHistoryTime(null)).toBe('')
+    expect(formatChatHistoryTime('业务时间.123')).toBe('业务时间')
+  })
+
+  it('带时区的 ISO 时间按浏览器本地时区展示', () => {
+    const value = '2026-08-28T00:30:00+08:00'
+    const expected = new Intl.DateTimeFormat('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(new Date(value))
+
+    expect(formatChatHistoryTime(value)).toBe(expected)
+    expect(groupChatHistorySessions([session('offset', '时区会话', value)], new Date(value))[0]?.label).toBe('今天')
+  })
+
+  it('非法日期和时间不会被归入真实日期组', () => {
+    const groups = groupChatHistorySessions(
+      [
+        session('invalid-date', '非法日期', '2026-02-30 12:00:00.123'),
+        session('invalid-hour', '非法时间', '2026-08-28 25:00:00.456'),
+      ],
+      new Date(2026, 7, 28),
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.key).toBe('undated')
+    expect(groups[0]?.sessions.map((item) => item.sessionId)).toEqual(['invalid-date', 'invalid-hour'])
+    expect(formatChatHistoryTime('2026-02-30 12:00:00.123')).toBe('2026-02-30 12:00:00')
+    expect(formatChatHistoryTime('2026-08-28 25:00:00.456')).toBe('2026-08-28 25:00:00')
+  })
+})

--- a/customer-admin-web/src/utils/chatHistoryPresentation.ts
+++ b/customer-admin-web/src/utils/chatHistoryPresentation.ts
@@ -1,0 +1,149 @@
+/** 历史会话展示层所需的最小数据契约。 */
+export interface ChatHistoryPresentableSession {
+  sessionId: string
+  preview: string
+  lastMessageTime: string | null
+  streaming?: boolean
+}
+
+/** 日期分组只组织展示顺序，不复制或改写会话对象。 */
+export interface ChatHistoryDateGroup<T extends ChatHistoryPresentableSession> {
+  key: string
+  label: string
+  sessions: T[]
+}
+
+const LOCAL_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?)?$/
+const OFFSET_DATE_TIME_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:?\d{2})$/
+const MILLISECOND_SUFFIX_PATTERN = /\.\d{1,9}(?=(?:Z|[+-]\d{2}:?\d{2})?$)/
+
+/**
+ * 仅筛选调用方已经加载到内存的会话。返回新数组，确保搜索不会改写原列表或分页状态。
+ */
+export function filterLoadedChatSessions<T extends ChatHistoryPresentableSession>(
+  sessions: readonly T[],
+  query: string,
+): T[] {
+  const keyword = query.trim().toLocaleLowerCase()
+  if (!keyword) {
+    return [...sessions]
+  }
+  return sessions.filter((session) => session.preview.toLocaleLowerCase().includes(keyword))
+}
+
+/**
+ * 按演示稿把会话分成「进行中 / 今天 / 具体日期 / 未记录时间」。now 由调用方传入，便于确定性测试。
+ */
+export function groupChatHistorySessions<T extends ChatHistoryPresentableSession>(
+  sessions: readonly T[],
+  now: Date,
+): ChatHistoryDateGroup<T>[] {
+  const groups = new Map<string, ChatHistoryDateGroup<T>>()
+
+  for (const session of sessions) {
+    const descriptor = describeDateGroup(session, now)
+    const group = groups.get(descriptor.key)
+    if (group) {
+      group.sessions.push(session)
+      continue
+    }
+    groups.set(descriptor.key, {
+      ...descriptor,
+      sessions: [session],
+    })
+  }
+
+  return Array.from(groups.values())
+}
+
+/** 后端时间可能带毫秒；侧栏只展示到分钟，避免无意义精度制造视觉噪声。 */
+export function formatChatHistoryTime(value: string | null | undefined): string {
+  if (!value) {
+    return ''
+  }
+  const parsed = parseChatHistoryTime(value)
+  if (!parsed) {
+    return value.trim().replace(MILLISECOND_SUFFIX_PATTERN, '')
+  }
+  return `${padTwoDigits(parsed.getHours())}:${padTwoDigits(parsed.getMinutes())}`
+}
+
+function describeDateGroup(
+  session: ChatHistoryPresentableSession,
+  now: Date,
+): Pick<ChatHistoryDateGroup<ChatHistoryPresentableSession>, 'key' | 'label'> {
+  if (session.streaming) {
+    return { key: 'streaming', label: '进行中' }
+  }
+
+  const date = parseChatHistoryTime(session.lastMessageTime)
+  if (!date) {
+    return { key: 'undated', label: '未记录时间' }
+  }
+
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const dateKey = `${year}-${padTwoDigits(month)}-${padTwoDigits(day)}`
+  if (isSameLocalDate(date, now)) {
+    return { key: dateKey, label: '今天' }
+  }
+  if (year === now.getFullYear()) {
+    return { key: dateKey, label: `${month} 月 ${day} 日` }
+  }
+  return { key: dateKey, label: `${year} 年 ${month} 月 ${day} 日` }
+}
+
+/**
+ * 后端 LocalDateTime 没有时区，按浏览器本地时间解析；带 Z/offset 的 ISO 时间交给 Date 做时区换算。
+ */
+function parseChatHistoryTime(value: string | null | undefined): Date | null {
+  if (!value) {
+    return null
+  }
+  const text = value.trim()
+  const localMatch = LOCAL_DATE_TIME_PATTERN.exec(text)
+  if (localMatch) {
+    const [, yearText, monthText, dayText, hourText = '0', minuteText = '0', secondText = '0', fraction = ''] =
+      localMatch
+    const year = Number(yearText)
+    const monthIndex = Number(monthText) - 1
+    const day = Number(dayText)
+    const hour = Number(hourText)
+    const minute = Number(minuteText)
+    const second = Number(secondText)
+    const millisecond = Number(fraction.padEnd(3, '0').slice(0, 3) || '0')
+    const parsed = new Date(year, monthIndex, day, hour, minute, second, millisecond)
+    if (
+      parsed.getFullYear() === year &&
+      parsed.getMonth() === monthIndex &&
+      parsed.getDate() === day &&
+      parsed.getHours() === hour &&
+      parsed.getMinutes() === minute &&
+      parsed.getSeconds() === second
+    ) {
+      return parsed
+    }
+    return null
+  }
+
+  if (!OFFSET_DATE_TIME_PATTERN.test(text)) {
+    return null
+  }
+  const timestamp = Date.parse(text)
+  return Number.isNaN(timestamp) ? null : new Date(timestamp)
+}
+
+function isSameLocalDate(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  )
+}
+
+function padTwoDigits(value: number): string {
+  return String(value).padStart(2, '0')
+}

--- a/customer-admin-web/src/utils/themeContrast.test.ts
+++ b/customer-admin-web/src/utils/themeContrast.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { PRESET_COLORS } from '@/store/theme'
+import {
+  chooseButtonTextColor,
+  colorContrastRatio,
+  DARK_BUTTON_TEXT,
+  LIGHT_BUTTON_TEXT,
+} from './themeContrast'
+
+describe('chooseButtonTextColor', () => {
+  it('全部预设主题色都满足普通文字 WCAG AA 对比度', () => {
+    for (const background of PRESET_COLORS) {
+      const foreground = chooseButtonTextColor(background)
+      expect(colorContrastRatio(background, foreground), background).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('亮背景选择黑字，深背景选择白字', () => {
+    expect(chooseButtonTextColor('#f59e0b')).toBe(DARK_BUTTON_TEXT)
+    expect(chooseButtonTextColor('#111827')).toBe(LIGHT_BUTTON_TEXT)
+  })
+
+  it('非法颜色安全回退为白字', () => {
+    expect(chooseButtonTextColor('var(--theme-primary)')).toBe(LIGHT_BUTTON_TEXT)
+    expect(colorContrastRatio('#ffffff', 'invalid')).toBeNull()
+  })
+})

--- a/customer-admin-web/src/utils/themeContrast.ts
+++ b/customer-admin-web/src/utils/themeContrast.ts
@@ -1,0 +1,50 @@
+const HEX_COLOR_PATTERN = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i
+
+export const LIGHT_BUTTON_TEXT = '#ffffff'
+export const DARK_BUTTON_TEXT = '#000000'
+
+/**
+ * 在主题色实心按钮上选择对比度更高的黑/白文字。
+ * 黑白两端至少有一端满足 WCAG AA 的 4.5:1，避免中间亮度主题色出现临界不可读状态。
+ */
+export function chooseButtonTextColor(background: string): string {
+  const backgroundLuminance = relativeLuminance(background)
+  if (backgroundLuminance === null) {
+    return LIGHT_BUTTON_TEXT
+  }
+  const whiteContrast = contrastFromLuminance(backgroundLuminance, 1)
+  const blackContrast = contrastFromLuminance(backgroundLuminance, 0)
+  return whiteContrast >= blackContrast ? LIGHT_BUTTON_TEXT : DARK_BUTTON_TEXT
+}
+
+/** 返回两个六位十六进制颜色的 WCAG 对比度；格式非法时返回 null。 */
+export function colorContrastRatio(first: string, second: string): number | null {
+  const firstLuminance = relativeLuminance(first)
+  const secondLuminance = relativeLuminance(second)
+  if (firstLuminance === null || secondLuminance === null) {
+    return null
+  }
+  return contrastFromLuminance(firstLuminance, secondLuminance)
+}
+
+function relativeLuminance(color: string): number | null {
+  const matched = HEX_COLOR_PATTERN.exec(color)
+  if (!matched) {
+    return null
+  }
+  const channelToLinear = (hex: string) => {
+    const channel = Number.parseInt(hex, 16) / 255
+    return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  }
+  return (
+    0.2126 * channelToLinear(matched[1])
+    + 0.7152 * channelToLinear(matched[2])
+    + 0.0722 * channelToLinear(matched[3])
+  )
+}
+
+function contrastFromLuminance(first: number, second: number): number {
+  const lighter = Math.max(first, second)
+  const darker = Math.min(first, second)
+  return (lighter + 0.05) / (darker + 0.05)
+}

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -11,6 +11,7 @@ import PlanConfirmCard from '@/components/PlanConfirmCard.vue'
 import AttachmentPendingList from '@/components/attachment/AttachmentPendingList.vue'
 import MessageAttachments from '@/components/attachment/MessageAttachments.vue'
 import { useThemeStore } from '@/store/theme'
+import '@/styles/workspace-conversation.css'
 import {
   useChatConversationsStore,
   type ChatConversation,
@@ -35,10 +36,19 @@ const anyAttachmentUploading = computed(() => active.value?.attachments.some((a)
 const historyLoading = ref(false)
 const scrollRef = ref<HTMLElement>()
 const historySidebar = ref<InstanceType<typeof ChatHistorySidebar>>()
+const historyCollapsed = ref(false)
 const themeStore = useThemeStore()
 
 function newSession() {
   store.newSession(props.agentCode)
+}
+
+function collapseHistory() {
+  historyCollapsed.value = true
+}
+
+function restoreHistory() {
+  historyCollapsed.value = false
 }
 
 // 附件上传（回形针按钮 + 输入框 ⌘/Ctrl+V 粘贴）统一走组合式函数，与 VibeCodingPanel 共用同一条链路
@@ -178,7 +188,7 @@ defineExpose({ newSession })
 </script>
 
 <template>
-  <div class="chat-panel">
+  <div class="chat-panel workspace-conversation" :class="{ 'is-history-collapsed': historyCollapsed }">
     <div class="chat-column">
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
         <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
@@ -208,44 +218,52 @@ defineExpose({ newSession })
         </div>
         <el-empty v-if="(active?.messages.length ?? 0) === 0" description="开始和智能体对话吧" />
       </div>
-      <AttachmentPendingList
-        v-if="active && active.attachments.length > 0"
-        class="attachment-tags"
-        :attachments="active.attachments"
-        @remove="removeAttachment"
-      />
-      <div class="input-bar">
-        <el-upload
-          :show-file-list="false"
-          :http-request="handleAttachmentUpload"
-          :before-upload="beforeAttachmentUpload"
-          :accept="ATTACHMENT_ACCEPT"
-        >
-          <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
-            <el-icon><Paperclip /></el-icon>
-          </el-button>
-        </el-upload>
-        <ExecutionModeSelect
-          v-if="active"
-          v-model="active.mode"
-          :disabled="active.streaming"
-        />
-        <el-input
-          v-if="active"
-          v-model="active.input"
-          placeholder="输入消息，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件"
-          :disabled="active.streaming"
-          @keyup.enter="send"
-          @paste="handleAttachmentPaste"
-        />
-        <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
-        <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">
-          {{ active?.interrupting ? '终止中…' : '终止' }}
-        </el-button>
-        <el-button v-if="active?.interrupted && !active?.streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
+      <div class="composer-wrap">
+        <div class="composer-shell">
+          <AttachmentPendingList
+            v-if="active && active.attachments.length > 0"
+            class="attachment-tags"
+            :attachments="active.attachments"
+            @remove="removeAttachment"
+          />
+          <div class="input-bar">
+            <el-input
+              v-if="active"
+              v-model="active.input"
+              placeholder="输入消息，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件"
+              :disabled="active.streaming"
+              @keyup.enter="send"
+              @paste="handleAttachmentPaste"
+            />
+            <div class="composer-send">
+              <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
+              <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">
+                {{ active?.interrupting ? '终止中…' : '终止' }}
+              </el-button>
+              <el-button v-if="active?.interrupted && !active?.streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
+            </div>
+          </div>
+          <div class="composer-toolbar">
+            <el-upload
+              :show-file-list="false"
+              :http-request="handleAttachmentUpload"
+              :before-upload="beforeAttachmentUpload"
+              :accept="ATTACHMENT_ACCEPT"
+            >
+              <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
+                <el-icon><Paperclip /></el-icon>
+              </el-button>
+            </el-upload>
+            <ExecutionModeSelect
+              v-if="active"
+              v-model="active.mode"
+              :disabled="active.streaming"
+            />
+          </div>
+        </div>
       </div>
     </div>
-    <div class="history-column">
+    <div class="history-column" :aria-hidden="historyCollapsed">
       <ChatHistorySidebar
         ref="historySidebar"
         :agent-code="agentCode"
@@ -253,128 +271,46 @@ defineExpose({ newSession })
         :live-sessions="liveSessions"
         @select="openSession"
         @initial-session="restoreMostRecentSession"
+        @collapse="collapseHistory"
       />
     </div>
+    <el-button
+      v-if="historyCollapsed"
+      class="history-restore"
+      circle
+      title="展开历史会话"
+      aria-label="展开历史会话"
+      @click="restoreHistory"
+    >
+      <el-icon><Expand /></el-icon>
+    </el-button>
   </div>
 </template>
 
 <style scoped>
 .chat-panel {
-  display: flex;
-  gap: 16px;
-  height: 60vh;
+  --conversation-messages-padding: 28px 32px 36px;
+  --conversation-composer-padding: 10px 24px 14px;
+  grid-template-columns: minmax(0, 1fr) 300px;
 }
 
-.chat-column {
-  flex: 3;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  background-color: var(--theme-page-bg, #fff);
-  border-radius: 8px;
-  padding: 12px;
-  transition: background-color 0.3s ease;
+.chat-panel.is-history-collapsed {
+  grid-template-columns: minmax(0, 1fr) 0;
 }
 
-.messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px;
-  border-radius: 6px;
-}
-
-.attachment-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 8px;
-}
-
-.message-row {
-  display: flex;
-  margin-bottom: 12px;
-}
-
-.message-row.user {
-  justify-content: flex-end;
-}
-
-.bubble {
-  min-width: 0;
-  word-break: break-word;
-}
-
-.message-row.user .bubble {
-  max-width: 70%;
-  padding: 10px 14px;
-  background: var(--theme-primary, var(--el-color-primary));
-  border-radius: 12px 12px 3px 12px;
-  color: #fff;
-  white-space: pre-wrap;
-}
-
-.message-row.user .bubble:hover {
-  background: var(--theme-primary-light, #79bbff);
-}
-
-.message-row.assistant .bubble {
-  width: 100%;
-  max-width: 100%;
-  padding: 0;
-}
-
-.input-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.input-bar :deep(.el-input) {
-  flex: 1;
-  min-width: 180px;
-}
-
-/* :not(.is-link) 排除"继续"链接按钮——link 按钮的文字色本就用的是同一个主题蓝（靠透明背景显色），
-   这条规则如果连它一起覆盖成纯色背景，文字会跟背景同色而"隐形"。 */
-.input-bar :deep(.el-button--primary:not(.is-link)) {
-  background-color: var(--theme-primary, var(--el-color-primary));
-  border-color: var(--theme-primary, var(--el-color-primary));
-}
-
-.input-bar :deep(.el-button--primary:not(.is-link):hover) {
-  background-color: var(--theme-primary-light, #79bbff);
-  border-color: var(--theme-primary-light, #79bbff);
-}
-
-.history-column {
-  flex: 1;
-  min-width: 200px;
-  border-left: 1px solid var(--el-border-color-lighter);
-  padding-left: 16px;
-}
-
-@media (max-width: 900px) {
+@container workspace-panel (max-width: 900px) {
   .chat-panel {
-    flex-direction: column;
-    height: auto;
-    min-height: 60vh;
+    --conversation-messages-padding: 24px 16px 30px;
+    --conversation-composer-padding: 10px 12px 14px;
+    --conversation-user-bubble-max-width: 88%;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(420px, 1fr) 210px;
+    overflow-y: auto;
   }
 
-  .history-column {
-    min-height: 180px;
-    padding-top: 14px;
-    padding-left: 0;
-    border-top: 1px solid var(--el-border-color-lighter);
-    border-left: 0;
-  }
-
-  .message-row.user .bubble {
-    max-width: 88%;
-  }
-
-  .input-bar {
-    flex-wrap: wrap;
+  .chat-panel.is-history-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) 0;
   }
 }
 </style>

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -24,6 +24,7 @@ import VibeCodingToolsDrawer from '@/components/VibeCodingToolsDrawer.vue'
 import AttachmentPendingList from '@/components/attachment/AttachmentPendingList.vue'
 import MessageAttachments from '@/components/attachment/MessageAttachments.vue'
 import { useThemeStore } from '@/store/theme'
+import '@/styles/workspace-conversation.css'
 import {
   useVibeConversationsStore,
   type PlanCard,
@@ -70,6 +71,7 @@ const collaborationMode = ref(false)
 const historyLoading = ref(false)
 const scrollRef = ref<HTMLElement>()
 const historySidebar = ref<InstanceType<typeof ChatHistorySidebar>>()
+const historyCollapsed = ref(false)
 const themeStore = useThemeStore()
 const toolsDrawer = ref<InstanceType<typeof VibeCodingToolsDrawer>>()
 
@@ -103,6 +105,14 @@ const saving = ref(false)
 
 function newSession() {
   store.newSession(props.agentCode)
+}
+
+function collapseHistory() {
+  historyCollapsed.value = true
+}
+
+function restoreHistory() {
+  historyCollapsed.value = false
 }
 
 // 附件上传（回形针按钮 + 输入框 ⌘/Ctrl+V 粘贴）统一走组合式函数，与 ChatPanel 共用同一条链路
@@ -561,7 +571,7 @@ defineExpose({ newSession })
 </script>
 
 <template>
-  <div class="vibecoding-panel">
+  <div class="vibecoding-panel workspace-conversation" :class="{ 'is-history-collapsed': historyCollapsed }">
     <!-- 左列：对话区 -->
     <div class="chat-column">
       <div ref="scrollRef" class="messages" v-loading="historyLoading">
@@ -652,50 +662,58 @@ defineExpose({ newSession })
         </div>
         <el-empty v-if="(active?.messages.length ?? 0) === 0" description="描述你想让智能体生成/修改的代码" />
       </div>
-      <AttachmentPendingList
-        v-if="active && active.attachments.length > 0"
-        class="attachment-tags"
-        :attachments="active.attachments"
-        @remove="removeAttachment"
-      />
-      <div class="input-bar">
-        <el-button title="运行命令、诊断日志、自动化重构与沙箱管理" @click="toolsDrawer?.open('run')">
-          <el-icon><Tools /></el-icon>
-          开发工具
-        </el-button>
-        <el-upload :show-file-list="false" :http-request="handleAttachmentUpload" :before-upload="beforeAttachmentUpload" :accept="ATTACHMENT_ACCEPT">
-          <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
-            <el-icon><Paperclip /></el-icon>
-          </el-button>
-        </el-upload>
-        <ExecutionModeSelect
-          v-if="active"
-          v-model="active.mode"
-          :disabled="active.streaming"
-        />
-        <el-input
-          v-model="input"
-          placeholder="描述需求，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件"
-          :disabled="active?.streaming"
-          @keyup.enter="send"
-          @paste="handleAttachmentPaste"
-        />
-        <el-tooltip
-          placement="top"
-          content="开启后按 需求分析→方案设计→编码实现→自测审查 多角色顺序协作"
-        >
-          <el-switch
-            v-model="collaborationMode"
-            :disabled="active?.streaming"
-            active-text="协作模式"
-            class="collaboration-switch"
+      <div class="composer-wrap">
+        <div class="composer-shell">
+          <AttachmentPendingList
+            v-if="active && active.attachments.length > 0"
+            class="attachment-tags"
+            :attachments="active.attachments"
+            @remove="removeAttachment"
           />
-        </el-tooltip>
-        <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
-        <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">
-          {{ active?.interrupting ? '终止中…' : '终止' }}
-        </el-button>
-        <el-button v-if="active?.interrupted && !active?.streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
+          <div class="input-bar">
+            <el-input
+              v-model="input"
+              placeholder="描述需求，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件"
+              :disabled="active?.streaming"
+              @keyup.enter="send"
+              @paste="handleAttachmentPaste"
+            />
+            <div class="composer-send">
+              <el-button v-if="!active?.streaming" type="primary" :disabled="anyAttachmentUploading" @click="send">发送</el-button>
+              <el-button v-else type="danger" :loading="active?.interrupting" @click="handleInterrupt">
+                {{ active?.interrupting ? '终止中…' : '终止' }}
+              </el-button>
+              <el-button v-if="active?.interrupted && !active?.streaming" link type="primary" @click="resumeInterrupted">继续</el-button>
+            </div>
+          </div>
+          <div class="composer-toolbar">
+            <el-button title="运行命令、诊断日志、自动化重构与沙箱管理" @click="toolsDrawer?.open('run')">
+              <el-icon><Tools /></el-icon>
+              开发工具
+            </el-button>
+            <el-upload :show-file-list="false" :http-request="handleAttachmentUpload" :before-upload="beforeAttachmentUpload" :accept="ATTACHMENT_ACCEPT">
+              <el-button :disabled="active?.streaming" title="上传附件（文档/表格/图片等），随消息一起发给智能体">
+                <el-icon><Paperclip /></el-icon>
+              </el-button>
+            </el-upload>
+            <ExecutionModeSelect
+              v-if="active"
+              v-model="active.mode"
+              :disabled="active.streaming"
+            />
+            <el-tooltip
+              placement="top"
+              content="开启后按 需求分析→方案设计→编码实现→自测审查 多角色顺序协作"
+            >
+              <el-switch
+                v-model="collaborationMode"
+                :disabled="active?.streaming"
+                active-text="协作模式"
+                class="collaboration-switch"
+              />
+            </el-tooltip>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -774,7 +792,7 @@ defineExpose({ newSession })
     </div>
 
     <!-- 右列：历史会话 -->
-    <div class="history-column">
+    <div class="history-column" :aria-hidden="historyCollapsed">
       <ChatHistorySidebar
         ref="historySidebar"
         :agent-code="agentCode"
@@ -782,8 +800,20 @@ defineExpose({ newSession })
         :live-sessions="liveSessions"
         @select="openSession"
         @initial-session="restoreMostRecentSession"
+        @collapse="collapseHistory"
       />
     </div>
+
+    <el-button
+      v-if="historyCollapsed"
+      class="history-restore"
+      circle
+      title="展开历史会话"
+      aria-label="展开历史会话"
+      @click="restoreHistory"
+    >
+      <el-icon><Expand /></el-icon>
+    </el-button>
 
     <!-- 文件内容预览抽屉 -->
     <el-drawer
@@ -931,102 +961,25 @@ defineExpose({ newSession })
 
 <style scoped>
 .vibecoding-panel {
-  display: flex;
-  gap: 16px;
-  height: 60vh;
+  --conversation-messages-padding: 28px 28px 36px;
+  --conversation-composer-padding: 10px 20px 14px;
+  grid-template-columns: minmax(520px, 1fr) minmax(220px, 260px) 300px;
 }
 
-.chat-column {
-  flex: 2;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  background-color: var(--theme-page-bg, #fff);
-  border-radius: 8px;
-  padding: 12px;
-  transition: background-color 0.3s ease;
-}
-
-.messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px;
-  border-radius: 6px;
-}
-
-.attachment-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 8px;
-}
-
-.message-row {
-  display: flex;
-  margin-bottom: 12px;
-}
-
-.message-row.user {
-  justify-content: flex-end;
-}
-
-.bubble {
-  min-width: 0;
-  word-break: break-word;
-}
-
-.message-row.user .bubble {
-  max-width: 88%;
-  padding: 10px 14px;
-  background: var(--theme-primary, var(--el-color-primary));
-  border-radius: 12px 12px 3px 12px;
-  color: #fff;
-  white-space: pre-wrap;
-}
-
-.message-row.user .bubble:hover {
-  background: var(--theme-primary-light, #79bbff);
-}
-
-.message-row.assistant .bubble {
-  width: 100%;
-  max-width: 100%;
-  padding: 0;
-}
-
-.input-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.input-bar :deep(.el-input) {
-  flex: 1;
-  min-width: 180px;
-}
-
-/* :not(.is-link) 排除"继续"链接按钮——link 按钮的文字色本就用的是同一个主题蓝（靠透明背景显色），
-   这条规则如果连它一起覆盖成纯色背景，文字会跟背景同色而"隐形"。 */
-.input-bar :deep(.el-button--primary:not(.is-link)) {
-  background-color: var(--theme-primary, var(--el-color-primary));
-  border-color: var(--theme-primary, var(--el-color-primary));
-}
-
-.input-bar :deep(.el-button--primary:not(.is-link):hover) {
-  background-color: var(--theme-primary-light, #79bbff);
-  border-color: var(--theme-primary-light, #79bbff);
+.vibecoding-panel.is-history-collapsed {
+  grid-template-columns: minmax(520px, 1fr) minmax(220px, 280px) 0;
 }
 
 /* 产物文件树列 */
 .artifacts-column {
-  flex: 1;
-  border-left: 1px solid var(--el-border-color-lighter);
-  padding-left: 16px;
   display: flex;
   flex-direction: column;
-  min-width: 200px;
+  min-width: 0;
+  min-height: 0;
   overflow: hidden;
+  padding: 15px 14px 12px 16px;
+  background: color-mix(in srgb, var(--el-fill-color-lighter) 42%, var(--el-bg-color));
+  border-left: 1px solid var(--el-border-color-lighter);
 }
 
 .artifacts-header {
@@ -1272,14 +1225,6 @@ defineExpose({ newSession })
   color: var(--theme-primary, var(--el-color-primary));
 }
 
-/* 历史会话列 */
-.history-column {
-  flex: 1;
-  border-left: 1px solid var(--el-border-color-lighter);
-  padding-left: 16px;
-  min-width: 180px;
-}
-
 /* 预览抽屉 */
 .preview-loading {
   display: flex;
@@ -1355,40 +1300,46 @@ defineExpose({ newSession })
   background: var(--el-bg-color);
 }
 
-@media (max-width: 1100px) {
+@container workspace-panel (max-width: 1040px) {
   .vibecoding-panel {
-    flex-wrap: wrap;
-    gap: 12px;
-    height: auto;
-    min-height: 60vh;
+    --conversation-messages-padding: 28px 20px 36px;
+    --conversation-composer-padding: 10px 14px 14px;
+    grid-template-columns: minmax(480px, 1fr) minmax(220px, 280px);
+    grid-template-rows: minmax(480px, 1fr) 210px;
+    overflow-y: auto;
+  }
+
+  .vibecoding-panel.is-history-collapsed {
+    grid-template-columns: minmax(480px, 1fr) minmax(220px, 280px);
+    grid-template-rows: minmax(0, 1fr) 0;
   }
 
   .history-column {
-    flex: 1 1 100%;
-    min-height: 180px;
-    padding-top: 14px;
-    padding-left: 0;
-    border-top: 1px solid var(--el-border-color-lighter);
-    border-left: 0;
-  }
-
-  .input-bar {
-    flex-wrap: wrap;
+    grid-column: 1 / -1;
   }
 }
 
-@media (max-width: 760px) {
-  .chat-column,
-  .artifacts-column {
-    flex: 1 1 100%;
-    min-height: 55vh;
+@container workspace-panel (max-width: 700px) {
+  .vibecoding-panel,
+  .vibecoding-panel.is-history-collapsed {
+    --conversation-user-bubble-max-width: 88%;
+    --conversation-toolbar-wrap: wrap;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(480px, 1fr) 260px 210px;
   }
 
   .artifacts-column {
-    padding-top: 14px;
-    padding-left: 0;
+    padding: 14px 16px;
     border-top: 1px solid var(--el-border-color-lighter);
     border-left: 0;
+  }
+
+  .history-column {
+    grid-column: 1;
+  }
+
+  .vibecoding-panel.is-history-collapsed {
+    grid-template-rows: minmax(480px, 1fr) 260px 0;
   }
 }
 </style>

--- a/customer-admin-web/src/views/workspace/WorkspaceView.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceView.vue
@@ -134,10 +134,27 @@ watch(
 <template>
   <div class="workspace-view">
     <div class="workspace-header">
-      <h2 class="agent-title">{{ agentNode?.name ?? agentCode }}</h2>
+      <div class="agent-identity">
+        <span class="agent-mark" aria-hidden="true">&lt;/&gt;</span>
+        <div class="agent-copy">
+          <h1 class="agent-title">{{ agentNode?.name ?? agentCode }}</h1>
+          <div class="agent-meta">
+            <span>智能体工作台</span>
+            <span class="meta-separator" aria-hidden="true">/</span>
+            <code class="agent-code">{{ agentCode }}</code>
+          </div>
+        </div>
+      </div>
       <div class="header-actions">
-        <!-- 与 ThemeToolbar 里两个按钮保持同一胶囊规格（34px 高/17px 圆角/13px 字号），蓝底白字 -->
-        <button type="button" class="knowledge-btn" @click="knowledgeVisible = true">代码知识库</button>
+        <button
+          type="button"
+          class="knowledge-btn"
+          aria-label="打开代码知识库"
+          @click="knowledgeVisible = true"
+        >
+          <el-icon aria-hidden="true"><Collection /></el-icon>
+          <span>代码知识库</span>
+        </button>
         <ThemeToolbar :on-new-session="newSession" />
       </div>
     </div>
@@ -147,7 +164,7 @@ watch(
     <el-dialog v-model="reviewDialogVisible" title="AI 代码审查报告" width="640px" destroy-on-close>
       <ReviewReport v-if="reviewDialogResult" :result="reviewDialogResult" :interactive="false" />
     </el-dialog>
-    <el-tabs v-model="activeTab" type="border-card" class="workspace-tabs">
+    <el-tabs v-model="activeTab" class="workspace-tabs">
       <el-tab-pane label="对话" name="chat">
         <!-- workspace/:agentCode 是同一条路由，只换参数，Vue Router 默认复用组件实例——
              不加 :key 的话切换智能体时 ChatPanel 内部的 messages/sessionId 状态会跟着串到下一个
@@ -165,58 +182,257 @@ watch(
 <style scoped>
 .workspace-view {
   height: 100%;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 18px;
+  box-shadow: var(--cw-card-shadow, 0 1px 3px rgb(16 24 40 / 6%));
 }
 
 .workspace-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 12px;
+  flex: 0 0 auto;
+  min-height: 64px;
+  gap: 24px;
+  padding: 10px 18px 10px 20px;
+  background: color-mix(in srgb, var(--el-bg-color) 96%, var(--theme-primary, var(--el-color-primary)) 4%);
+}
+
+.agent-identity {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 12px;
+}
+
+.agent-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  color: #fff;
+  background: linear-gradient(145deg, #2d374b, #151c2a);
+  border-radius: 11px;
+  box-shadow: 0 5px 14px rgb(18 25 39 / 18%);
+  font-family: "SFMono-Regular", "JetBrains Mono", Consolas, monospace;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.08em;
+}
+
+.agent-copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
 }
 
 .agent-title {
   margin: 0;
+  overflow: hidden;
+  color: var(--el-text-color-primary);
+  font-family: "SF Pro Display", "PingFang SC", "Microsoft YaHei", sans-serif;
+  font-size: 20px;
+  font-weight: 680;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-meta {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 7px;
+  color: var(--el-text-color-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.meta-separator {
+  color: var(--el-text-color-placeholder);
+}
+
+.agent-code {
+  overflow: hidden;
+  color: var(--el-text-color-regular);
+  font-family: "SFMono-Regular", "JetBrains Mono", Consolas, monospace;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  flex: 0 0 auto;
+  gap: 8px;
 }
 
-/* 代码知识库：蓝底白字胶囊，规格与 ThemeToolbar 的主题色/新建会话按钮一致（34px 高/17px 圆角） */
 .knowledge-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  height: 34px;
-  padding: 0 18px;
-  border: none;
-  border-radius: 17px;
-  background: #409eff;
-  color: #fff;
-  font-size: 13px;
-  font-weight: 500;
+  height: 36px;
+  padding: 0 12px;
+  color: var(--el-text-color-regular);
+  background: var(--el-bg-color);
+  border: 1px solid var(--el-border-color);
+  border-radius: 10px;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
+  font-size: 12px;
+  font-weight: 560;
+  box-shadow: 0 1px 2px rgb(16 24 40 / 3%);
+  transition: border-color 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.knowledge-btn .el-icon {
+  color: #2563eb;
+  font-size: 15px;
 }
 
 .knowledge-btn:hover {
-  filter: brightness(1.08);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  color: var(--el-text-color-primary);
+  border-color: var(--theme-primary, var(--el-color-primary));
+  box-shadow: 0 4px 10px rgb(16 24 40 / 8%);
   transform: translateY(-1px);
 }
 
 .knowledge-btn:active {
   transform: translateY(0);
-  filter: brightness(0.96);
+}
+
+.knowledge-btn:focus-visible {
+  outline: 0;
+  box-shadow:
+    0 0 0 2px var(--el-bg-color),
+    0 0 0 4px var(--el-text-color-primary);
 }
 
 .workspace-tabs {
   flex: 1;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.workspace-tabs :deep(.el-tabs__header) {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0 20px;
+  background: color-mix(in srgb, var(--el-bg-color) 97%, var(--theme-primary, var(--el-color-primary)) 3%);
+}
+
+.workspace-tabs :deep(.el-tabs__nav-wrap::after) {
+  height: 1px;
+  background: var(--el-border-color-lighter);
+}
+
+.workspace-tabs :deep(.el-tabs__item) {
+  height: 42px;
+  padding: 0 2px;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.workspace-tabs :deep(.el-tabs__item + .el-tabs__item) {
+  margin-left: 22px;
+}
+
+.workspace-tabs :deep(.el-tabs__item:hover),
+.workspace-tabs :deep(.el-tabs__item.is-active) {
+  color: var(--el-text-color-primary);
+}
+
+.workspace-tabs :deep(.el-tabs__active-bar) {
+  height: 2px;
+  background: var(--theme-primary, var(--el-color-primary));
+  border-radius: 2px 2px 0 0;
+}
+
+.workspace-tabs :deep(.el-tabs__content) {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  container-name: workspace-panel;
+  container-type: inline-size;
+}
+
+.workspace-tabs :deep(.el-tab-pane) {
+  height: 100%;
+  min-height: 0;
+}
+
+@media (max-width: 760px) {
+  .workspace-view {
+    border-radius: 12px;
+  }
+
+  .workspace-header {
+    align-items: flex-start;
+    flex-direction: column;
+    min-height: auto;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .agent-mark {
+    flex-basis: 36px;
+    width: 36px;
+    height: 36px;
+  }
+
+  .agent-title {
+    font-size: 18px;
+  }
+
+  .header-actions {
+    justify-content: flex-end;
+    width: 100%;
+  }
+
+  .workspace-tabs :deep(.el-tabs__header) {
+    padding: 0 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .knowledge-btn {
+    width: 36px;
+    padding: 0;
+  }
+
+  .knowledge-btn span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .knowledge-btn {
+    transition: none;
+  }
+
+  .knowledge-btn:hover {
+    transform: none;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更说明 / What

重构智能体工作区的页面层级与对话布局，使 Chat 与 VibeCoding 在桌面端、窄屏和暗色主题下都保持清晰、稳定，同时保留既有业务调用与状态恢复契约。

- 将工作区标题、操作入口和模式切换统一为紧凑的工作台头部
- 优化消息时间线、执行过程、结果区与底部输入区的视觉层级
- 重做历史会话侧栏：支持本地搜索、日期分组、刷新、收起与恢复
- 为 Chat/VibeCoding 抽取命名空间隔离的共享样式，并使用容器查询适配不同工作区宽度
- 完善主题色选择的对比度、键盘操作、焦点恢复与弹层关闭行为
- 新增历史时间展示与主题文字对比度的确定性单元测试

## 功能边界 / Compatibility

- 保持 Chat 与 VibeCoding 原有 SSE 请求、终止/继续、附件、执行模式、开发工具、协作模式和产物文件事件不变
- 保持会话选择、分页、刷新、恢复、Project 关联和租户/会话权限调用链不变
- 未新增后端接口、数据库迁移、依赖或配置项

## 类型 / Type

- [x] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 验证 / Verification

- `npm test`：7 个测试文件、37 项测试全部通过
- `npm run build`：生产构建通过
- 浏览器回归：Chat/VibeCoding 发送链路、主题键盘交互、历史搜索/刷新/收起恢复、亮暗主题、5 次 F5、离开重进、冷启动恢复均通过
- 响应式回归：1440×900、1024×768、760×900、375×812 均无页面级溢出，输入区保持可见
- 浏览器回归采用隔离 API fixture 控制数据与 SSE 次数；后端真实 MySQL/集成链路由完整 Maven 门禁覆盖
- `mvn -B -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.xml clean test -Djacoco.skip=true -Dtest='!RedisSessionPersistenceTest' -Dsurefire.failIfNoSpecifiedTests=false`：6 个模块全部成功，`BUILD SUCCESS`
- 代码质量复核与安全审计均无遗留问题

## 自查 / Checklist

- [x] `mvn test` 全绿（新增功能附了单元测试）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 未新增外部后端
- [x] 本次不涉及 README 或配置项变更
