### PR TITLE
feat(app): 重构 H5 客户端服务体验

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,6 @@ jobs:
         run: npm ci
 
       - name: Run frontend unit tests
-        if: ${{ matrix.project == 'customer-admin-web' }}
         working-directory: ${{ matrix.project }}
         run: npm test
 

--- a/customer-work-app/README.md
+++ b/customer-work-app/README.md
@@ -17,6 +17,7 @@ npm run dev        # 端口 5175；/api 与 /ws 经 vite proxy 转发到 localho
 ## 构建与部署
 
 ```bash
+npm test           # Vitest：认证迁移、头像兜底、请求竞态与页面状态回归
 npm run build      # vue-tsc 类型检查 + vite build，产物 dist/
 ```
 

--- a/customer-work-app/package-lock.json
+++ b/customer-work-app/package-lock.json
@@ -18,9 +18,12 @@
       "devDependencies": {
         "@types/node": "^24.13.2",
         "@vitejs/plugin-vue": "^6.0.7",
+        "@vue/test-utils": "^2.5.0",
         "@vue/tsconfig": "^0.9.1",
+        "happy-dom": "^20.11.12",
         "typescript": "~6.0.2",
         "vite": "^8.1.1",
+        "vitest": "^4.1.11",
         "vue-tsc": "^3.3.5"
       }
     },
@@ -128,6 +131,13 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmmirror.com/@one-ini/wasm/-/wasm-0.2.1.tgz",
+      "integrity": "sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
@@ -421,6 +431,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -432,6 +449,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.13.3.tgz",
@@ -440,6 +482,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vant/popperjs": {
@@ -478,6 +537,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -631,6 +813,27 @@
       "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmmirror.com/@vue/test-utils/-/test-utils-2.5.0.tgz",
+      "integrity": "sha512-6Clu5EKR/r6cDPYrKsu+8wenciWJJ3rhS9OEGsfDlZeZIhlJeEPGIZQHxE4lHRJCzPSq3EWMsFxQUqCvrbHQuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^2.0.0",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.9.1",
       "resolved": "https://registry.npmmirror.com/@vue/tsconfig/-/tsconfig-0.9.1.tgz",
@@ -648,6 +851,16 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/abbrev/-/abbrev-5.0.0.tgz",
+      "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -669,6 +882,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
@@ -687,6 +910,42 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmmirror.com/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -700,6 +959,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -711,6 +980,34 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmmirror.com/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -768,6 +1065,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/editorconfig/-/editorconfig-3.0.2.tgz",
+      "integrity": "sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.2.1",
+        "commander": "^14.0.3",
+        "minimatch": "~10.2.4",
+        "semver": "^7.7.4"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmmirror.com/entities/-/entities-7.0.1.tgz",
@@ -797,6 +1113,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -830,6 +1153,16 @@
       "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -946,6 +1279,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
@@ -956,6 +1307,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.12",
+      "resolved": "https://registry.npmmirror.com/happy-dom/-/happy-dom-20.11.12.tgz",
+      "integrity": "sha512-7+mrTTD+6fOG3dx0URrDLrCX8QDTE+YujSOQD4VPZcYze/yJ0vVhRKaIBTjqlk+R4NetxVz21odnevHYIjIJ+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-symbols": {
@@ -1009,6 +1379,42 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmmirror.com/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-beautify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/js-beautify/-/js-beautify-2.0.3.tgz",
+      "integrity": "sha512-cyFbh3tkPhknnTD/0bLf0T0yy2ZIbqL05mttzbt4y1Zfr7NxqXQZ62dkBLKs3oHH/lpjmDRAnciJiSUyOy8XwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^3.0.2",
+        "glob": "^13.0.6",
+        "js-cookie": "^3.0.8",
+        "nopt": "^10.0.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmmirror.com/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1283,6 +1689,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
@@ -1322,6 +1738,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
@@ -1353,10 +1795,64 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nopt": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmmirror.com/nopt/-/nopt-10.0.1.tgz",
+      "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^5.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1429,6 +1925,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -1472,6 +1975,26 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1479,6 +2002,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1496,6 +2050,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1619,6 +2183,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -1646,6 +2300,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmmirror.com/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+      "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-demi": {
       "version": "0.14.10",
@@ -1703,6 +2364,55 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/customer-work-app/package.json
+++ b/customer-work-app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@vant/touch-emulator": "^1.4.0",
@@ -19,9 +20,12 @@
   "devDependencies": {
     "@types/node": "^24.13.2",
     "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/test-utils": "^2.5.0",
     "@vue/tsconfig": "^0.9.1",
+    "happy-dom": "^20.11.12",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
+    "vitest": "^4.1.11",
     "vue-tsc": "^3.3.5"
   }
 }

--- a/customer-work-app/src/App.vue
+++ b/customer-work-app/src/App.vue
@@ -8,12 +8,23 @@
 
 <style scoped>
 .mobile-shell {
-  max-width: 480px;
+  position: relative;
+  width: 100%;
+  max-width: var(--cw-shell-width);
   min-height: 100vh;
+  min-height: 100dvh;
   margin: 0 auto;
-  background: var(--cw-page-bg);
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.08);
   display: flex;
   flex-direction: column;
+  isolation: isolate;
+  overflow-x: hidden;
+  background: var(--cw-page-bg);
+  box-shadow: 0 28px 76px rgba(31, 48, 78, 0.2);
+}
+
+@media (max-width: 480px) {
+  .mobile-shell {
+    box-shadow: none;
+  }
 }
 </style>

--- a/customer-work-app/src/components/AppTabbar.vue
+++ b/customer-work-app/src/components/AppTabbar.vue
@@ -1,12 +1,103 @@
 <script setup lang="ts">
-// 底部导航：route 模式，van-tabbar 按当前路由高亮。固定在视口底部（fixed），
-// 各页面自行预留底部空间防遮挡（聊天页用 padding-bottom，滚动页在滚动区留白）。
+// 底部导航保留 Vant route 模式和原路由行为；外层船坞负责居中、移动壳约束与安全区。
 </script>
 
 <template>
-  <van-tabbar route>
-    <van-tabbar-item to="/messages" icon="chat-o">消息</van-tabbar-item>
-    <van-tabbar-item to="/orders" icon="orders-o">订单</van-tabbar-item>
-    <van-tabbar-item to="/profile" icon="user-o">我的</van-tabbar-item>
-  </van-tabbar>
+  <div class="app-tabbar-dock">
+    <van-tabbar route :fixed="false" :border="false" :safe-area-inset-bottom="false" aria-label="主导航">
+      <van-tabbar-item to="/messages" icon="chat-o">消息</van-tabbar-item>
+      <van-tabbar-item to="/orders" icon="orders-o">订单</van-tabbar-item>
+      <van-tabbar-item to="/profile" icon="user-o">我的</van-tabbar-item>
+    </van-tabbar>
+  </div>
 </template>
+
+<style scoped>
+.app-tabbar-dock {
+  position: fixed;
+  z-index: 100;
+  left: 50%;
+  bottom: 9px;
+  bottom: max(9px, constant(safe-area-inset-bottom));
+  bottom: max(9px, env(safe-area-inset-bottom));
+  width: min(calc(100% - 20px), calc(var(--cw-shell-width) - 20px));
+  height: var(--cw-tabbar-height);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+:deep(.van-tabbar) {
+  --van-tabbar-height: var(--cw-tabbar-height);
+  --van-tabbar-background: rgba(255, 255, 255, 0.94);
+  --van-tabbar-item-font-size: 10px;
+  --van-tabbar-item-text-color: var(--cw-text-muted);
+  --van-tabbar-item-active-color: var(--cw-primary);
+  --van-tabbar-item-active-background: var(--cw-primary-soft);
+  --van-tabbar-item-icon-size: 22px;
+  --van-tabbar-item-icon-margin-bottom: 3px;
+  box-sizing: border-box;
+  height: var(--cw-tabbar-height);
+  padding: 6px;
+  overflow: hidden;
+  border: 1px solid rgba(225, 231, 240, 0.9);
+  border-radius: 22px;
+  background: var(--van-tabbar-background);
+  box-shadow: 0 16px 34px rgba(37, 55, 85, 0.17);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  pointer-events: auto;
+}
+
+:deep(.van-tabbar-item) {
+  position: relative;
+  height: 58px;
+  border-radius: 17px;
+  letter-spacing: 0.02em;
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+:deep(.van-tabbar-item--active) {
+  font-weight: 700;
+}
+
+:deep(.van-tabbar-item--active::before) {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 12px;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--cw-primary);
+  content: '';
+  transform: translateX(-50%);
+}
+
+:deep(.van-tabbar-item--active .van-tabbar-item__icon) {
+  transform: translateY(-1px);
+}
+
+:deep(.van-tabbar-item:focus-visible) {
+  outline: 3px solid var(--cw-focus-ring);
+  outline-offset: -2px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  :deep(.van-tabbar-item:not(.van-tabbar-item--active):hover) {
+    color: var(--cw-ink-soft);
+    background: rgba(234, 241, 255, 0.62);
+  }
+}
+
+@media (max-width: 359px) {
+  .app-tabbar-dock {
+    width: calc(100% - 14px);
+  }
+
+  :deep(.van-tabbar) {
+    border-radius: 20px;
+  }
+}
+</style>

--- a/customer-work-app/src/components/CsatSurveyCard.vue
+++ b/customer-work-app/src/components/CsatSurveyCard.vue
@@ -99,10 +99,15 @@ watch(
     @close="handleClose"
   >
     <div class="csat-card">
+      <div class="sheet-handle" aria-hidden="true"></div>
+      <div class="csat-mark" aria-hidden="true">✓</div>
+      <div class="csat-kicker">SERVICE COMPLETE</div>
       <div class="csat-title">本次服务您还满意吗？</div>
-      <div class="csat-sub">您的评价会帮我们改进服务</div>
+      <div class="csat-sub">只需几秒，您的真实感受会帮助我们持续改进</div>
 
-      <van-rate v-model="score" :size="32" gutter="10" color="#ffd21e" void-icon="star" void-color="#eee" />
+      <div class="rate-shell">
+        <van-rate v-model="score" :size="34" gutter="9" color="#f6b73c" void-icon="star" void-color="#e7ecf3" />
+      </div>
       <div class="csat-score-label">{{ SCORE_LABELS[score] || '请点击星星评分' }}</div>
 
       <!-- 只在低分时追问原因：满意的用户不该被额外打扰，而低分留言才是能拿来改进的东西 -->
@@ -127,43 +132,96 @@ watch(
       >
         提交评价
       </van-button>
+      <div class="privacy-note">评价仅用于服务质量改进</div>
     </div>
   </van-popup>
 </template>
 
 <style scoped>
 .csat-card {
-  padding: 28px 20px 24px;
+  position: relative;
+  padding: 15px 22px calc(24px + env(safe-area-inset-bottom));
   text-align: center;
+  background:
+    radial-gradient(circle at 50% 5%, rgba(24, 119, 242, 0.08), transparent 30%),
+    #fff;
+}
+
+.sheet-handle {
+  width: 42px;
+  height: 4px;
+  margin: 0 auto 18px;
+  border-radius: 999px;
+  background: #dce3ed;
+}
+
+.csat-mark {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  margin: 0 auto 11px;
+  place-items: center;
+  border-radius: 15px;
+  color: #fff;
+  background: linear-gradient(145deg, #2bd09a, #18a978);
+  font-size: 21px;
+  font-weight: 800;
+  box-shadow: 0 11px 24px rgba(37, 196, 138, 0.23);
+}
+
+.csat-kicker {
+  margin-bottom: 4px;
+  color: #1677ff;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 1.7px;
 }
 
 .csat-title {
-  font-size: 17px;
-  font-weight: 600;
-  color: #323233;
+  font-size: 20px;
+  font-weight: 750;
+  color: #13233a;
 }
 
 .csat-sub {
+  max-width: 270px;
+  margin: 7px auto 18px;
   font-size: 12px;
-  color: #969799;
-  margin-top: 6px;
-  margin-bottom: 20px;
+  color: #718096;
+  line-height: 1.55;
+}
+
+.rate-shell {
+  display: inline-flex;
+  padding: 12px 14px;
+  border: 1px solid rgba(19, 35, 58, 0.06);
+  border-radius: 18px;
+  background: #f8fafc;
 }
 
 .csat-score-label {
   font-size: 13px;
-  color: #646566;
-  margin-top: 12px;
+  color: #45566d;
+  margin-top: 10px;
   min-height: 18px;
 }
 
 .csat-comment {
   margin-top: 16px;
-  background: #f7f8fa;
-  border-radius: 8px;
+  border: 1px solid rgba(19, 35, 58, 0.06);
+  border-radius: 14px;
+  background: #f7f9fc;
 }
 
 .csat-submit {
   margin-top: 20px;
+  min-height: 48px;
+  box-shadow: 0 11px 24px rgba(24, 119, 242, 0.2);
+}
+
+.privacy-note {
+  margin-top: 12px;
+  color: #a1abba;
+  font-size: 10px;
 }
 </style>

--- a/customer-work-app/src/components/UserAvatar.test.ts
+++ b/customer-work-app/src/components/UserAvatar.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import UserAvatar from './UserAvatar.vue'
+
+const globalOptions = {
+  stubs: {
+    'van-icon': { template: '<i data-testid="fallback-icon"></i>' },
+  },
+}
+
+describe('UserAvatar', () => {
+  it('没有图片时用姓名首字母提供稳定兜底', () => {
+    const wrapper = mount(UserAvatar, {
+      props: { name: 'Richard Fyoung' },
+      global: globalOptions,
+    })
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.get('.avatar-initials').text()).toBe('RF')
+  })
+
+  it('图片加载失败后切换为姓名兜底', async () => {
+    const wrapper = mount(UserAvatar, {
+      props: { src: '/broken-avatar.png', name: 'Richard Fyoung' },
+      global: globalOptions,
+    })
+
+    await wrapper.get('img').trigger('error')
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.get('.avatar-initials').text()).toBe('RF')
+  })
+
+  it('头像地址更新后会重新尝试加载新图片', async () => {
+    const wrapper = mount(UserAvatar, {
+      props: { src: '/broken-avatar.png', name: 'Richard Fyoung' },
+      global: globalOptions,
+    })
+    await wrapper.get('img').trigger('error')
+
+    await wrapper.setProps({ src: '/new-avatar.png' })
+
+    expect(wrapper.get('img').attributes('src')).toBe('/new-avatar.png')
+  })
+
+  it('姓名也为空时展示通用用户图标', () => {
+    const wrapper = mount(UserAvatar, { global: globalOptions })
+
+    expect(wrapper.find('[data-testid="fallback-icon"]').exists()).toBe(true)
+  })
+})

--- a/customer-work-app/src/components/UserAvatar.vue
+++ b/customer-work-app/src/components/UserAvatar.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    src?: string | null
+    name?: string | null
+    alt?: string
+  }>(),
+  {
+    src: null,
+    name: null,
+    alt: '用户头像',
+  },
+)
+
+const imageFailed = ref(false)
+
+watch(
+  () => props.src,
+  () => {
+    imageFailed.value = false
+  },
+)
+
+const showImage = computed(() => Boolean(props.src) && !imageFailed.value)
+
+const initials = computed(() => {
+  const normalized = props.name?.trim()
+  if (!normalized) {
+    return ''
+  }
+
+  const words = normalized.split(/\s+/).filter(Boolean)
+  if (words.length > 1) {
+    return words
+      .slice(0, 2)
+      .map((word) => word.charAt(0))
+      .join('')
+      .toUpperCase()
+  }
+
+  const latinParts = normalized.match(/[A-Z]?[a-z]+|[A-Z]+(?![a-z])|\d+/g)
+  if (latinParts && latinParts.length > 1) {
+    return latinParts
+      .slice(0, 2)
+      .map((part) => part.charAt(0))
+      .join('')
+      .toUpperCase()
+  }
+
+  return normalized.charAt(0).toUpperCase()
+})
+</script>
+
+<template>
+  <span class="user-avatar" role="img" :aria-label="alt">
+    <img v-if="showImage" :src="src || undefined" :alt="alt" @error="imageFailed = true" />
+    <span v-else-if="initials" class="avatar-initials" aria-hidden="true">{{ initials }}</span>
+    <van-icon v-else name="manager" class="avatar-icon" aria-hidden="true" />
+  </span>
+</template>
+
+<style scoped>
+.user-avatar {
+  width: 100%;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: var(--cw-signal, #316cff);
+  color: #fff;
+}
+
+.user-avatar img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.avatar-initials {
+  font-size: var(--user-avatar-initials-size, 22px);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.avatar-icon {
+  font-size: var(--user-avatar-icon-size, 29px);
+}
+</style>

--- a/customer-work-app/src/style.css
+++ b/customer-work-app/src/style.css
@@ -1,43 +1,153 @@
-* {
-  box-sizing: border-box;
+:root {
+  /* Service Pulse 视觉基线：深海蓝承载信息，服务蓝承载交互，状态绿只表达正常/完成。 */
+  --cw-ink: #142033;
+  --cw-ink-soft: #526078;
+  --cw-primary: #316cff;
+  --cw-primary-light: #5f8cff;
+  --cw-primary-dark: #1748bf;
+  --cw-primary-soft: #eaf1ff;
+  --cw-success: #19a995;
+  --cw-success-dark: #137b6e;
+  --cw-success-soft: #e5f8f3;
+  --cw-warning: #d88717;
+  --cw-warning-soft: #fff4df;
+  --cw-danger: #e85d5d;
+  --cw-danger-soft: #fff0f0;
+  --cw-page-bg: #f4f7fb;
+  --cw-card-bg: #ffffff;
+  --cw-line: #e6ebf2;
+  --cw-border-color: var(--cw-line);
+  --cw-text-primary: var(--cw-ink);
+  --cw-text-secondary: var(--cw-ink-soft);
+  --cw-text-muted: #8490a2;
+  --cw-gradient-brand: linear-gradient(135deg, #2257d5 0%, #316cff 58%, #19a995 142%);
+  --cw-gradient-hero: linear-gradient(145deg, #142033 0%, #1d3f87 68%, #316cff 132%);
+  --cw-bubble-user-bg: #eaf1ff;
+  --cw-card-radius: 18px;
+  --cw-card-radius-lg: 24px;
+  --cw-card-radius-sm: 12px;
+  --cw-card-shadow: 0 12px 34px rgba(37, 55, 85, 0.1);
+  --cw-card-shadow-soft: 0 6px 20px rgba(37, 55, 85, 0.07);
+  --cw-shell-width: 480px;
+  --cw-tabbar-height: 72px;
+  --cw-tabbar-space: calc(96px + max(0px, env(safe-area-inset-bottom)));
+  --cw-focus-ring: rgba(49, 108, 255, 0.32);
+  --cw-font-sans: 'HarmonyOS Sans SC', 'MiSans', 'PingFang SC', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', 'Microsoft YaHei', sans-serif;
+  --cw-font-data: 'DIN Alternate', 'SFMono-Regular', 'Roboto Mono', 'Menlo', 'Consolas',
+    'PingFang SC', monospace;
+
+  /* Vant 仍负责组件行为，只将其语义 token 对齐到本项目的视觉系统。 */
+  --van-primary-color: var(--cw-primary);
+  --van-success-color: var(--cw-success);
+  --van-warning-color: var(--cw-warning);
+  --van-danger-color: var(--cw-danger);
+  --van-text-color: var(--cw-text-primary);
+  --van-text-color-2: var(--cw-text-secondary);
+  --van-text-color-3: var(--cw-text-muted);
+  --van-active-color: var(--cw-primary-soft);
+  --van-background: var(--cw-page-bg);
+  --van-background-2: var(--cw-card-bg);
+  --van-background-3: var(--cw-card-bg);
+  --van-border-color: var(--cw-border-color);
+  --van-base-font: var(--cw-font-sans);
+  --van-price-font: var(--cw-font-data);
+  --van-radius-md: 8px;
+  --van-radius-lg: 12px;
 }
 
-:root {
-  /* 主题色沿用 Vant 默认蓝（与 --van-primary-color 一致），渐变/背景/卡片等派生变量统一从这里读取，
-     各页面 scoped style 引用 var(--cw-*) 而非散落硬编码色值。 */
-  --cw-primary: #1989fa;
-  --cw-primary-light: #4facfe;
-  --cw-primary-dark: #0b5fd1;
-  --cw-gradient-brand: linear-gradient(135deg, #4facfe 0%, #1989fa 55%, #0b5fd1 100%);
-  --cw-page-bg: #f5f7fa;
-  --cw-card-bg: #ffffff;
-  --cw-card-radius: 12px;
-  --cw-card-shadow: 0 2px 12px rgba(25, 137, 250, 0.08);
-  --cw-border-color: #ebedf0;
-  --cw-text-primary: #323233;
-  --cw-text-secondary: #969799;
-  --cw-danger: #ee0a24;
-  --cw-bubble-user-bg: #d6ebff;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 html,
 body,
 #app {
+  width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
 }
 
+html {
+  color: var(--cw-text-primary);
+  background: #e9eef6;
+  font-family: var(--cw-font-sans);
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 body {
-  background: var(--cw-page-bg);
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    'Helvetica Neue',
-    Helvetica,
-    'PingFang SC',
-    'Hiragino Sans GB',
-    'Microsoft YaHei',
-    Arial,
-    sans-serif;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 78% 12%, rgba(49, 108, 255, 0.11), transparent 28%),
+    radial-gradient(circle at 18% 83%, rgba(25, 169, 149, 0.09), transparent 24%),
+    #edf2f8;
+  color: var(--cw-text-primary);
+  font-family: var(--cw-font-sans);
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#app {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button,
+[role='button'],
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+a {
+  color: var(--cw-primary);
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+a:focus-visible,
+[tabindex]:focus-visible {
+  outline: 3px solid var(--cw-focus-ring);
+  outline-offset: 2px;
+}
+
+/* 订单金额、编号、时间等可按需挂载该角色，数字排版保持等宽稳定。 */
+.cw-data,
+[data-cw-data] {
+  font-family: var(--cw-font-data);
+  font-variant-numeric: tabular-nums lining-nums;
+}
+
+@media (max-width: 480px) {
+  html,
+  body {
+    background: var(--cw-page-bg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }

--- a/customer-work-app/src/types/api.test.ts
+++ b/customer-work-app/src/types/api.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ticketActorTypeText,
+  ticketCategoryText,
+  ticketEventTypeText,
+  ticketPriorityText,
+} from './api'
+
+describe('ticket display text', () => {
+  it('把后端工单枚举转换为用户可理解的中文', () => {
+    expect(ticketCategoryText('ORDER')).toBe('订单')
+    expect(ticketPriorityText('NORMAL')).toBe('普通')
+    expect(ticketEventTypeText('REQUEST_HANDOFF')).toBe('申请转人工')
+    expect(ticketActorTypeText('AGENT')).toBe('客服')
+  })
+
+  it('服务端新增枚举时保留原值而不是伪造含义', () => {
+    expect(ticketCategoryText('FUTURE_CATEGORY')).toBe('FUTURE_CATEGORY')
+    expect(ticketEventTypeText('FUTURE_EVENT')).toBe('FUTURE_EVENT')
+  })
+})

--- a/customer-work-app/src/types/api.ts
+++ b/customer-work-app/src/types/api.ts
@@ -41,6 +41,66 @@ export function isTicketEnded(status: TicketStatus): boolean {
   return ENDED_TICKET_STATUSES.has(status)
 }
 
+const TICKET_CATEGORY_TEXT: Readonly<Record<string, string>> = {
+  CONSULT: '咨询',
+  ORDER: '订单',
+  AFTER_SALE: '售后',
+  COMPLAINT: '投诉',
+  OTHER: '其他',
+}
+
+const TICKET_PRIORITY_TEXT: Readonly<Record<string, string>> = {
+  LOW: '低',
+  NORMAL: '普通',
+  HIGH: '高',
+  URGENT: '紧急',
+}
+
+const TICKET_EVENT_TYPE_TEXT: Readonly<Record<string, string>> = {
+  CREATE: '创建工单',
+  REQUEST_HANDOFF: '申请转人工',
+  CANCEL_HANDOFF: '撤销转人工',
+  CLAIM: '客服接单',
+  HOLD: '挂起处理',
+  RESUME: '恢复处理',
+  TRANSFER: '转派工单',
+  MARK_RESOLVED: '处理完成',
+  CONFIRM: '确认解决',
+  REJECT: '反馈未解决',
+  CLOSE: '关闭工单',
+  FORCE_CLOSE: '结束工单',
+  REOPEN: '重新打开',
+  PRIORITY_CHANGE: '调整优先级',
+  CATEGORY_CHANGE: '调整分类',
+  HANDOFF_RESOLVE: '人工服务完成',
+  ROUTING_SUGGESTION: '更新路由建议',
+  HANDOFF_MIGRATED: '迁移历史记录',
+}
+
+const TICKET_ACTOR_TYPE_TEXT: Readonly<Record<string, string>> = {
+  USER: '用户',
+  AGENT: '客服',
+  BOT: '智能助手',
+  SYSTEM: '系统',
+}
+
+/** 显示层使用中文语义；遇到服务端未来新增值时保留原值，避免把真实数据误写成“未知”。 */
+export function ticketCategoryText(category: string): string {
+  return TICKET_CATEGORY_TEXT[category] || category
+}
+
+export function ticketPriorityText(priority: string): string {
+  return TICKET_PRIORITY_TEXT[priority] || priority
+}
+
+export function ticketEventTypeText(eventType: string): string {
+  return TICKET_EVENT_TYPE_TEXT[eventType] || eventType
+}
+
+export function ticketActorTypeText(actorType: string): string {
+  return TICKET_ACTOR_TYPE_TEXT[actorType] || actorType
+}
+
 /** 消息发送者类型 */
 export type SenderType = 'USER' | 'BOT' | 'AGENT' | 'SYSTEM'
 

--- a/customer-work-app/src/views/Chat.test.ts
+++ b/customer-work-app/src/views/Chat.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatMessage, FeedbackType, TicketDetail, UserQuota } from '@/types/api'
+import ChatView from './Chat.vue'
+
+const {
+  fetchMessagesMock,
+  fetchMyQuotaMock,
+  fetchSessionFeedbackMock,
+  fetchTicketDetailMock,
+  sendMock,
+  submitFeedbackMock,
+  wsHandlers,
+} = vi.hoisted(() => ({
+  fetchMessagesMock: vi.fn(),
+  fetchMyQuotaMock: vi.fn(),
+  fetchSessionFeedbackMock: vi.fn(),
+  fetchTicketDetailMock: vi.fn(),
+  sendMock: vi.fn(),
+  submitFeedbackMock: vi.fn(),
+  wsHandlers: new Map<string, (data: unknown) => void>(),
+}))
+
+vi.mock('@/api/ticket', () => ({
+  closeTicket: vi.fn(),
+  confirmTicket: vi.fn(),
+  createSession: vi.fn(),
+  fetchMessages: fetchMessagesMock,
+  fetchTicketDetail: fetchTicketDetailMock,
+  handoffTicket: vi.fn(),
+  rejectTicket: vi.fn(),
+  reopenTicket: vi.fn(),
+}))
+
+vi.mock('@/api/feedback', () => ({
+  fetchSessionFeedback: fetchSessionFeedbackMock,
+  submitFeedback: submitFeedbackMock,
+}))
+
+vi.mock('@/api/chat', () => ({ uploadChatAttachment: vi.fn() }))
+vi.mock('@/api/quota', () => ({ fetchMyQuota: fetchMyQuotaMock }))
+vi.mock('@/components/CsatSurveyCard.vue', () => ({
+  default: defineComponent({ name: 'CsatSurveyCard', template: '<div></div>' }),
+}))
+vi.mock('@/store/auth', () => ({
+  useAuthStore: () => ({ token: 'token-1', userId: 'user-1' }),
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: { ticketId: 'ticket-1' } }),
+  useRouter: () => ({ back: vi.fn() }),
+}))
+vi.mock('@/utils/ws', () => ({
+  chatSocket: {
+    close: vi.fn(),
+    connect: vi.fn(() => wsHandlers.get('open')?.(null)),
+    off: vi.fn((type: string) => wsHandlers.delete(type)),
+    on: vi.fn((type: string, handler: (data: unknown) => void) => wsHandlers.set(type, handler)),
+    send: sendMock,
+  },
+}))
+vi.mock('vant', () => ({
+  showConfirmDialog: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+const FieldStub = defineComponent({
+  name: 'VanField',
+  inheritAttrs: false,
+  props: { disabled: Boolean, modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue'],
+  setup(props, { attrs, emit }) {
+    return () => h('input', {
+      ...attrs,
+      disabled: props.disabled,
+      value: props.modelValue,
+      onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).value),
+    })
+  },
+})
+
+const ButtonStub = defineComponent({
+  name: 'VanButton',
+  inheritAttrs: false,
+  props: { disabled: Boolean, loading: Boolean },
+  emits: ['click'],
+  setup(props, { attrs, emit, slots }) {
+    return () => h('button', {
+      ...attrs,
+      disabled: props.disabled || props.loading,
+      type: 'button',
+      onClick: () => emit('click'),
+    }, slots.default?.())
+  },
+})
+
+const SlotStub = defineComponent({
+  inheritAttrs: false,
+  setup(_props, { attrs, slots }) {
+    return () => h('div', attrs, slots.default?.())
+  },
+})
+
+const NavBarStub = defineComponent({
+  name: 'VanNavBar',
+  setup(_props, { slots }) {
+    return () => h('header', [slots.default?.(), slots.right?.()])
+  },
+})
+
+const globalOptions = {
+  config: { errorHandler: vi.fn() },
+  stubs: {
+    CsatSurveyCard: true,
+    'van-action-sheet': SlotStub,
+    'van-button': ButtonStub,
+    'van-dialog': SlotStub,
+    'van-field': FieldStub,
+    'van-icon': { template: '<i></i>' },
+    'van-loading': SlotStub,
+    'van-nav-bar': NavBarStub,
+    'van-tag': SlotStub,
+    'van-uploader': SlotStub,
+  },
+}
+
+const detail: TicketDetail = {
+  ticket: {
+    id: 'ticket-1',
+    sessionId: 'session-1',
+    userId: 'user-1',
+    title: '订单物流咨询',
+    category: 'ORDER',
+    priority: 'NORMAL',
+    status: 'PROCESSING',
+    assignee: '客服 07',
+    handoffReason: null,
+    resolveNote: null,
+    reopenCount: 0,
+    createdAtMs: 1_777_520_000_000,
+    updatedAtMs: 1_777_520_060_000,
+  },
+  events: [],
+}
+
+const botMessage: ChatMessage = {
+  id: 1,
+  messageId: 'message-bot-1',
+  sessionId: 'session-1',
+  ticketId: 'ticket-1',
+  senderType: 'BOT',
+  senderId: null,
+  content: '您的订单正在配送中。',
+  createdAtMs: 1_777_520_060_000,
+}
+
+const unlimitedQuota: UserQuota = {
+  levelCode: null,
+  windowSeconds: 3600,
+  tokenUsed: 0,
+  tokenLimit: 0,
+  tokenRemaining: -1,
+  requestUsed: 0,
+  requestLimit: 0,
+  requestRemaining: -1,
+  limited: false,
+}
+
+function savedFeedback(type: FeedbackType) {
+  return {
+    messageId: botMessage.messageId,
+    sessionId: botMessage.sessionId,
+    type,
+    comment: null,
+    createdAtMs: 1_777_520_120_000,
+  }
+}
+
+async function mountReadyChat() {
+  const wrapper = mount(ChatView, { global: globalOptions })
+  await flushPromises()
+  return wrapper
+}
+
+describe('Chat', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    wsHandlers.clear()
+    fetchMessagesMock.mockReset().mockResolvedValue([botMessage])
+    fetchMyQuotaMock.mockReset().mockResolvedValue(unlimitedQuota)
+    fetchSessionFeedbackMock.mockReset().mockResolvedValue([])
+    fetchTicketDetailMock.mockReset().mockResolvedValue(detail)
+    sendMock.mockReset()
+    submitFeedbackMock.mockReset().mockImplementation(({ type }: { type: FeedbackType }) =>
+      Promise.resolve(savedFeedback(type)),
+    )
+  })
+
+  it('发送前裁剪空格，使用当前会话构造 WebSocket 帧，并立即更新本地消息', async () => {
+    const wrapper = await mountReadyChat()
+    const input = wrapper.get('.message-input')
+
+    await input.setValue('  请帮我查询物流  ')
+    await wrapper.get('.send-button').trigger('click')
+    await flushPromises()
+
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenCalledWith({
+      type: 'chat',
+      data: { sessionId: 'session-1', content: '请帮我查询物流' },
+    })
+    expect(wrapper.text()).toContain('请帮我查询物流')
+    expect(wrapper.findAll('.row-USER')).toHaveLength(1)
+    expect((input.element as HTMLInputElement).value).toBe('')
+  })
+
+  it('同类型反馈不重复提交，切换类型后更新选中状态', async () => {
+    const wrapper = await mountReadyChat()
+    const up = wrapper.get('button[aria-label="回复有帮助"]')
+    const down = wrapper.get('button[aria-label="回复没有帮助"]')
+
+    await up.trigger('click')
+    await flushPromises()
+    expect(submitFeedbackMock).toHaveBeenCalledTimes(1)
+    expect(submitFeedbackMock).toHaveBeenLastCalledWith({
+      sessionId: 'session-1',
+      messageId: 'message-bot-1',
+      type: 'UP',
+    })
+    expect(up.attributes('aria-pressed')).toBe('true')
+
+    await up.trigger('click')
+    await flushPromises()
+    expect(submitFeedbackMock).toHaveBeenCalledTimes(1)
+
+    await down.trigger('click')
+    await flushPromises()
+    expect(submitFeedbackMock).toHaveBeenCalledTimes(2)
+    expect(submitFeedbackMock).toHaveBeenLastCalledWith({
+      sessionId: 'session-1',
+      messageId: 'message-bot-1',
+      type: 'DOWN',
+    })
+    expect(up.attributes('aria-pressed')).toBe('false')
+    expect(down.attributes('aria-pressed')).toBe('true')
+  })
+
+  it('反馈提交失败后释放提交锁，允许用户原地重试', async () => {
+    submitFeedbackMock.mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce(savedFeedback('UP'))
+    const wrapper = await mountReadyChat()
+    const up = wrapper.get('button[aria-label="回复有帮助"]')
+
+    await up.trigger('click')
+    await flushPromises()
+    expect(submitFeedbackMock).toHaveBeenCalledTimes(1)
+    expect(up.attributes('aria-pressed')).toBe('false')
+
+    await up.trigger('click')
+    await flushPromises()
+    expect(submitFeedbackMock).toHaveBeenCalledTimes(2)
+    expect(up.attributes('aria-pressed')).toBe('true')
+  })
+})

--- a/customer-work-app/src/views/Chat.vue
+++ b/customer-work-app/src/views/Chat.vue
@@ -43,6 +43,7 @@ const inputContent = ref('')
 const wsConnected = ref(false)
 const wsReconnecting = ref(false)
 const initializing = ref(true)
+const initializationError = ref('')
 
 // 机器人流式回复：chat_chunk 增量拼接到这里做打字机效果，chat_done 定稿后清空并落入 messages
 const streamingContent = ref('')
@@ -132,6 +133,27 @@ const canHandoff = computed(() => {
 
 // 会话已结束（CLOSED/RESOLVED）：历史消息只读展示，输入区替换为"重新开始对话"
 const ended = computed(() => (ticket.value ? isTicketEnded(ticket.value.status) : false))
+
+const statusHint = computed(() => {
+  switch (ticket.value?.status) {
+    case 'AI_SERVING':
+      return '智能助手正在为您服务'
+    case 'WAITING_AGENT':
+      return '已进入人工队列，请稍候'
+    case 'PROCESSING':
+      return '人工客服已接入当前会话'
+    case 'ON_HOLD':
+      return '问题处理中，消息会继续保留'
+    case 'WAITING_CONFIRM':
+      return '处理结果等待您的确认'
+    case 'RESOLVED':
+      return '本次服务已解决'
+    case 'CLOSED':
+      return '本次会话已关闭'
+    default:
+      return '正在准备服务会话'
+  }
+})
 
 // 顶栏会话管理 action-sheet
 const sessionMenuVisible = ref(false)
@@ -636,12 +658,20 @@ async function onCloseSession() {
   }
 }
 
-onMounted(async () => {
+async function initializeChat() {
+  initializing.value = true
+  initializationError.value = ''
   try {
     await initSession()
+  } catch {
+    initializationError.value = '会话暂时加载失败，请稍后重试'
   } finally {
     initializing.value = false
   }
+}
+
+onMounted(async () => {
+  await initializeChat()
   // 带 orderId 进入（订单详情跳转）：预填咨询文案，仅预填不自动发送
   const orderId = route.query.orderId
   if (typeof orderId === 'string' && orderId) {
@@ -659,113 +689,170 @@ onUnmounted(() => {
 
 <template>
   <div class="chat-page">
-    <van-nav-bar title="智能客服" left-arrow @click-left="router.back()">
+    <van-nav-bar title="智能客服" left-arrow safe-area-inset-top @click-left="router.back()">
       <template #right>
-        <van-icon name="ellipsis" size="20" @click="openSessionMenu" />
+        <button class="nav-action" type="button" aria-label="会话管理" @click="openSessionMenu">
+          <van-icon name="ellipsis" size="22" />
+        </button>
       </template>
     </van-nav-bar>
 
-    <div class="status-bar">
-      <van-tag v-if="ticket" :type="TICKET_STATUS_TAG_TYPE[ticket.status]" size="medium">
-        {{ TICKET_STATUS_TEXT[ticket.status] }}
-      </van-tag>
-      <van-button size="small" round plain type="primary" :disabled="!canHandoff" :loading="acting" @click="onHandoff">
+    <div class="status-card">
+      <div class="status-copy">
+        <span class="status-pulse" :class="{ offline: !wsConnected }" aria-hidden="true"></span>
+        <div>
+          <div class="status-title">
+            {{ ticket ? TICKET_STATUS_TEXT[ticket.status] : '正在连接' }}
+            <van-tag v-if="ticket" :type="TICKET_STATUS_TAG_TYPE[ticket.status]" plain size="medium">
+              {{ wsConnected ? '在线' : '连接中' }}
+            </van-tag>
+          </div>
+          <p>{{ statusHint }}</p>
+        </div>
+      </div>
+      <van-button
+        class="handoff-button"
+        size="small"
+        round
+        plain
+        type="primary"
+        :disabled="!canHandoff"
+        :loading="acting"
+        @click="onHandoff"
+      >
         转人工
       </van-button>
     </div>
 
-    <div v-if="wsReconnecting" class="reconnect-tip">连接已断开，正在重连...</div>
+    <div v-if="wsReconnecting" class="reconnect-tip" role="status">
+      <van-loading size="13" />
+      连接已断开，正在重连…
+    </div>
 
     <div ref="scrollBox" class="message-area">
-      <van-loading v-if="initializing" class="loading" vertical>加载中...</van-loading>
+      <div v-if="initializing" class="state-panel" role="status">
+        <van-loading color="var(--cw-primary, #1677ff)" vertical>正在加载会话…</van-loading>
+      </div>
+      <div v-else-if="initializationError" class="state-panel state-error">
+        <div class="state-symbol" aria-hidden="true">!</div>
+        <strong>会话没有加载成功</strong>
+        <p>{{ initializationError }}</p>
+        <van-button round type="primary" size="small" @click="initializeChat">重新加载</van-button>
+      </div>
       <template v-else>
-        <div v-for="message in messages" :key="message.messageId" class="message-row" :class="`row-${message.senderType}`">
-          <div v-if="message.senderType === 'SYSTEM'" class="system-line">{{ message.content }}</div>
-          <div v-else class="bubble-wrap">
-            <div v-if="message.senderType === 'AGENT'" class="badge">人工客服</div>
-            <div v-else-if="message.senderType === 'BOT'" class="badge">智能助手</div>
-            <div class="bubble">{{ message.content }}</div>
-            <div v-if="message.senderType === 'BOT'" class="feedback-actions">
-              <van-icon
-                :name="feedbackByMessage[message.messageId] === 'UP' ? 'good-job' : 'good-job-o'"
-                :class="{ active: feedbackByMessage[message.messageId] === 'UP' }"
-                @click="onFeedback(message, 'UP')"
-              />
-              <van-icon
-                :name="feedbackByMessage[message.messageId] === 'DOWN' ? 'good-job' : 'good-job-o'"
-                class="thumb-down"
-                :class="{ active: feedbackByMessage[message.messageId] === 'DOWN' }"
-                @click="onFeedback(message, 'DOWN')"
-              />
-            </div>
+        <div v-if="messages.length === 0" class="welcome-card">
+          <div class="welcome-mark">AI</div>
+          <div>
+            <strong>您好，我是智能客服</strong>
+            <p>请描述您遇到的问题，我会结合服务记录为您提供帮助。</p>
           </div>
         </div>
+        <div
+          v-for="message in messages"
+          :key="message.messageId"
+          class="message-row"
+          :class="`row-${message.senderType}`"
+        >
+          <div v-if="message.senderType === 'SYSTEM'" class="system-line">{{ message.content }}</div>
+          <template v-else>
+            <div class="sender-avatar" aria-hidden="true">
+              {{ message.senderType === 'BOT' ? 'AI' : message.senderType === 'AGENT' ? '客' : '我' }}
+            </div>
+            <div class="bubble-wrap">
+              <div class="badge">
+                {{ message.senderType === 'AGENT' ? '人工客服' : message.senderType === 'BOT' ? '智能助手' : '我' }}
+              </div>
+              <div class="bubble">{{ message.content }}</div>
+              <div v-if="message.senderType === 'BOT'" class="feedback-actions" aria-label="评价这条回复">
+                <button
+                  type="button"
+                  aria-label="回复有帮助"
+                  :aria-pressed="feedbackByMessage[message.messageId] === 'UP'"
+                  :class="{ active: feedbackByMessage[message.messageId] === 'UP' }"
+                  @click="onFeedback(message, 'UP')"
+                >
+                  <van-icon :name="feedbackByMessage[message.messageId] === 'UP' ? 'good-job' : 'good-job-o'" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="回复没有帮助"
+                  :aria-pressed="feedbackByMessage[message.messageId] === 'DOWN'"
+                  class="thumb-down"
+                  :class="{ active: feedbackByMessage[message.messageId] === 'DOWN' }"
+                  @click="onFeedback(message, 'DOWN')"
+                >
+                  <van-icon :name="feedbackByMessage[message.messageId] === 'DOWN' ? 'good-job' : 'good-job-o'" />
+                </button>
+              </div>
+            </div>
+          </template>
+        </div>
         <div v-if="streamingActive" class="message-row row-BOT">
+          <div class="sender-avatar" aria-hidden="true">AI</div>
           <div class="bubble-wrap">
             <div class="badge">智能助手</div>
-            <div class="bubble">{{ streamingContent }}<span class="cursor">|</span></div>
+            <div class="bubble">{{ streamingContent }}<span class="cursor" aria-hidden="true">|</span></div>
           </div>
         </div>
       </template>
     </div>
 
     <div v-if="ticket?.status === 'WAITING_CONFIRM'" class="confirm-card">
-      <van-cell-group inset>
-        <van-cell title="客服已处理完毕，请确认是否解决">
-          <template #value>
-            <div class="confirm-actions">
-              <van-button size="small" type="primary" :loading="acting" @click="onConfirmResolved">确认解决</van-button>
-              <van-button size="small" plain :loading="acting" @click="openReject">仍有问题</van-button>
-            </div>
-          </template>
-        </van-cell>
-      </van-cell-group>
+      <div class="confirm-copy">
+        <span class="confirm-icon" aria-hidden="true">✓</span>
+        <div><strong>问题已处理完成</strong><p>请确认本次服务是否解决了您的问题</p></div>
+      </div>
+      <div class="confirm-actions">
+        <van-button size="small" type="primary" round :loading="acting" @click="onConfirmResolved">确认解决</van-button>
+        <van-button size="small" plain round :loading="acting" @click="openReject">仍有问题</van-button>
+      </div>
     </div>
 
     <div v-if="ended" class="ended-bar">
+      <div><strong>本次会话已结束</strong><p>历史消息会一直保留，您也可以继续咨询。</p></div>
       <van-button block round type="primary" :loading="acting" @click="onReopen">重新开始对话</van-button>
     </div>
     <template v-else>
-      <div v-if="attachments.length > 0" class="attachment-chips">
-        <van-tag
-          v-for="a in attachments"
-          :key="a.localId"
-          :closeable="a.status !== 'uploading'"
-          :type="a.status === 'failed' ? 'danger' : 'primary'"
-          plain
-          size="medium"
-          @close="removeAttachment(a.localId)"
-        >
-          <van-loading v-if="a.status === 'uploading'" size="12" class="chip-loading" />
-          📎 {{ a.name }}
-        </van-tag>
-      </div>
-      <div v-if="quotaHint" class="quota-hint">
-        <van-icon name="info-o" class="quota-hint-icon" />
-        {{ quotaHint }}
-      </div>
-      <div class="input-bar">
-        <van-field
-          v-model="inputContent"
-          placeholder="请输入消息"
-          :disabled="!wsConnected"
-          @keyup.enter="sendMessage"
-        >
-          <template #left-icon>
-            <van-uploader
-              :accept="ATTACHMENT_ACCEPT"
-              :before-read="beforeReadAttachment"
-              :after-read="afterReadAttachment"
-            >
-              <van-icon name="link-o" size="20" class="attach-icon" />
-            </van-uploader>
-          </template>
-          <template #button>
-            <van-button size="small" type="primary" :disabled="!canSend" @click="sendMessage">
-              {{ wsConnected ? '发送' : '重连中' }}
-            </van-button>
-          </template>
-        </van-field>
+      <div class="composer-shell">
+        <div v-if="attachments.length > 0" class="attachment-chips">
+          <van-tag
+            v-for="a in attachments"
+            :key="a.localId"
+            :closeable="a.status !== 'uploading'"
+            :type="a.status === 'failed' ? 'danger' : 'primary'"
+            plain
+            size="medium"
+            @close="removeAttachment(a.localId)"
+          >
+            <van-loading v-if="a.status === 'uploading'" size="12" class="chip-loading" />
+            📎 {{ a.name }}
+          </van-tag>
+        </div>
+        <div v-if="quotaHint" class="quota-hint">
+          <van-icon name="info-o" class="quota-hint-icon" />
+          {{ quotaHint }}
+        </div>
+        <div class="input-bar">
+          <van-uploader
+            :accept="ATTACHMENT_ACCEPT"
+            :before-read="beforeReadAttachment"
+            :after-read="afterReadAttachment"
+          >
+            <button class="attach-button" type="button" aria-label="添加附件">
+              <van-icon name="link-o" size="22" />
+            </button>
+          </van-uploader>
+          <van-field
+            v-model="inputContent"
+            class="message-input"
+            placeholder="输入消息…"
+            :disabled="!wsConnected"
+            @keyup.enter="sendMessage"
+          />
+          <van-button class="send-button" round type="primary" :disabled="!canSend" @click="sendMessage">
+            {{ wsConnected ? '发送' : '重连中' }}
+          </van-button>
+        </div>
       </div>
     </template>
 
@@ -791,53 +878,209 @@ onUnmounted(() => {
 .chat-page {
   display: flex;
   flex-direction: column;
-  /* 锁定视口高度并禁止自身溢出：顶部导航/状态条与底部输入栏固定，仅消息区内部滚动。
-     不能加 flex:1——其 flex-basis:0 会让父级 .mobile-shell 按消息内容 max-content 撑高，
-     滚动落到 body 上导致顶栏被顶走。
-     不再是 tabbar 根页面（改由消息列表点入），无需再为固定 tabbar 预留 padding-bottom。 */
   height: 100vh;
+  height: 100dvh;
   max-height: 100vh;
+  max-height: 100dvh;
   overflow: hidden;
   box-sizing: border-box;
-  background: var(--cw-page-bg);
+  background:
+    radial-gradient(circle at 10% 4%, rgba(24, 119, 242, 0.09), transparent 27%),
+    var(--cw-page-bg, #f4f7fb);
 }
 
-.status-bar {
+.nav-action,
+.feedback-actions button,
+.attach-button {
+  display: inline-grid;
+  place-items: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.status-card {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  background: var(--cw-card-bg);
-  border-bottom: 1px solid var(--cw-border-color);
+  gap: 12px;
+  margin: 10px 12px 4px;
+  padding: 13px 14px;
+  border: 1px solid rgba(24, 119, 242, 0.12);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.93);
+  box-shadow: 0 10px 26px rgba(21, 52, 92, 0.07);
+}
+
+.status-copy {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 10px;
+}
+
+.status-pulse {
+  position: relative;
+  flex: 0 0 10px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--cw-success, #25c48a);
+  box-shadow: 0 0 0 5px rgba(37, 196, 138, 0.13);
+}
+
+.status-pulse::after {
+  position: absolute;
+  inset: -5px;
+  border: 1px solid rgba(37, 196, 138, 0.45);
+  border-radius: inherit;
+  content: '';
+  animation: status-pulse 1.8s ease-out infinite;
+}
+
+.status-pulse.offline {
+  background: #aeb7c4;
+  box-shadow: 0 0 0 5px rgba(174, 183, 196, 0.13);
+}
+
+.status-pulse.offline::after {
+  display: none;
+}
+
+.status-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--cw-text-primary, #13233a);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.status-copy p,
+.confirm-copy p,
+.ended-bar p,
+.welcome-card p,
+.state-panel p {
+  margin: 3px 0 0;
+  color: var(--cw-text-secondary, #718096);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.handoff-button {
+  flex: 0 0 auto;
+  min-height: 36px;
 }
 
 .reconnect-tip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 5px 12px 0;
+  border-radius: 10px;
   text-align: center;
   font-size: 12px;
-  color: var(--cw-danger);
-  background: #fff4f4;
-  padding: 4px 0;
+  color: #a46100;
+  background: #fff5df;
+  padding: 7px 10px;
 }
 
 .message-area {
   flex: 1;
-  /* flex 子项默认 min-height:auto 不会收缩到内容以下，必须显式归零，滚动才发生在本区域内 */
   min-height: 0;
   overflow-y: auto;
-  padding: 12px;
+  overscroll-behavior: contain;
+  padding: 14px 12px 20px;
+  scrollbar-width: none;
 }
 
-.loading {
-  margin-top: 30vh;
+.message-area::-webkit-scrollbar {
+  display: none;
+}
+
+.state-panel {
+  display: flex;
+  min-height: 48vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+}
+
+.state-panel strong {
+  margin-top: 12px;
+  color: var(--cw-text-primary, #13233a);
+  font-size: 16px;
+}
+
+.state-error .van-button {
+  margin-top: 16px;
+}
+
+.state-symbol {
+  display: grid;
+  width: 50px;
+  height: 50px;
+  place-items: center;
+  border-radius: 16px;
+  color: #fff;
+  background: #ef6d6d;
+  font-size: 24px;
+  font-weight: 800;
+  box-shadow: 0 10px 22px rgba(239, 109, 109, 0.25);
+}
+
+.welcome-card {
+  display: flex;
+  gap: 12px;
+  margin: 6px 0 18px;
+  padding: 16px;
+  border: 1px solid rgba(24, 119, 242, 0.1);
+  border-radius: 18px;
+  background: linear-gradient(135deg, #fff 20%, #f1f7ff 100%);
+  box-shadow: 0 10px 30px rgba(21, 52, 92, 0.06);
+}
+
+.welcome-card strong {
+  color: var(--cw-text-primary, #13233a);
+  font-size: 15px;
+}
+
+.welcome-mark,
+.sender-avatar {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  color: #fff;
+  background: linear-gradient(145deg, #258cff, #0b61da);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  box-shadow: 0 7px 16px rgba(24, 119, 242, 0.22);
+}
+
+.welcome-mark {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
 }
 
 .message-row {
-  margin-bottom: 12px;
   display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 16px;
 }
 
 .row-USER {
-  justify-content: flex-end;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
 }
 
 .row-BOT,
@@ -850,44 +1093,83 @@ onUnmounted(() => {
 }
 
 .system-line {
+  max-width: 88%;
   font-size: 12px;
-  color: var(--cw-text-secondary);
-  background: rgba(0, 0, 0, 0.04);
-  padding: 4px 10px;
-  border-radius: 10px;
+  color: var(--cw-text-secondary, #718096);
+  background: rgba(19, 35, 58, 0.06);
+  padding: 6px 12px;
+  border-radius: 999px;
+  text-align: center;
+}
+
+.sender-avatar {
+  width: 34px;
+  height: 34px;
+  margin-top: 18px;
+  border-radius: 11px;
+}
+
+.row-USER .sender-avatar {
+  background: linear-gradient(145deg, #193b66, #102642);
+  box-shadow: 0 7px 16px rgba(16, 38, 66, 0.2);
+}
+
+.row-AGENT .sender-avatar {
+  color: #0d6e54;
+  background: #dff8ee;
+  box-shadow: 0 7px 16px rgba(37, 196, 138, 0.14);
 }
 
 .bubble-wrap {
-  max-width: 78%;
+  max-width: calc(82% - 42px);
 }
 
 .badge {
   font-size: 11px;
-  color: var(--cw-text-secondary);
-  margin-bottom: 2px;
+  color: var(--cw-text-secondary, #718096);
+  margin: 0 2px 4px;
+}
+
+.row-USER .badge {
+  text-align: right;
 }
 
 .bubble {
-  padding: 8px 12px;
-  border-radius: 10px;
-  background: var(--cw-card-bg);
-  box-shadow: var(--cw-card-shadow);
+  padding: 10px 13px;
+  border: 1px solid rgba(19, 35, 58, 0.05);
+  border-radius: 6px 17px 17px;
+  color: var(--cw-text-primary, #13233a);
+  background: var(--cw-card-bg, #fff);
+  box-shadow: 0 7px 20px rgba(21, 52, 92, 0.07);
   word-break: break-word;
   white-space: pre-wrap;
-  line-height: 1.5;
+  line-height: 1.55;
 }
 
 .row-USER .bubble {
-  background: var(--cw-bubble-user-bg);
+  border-color: rgba(24, 119, 242, 0.15);
+  border-radius: 17px 6px 17px 17px;
+  color: #fff;
+  background: linear-gradient(135deg, #268cff, #1268df);
+  box-shadow: 0 9px 22px rgba(24, 119, 242, 0.2);
 }
 
 .feedback-actions {
   display: flex;
-  gap: 14px;
-  margin-top: 4px;
-  padding-left: 2px;
-  font-size: 15px;
-  color: var(--cw-text-secondary);
+  gap: 2px;
+  margin-top: 2px;
+  color: var(--cw-text-secondary, #718096);
+}
+
+.feedback-actions button {
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 12px;
+  font-size: 16px;
+}
+
+.feedback-actions button:active {
+  background: rgba(24, 119, 242, 0.08);
 }
 
 /* Vant 无独立点踩图标，复用 good-job 旋转 180 度表达"踩" */
@@ -896,7 +1178,8 @@ onUnmounted(() => {
 }
 
 .feedback-actions .active {
-  color: var(--van-primary-color, #1989fa);
+  color: var(--van-primary-color, #1677ff);
+  background: rgba(24, 119, 242, 0.08);
 }
 
 .cursor {
@@ -909,23 +1192,63 @@ onUnmounted(() => {
   }
 }
 
+@keyframes status-pulse {
+  from { transform: scale(0.75); opacity: 1; }
+  to { transform: scale(1.55); opacity: 0; }
+}
+
 .confirm-card {
-  padding: 8px 0;
-  background: var(--cw-card-bg);
+  display: grid;
+  gap: 12px;
+  margin: 0 12px 10px;
+  padding: 14px;
+  border: 1px solid rgba(37, 196, 138, 0.2);
+  border-radius: 18px;
+  background: #f4fcf9;
+  box-shadow: 0 9px 24px rgba(20, 91, 71, 0.08);
+}
+
+.confirm-copy {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--cw-text-primary, #13233a);
+}
+
+.confirm-icon {
+  display: grid;
+  flex: 0 0 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 12px;
+  color: #fff;
+  background: var(--cw-success, #25c48a);
+  font-weight: 800;
 }
 
 .confirm-actions {
   display: flex;
   gap: 8px;
+  padding-left: 46px;
+}
+
+.confirm-actions .van-button {
+  min-height: 36px;
+}
+
+.composer-shell {
+  z-index: 2;
+  padding: 7px 10px calc(8px + env(safe-area-inset-bottom));
+  border-top: 1px solid rgba(19, 35, 58, 0.06);
+  background: rgba(244, 247, 251, 0.92);
+  backdrop-filter: blur(14px);
 }
 
 .attachment-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  padding: 8px 12px 0;
-  border-top: 1px solid var(--cw-border-color);
-  background: var(--cw-card-bg);
+  padding: 0 4px 7px;
 }
 
 .chip-loading {
@@ -933,19 +1256,16 @@ onUnmounted(() => {
   vertical-align: middle;
 }
 
-.attach-icon {
-  color: var(--cw-text-secondary);
-  padding: 0 4px;
-}
-
 .quota-hint {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 6px 12px;
+  margin-bottom: 6px;
+  padding: 7px 10px;
+  border-radius: 10px;
   font-size: 12px;
-  color: var(--van-orange, #ff976a);
-  background: #fff7e8;
+  color: #9b5e00;
+  background: #fff4dc;
 }
 
 .quota-hint-icon {
@@ -953,17 +1273,82 @@ onUnmounted(() => {
 }
 
 .input-bar {
-  border-top: 1px solid var(--cw-border-color);
-  background: var(--cw-card-bg);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 5px;
+  border: 1px solid rgba(19, 35, 58, 0.08);
+  border-radius: 18px;
+  background: var(--cw-card-bg, #fff);
+  box-shadow: 0 9px 28px rgba(21, 52, 92, 0.1);
+}
+
+.attach-button {
+  color: var(--cw-text-secondary, #718096);
+  border-radius: 14px;
+}
+
+.message-input {
+  min-width: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.send-button {
+  flex: 0 0 auto;
+  min-width: 66px;
+  min-height: 40px;
+  padding: 0 16px;
 }
 
 .ended-bar {
-  padding: 10px 16px;
-  border-top: 1px solid var(--cw-border-color);
-  background: var(--cw-card-bg);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px calc(12px + env(safe-area-inset-bottom));
+  border-top: 1px solid rgba(19, 35, 58, 0.07);
+  color: var(--cw-text-primary, #13233a);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.ended-bar .van-button {
+  width: auto;
+  min-height: 42px;
+  padding: 0 18px;
 }
 
 .dialog-field {
   padding: 16px;
+}
+
+@media (max-width: 340px) {
+  .status-card {
+    align-items: flex-start;
+  }
+
+  .status-copy p {
+    display: none;
+  }
+
+  .bubble-wrap {
+    max-width: calc(86% - 42px);
+  }
+
+  .send-button {
+    min-width: 58px;
+    padding: 0 12px;
+  }
+
+  .confirm-actions {
+    padding-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-pulse::after,
+  .cursor {
+    animation: none;
+  }
 }
 </style>

--- a/customer-work-app/src/views/Login.test.ts
+++ b/customer-work-app/src/views/Login.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginView from './Login.vue'
+
+const { applyLoginMock, loginMock, replaceMock } = vi.hoisted(() => ({
+  applyLoginMock: vi.fn(),
+  loginMock: vi.fn(),
+  replaceMock: vi.fn(),
+}))
+
+vi.mock('@/api/auth', () => ({ login: loginMock }))
+vi.mock('@/store/auth', () => ({ useAuthStore: () => ({ applyLogin: applyLoginMock }) }))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ currentRoute: { value: { query: {} } }, replace: replaceMock }),
+}))
+vi.mock('vant', () => ({ showToast: vi.fn() }))
+
+const globalOptions = {
+  stubs: {
+    'van-form': {
+      emits: ['submit'],
+      template: '<form @submit.prevent="$emit(\'submit\')"><slot /></form>',
+    },
+    'van-field': {
+      props: ['modelValue', 'name', 'type', 'id'],
+      emits: ['update:modelValue'],
+      template:
+        '<input :id="id" :name="name" :type="type || \'text\'" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+    },
+    'van-checkbox': {
+      props: ['modelValue'],
+      emits: ['update:modelValue'],
+      template:
+        '<label><input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" /><slot /></label>',
+    },
+    'van-button': {
+      props: ['nativeType'],
+      template: '<button :type="nativeType || \'button\'"><slot /></button>',
+    },
+    'router-link': { template: '<a><slot /></a>' },
+  },
+}
+
+function storedValues(): string[] {
+  return Array.from({ length: localStorage.length }, (_, index) => localStorage.getItem(localStorage.key(index) || '') || '')
+}
+
+describe('Login credential persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    applyLoginMock.mockReset()
+    loginMock.mockReset()
+    replaceMock.mockReset()
+  })
+
+  it('迁移旧凭据时只保留用户名并立即删除旧密码记录', async () => {
+    localStorage.setItem(
+      'cw-remembered-credential',
+      window.btoa(JSON.stringify({ username: 'RichardFyoung', password: 'legacy-secret' })),
+    )
+
+    const wrapper = mount(LoginView, { global: globalOptions })
+    await flushPromises()
+
+    expect(wrapper.get('input[name="username"]').element).toHaveProperty('value', 'RichardFyoung')
+    expect(wrapper.get('input[name="password"]').element).toHaveProperty('value', '')
+    expect(localStorage.getItem('cw-remembered-credential')).toBeNull()
+    expect(localStorage.getItem('cw-remembered-username')).toBe('RichardFyoung')
+    expect(storedValues().join('|')).not.toContain('legacy-secret')
+    expect(wrapper.text()).toContain('记住用户名')
+    expect(wrapper.text()).not.toContain('记住用户名和密码')
+  })
+
+  it('登录后仅持久化用户名，密码不会写入 localStorage', async () => {
+    loginMock.mockResolvedValue({
+      token: 'token-1',
+      userId: 'user-1',
+      nickname: 'RichardFyoung',
+      expiresAtMs: Date.now() + 60_000,
+    })
+    const wrapper = mount(LoginView, { global: globalOptions })
+    await wrapper.get('input[name="username"]').setValue('RichardFyoung')
+    await wrapper.get('input[name="password"]').setValue('new-secret')
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(loginMock).toHaveBeenCalledWith({ username: 'RichardFyoung', password: 'new-secret' })
+    expect(localStorage.getItem('cw-remembered-username')).toBe('RichardFyoung')
+    expect(localStorage.getItem('cw-remembered-credential')).toBeNull()
+    expect(storedValues().join('|')).not.toContain('new-secret')
+    expect(applyLoginMock).toHaveBeenCalledWith('token-1', 'user-1', 'RichardFyoung')
+    expect(replaceMock).toHaveBeenCalledWith('/messages')
+  })
+
+  it('新旧记录同时存在时优先新用户名并清除旧密码记录', async () => {
+    localStorage.setItem('cw-remembered-username', 'CurrentUser')
+    localStorage.setItem(
+      'cw-remembered-credential',
+      window.btoa(JSON.stringify({ username: 'LegacyUser', password: 'legacy-secret' })),
+    )
+
+    const wrapper = mount(LoginView, { global: globalOptions })
+    await flushPromises()
+
+    expect(wrapper.get('input[name="username"]').element).toHaveProperty('value', 'CurrentUser')
+    expect(wrapper.get('input[name="password"]').element).toHaveProperty('value', '')
+    expect(localStorage.getItem('cw-remembered-credential')).toBeNull()
+    expect(localStorage.getItem('cw-remembered-username')).toBe('CurrentUser')
+    expect(storedValues().join('|')).not.toContain('legacy-secret')
+  })
+
+  it('兼容迁移旧版本 UTF-8 中文用户名且不恢复密码', async () => {
+    const legacyJson = JSON.stringify({ username: '小明', password: '中文密码' })
+    const legacyBytes = new TextEncoder().encode(legacyJson)
+    const legacyBase64 = window.btoa(String.fromCharCode(...legacyBytes))
+    localStorage.setItem('cw-remembered-credential', legacyBase64)
+
+    const wrapper = mount(LoginView, { global: globalOptions })
+    await flushPromises()
+
+    expect(wrapper.get('input[name="username"]').element).toHaveProperty('value', '小明')
+    expect(wrapper.get('input[name="password"]').element).toHaveProperty('value', '')
+    expect(localStorage.getItem('cw-remembered-username')).toBe('小明')
+    expect(localStorage.getItem('cw-remembered-credential')).toBeNull()
+    expect(storedValues().join('|')).not.toContain('中文密码')
+  })
+})

--- a/customer-work-app/src/views/Login.vue
+++ b/customer-work-app/src/views/Login.vue
@@ -5,25 +5,17 @@ import { showToast } from 'vant'
 import { login } from '@/api/auth'
 import { useAuthStore } from '@/store/auth'
 
-// 仅本地便捷用途：记住的用户名/密码以 Base64 编码存本地，Base64 为混淆非加密，不具备安全性
-const REMEMBERED_CREDENTIAL_KEY = 'cw-remembered-credential'
+const REMEMBERED_USERNAME_KEY = 'cw-remembered-username'
+/** 旧版本曾把密码做 Base64 后写入 localStorage；Base64 不具备保密性，仅用于一次性迁移用户名后立即删除。 */
+const LEGACY_CREDENTIAL_KEY = 'cw-remembered-credential'
 
-interface RememberedCredential {
-  username: string
-  password: string
-}
-
-function encodeCredential(credential: RememberedCredential): string {
-  const json = JSON.stringify(credential)
-  return window.btoa(unescape(encodeURIComponent(json)))
-}
-
-function decodeCredential(encoded: string): RememberedCredential | null {
+function decodeLegacyUsername(encoded: string): string | null {
   try {
-    const json = decodeURIComponent(escape(window.atob(encoded)))
+    const bytes = Uint8Array.from(window.atob(encoded), (character) => character.charCodeAt(0))
+    const json = new TextDecoder().decode(bytes)
     const parsed = JSON.parse(json)
-    if (parsed && typeof parsed.username === 'string' && typeof parsed.password === 'string') {
-      return parsed
+    if (parsed && typeof parsed.username === 'string') {
+      return parsed.username
     }
     return null
   } catch {
@@ -36,21 +28,29 @@ const authStore = useAuthStore()
 
 const username = ref('')
 const password = ref('')
-const rememberMe = ref(false)
+const rememberUsername = ref(false)
 const submitting = ref(false)
 
 onMounted(() => {
-  const encoded = localStorage.getItem(REMEMBERED_CREDENTIAL_KEY)
-  if (!encoded) {
+  const legacyCredential = localStorage.getItem(LEGACY_CREDENTIAL_KEY)
+  // 无论是否已有新格式用户名，都先删除旧值，避免升级后旧密码因提前 return 继续驻留。
+  localStorage.removeItem(LEGACY_CREDENTIAL_KEY)
+  const rememberedUsername = localStorage.getItem(REMEMBERED_USERNAME_KEY)
+  if (rememberedUsername) {
+    username.value = rememberedUsername
+    rememberUsername.value = true
     return
   }
-  const credential = decodeCredential(encoded)
-  if (!credential) {
+
+  if (!legacyCredential) {
     return
   }
-  username.value = credential.username
-  password.value = credential.password
-  rememberMe.value = true
+  const migratedUsername = decodeLegacyUsername(legacyCredential)
+  if (migratedUsername) {
+    username.value = migratedUsername
+    rememberUsername.value = true
+    localStorage.setItem(REMEMBERED_USERNAME_KEY, migratedUsername)
+  }
 })
 
 async function onSubmit() {
@@ -58,13 +58,11 @@ async function onSubmit() {
   try {
     const result = await login({ username: username.value, password: password.value })
     authStore.applyLogin(result.token, result.userId, result.nickname)
-    if (rememberMe.value) {
-      localStorage.setItem(
-        REMEMBERED_CREDENTIAL_KEY,
-        encodeCredential({ username: username.value, password: password.value }),
-      )
+    localStorage.removeItem(LEGACY_CREDENTIAL_KEY)
+    if (rememberUsername.value) {
+      localStorage.setItem(REMEMBERED_USERNAME_KEY, username.value)
     } else {
-      localStorage.removeItem(REMEMBERED_CREDENTIAL_KEY)
+      localStorage.removeItem(REMEMBERED_USERNAME_KEY)
     }
     showToast('登录成功')
     const redirect = router.currentRoute.value.query.redirect
@@ -77,97 +75,373 @@ async function onSubmit() {
 
 <template>
   <div class="login-page">
-    <div class="hero">
-      <div class="hero-brand">智能客服</div>
-      <div class="hero-sub">随时随地，贴心服务</div>
-    </div>
-    <div class="card">
-    <van-form @submit="onSubmit">
-      <van-cell-group inset>
-        <van-field
-          v-model="username"
-          name="username"
-          label="用户名"
-          placeholder="请输入用户名"
-          :rules="[{ required: true, message: '请输入用户名' }]"
-        />
-        <van-field
-          v-model="password"
-          type="password"
-          name="password"
-          label="密码"
-          placeholder="请输入密码"
-          :rules="[{ required: true, message: '请输入密码' }]"
-        />
-      </van-cell-group>
-      <div class="remember-wrap">
-        <van-checkbox v-model="rememberMe">记住用户名和密码</van-checkbox>
+    <section class="login-hero">
+      <div class="login-brand">
+        <span class="assistant-mark" aria-hidden="true"><span class="assistant-glyph"><i></i></span></span>
+        <span>
+          <strong>智能客服</strong>
+          <small>SERVICE COMPANION</small>
+        </span>
       </div>
-      <div class="submit-wrap">
-        <van-button round block type="primary" native-type="submit" :loading="submitting">登录</van-button>
-      </div>
-    </van-form>
-    <div class="link-wrap">
-      还没有账号？
-      <router-link to="/register">立即注册</router-link>
-    </div>
-    </div>
+      <h1>问题有人回应，<br />进度清晰可见。</h1>
+      <p>登录后继续您的会话、订单与服务记录。</p>
+    </section>
+
+    <section class="login-panel">
+      <van-form class="auth-form" @submit="onSubmit">
+        <div class="input-group">
+          <label for="loginUsername">用户名</label>
+          <van-field
+            id="loginUsername"
+            v-model="username"
+            class="auth-field"
+            name="username"
+            left-icon="contact"
+            placeholder="请输入用户名"
+            autocomplete="username"
+            autocapitalize="none"
+            :rules="[{ required: true, message: '请输入用户名' }]"
+          />
+        </div>
+        <div class="input-group">
+          <label for="loginPassword">密码</label>
+          <van-field
+            id="loginPassword"
+            v-model="password"
+            class="auth-field"
+            type="password"
+            name="password"
+            left-icon="lock"
+            placeholder="请输入密码"
+            autocomplete="current-password"
+            :rules="[{ required: true, message: '请输入密码' }]"
+          />
+        </div>
+        <div class="remember-wrap">
+          <van-checkbox v-model="rememberUsername" shape="square" icon-size="18px">记住用户名</van-checkbox>
+        </div>
+        <van-button
+          class="submit-button"
+          block
+          type="primary"
+          native-type="submit"
+          :loading="submitting"
+          loading-text="正在登录…"
+        >
+          登录
+        </van-button>
+      </van-form>
+      <p class="link-wrap">
+        还没有账号？
+        <router-link to="/register">立即注册</router-link>
+      </p>
+    </section>
   </div>
 </template>
 
 <style scoped>
 .login-page {
+  --auth-ink: var(--cw-ink, #142033);
+  --auth-signal: var(--cw-primary, #316cff);
+  --auth-paper: var(--cw-card-bg, #fff);
   flex: 1;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
+  background: var(--auth-paper);
+  color: var(--auth-ink);
+  scrollbar-width: none;
 }
 
-.hero {
-  background: var(--cw-gradient-brand);
+.login-page::-webkit-scrollbar {
+  display: none;
+}
+
+.login-hero {
+  position: relative;
+  min-height: 305px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  padding: calc(62px + env(safe-area-inset-top)) 28px 54px;
+  background: var(--auth-ink);
   color: #fff;
-  padding: 64px 24px 56px;
-  text-align: center;
-  border-radius: 0 0 28px 28px;
 }
 
-.hero-brand {
-  font-size: 26px;
-  font-weight: 700;
+.login-hero::before,
+.login-hero::after {
+  content: '';
+  position: absolute;
+  border: 1px solid rgba(94, 140, 255, 0.38);
+  border-radius: 50%;
+  pointer-events: none;
 }
 
-.hero-sub {
-  margin-top: 8px;
-  font-size: 13px;
-  opacity: 0.85;
+.login-hero::before {
+  width: 260px;
+  height: 260px;
+  right: -120px;
+  top: -105px;
+  box-shadow: 0 0 0 34px rgba(49, 108, 255, 0.05);
 }
 
-.card {
+.login-hero::after {
+  width: 112px;
+  height: 112px;
+  left: -66px;
+  bottom: -46px;
+}
+
+.login-brand {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 13px;
+  margin-bottom: 36px;
+}
+
+.assistant-mark {
+  position: relative;
+  width: 46px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 15px;
+  background: #fff;
+  color: var(--auth-signal);
+  box-shadow: 0 10px 26px rgba(13, 38, 103, 0.22);
+}
+
+.assistant-mark::before,
+.assistant-mark::after {
+  content: '';
+  position: absolute;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  animation: beacon 2.4s ease-out infinite;
+}
+
+.assistant-mark::before {
+  inset: -6px;
+}
+
+.assistant-mark::after {
+  inset: -12px;
+  animation-delay: 0.8s;
+}
+
+.assistant-glyph {
+  position: relative;
+  width: 23px;
+  height: 18px;
+  border: 2px solid currentColor;
+  border-radius: 10px 10px 9px 9px;
+}
+
+.assistant-glyph::before,
+.assistant-glyph::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.assistant-glyph::before {
+  left: 5px;
+}
+
+.assistant-glyph::after {
+  right: 5px;
+}
+
+.assistant-glyph i {
+  position: absolute;
+  left: 50%;
+  bottom: -6px;
+  width: 8px;
+  height: 7px;
+  border-left: 2px solid currentColor;
+  transform: skew(-24deg) translateX(-50%);
+}
+
+.login-brand strong,
+.login-brand small {
+  display: block;
+}
+
+.login-brand strong {
+  font-size: 15px;
+}
+
+.login-brand small {
+  margin-top: 3px;
+  color: #8fa0bb;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
+.login-hero h1,
+.login-hero p {
+  position: relative;
+  z-index: 1;
+}
+
+.login-hero h1 {
+  margin: 0;
+  font-size: 31px;
+  line-height: 1.22;
+  letter-spacing: -0.045em;
+}
+
+.login-hero p {
+  margin: 10px 0 0;
+  color: #aebbd0;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.login-panel {
+  position: relative;
+  z-index: 2;
   flex: 1;
-  background: var(--cw-card-bg);
-  border-radius: var(--cw-card-radius) var(--cw-card-radius) 0 0;
-  margin-top: -28px;
-  padding-top: 24px;
-  box-shadow: var(--cw-card-shadow);
+  margin-top: -31px;
+  padding: 27px 22px calc(28px + env(safe-area-inset-bottom));
+  border-radius: 30px 30px 0 0;
+  background: var(--auth-paper);
+}
+
+.input-group {
+  margin-bottom: 16px;
+}
+
+.input-group > label {
+  display: block;
+  margin: 0 2px 7px;
+  color: #637087;
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.auth-field {
+  min-height: 52px;
+  padding: 8px 14px;
+  border: 1px solid #dfe5ee;
+  border-radius: 15px;
+  background: #f8fafd;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.auth-field::after {
+  display: none;
+}
+
+.auth-field:focus-within {
+  border-color: color-mix(in srgb, var(--auth-signal) 74%, #fff);
+  background: #fff;
+  box-shadow: 0 0 0 3px rgba(49, 108, 255, 0.1);
+}
+
+.auth-field :deep(.van-field__left-icon) {
+  margin-right: 10px;
+  color: #8490a3;
+  font-size: 18px;
+}
+
+.auth-field :deep(.van-field__control) {
+  color: var(--auth-ink);
+  font-size: 13px;
+}
+
+.auth-field :deep(.van-field__control::placeholder) {
+  color: #a4adba;
+}
+
+.auth-field :deep(.van-field__error-message) {
+  margin-top: 5px;
+  font-size: 10px;
 }
 
 .remember-wrap {
-  margin: 12px 16px 0;
+  margin: 2px 2px 21px;
+  color: #69768b;
+  font-size: 11px;
 }
 
-.submit-wrap {
-  margin: 24px 16px 0;
+.remember-wrap :deep(.van-checkbox__icon--checked .van-icon) {
+  border-color: var(--auth-signal);
+  background: var(--auth-signal);
+}
+
+.remember-wrap :deep(.van-checkbox__label) {
+  color: inherit;
+}
+
+.submit-button {
+  min-height: 50px;
+  border: 0;
+  border-radius: 16px;
+  background: var(--auth-signal);
+  font-size: 14px;
+  font-weight: 750;
+  box-shadow: 0 12px 26px rgba(49, 108, 255, 0.23);
+}
+
+.submit-button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.3);
+  outline-offset: 3px;
 }
 
 .link-wrap {
+  margin: 18px 0 0;
   text-align: center;
-  margin-top: 16px;
-  padding-bottom: 24px;
-  font-size: 14px;
-  color: var(--cw-text-secondary);
+  color: #8792a3;
+  font-size: 11px;
 }
 
 .link-wrap a {
-  color: var(--cw-primary);
+  color: var(--auth-signal);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.link-wrap a:focus-visible {
+  outline: 2px solid rgba(49, 108, 255, 0.32);
+  outline-offset: 3px;
+}
+
+@keyframes beacon {
+  0% {
+    opacity: 0.34;
+    transform: scale(0.88);
+  }
+  72%,
+  100% {
+    opacity: 0;
+    transform: scale(1.08);
+  }
+}
+
+@media (max-width: 340px) {
+  .login-hero {
+    padding-inline: 22px;
+  }
+
+  .login-panel {
+    padding-inline: 17px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-mark::before,
+  .assistant-mark::after {
+    animation: none;
+    opacity: 0.18;
+  }
 }
 </style>

--- a/customer-work-app/src/views/Messages.test.ts
+++ b/customer-work-app/src/views/Messages.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ticket, TicketPage } from '@/types/api'
+import MessagesView from './Messages.vue'
+
+const { createSessionMock, fetchTicketsMock, pushMock } = vi.hoisted(() => ({
+  createSessionMock: vi.fn(),
+  fetchTicketsMock: vi.fn(),
+  pushMock: vi.fn(),
+}))
+
+vi.mock('@/api/ticket', () => ({ createSession: createSessionMock, fetchTickets: fetchTicketsMock }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: pushMock }) }))
+vi.mock('vant', () => ({ showToast: vi.fn() }))
+
+const PullRefreshStub = defineComponent({
+  name: 'VanPullRefresh',
+  props: { modelValue: Boolean, disabled: Boolean },
+  emits: ['update:modelValue', 'refresh'],
+  setup(_props, { slots }) {
+    return () => h('div', { 'data-testid': 'pull-refresh' }, slots.default?.())
+  },
+})
+
+const ListStub = defineComponent({
+  name: 'VanList',
+  props: { loading: Boolean, finished: Boolean },
+  emits: ['update:loading', 'load'],
+  setup(_props, { slots }) {
+    return () => h('div', { 'data-testid': 'ticket-list' }, [slots.default?.(), slots.finished?.()])
+  },
+})
+
+const globalOptions = {
+  stubs: {
+    AppTabbar: true,
+    'van-pull-refresh': PullRefreshStub,
+    'van-list': ListStub,
+    'van-loading': { template: '<span></span>' },
+    'van-icon': { template: '<i></i>' },
+  },
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function ticket(id: string, title: string): Ticket {
+  return {
+    id,
+    sessionId: `session-${id}`,
+    userId: 'user-1',
+    title,
+    category: 'ORDER',
+    priority: 'NORMAL',
+    status: 'AI_SERVING',
+    assignee: null,
+    handoffReason: null,
+    resolveNote: null,
+    reopenCount: 0,
+    createdAtMs: 1_777_520_000_000,
+    updatedAtMs: 1_777_520_060_000,
+  }
+}
+
+describe('Messages request ordering', () => {
+  beforeEach(() => {
+    createSessionMock.mockReset()
+    fetchTicketsMock.mockReset()
+    pushMock.mockReset()
+  })
+
+  it('刷新结果不会被更早发出的分页响应覆盖', async () => {
+    const initial = deferred<TicketPage>()
+    const staleLoadMore = deferred<TicketPage>()
+    const refresh = deferred<TicketPage>()
+    fetchTicketsMock
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(staleLoadMore.promise)
+      .mockReturnValueOnce(refresh.promise)
+
+    const wrapper = mount(MessagesView, { global: globalOptions })
+    initial.resolve({ total: 3, items: [ticket('old-1', '刷新前会话')] })
+    await flushPromises()
+
+    const list = wrapper.findComponent(ListStub)
+    list.vm.$emit('update:loading', true)
+    list.vm.$emit('load')
+    await flushPromises()
+    expect(fetchTicketsMock).toHaveBeenCalledTimes(2)
+
+    const pullRefresh = wrapper.findComponent(PullRefreshStub)
+    pullRefresh.vm.$emit('update:modelValue', true)
+    pullRefresh.vm.$emit('refresh')
+    await flushPromises()
+    expect(fetchTicketsMock).toHaveBeenCalledTimes(3)
+
+    refresh.resolve({ total: 1, items: [ticket('fresh-1', '刷新后会话')] })
+    await flushPromises()
+    staleLoadMore.resolve({ total: 3, items: [ticket('stale-2', '迟到的旧分页')] })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('刷新后会话')
+    expect(wrapper.text()).not.toContain('刷新前会话')
+    expect(wrapper.text()).not.toContain('迟到的旧分页')
+    expect(wrapper.findAll('.conversation-card')).toHaveLength(1)
+  })
+
+  it('分页失败后由用户显式重试并追加下一页', async () => {
+    fetchTicketsMock
+      .mockResolvedValueOnce({ total: 2, items: [ticket('page-1', '第一页会话')] })
+      .mockRejectedValueOnce(new Error('load more failed'))
+      .mockResolvedValueOnce({ total: 2, items: [ticket('page-2', '第二页会话')] })
+    const wrapper = mount(MessagesView, { global: globalOptions })
+    await flushPromises()
+
+    const list = wrapper.findComponent(ListStub)
+    list.vm.$emit('update:loading', true)
+    list.vm.$emit('load')
+    await flushPromises()
+    expect(wrapper.text()).toContain('更多会话加载失败')
+
+    await wrapper.get('.load-more-error button').trigger('click')
+    await flushPromises()
+
+    expect(fetchTicketsMock).toHaveBeenCalledTimes(3)
+    expect(wrapper.text()).toContain('第一页会话')
+    expect(wrapper.text()).toContain('第二页会话')
+    expect(wrapper.findAll('.conversation-card')).toHaveLength(2)
+  })
+
+  it('下拉刷新失败时保留当前可用列表', async () => {
+    fetchTicketsMock
+      .mockResolvedValueOnce({ total: 1, items: [ticket('existing-1', '当前可用会话')] })
+      .mockRejectedValueOnce(new Error('refresh failed'))
+    const wrapper = mount(MessagesView, { global: globalOptions })
+    await flushPromises()
+
+    const pullRefresh = wrapper.findComponent(PullRefreshStub)
+    pullRefresh.vm.$emit('update:modelValue', true)
+    pullRefresh.vm.$emit('refresh')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('当前可用会话')
+    expect(wrapper.text()).not.toContain('会话加载失败')
+    expect(wrapper.findAll('.conversation-card')).toHaveLength(1)
+  })
+})

--- a/customer-work-app/src/views/Messages.vue
+++ b/customer-work-app/src/views/Messages.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { showToast } from 'vant'
 import { createSession, fetchTickets } from '@/api/ticket'
-import type { Ticket } from '@/types/api'
-import { isTicketEnded } from '@/types/api'
+import type { Ticket, TicketStatus } from '@/types/api'
+import { isTicketEnded, ticketCategoryText, TICKET_STATUS_TEXT } from '@/types/api'
 import AppTabbar from '@/components/AppTabbar.vue'
 
 const PAGE_SIZE = 10
@@ -12,47 +12,135 @@ const PAGE_SIZE = 10
 const router = useRouter()
 
 const tickets = ref<Ticket[]>([])
+const total = ref(0)
 const page = ref(1)
+const initialLoading = ref(true)
 const loading = ref(false)
 const finished = ref(false)
 const refreshing = ref(false)
+const loadError = ref(false)
+const loadMoreError = ref(false)
 const creating = ref(false)
+let requestGeneration = 0
 
-async function loadPage() {
-  const result = await fetchTickets({ page: page.value, size: PAGE_SIZE })
-  if (page.value === 1) {
-    tickets.value = result.items
-  } else {
-    tickets.value = [...tickets.value, ...result.items]
+const listSummary = computed(() => {
+  if (initialLoading.value) {
+    return '同步中'
   }
+  if (loadError.value) {
+    return '获取失败'
+  }
+  return `${total.value} 条`
+})
+
+async function loadPage(currentPage: number, generation: number) {
+  const result = await fetchTickets({ page: currentPage, size: PAGE_SIZE })
+  // 下拉刷新会推进 generation，使刷新前尚未返回的分页请求失效，避免旧页污染新列表。
+  if (generation !== requestGeneration) {
+    return
+  }
+  tickets.value = currentPage === 1 ? result.items : [...tickets.value, ...result.items]
+  total.value = result.total
   finished.value = tickets.value.length >= result.total
-  page.value += 1
+  page.value = currentPage + 1
+}
+
+async function loadInitial() {
+  const generation = ++requestGeneration
+  initialLoading.value = true
+  loadError.value = false
+  loadMoreError.value = false
+  page.value = 1
+  finished.value = false
+  try {
+    await loadPage(1, generation)
+  } catch {
+    if (generation === requestGeneration) {
+      loadError.value = true
+      finished.value = true
+    }
+  } finally {
+    if (generation === requestGeneration) {
+      initialLoading.value = false
+    }
+  }
 }
 
 async function onLoad() {
+  if (initialLoading.value || refreshing.value || loadError.value || finished.value) {
+    loading.value = false
+    return
+  }
+
+  loadMoreError.value = false
+  const generation = requestGeneration
   try {
-    await loadPage()
+    await loadPage(page.value, generation)
+  } catch {
+    // 停止 Vant 的触底自动重试，交给用户显式重试，避免弱网下连续请求。
+    if (generation === requestGeneration) {
+      loadMoreError.value = true
+      finished.value = true
+    }
   } finally {
     loading.value = false
   }
 }
 
+async function retryLoadMore() {
+  loadMoreError.value = false
+  finished.value = false
+  loading.value = true
+  await onLoad()
+}
+
 async function onRefresh() {
+  const generation = ++requestGeneration
+  const previousPage = page.value
+  const previousFinished = finished.value
+  const previousTotal = total.value
+  const previousLoadMoreError = loadMoreError.value
+
   page.value = 1
   finished.value = false
+  loadError.value = false
+  loadMoreError.value = false
+  // 中止 Vant List 的加载态；其迟到响应会被 generation 丢弃。
+  loading.value = false
   try {
-    await loadPage()
+    await loadPage(1, generation)
+  } catch {
+    // 刷新失败时保留屏幕上已有的会话，避免一次网络抖动把可用内容清空。
+    if (generation === requestGeneration) {
+      page.value = previousPage
+      finished.value = previousFinished
+      total.value = previousTotal
+      loadMoreError.value = previousLoadMoreError
+      if (tickets.value.length === 0) {
+        loadError.value = true
+        finished.value = true
+      }
+    }
   } finally {
-    refreshing.value = false
+    if (generation === requestGeneration) {
+      refreshing.value = false
+      initialLoading.value = false
+    }
   }
 }
+
+onMounted(loadInitial)
 
 function goChat(ticket: Ticket) {
   router.push({ path: '/chat', query: { ticketId: ticket.id } })
 }
 
-// 发起新会话：用户已有进行中会话时 createSession 内部已吸收 409 并直接返回该会话，这里统一走进聊天页
+// 发起新会话：用户已有进行中会话时 createSession 内部已吸收 409 并直接返回该会话，这里统一走进聊天页。
 async function onCreateSession() {
+  if (creating.value) {
+    return
+  }
+
   creating.value = true
   try {
     const result = await createSession()
@@ -65,39 +153,162 @@ async function onCreateSession() {
   }
 }
 
+function ticketStatusClass(status: TicketStatus) {
+  if (status === 'PROCESSING') {
+    return 'status-pill--success'
+  }
+  if (status === 'WAITING_AGENT' || status === 'WAITING_CONFIRM') {
+    return 'status-pill--warning'
+  }
+  if (status === 'ON_HOLD' || status === 'RESOLVED' || status === 'CLOSED') {
+    return 'status-pill--muted'
+  }
+  return 'status-pill--primary'
+}
+
 function formatTime(ms: number) {
-  return new Date(ms).toLocaleString('zh-CN', { hour12: false })
+  const date = new Date(ms)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+
+  const now = new Date()
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+  const time = date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false })
+
+  if (startOfDate === startOfToday) {
+    return `今天 ${time}`
+  }
+  if (startOfDate === startOfToday - 24 * 60 * 60 * 1000) {
+    return `昨天 ${time}`
+  }
+  if (date.getFullYear() === now.getFullYear()) {
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${month}-${day} ${time}`
+  }
+  return date.toLocaleDateString('zh-CN')
 }
 </script>
 
 <template>
   <div class="messages-page">
-    <van-nav-bar title="消息" />
-    <van-pull-refresh v-model="refreshing" @refresh="onRefresh" class="refresh-area">
-      <van-list v-model:loading="loading" :finished="finished" finished-text="没有更多了" @load="onLoad">
-        <van-cell-group v-if="tickets.length" inset>
-          <van-cell v-for="ticket in tickets" :key="ticket.id" clickable @click="goChat(ticket)">
-            <template #title>
-              <span class="conversation-title">{{ ticket.title || `会话 #${ticket.id}` }}</span>
-            </template>
-            <template #label>
-              <div class="conversation-meta">{{ formatTime(ticket.updatedAtMs) }}</div>
-            </template>
-            <template #value>
-              <van-tag :type="isTicketEnded(ticket.status) ? 'default' : 'primary'">
-                {{ isTicketEnded(ticket.status) ? '已结束' : '进行中' }}
-              </van-tag>
-            </template>
-          </van-cell>
-        </van-cell-group>
-        <van-empty v-else-if="finished" description="暂无会话" />
-      </van-list>
-    </van-pull-refresh>
+    <header class="root-header">
+      <div>
+        <span class="header-eyebrow">客服中心</span>
+        <h1>消息</h1>
+      </div>
+      <span class="service-presence"><i aria-hidden="true"></i>智能服务</span>
+    </header>
 
-    <button class="fab" :disabled="creating" @click="onCreateSession">
-      <van-icon name="plus" size="18" />
-      发起新会话
-    </button>
+    <van-pull-refresh
+      v-model="refreshing"
+      class="refresh-area"
+      :disabled="initialLoading || loading"
+      @refresh="onRefresh"
+    >
+      <main class="page-content">
+        <section class="service-hero" aria-labelledby="service-hero-title">
+          <span class="assistant-mark" aria-hidden="true">
+            <span class="assistant-glyph"><i></i></span>
+          </span>
+          <div class="service-copy">
+            <small>智能客服</small>
+            <h2 id="service-hero-title">需要帮助？我们现在就开始。</h2>
+            <p>新会话会自动延续您的服务记录。</p>
+          </div>
+          <button
+            class="hero-action"
+            type="button"
+            :disabled="creating"
+            :aria-label="creating ? '正在发起新会话' : '发起新会话'"
+            @click="onCreateSession"
+          >
+            <van-loading v-if="creating" color="#fff" size="18" />
+            <van-icon v-else name="plus" size="21" />
+          </button>
+        </section>
+
+        <section class="conversation-section" aria-labelledby="conversation-heading">
+          <div class="section-heading">
+            <h2 id="conversation-heading">最近会话</h2>
+            <span>{{ listSummary }}</span>
+          </div>
+
+          <div v-if="initialLoading" class="skeleton-list" aria-label="会话加载中" aria-busy="true">
+            <div v-for="index in 3" :key="index" class="skeleton-card">
+              <span class="skeleton-avatar"></span>
+              <span class="skeleton-lines"><i></i><i></i></span>
+              <span class="skeleton-aside"></span>
+            </div>
+          </div>
+
+          <div v-else-if="loadError && tickets.length === 0" class="state-panel" role="alert">
+            <span class="state-visual"><van-icon name="chat-o" size="34" /></span>
+            <h3>会话加载失败</h3>
+            <p>网络似乎不太稳定，请重新加载。</p>
+            <button class="primary-button" type="button" @click="loadInitial">重新加载</button>
+          </div>
+
+          <div v-else-if="tickets.length === 0" class="state-panel">
+            <span class="state-visual"><van-icon name="chat-o" size="34" /></span>
+            <h3>还没有会话</h3>
+            <p>发起一次新会话，服务记录会保存在这里。</p>
+            <button class="primary-button" type="button" :disabled="creating" @click="onCreateSession">
+              <van-loading v-if="creating" color="#fff" size="16" />
+              <van-icon v-else name="plus" />
+              <span>{{ creating ? '正在发起' : '发起新会话' }}</span>
+            </button>
+          </div>
+
+          <van-list
+            v-else
+            v-model:loading="loading"
+            :finished="finished"
+            finished-text="没有更多会话了"
+            @load="onLoad"
+          >
+            <div class="conversation-list">
+              <button
+                v-for="ticket in tickets"
+                :key="ticket.id"
+                class="conversation-card"
+                :class="{ 'conversation-card--ended': isTicketEnded(ticket.status) }"
+                type="button"
+                @click="goChat(ticket)"
+              >
+                <span class="conversation-symbol" aria-hidden="true"><van-icon name="chat-o" size="21" /></span>
+                <span class="card-main">
+                  <strong class="card-title">{{ ticket.title || `会话 #${ticket.id}` }}</strong>
+                  <span class="card-meta">
+                    <template v-if="ticket.category">
+                      <span>{{ ticketCategoryText(ticket.category) }}</span>
+                      <i></i>
+                    </template>
+                    <span>会话 #{{ ticket.id }}</span>
+                  </span>
+                </span>
+                <span class="card-aside">
+                  <span class="time-text">{{ formatTime(ticket.updatedAtMs) }}</span>
+                  <span class="status-pill" :class="ticketStatusClass(ticket.status)">
+                    {{ TICKET_STATUS_TEXT[ticket.status] }}
+                  </span>
+                </span>
+              </button>
+            </div>
+
+            <template #finished>
+              <p v-if="loadMoreError" class="load-more-error">
+                更多会话加载失败
+                <button type="button" @click="retryLoadMore">重试</button>
+              </p>
+              <p v-else-if="tickets.length > PAGE_SIZE" class="list-finished">没有更多会话了</p>
+            </template>
+          </van-list>
+        </section>
+      </main>
+    </van-pull-refresh>
 
     <AppTabbar />
   </div>
@@ -105,52 +316,567 @@ function formatTime(ms: number) {
 
 <style scoped>
 .messages-page {
+  --page-ink: var(--cw-ink, #142033);
+  --page-ink-soft: var(--cw-ink-soft, #526078);
+  --page-primary: var(--cw-primary, #316cff);
+  --page-primary-dark: var(--cw-primary-dark, #1748bf);
+  --page-primary-soft: var(--cw-primary-soft, #eaf1ff);
+  --page-success: var(--cw-success, #19a995);
+  --page-success-soft: var(--cw-success-soft, #e5f8f3);
+  --page-line: var(--cw-line, #e6ebf2);
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
-  position: relative;
+  background: var(--cw-page-bg, #f4f7fb);
+  color: var(--page-ink);
+}
+
+button {
+  font: inherit;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.26);
+  outline-offset: 2px;
+}
+
+.root-header {
+  min-height: calc(77px + env(safe-area-inset-top));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: calc(14px + env(safe-area-inset-top)) 17px 10px;
+  background: rgba(255, 255, 255, 0.96);
+  border-bottom: 1px solid rgba(230, 235, 242, 0.76);
+}
+
+.header-eyebrow {
+  display: block;
+  margin-bottom: 2px;
+  color: #8290a5;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.root-header h1 {
+  margin: 0;
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+.service-presence {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 30px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--page-success-soft);
+  color: #117d6f;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.service-presence i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--page-success);
+  box-shadow: 0 0 0 4px rgba(25, 169, 149, 0.12);
 }
 
 .refresh-area {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  padding-top: 12px;
-  /* 底部预留 tabbar 高度，防止最后一条被固定导航遮挡 */
-  padding-bottom: 66px;
 }
 
-.conversation-title {
-  font-weight: 500;
-  color: var(--cw-text-primary);
+.page-content {
+  min-height: 100%;
+  padding: 13px 14px var(--cw-tabbar-space, 100px);
 }
 
-.conversation-meta {
-  font-size: 12px;
-  color: var(--cw-text-secondary);
-  margin-top: 4px;
+.service-hero {
+  position: relative;
+  overflow: hidden;
+  min-height: 139px;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 20px;
+  border-radius: 24px;
+  background: var(--page-ink);
+  color: #fff;
+  box-shadow: 0 16px 34px rgba(20, 32, 51, 0.16);
 }
 
-.fab {
-  /* absolute 而非 fixed：van-tabbar 用 fixed+width:100% 已相对整个视口铺满（忽略 480px 居中壳层），
-     这里用 absolute 相对 .messages-page（shell 内 flex:1 子项，min-height 100vh 保证撑满视口）定位，
-     宽屏桌面浏览器验证时按钮才会落在居中的 480px 列内，而不是贴到真实视口右边缘。 */
+.service-hero::after {
+  content: '';
   position: absolute;
-  right: 20px;
-  bottom: 78px;
+  width: 152px;
+  height: 152px;
+  right: -67px;
+  top: -77px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 50%;
+  box-shadow: 0 0 0 25px rgba(255, 255, 255, 0.035);
+}
+
+.assistant-mark {
+  position: relative;
+  z-index: 1;
+  width: 54px;
+  height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: 18px;
+  background: var(--page-primary);
+  color: #fff;
+  box-shadow: 0 10px 23px rgba(49, 108, 255, 0.33);
+}
+
+.assistant-glyph {
+  position: relative;
+  width: 27px;
+  height: 21px;
+  border: 2px solid currentColor;
+  border-radius: 11px 11px 9px 9px;
+}
+
+.assistant-glyph::before,
+.assistant-glyph::after {
+  content: '';
+  position: absolute;
+  top: 7px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.assistant-glyph::before {
+  left: 5px;
+}
+
+.assistant-glyph::after {
+  right: 5px;
+}
+
+.assistant-glyph i {
+  position: absolute;
+  left: 50%;
+  bottom: -7px;
+  width: 8px;
+  height: 8px;
+  border-left: 2px solid currentColor;
+  transform: skew(-24deg) translateX(-50%);
+}
+
+.service-copy {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  flex: 1;
+}
+
+.service-copy small {
+  display: block;
+  margin-bottom: 5px;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.service-copy h2 {
+  margin: 0;
+  font-size: 19px;
+  line-height: 1.28;
+  letter-spacing: -0.025em;
+}
+
+.service-copy p {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.73);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.hero-action {
+  position: relative;
+  z-index: 2;
+  width: 45px;
+  height: 45px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.13);
+  color: #fff;
+  backdrop-filter: blur(8px);
+}
+
+.hero-action:disabled,
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
+}
+
+.conversation-section {
+  margin-top: 23px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 3px 11px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+.section-heading > span {
+  color: #7d899c;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 11px;
+}
+
+.conversation-list,
+.skeleton-list {
+  display: grid;
+  gap: 10px;
+}
+
+.conversation-card,
+.skeleton-card {
+  width: 100%;
+  min-height: 84px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 13px 14px;
+  border: 1px solid rgba(230, 235, 242, 0.9);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 7px 22px rgba(37, 55, 85, 0.055);
+}
+
+.conversation-card {
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.conversation-card:active {
+  transform: scale(0.988);
+  box-shadow: 0 3px 12px rgba(37, 55, 85, 0.06);
+}
+
+.conversation-symbol {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 15px;
+  background: var(--page-primary-soft);
+  color: var(--page-primary);
+}
+
+.conversation-symbol::after {
+  content: '';
+  position: absolute;
+  right: 1px;
+  bottom: 1px;
+  width: 9px;
+  height: 9px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: var(--page-success);
+}
+
+.conversation-card--ended .conversation-symbol {
+  background: #f0f2f5;
+  color: #7d899c;
+}
+
+.conversation-card--ended .conversation-symbol::after {
+  background: #a7b0bf;
+}
+
+.card-main {
+  min-width: 0;
+}
+
+.card-title {
+  display: block;
+  overflow: hidden;
+  color: var(--page-ink);
+  font-size: 14px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-meta {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 10px 18px;
-  border: none;
-  border-radius: 999px;
-  color: #fff;
-  font-size: 14px;
-  background: var(--cw-gradient-brand);
-  box-shadow: 0 4px 14px rgba(25, 137, 250, 0.35);
+  min-width: 0;
+  margin-top: 7px;
+  overflow: hidden;
+  color: #59687c;
+  font-size: 12px;
+  white-space: nowrap;
 }
 
-.fab:disabled {
-  opacity: 0.6;
+.card-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-meta i {
+  width: 3px;
+  height: 3px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #b8c0cd;
+}
+
+.card-aside {
+  display: grid;
+  justify-items: end;
+  gap: 8px;
+}
+
+.time-text {
+  color: #59687c;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.status-pill::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-pill--primary {
+  background: var(--page-primary-soft);
+  color: var(--page-primary-dark);
+}
+
+.status-pill--success {
+  background: var(--page-success-soft);
+  color: #117d6f;
+}
+
+.status-pill--warning {
+  background: #fff4df;
+  color: #a86300;
+}
+
+.status-pill--muted {
+  background: #f0f2f5;
+  color: #59687c;
+}
+
+.state-panel {
+  min-height: 282px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 22px;
+  text-align: center;
+}
+
+.state-visual {
+  width: 82px;
+  height: 82px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+  border-radius: 28px;
+  background: var(--page-primary-soft);
+  color: var(--page-primary);
+  transform: rotate(-4deg);
+}
+
+.state-panel h3 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.state-panel p {
+  max-width: 250px;
+  margin: 8px 0 18px;
+  color: #7d899c;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.primary-button {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 10px 18px;
+  border: 0;
+  border-radius: 14px;
+  background: var(--page-primary);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: 0 9px 20px rgba(49, 108, 255, 0.2);
+}
+
+.skeleton-card {
+  grid-template-columns: 42px minmax(0, 1fr) 64px;
+}
+
+.skeleton-avatar,
+.skeleton-lines i,
+.skeleton-aside {
+  display: block;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%);
+  background-size: 200% 100%;
+  animation: skeleton 1.35s ease-in-out infinite;
+}
+
+.skeleton-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 15px;
+}
+
+.skeleton-lines {
+  display: grid;
+  gap: 10px;
+}
+
+.skeleton-lines i:first-child {
+  width: 74%;
+  height: 12px;
+}
+
+.skeleton-lines i:last-child {
+  width: 48%;
+  height: 9px;
+}
+
+.skeleton-aside {
+  width: 64px;
+  height: 23px;
+}
+
+.load-more-error,
+.list-finished {
+  margin: 15px 0 2px;
+  color: #657388;
+  font-size: 12px;
+  text-align: center;
+}
+
+.load-more-error button {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 5px;
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  color: var(--page-primary);
+  font-weight: 700;
+}
+
+@keyframes skeleton {
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (max-width: 350px) {
+  .service-hero {
+    gap: 11px;
+    padding: 17px;
+  }
+
+  .assistant-mark {
+    width: 48px;
+    height: 48px;
+  }
+
+  .service-copy h2 {
+    font-size: 17px;
+  }
+
+  .service-copy p {
+    display: none;
+  }
+
+  .conversation-card {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .conversation-symbol {
+    width: 38px;
+    height: 38px;
+  }
+
+  .card-aside {
+    grid-column: 2;
+    grid-row: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    margin-top: -5px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conversation-card,
+  .skeleton-avatar,
+  .skeleton-lines i,
+  .skeleton-aside {
+    animation: none;
+    transition: none;
+  }
 }
 </style>

--- a/customer-work-app/src/views/OrderDetail.test.ts
+++ b/customer-work-app/src/views/OrderDetail.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OrderView } from '@/types/api'
+import OrderDetailView from './OrderDetail.vue'
+
+const { fetchOrderDetailMock } = vi.hoisted(() => ({ fetchOrderDetailMock: vi.fn() }))
+
+vi.mock('@/api/order', () => ({ fetchOrderDetail: fetchOrderDetailMock }))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ back: vi.fn(), push: vi.fn(), replace: vi.fn() }),
+}))
+
+const detail: OrderView = {
+  orderId: 'ORDER-20260828-01',
+  productId: 'SKU-HEADPHONE-01',
+  productName: '旗舰款无线降噪耳机',
+  amount: '399.00',
+  status: '运输中',
+  receiverAddr: '上海市示例路 88 号',
+  logisticsTrace: '【已揽收。】 → 【运输中。】 → 【派送中。】',
+  createdAtMs: 1_777_520_060_000,
+}
+
+const globalOptions = {
+  stubs: {
+    'van-icon': { template: '<i></i>' },
+  },
+}
+
+describe('OrderDetail', () => {
+  beforeEach(() => {
+    fetchOrderDetailMock.mockReset()
+  })
+
+  it('首次失败后可重新加载订单，并将最新物流节点排在最前', async () => {
+    fetchOrderDetailMock.mockRejectedValueOnce(new Error('order unavailable')).mockResolvedValueOnce(detail)
+    const wrapper = mount(OrderDetailView, {
+      props: { id: detail.orderId },
+      global: globalOptions,
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('订单详情加载失败')
+    expect(wrapper.text()).toContain('重新加载')
+
+    await wrapper.get('.retry-button').trigger('click')
+    await flushPromises()
+
+    expect(fetchOrderDetailMock).toHaveBeenCalledTimes(2)
+    expect(fetchOrderDetailMock).toHaveBeenNthCalledWith(1, detail.orderId)
+    expect(fetchOrderDetailMock).toHaveBeenNthCalledWith(2, detail.orderId)
+    expect(wrapper.text()).toContain(detail.orderId)
+    expect(wrapper.text()).toContain(`¥${detail.amount}`)
+
+    const traceNodes = wrapper.findAll('.timeline-item strong').map((node) => node.text())
+    expect(traceNodes).toEqual(['派送中', '运输中', '已揽收'])
+    expect(wrapper.get('.timeline-item--active strong').text()).toBe('派送中')
+  })
+})

--- a/customer-work-app/src/views/OrderDetail.vue
+++ b/customer-work-app/src/views/OrderDetail.vue
@@ -8,11 +8,13 @@ const props = defineProps<{ id: string }>()
 const router = useRouter()
 
 const order = ref<OrderView | null>(null)
-const loading = ref(true)
+const initialLoading = ref(true)
+const loadError = ref(false)
 
 const orderId = computed(() => props.id)
 
-// 物流轨迹按分隔符拆成多行展示（后端文案用「→」或换行拼接）
+// 后端以「起点 → 当前节点」顺序返回轨迹；详情页倒序展示，让最新节点优先被看到。
+// 仅清理轨迹的包装括号和句末标点，不补写后端未返回的物流时间。
 const traceLines = computed(() => {
   const trace = order.value?.logisticsTrace
   if (!trace) {
@@ -20,26 +22,46 @@ const traceLines = computed(() => {
   }
   return trace
     .split(/→|\n/)
-    .map((line) => line.trim())
+    .map((line) => line.trim().replace(/^[\[【]+/, '').replace(/[\]】。]+$/, '').trim())
     .filter((line) => line.length > 0)
+    .reverse()
 })
 
 async function loadDetail() {
-  loading.value = true
+  initialLoading.value = true
+  loadError.value = false
   try {
     order.value = await fetchOrderDetail(orderId.value)
+  } catch {
+    order.value = null
+    loadError.value = true
   } finally {
-    loading.value = false
+    initialLoading.value = false
   }
 }
 
 onMounted(loadDetail)
 
 function formatTime(ms: number) {
-  return new Date(ms).toLocaleString('zh-CN', { hour12: false })
+  const date = new Date(ms)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
 }
 
-// 右上角"智能客服"：带订单号跳转聊天页，聊天页据此预填咨询文案
+function goOrders() {
+  router.replace('/orders')
+}
+
+// 携带订单号跳转聊天页，Chat 页继续按既有逻辑预填订单咨询文案。
 function goChat() {
   router.push({ path: '/chat', query: { orderId: orderId.value } })
 }
@@ -47,82 +69,506 @@ function goChat() {
 
 <template>
   <div class="order-detail-page">
-    <van-nav-bar title="订单详情" left-arrow @click-left="router.back()">
-      <template #right>
-        <span class="nav-service" @click="goChat">智能客服</span>
-      </template>
-    </van-nav-bar>
+    <header class="detail-header">
+      <button class="icon-button" type="button" aria-label="返回上一页" @click="router.back()">
+        <van-icon name="arrow-left" size="20" />
+      </button>
+      <h1>订单详情</h1>
+      <button class="service-button" type="button" @click="goChat">
+        <van-icon name="chat-o" size="17" />
+        <span>客服</span>
+      </button>
+    </header>
 
-    <div class="content">
-      <van-loading v-if="loading" class="loading" vertical>加载中...</van-loading>
+    <main class="detail-scroll">
+      <div v-if="initialLoading" class="skeleton-list" aria-label="订单详情加载中" aria-busy="true">
+        <div class="skeleton-hero"></div>
+        <div v-for="index in 3" :key="index" class="skeleton-card">
+          <span></span><span></span><span></span>
+        </div>
+      </div>
+
+      <div v-else-if="loadError" class="state-panel" role="alert">
+        <span class="state-visual"><van-icon name="orders-o" size="34" /></span>
+        <h2>订单详情加载失败</h2>
+        <p>暂时无法获取订单信息，请重新加载。</p>
+        <button class="primary-button retry-button" type="button" @click="loadDetail">重新加载</button>
+      </div>
+
       <template v-else-if="order">
-        <van-cell-group inset title="商品信息">
-          <van-cell title="商品名称" :value="order.productName" />
-          <van-cell title="商品编号" :value="order.productId" />
-          <van-cell title="金额" :value="`¥${order.amount}`" />
-          <van-cell title="订单状态" :value="order.status" />
-          <van-cell title="订单号" :value="order.orderId" />
-          <van-cell title="下单时间" :value="formatTime(order.createdAtMs)" />
-        </van-cell-group>
-
-        <van-cell-group inset title="收货信息">
-          <van-cell title="收货地址" :label="order.receiverAddr" />
-        </van-cell-group>
-
-        <van-cell-group inset title="物流轨迹">
-          <div v-if="traceLines.length" class="trace">
-            <div v-for="(line, index) in traceLines" :key="index" class="trace-line">{{ line }}</div>
+        <section class="order-status-hero" aria-labelledby="order-status-heading">
+          <div>
+            <span class="status-eyebrow">订单状态</span>
+            <h2 id="order-status-heading">{{ order.status }}</h2>
+            <p>{{ order.orderId }}</p>
           </div>
-          <van-cell v-else title="暂无物流轨迹" />
-        </van-cell-group>
+          <span class="status-illustration" aria-hidden="true"><van-icon name="logistics" size="28" /></span>
+        </section>
+
+        <section class="detail-section" aria-labelledby="product-heading">
+          <h2 id="product-heading">商品信息</h2>
+          <div class="info-card">
+            <div class="info-row">
+              <span class="info-label">商品名称</span>
+              <strong class="info-value">{{ order.productName }}</strong>
+            </div>
+            <div class="info-row">
+              <span class="info-label">商品编号</span>
+              <strong class="info-value data-value">{{ order.productId }}</strong>
+            </div>
+            <div class="info-row">
+              <span class="info-label">订单金额</span>
+              <strong class="info-value amount-value">¥{{ order.amount }}</strong>
+            </div>
+            <div class="info-row">
+              <span class="info-label">下单时间</span>
+              <strong class="info-value data-value">{{ formatTime(order.createdAtMs) }}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section class="detail-section" aria-labelledby="receiver-heading">
+          <h2 id="receiver-heading">收货信息</h2>
+          <div class="info-card">
+            <div class="info-row info-row--address">
+              <span class="info-label">收货地址</span>
+              <strong class="info-value">{{ order.receiverAddr || '—' }}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section class="detail-section" aria-labelledby="logistics-heading">
+          <h2 id="logistics-heading">物流轨迹</h2>
+          <div class="info-card">
+            <div v-if="traceLines.length" class="timeline">
+              <div
+                v-for="(line, index) in traceLines"
+                :key="`${line}-${index}`"
+                class="timeline-item"
+                :class="{ 'timeline-item--active': index === 0 }"
+              >
+                <span class="timeline-dot" aria-hidden="true"></span>
+                <span class="timeline-copy">
+                  <strong>{{ line }}</strong>
+                  <span v-if="index === 0">当前节点</span>
+                </span>
+              </div>
+            </div>
+            <div v-else class="trace-empty">
+              <van-icon name="logistics" size="24" />
+              <span>暂无物流轨迹</span>
+            </div>
+          </div>
+        </section>
+
+        <div class="detail-actions">
+          <button class="secondary-button" type="button" @click="goOrders">返回订单</button>
+          <button class="primary-button" type="button" @click="goChat">
+            <van-icon name="chat-o" size="17" />
+            <span>咨询客服</span>
+          </button>
+        </div>
       </template>
-    </div>
+    </main>
   </div>
 </template>
 
 <style scoped>
 .order-detail-page {
+  --page-ink: var(--cw-ink, #142033);
+  --page-primary: var(--cw-primary, #316cff);
+  --page-primary-soft: var(--cw-primary-soft, #eaf1ff);
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
+  background: var(--cw-page-bg, #f4f7fb);
+  color: var(--page-ink);
 }
 
-.nav-service {
-  color: var(--cw-primary);
+button {
+  font: inherit;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.26);
+  outline-offset: 2px;
+}
+
+.detail-header {
+  min-height: calc(58px + env(safe-area-inset-top));
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) 72px;
+  align-items: center;
+  padding: calc(6px + env(safe-area-inset-top)) 8px 6px;
+  border-bottom: 1px solid rgba(230, 235, 242, 0.8);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.detail-header h1 {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.icon-button,
+.service-button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  border: 0;
+  border-radius: 13px;
+  background: transparent;
+  color: var(--page-ink);
+}
+
+.icon-button {
+  width: 44px;
+  justify-content: center;
+}
+
+.service-button {
+  justify-content: flex-end;
+  gap: 5px;
+  padding: 0 8px;
+  color: var(--page-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.detail-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 13px 14px calc(26px + env(safe-area-inset-bottom));
+}
+
+.order-status-hero {
+  position: relative;
+  overflow: hidden;
+  min-height: 122px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 21px;
+  border-radius: 24px;
+  background: var(--page-ink);
+  color: #fff;
+  box-shadow: 0 16px 34px rgba(20, 32, 51, 0.16);
+}
+
+.order-status-hero::after {
+  content: '';
+  position: absolute;
+  width: 148px;
+  height: 148px;
+  right: -64px;
+  top: -78px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 50%;
+  box-shadow: 0 0 0 24px rgba(255, 255, 255, 0.035);
+}
+
+.status-eyebrow {
+  color: #94a6c3;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.order-status-hero h2 {
+  margin: 6px 0 5px;
+  font-size: 23px;
+  letter-spacing: -0.025em;
+}
+
+.order-status-hero p {
+  margin: 0;
+  color: #aebcd2;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 10px;
+}
+
+.status-illustration {
+  position: relative;
+  z-index: 1;
+  width: 55px;
+  height: 55px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: 19px;
+  background: #fff;
+  color: var(--page-primary);
+  transform: rotate(4deg);
+}
+
+.detail-section {
+  margin-top: 18px;
+}
+
+.detail-section > h2 {
+  margin: 0 3px 9px;
+  font-size: 13px;
+}
+
+.info-card {
+  overflow: hidden;
+  border: 1px solid rgba(230, 235, 242, 0.9);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 7px 22px rgba(37, 55, 85, 0.055);
+}
+
+.info-row {
+  min-height: 49px;
+  display: grid;
+  grid-template-columns: 84px minmax(0, 1fr);
+  align-items: center;
+  gap: 14px;
+  padding: 11px 14px;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.info-row:last-child {
+  border-bottom: 0;
+}
+
+.info-label {
+  color: #59687c;
+  font-size: 12px;
+}
+
+.info-value {
+  color: var(--page-ink);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.55;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.data-value,
+.amount-value {
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+}
+
+.amount-value {
   font-size: 14px;
 }
 
-.content {
-  flex: 1;
-  overflow-y: auto;
-  padding-bottom: 24px;
+.timeline {
+  padding: 18px 15px 4px;
 }
 
-.loading {
-  margin-top: 40vh;
-}
-
-.trace {
-  padding: 12px 16px;
-}
-
-.trace-line {
-  font-size: 13px;
-  color: #646566;
-  line-height: 1.8;
+.timeline-item {
   position: relative;
-  padding-left: 14px;
+  min-height: 45px;
+  display: grid;
+  grid-template-columns: 17px minmax(0, 1fr);
+  gap: 10px;
+  padding-bottom: 17px;
 }
 
-.trace-line::before {
+.timeline-item:not(:last-child)::before {
   content: '';
   position: absolute;
-  left: 0;
-  top: 10px;
-  width: 6px;
-  height: 6px;
+  left: 5px;
+  top: 12px;
+  bottom: -2px;
+  width: 1px;
+  background: #dbe3ef;
+}
+
+.timeline-dot {
+  position: relative;
+  z-index: 1;
+  width: 11px;
+  height: 11px;
+  margin-top: 3px;
+  border: 3px solid #fff;
   border-radius: 50%;
-  background: var(--cw-primary);
+  background: #a9b4c4;
+  box-shadow: 0 0 0 1px #ced7e4;
+}
+
+.timeline-item--active .timeline-dot {
+  background: var(--page-primary);
+  box-shadow: 0 0 0 1px var(--page-primary), 0 0 0 6px rgba(49, 108, 255, 0.09);
+}
+
+.timeline-copy strong {
+  display: block;
+  color: #58667b;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.55;
+}
+
+.timeline-item--active .timeline-copy strong {
+  color: var(--page-ink);
+  font-weight: 750;
+}
+
+.timeline-copy span {
+  display: block;
+  margin-top: 4px;
+  color: var(--page-primary);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.trace-empty {
+  min-height: 82px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  color: #59687c;
+  font-size: 12px;
+}
+
+.detail-actions {
+  display: grid;
+  grid-template-columns: 1fr 1.45fr;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.primary-button,
+.secondary-button {
+  min-height: 45px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.primary-button {
+  border: 0;
+  background: var(--page-primary);
+  color: #fff;
+  box-shadow: 0 9px 20px rgba(49, 108, 255, 0.2);
+}
+
+.secondary-button {
+  border: 1px solid #dfe5ee;
+  background: #fff;
+  color: var(--page-ink);
+}
+
+.state-panel {
+  min-height: calc(100vh - 110px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 22px;
+  text-align: center;
+}
+
+.state-visual {
+  width: 82px;
+  height: 82px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+  border-radius: 28px;
+  background: var(--page-primary-soft);
+  color: var(--page-primary);
+  transform: rotate(-4deg);
+}
+
+.state-panel h2 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.state-panel p {
+  margin: 8px 0 18px;
+  color: #7d899c;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.retry-button {
+  padding: 0 18px;
+}
+
+.skeleton-list {
+  display: grid;
+  gap: 17px;
+}
+
+.skeleton-hero,
+.skeleton-card,
+.skeleton-card span {
+  background: linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%);
+  background-size: 200% 100%;
+  animation: skeleton 1.35s ease-in-out infinite;
+}
+
+.skeleton-hero {
+  height: 122px;
+  border-radius: 24px;
+}
+
+.skeleton-card {
+  min-height: 145px;
+  display: grid;
+  gap: 13px;
+  padding: 17px;
+  border-radius: 18px;
+}
+
+.skeleton-card span {
+  width: 100%;
+  height: 11px;
+  display: block;
+  border-radius: 999px;
+}
+
+.skeleton-card span:nth-child(2) {
+  width: 72%;
+}
+
+.skeleton-card span:nth-child(3) {
+  width: 86%;
+}
+
+@keyframes skeleton {
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (max-width: 350px) {
+  .detail-header {
+    grid-template-columns: 60px minmax(0, 1fr) 60px;
+  }
+
+  .detail-scroll {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+
+  .info-row {
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-hero,
+  .skeleton-card,
+  .skeleton-card span {
+    animation: none;
+  }
 }
 </style>

--- a/customer-work-app/src/views/OrderList.test.ts
+++ b/customer-work-app/src/views/OrderList.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OrderView } from '@/types/api'
+import OrderListView from './OrderList.vue'
+
+const { fetchOrdersMock, pushMock } = vi.hoisted(() => ({ fetchOrdersMock: vi.fn(), pushMock: vi.fn() }))
+
+vi.mock('@/api/order', () => ({ fetchOrders: fetchOrdersMock }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: pushMock }) }))
+
+const PullRefreshStub = defineComponent({
+  name: 'VanPullRefresh',
+  props: { modelValue: Boolean, disabled: Boolean },
+  emits: ['update:modelValue', 'refresh'],
+  setup(_props, { slots }) {
+    return () => h('div', { 'data-testid': 'pull-refresh' }, slots.default?.())
+  },
+})
+
+const globalOptions = {
+  stubs: {
+    AppTabbar: true,
+    'van-pull-refresh': PullRefreshStub,
+    'van-loading': { template: '<span></span>' },
+    'van-icon': { template: '<i></i>' },
+  },
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function order(orderId: string, productName: string): OrderView {
+  return {
+    orderId,
+    productId: `SKU-${orderId}`,
+    productName,
+    amount: '299.00',
+    status: '已发货',
+    receiverAddr: '上海市示例路 88 号',
+    logisticsTrace: null,
+    createdAtMs: 1_777_520_060_000,
+  }
+}
+
+describe('OrderList request ordering', () => {
+  beforeEach(() => {
+    fetchOrdersMock.mockReset()
+    pushMock.mockReset()
+  })
+
+  it('较早的首次请求迟到时不会覆盖刷新结果', async () => {
+    const initial = deferred<OrderView[]>()
+    const refresh = deferred<OrderView[]>()
+    fetchOrdersMock.mockReturnValueOnce(initial.promise).mockReturnValueOnce(refresh.promise)
+
+    const wrapper = mount(OrderListView, { global: globalOptions })
+    const pullRefresh = wrapper.findComponent(PullRefreshStub)
+    pullRefresh.vm.$emit('update:modelValue', true)
+    pullRefresh.vm.$emit('refresh')
+    await flushPromises()
+
+    refresh.resolve([order('new-1', '刷新后的订单')])
+    await flushPromises()
+    initial.resolve([order('old-1', '迟到的旧订单')])
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('刷新后的订单')
+    expect(wrapper.text()).not.toContain('迟到的旧订单')
+    expect(wrapper.findAll('.order-card')).toHaveLength(1)
+  })
+
+  it('首次加载失败后可以原地重试恢复订单', async () => {
+    fetchOrdersMock
+      .mockRejectedValueOnce(new Error('orders unavailable'))
+      .mockResolvedValueOnce([order('retry-1', '重试恢复的订单')])
+    const wrapper = mount(OrderListView, { global: globalOptions })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('订单加载失败')
+    await wrapper.get('.state-panel .primary-button').trigger('click')
+    await flushPromises()
+
+    expect(fetchOrdersMock).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('重试恢复的订单')
+    expect(wrapper.findAll('.order-card')).toHaveLength(1)
+  })
+})

--- a/customer-work-app/src/views/OrderList.vue
+++ b/customer-work-app/src/views/OrderList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { fetchOrders } from '@/api/order'
 import type { OrderView } from '@/types/api'
@@ -8,14 +8,59 @@ import AppTabbar from '@/components/AppTabbar.vue'
 const router = useRouter()
 
 const orders = ref<OrderView[]>([])
-const loading = ref(true)
+const initialLoading = ref(true)
+const loadError = ref(false)
+const refreshing = ref(false)
+let requestGeneration = 0
+
+const listSummary = computed(() => {
+  if (initialLoading.value) {
+    return '同步中'
+  }
+  if (loadError.value) {
+    return '获取失败'
+  }
+  return `${orders.value.length} 笔`
+})
 
 async function loadOrders() {
-  loading.value = true
+  const generation = ++requestGeneration
+  initialLoading.value = true
+  loadError.value = false
   try {
-    orders.value = await fetchOrders()
+    const result = await fetchOrders()
+    if (generation === requestGeneration) {
+      orders.value = result
+    }
+  } catch {
+    if (generation === requestGeneration) {
+      loadError.value = true
+    }
   } finally {
-    loading.value = false
+    if (generation === requestGeneration) {
+      initialLoading.value = false
+    }
+  }
+}
+
+async function onRefresh() {
+  const generation = ++requestGeneration
+  try {
+    const result = await fetchOrders()
+    if (generation === requestGeneration) {
+      orders.value = result
+      loadError.value = false
+    }
+  } catch {
+    // 已有订单仍可继续使用；只有无可用内容时才切换到整页错误态。
+    if (generation === requestGeneration && orders.value.length === 0) {
+      loadError.value = true
+    }
+  } finally {
+    if (generation === requestGeneration) {
+      refreshing.value = false
+      initialLoading.value = false
+    }
   }
 }
 
@@ -25,51 +70,111 @@ function goDetail(orderId: string) {
   router.push(`/orders/${orderId}`)
 }
 
-// 订单状态标签色：已发货/已签收偏成功，待发货偏警示，已取消/已退款置灰
-function statusTagType(status: string): 'primary' | 'success' | 'warning' | 'danger' | 'default' {
+function goMessages() {
+  router.push('/messages')
+}
+
+function statusClass(status: string) {
   if (status.includes('签收') || status.includes('已发货')) {
-    return 'success'
+    return 'status-pill--success'
   }
   if (status.includes('待')) {
-    return 'warning'
+    return 'status-pill--warning'
   }
   if (status.includes('取消') || status.includes('退')) {
-    return 'default'
+    return 'status-pill--muted'
   }
-  return 'primary'
+  return 'status-pill--primary'
 }
 
 function formatTime(ms: number) {
-  return new Date(ms).toLocaleString('zh-CN', { hour12: false })
+  const date = new Date(ms)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
 }
 </script>
 
 <template>
   <div class="order-list-page">
-    <van-nav-bar title="我的订单" />
-    <div class="content">
-      <van-loading v-if="loading" class="loading" vertical>加载中...</van-loading>
-      <template v-else>
-        <van-cell-group v-if="orders.length" inset>
-          <van-cell v-for="order in orders" :key="order.orderId" clickable @click="goDetail(order.orderId)">
-            <template #title>
-              <span class="order-title">{{ order.productName }}</span>
-            </template>
-            <template #label>
-              <div class="order-meta">单号 {{ order.orderId }}</div>
-              <div class="order-meta">{{ formatTime(order.createdAtMs) }}</div>
-            </template>
-            <template #value>
-              <div class="order-value">
-                <div class="order-amount">¥{{ order.amount }}</div>
-                <van-tag :type="statusTagType(order.status)">{{ order.status }}</van-tag>
-              </div>
-            </template>
-          </van-cell>
-        </van-cell-group>
-        <van-empty v-else description="暂无订单" />
-      </template>
-    </div>
+    <header class="root-header">
+      <div>
+        <span class="header-eyebrow">服务记录</span>
+        <h1>我的订单</h1>
+      </div>
+    </header>
+
+    <van-pull-refresh v-model="refreshing" class="refresh-area" :disabled="initialLoading" @refresh="onRefresh">
+      <main class="page-content">
+        <section aria-labelledby="order-list-heading">
+          <div class="section-heading">
+            <h2 id="order-list-heading">全部订单</h2>
+            <span>{{ listSummary }}</span>
+          </div>
+
+          <div v-if="initialLoading" class="skeleton-list" aria-label="订单加载中" aria-busy="true">
+            <div v-for="index in 3" :key="index" class="skeleton-card">
+              <span class="skeleton-top"></span>
+              <span class="skeleton-body">
+                <i class="skeleton-package"></i>
+                <i class="skeleton-lines"></i>
+                <i class="skeleton-amount"></i>
+              </span>
+              <span class="skeleton-bottom"></span>
+            </div>
+          </div>
+
+          <div v-else-if="loadError && orders.length === 0" class="state-panel" role="alert">
+            <span class="state-visual"><van-icon name="orders-o" size="34" /></span>
+            <h3>订单加载失败</h3>
+            <p>暂时无法获取订单，请稍后重试。</p>
+            <button class="primary-button" type="button" @click="loadOrders">重新加载</button>
+          </div>
+
+          <div v-else-if="orders.length === 0" class="state-panel">
+            <span class="state-visual"><van-icon name="orders-o" size="34" /></span>
+            <h3>暂无订单</h3>
+            <p>账号下的订单会统一显示在这里。</p>
+            <button class="secondary-button" type="button" @click="goMessages">联系客服</button>
+          </div>
+
+          <div v-else class="order-list">
+            <button
+              v-for="order in orders"
+              :key="order.orderId"
+              class="order-card"
+              type="button"
+              @click="goDetail(order.orderId)"
+            >
+              <span class="order-card-top">
+                <span class="order-number">订单号 {{ order.orderId }}</span>
+                <span class="status-pill" :class="statusClass(order.status)">{{ order.status }}</span>
+              </span>
+              <span class="order-product">
+                <span class="package-symbol" aria-hidden="true"><van-icon name="gift-o" size="25" /></span>
+                <span class="product-copy">
+                  <strong class="order-product-name">{{ order.productName }}</strong>
+                  <span class="order-product-id">{{ order.productId }}</span>
+                </span>
+                <strong class="order-amount">¥{{ order.amount }}</strong>
+              </span>
+              <span class="order-card-bottom">
+                <span class="order-date">{{ formatTime(order.createdAtMs) }}</span>
+                <span class="detail-link">查看详情<van-icon name="arrow" /></span>
+              </span>
+            </button>
+          </div>
+        </section>
+      </main>
+    </van-pull-refresh>
 
     <AppTabbar />
   </div>
@@ -77,43 +182,384 @@ function formatTime(ms: number) {
 
 <style scoped>
 .order-list-page {
+  --page-ink: var(--cw-ink, #142033);
+  --page-primary: var(--cw-primary, #316cff);
+  --page-primary-dark: var(--cw-primary-dark, #1748bf);
+  --page-primary-soft: var(--cw-primary-soft, #eaf1ff);
+  --page-success-soft: var(--cw-success-soft, #e5f8f3);
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
+  background: var(--cw-page-bg, #f4f7fb);
+  color: var(--page-ink);
 }
 
-.content {
+button {
+  font: inherit;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.26);
+  outline-offset: 2px;
+}
+
+.root-header {
+  min-height: calc(77px + env(safe-area-inset-top));
+  display: flex;
+  align-items: center;
+  padding: calc(14px + env(safe-area-inset-top)) 17px 10px;
+  border-bottom: 1px solid rgba(230, 235, 242, 0.76);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.header-eyebrow {
+  display: block;
+  margin-bottom: 2px;
+  color: #8290a5;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.root-header h1 {
+  margin: 0;
+  font-size: 23px;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+.refresh-area {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  padding-top: 12px;
-  /* 底部预留 tabbar 高度，防止最后一条被固定导航遮挡 */
-  padding-bottom: 66px;
 }
 
-.loading {
-  margin-top: 40vh;
+.page-content {
+  min-height: 100%;
+  padding: 14px 14px var(--cw-tabbar-space, 100px);
 }
 
-.order-title {
-  font-weight: 500;
-}
-
-.order-meta {
-  font-size: 12px;
-  color: var(--cw-text-secondary);
-  margin-top: 4px;
-}
-
-.order-value {
+.section-heading {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 3px 11px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+.section-heading span {
+  color: #7d899c;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 11px;
+}
+
+.order-list,
+.skeleton-list {
+  display: grid;
+  gap: 10px;
+}
+
+.order-card,
+.skeleton-card {
+  width: 100%;
+  padding: 15px;
+  border: 1px solid rgba(230, 235, 242, 0.9);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 7px 22px rgba(37, 55, 85, 0.055);
+}
+
+.order-card {
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.order-card:active {
+  transform: scale(0.988);
+  box-shadow: 0 3px 12px rgba(37, 55, 85, 0.06);
+}
+
+.order-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.order-number {
+  min-width: 0;
+  overflow: hidden;
+  color: #59687c;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.status-pill::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-pill--primary {
+  background: var(--page-primary-soft);
+  color: var(--page-primary-dark);
+}
+
+.status-pill--success {
+  background: var(--page-success-soft);
+  color: #117d6f;
+}
+
+.status-pill--warning {
+  background: #fff4df;
+  color: #a86300;
+}
+
+.status-pill--muted {
+  background: #f0f2f5;
+  color: #59687c;
+}
+
+.order-product {
+  display: grid;
+  grid-template-columns: 50px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding-top: 14px;
+}
+
+.package-symbol {
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  background: #eef3fb;
+  color: #657a9c;
+}
+
+.product-copy {
+  min-width: 0;
+}
+
+.order-product-name {
+  display: block;
+  overflow: hidden;
+  color: var(--page-ink);
+  font-size: 14px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.order-product-id {
+  display: block;
+  margin-top: 6px;
+  color: #657388;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 12px;
 }
 
 .order-amount {
-  font-weight: 600;
-  color: var(--cw-text-primary);
+  color: var(--page-ink);
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 16px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.order-card-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 13px;
+}
+
+.order-date {
+  overflow: hidden;
+  color: #59687c;
+  font-family: 'DIN Alternate', 'SF Pro Display', 'PingFang SC', sans-serif;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-link {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  color: var(--page-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.state-panel {
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 22px;
+  text-align: center;
+}
+
+.state-visual {
+  width: 82px;
+  height: 82px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+  border-radius: 28px;
+  background: var(--page-primary-soft);
+  color: var(--page-primary);
+  transform: rotate(-4deg);
+}
+
+.state-panel h3 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.state-panel p {
+  margin: 8px 0 18px;
+  color: #7d899c;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.primary-button,
+.secondary-button {
+  min-height: 42px;
+  padding: 10px 18px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.primary-button {
+  border: 0;
+  background: var(--page-primary);
+  color: #fff;
+  box-shadow: 0 9px 20px rgba(49, 108, 255, 0.2);
+}
+
+.secondary-button {
+  border: 1px solid #dfe5ee;
+  background: #fff;
+  color: var(--page-ink);
+}
+
+.skeleton-card {
+  min-height: 155px;
+}
+
+.skeleton-top,
+.skeleton-package,
+.skeleton-lines,
+.skeleton-amount,
+.skeleton-bottom {
+  display: block;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%);
+  background-size: 200% 100%;
+  animation: skeleton 1.35s ease-in-out infinite;
+}
+
+.skeleton-top {
+  width: 46%;
+  height: 10px;
+}
+
+.skeleton-body {
+  display: grid;
+  grid-template-columns: 50px minmax(0, 1fr) 52px;
+  align-items: center;
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.skeleton-package {
+  width: 50px;
+  height: 50px;
+  border-radius: 16px;
+}
+
+.skeleton-lines {
+  width: 78%;
+  height: 12px;
+}
+
+.skeleton-amount {
+  width: 52px;
+  height: 15px;
+}
+
+.skeleton-bottom {
+  width: 32%;
+  height: 9px;
+}
+
+@keyframes skeleton {
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (max-width: 350px) {
+  .order-product {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .package-symbol {
+    width: 44px;
+    height: 44px;
+  }
+
+  .order-amount {
+    grid-column: 2;
+    margin-top: -6px;
+    font-size: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .order-card,
+  .skeleton-top,
+  .skeleton-package,
+  .skeleton-lines,
+  .skeleton-amount,
+  .skeleton-bottom {
+    animation: none;
+    transition: none;
+  }
 }
 </style>

--- a/customer-work-app/src/views/Profile.test.ts
+++ b/customer-work-app/src/views/Profile.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UserInfo } from '@/types/api'
+import ProfileView from './Profile.vue'
+
+const {
+  authClearMock,
+  fetchMeMock,
+  replaceMock,
+  revokeSessionsMock,
+  showToastMock,
+  socketCloseMock,
+} = vi.hoisted(() => ({
+  authClearMock: vi.fn(),
+  fetchMeMock: vi.fn(),
+  replaceMock: vi.fn(),
+  revokeSessionsMock: vi.fn(),
+  showToastMock: vi.fn(),
+  socketCloseMock: vi.fn(),
+}))
+
+vi.mock('@/api/auth', () => ({ fetchMe: fetchMeMock, revokeSessions: revokeSessionsMock }))
+vi.mock('@/store/auth', () => ({
+  useAuthStore: () => ({ nickname: 'RichardFyoung', clear: authClearMock }),
+}))
+vi.mock('@/utils/ws', () => ({ chatSocket: { close: socketCloseMock } }))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+}))
+vi.mock('vant', () => ({ showToast: showToastMock }))
+
+const profile: UserInfo = {
+  userId: 'user-1',
+  username: 'RichardFyoung',
+  nickname: 'RichardFyoung',
+  phone: '13800000000',
+  avatarUrl: null,
+}
+
+const globalOptions = {
+  stubs: {
+    AppTabbar: true,
+    UserAvatar: { template: '<span class="user-avatar-stub"></span>' },
+    'van-icon': { template: '<i></i>' },
+    'van-loading': { template: '<span></span>' },
+  },
+}
+
+async function mountProfile() {
+  const wrapper = mount(ProfileView, { attachTo: document.body, global: globalOptions })
+  await flushPromises()
+  return wrapper
+}
+
+async function openAndConfirmLogout(wrapper: Awaited<ReturnType<typeof mountProfile>>, label: string) {
+  const action = wrapper.findAll('button').find((button) => button.text().includes(label))
+  expect(action).toBeDefined()
+  await action!.trigger('click')
+  await wrapper.get('.sheet-button.danger').trigger('click')
+  await flushPromises()
+}
+
+describe('Profile logout boundaries', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    localStorage.clear()
+    authClearMock.mockReset()
+    fetchMeMock.mockReset().mockResolvedValue(profile)
+    replaceMock.mockReset()
+    revokeSessionsMock.mockReset()
+    showToastMock.mockReset()
+    socketCloseMock.mockReset()
+  })
+
+  it('退出当前设备不撤销其他会话，只删除旧密码记录并保留记住的用户名', async () => {
+    localStorage.setItem('cw-remembered-credential', 'legacy-base64-password')
+    localStorage.setItem('cw-remembered-username', 'RichardFyoung')
+    const wrapper = await mountProfile()
+
+    await openAndConfirmLogout(wrapper, '退出当前设备')
+
+    expect(revokeSessionsMock).not.toHaveBeenCalled()
+    expect(localStorage.getItem('cw-remembered-credential')).toBeNull()
+    expect(localStorage.getItem('cw-remembered-username')).toBe('RichardFyoung')
+    expect(authClearMock).toHaveBeenCalledOnce()
+    expect(socketCloseMock).toHaveBeenCalledOnce()
+    expect(replaceMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('退出所有设备成功后先撤销服务端会话，再清理当前登录态', async () => {
+    revokeSessionsMock.mockResolvedValue({ revoked: true, sessionEpoch: 2 })
+    localStorage.setItem('cw-remembered-credential', 'legacy-base64-password')
+    localStorage.setItem('cw-remembered-username', 'RichardFyoung')
+    const wrapper = await mountProfile()
+
+    await openAndConfirmLogout(wrapper, '退出所有设备')
+
+    expect(revokeSessionsMock).toHaveBeenCalledOnce()
+    expect(localStorage.getItem('cw-remembered-credential')).toBeNull()
+    expect(localStorage.getItem('cw-remembered-username')).toBe('RichardFyoung')
+    expect(authClearMock).toHaveBeenCalledOnce()
+    expect(socketCloseMock).toHaveBeenCalledOnce()
+    expect(replaceMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('退出所有设备接口失败时保留登录态，并允许用户原地再次操作', async () => {
+    revokeSessionsMock
+      .mockRejectedValueOnce(new Error('revoke unavailable'))
+      .mockResolvedValueOnce({ revoked: true, sessionEpoch: 3 })
+    localStorage.setItem('cw-remembered-credential', 'legacy-base64-password')
+    localStorage.setItem('cw-remembered-username', 'RichardFyoung')
+    const wrapper = await mountProfile()
+
+    await openAndConfirmLogout(wrapper, '退出所有设备')
+
+    expect(revokeSessionsMock).toHaveBeenCalledOnce()
+    expect(localStorage.getItem('cw-remembered-credential')).toBe('legacy-base64-password')
+    expect(localStorage.getItem('cw-remembered-username')).toBe('RichardFyoung')
+    expect(authClearMock).not.toHaveBeenCalled()
+    expect(socketCloseMock).not.toHaveBeenCalled()
+    expect(replaceMock).not.toHaveBeenCalled()
+    expect(wrapper.get('.sheet-button.danger').attributes('disabled')).toBeUndefined()
+
+    await wrapper.get('.sheet-button.danger').trigger('click')
+    await flushPromises()
+
+    expect(revokeSessionsMock).toHaveBeenCalledTimes(2)
+    expect(authClearMock).toHaveBeenCalledOnce()
+    expect(socketCloseMock).toHaveBeenCalledOnce()
+    expect(replaceMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('退出弹层圈闭焦点，Escape 关闭后将焦点归还触发按钮', async () => {
+    const wrapper = await mountProfile()
+    const trigger = wrapper.findAll('button').find((button) => button.text().includes('退出当前设备'))!
+    const triggerElement = trigger.element as HTMLButtonElement
+    triggerElement.focus()
+
+    await trigger.trigger('click')
+    await flushPromises()
+
+    const confirm = wrapper.get('.sheet-button.danger')
+    const cancel = wrapper.get('.sheet-button.secondary')
+    expect(document.activeElement).toBe(confirm.element)
+    expect(wrapper.get('.account-header').attributes('inert')).toBeDefined()
+
+    await confirm.trigger('keydown', { key: 'Tab' })
+    expect(document.activeElement).toBe(cancel.element)
+    await cancel.trigger('keydown', { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(confirm.element)
+
+    await confirm.trigger('keydown', { key: 'Escape' })
+    await flushPromises()
+    expect(wrapper.find('.logout-sheet').exists()).toBe(false)
+    expect(document.activeElement).toBe(triggerElement)
+  })
+})

--- a/customer-work-app/src/views/Profile.vue
+++ b/customer-work-app/src/views/Profile.vue
@@ -1,24 +1,49 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { showConfirmDialog, showToast } from 'vant'
+import { showToast } from 'vant'
 import { fetchMe, revokeSessions } from '@/api/auth'
-import { useAuthStore } from '@/store/auth'
-import { chatSocket } from '@/utils/ws'
-import type { UserInfo } from '@/types/api'
 import AppTabbar from '@/components/AppTabbar.vue'
+import UserAvatar from '@/components/UserAvatar.vue'
+import { useAuthStore } from '@/store/auth'
+import type { UserInfo } from '@/types/api'
+import { chatSocket } from '@/utils/ws'
+
+type LogoutAction = 'current' | 'all'
+const LEGACY_CREDENTIAL_KEY = 'cw-remembered-credential'
 
 const router = useRouter()
 const auth = useAuthStore()
 
 const profile = ref<UserInfo | null>(null)
 const loading = ref(true)
+const loadFailed = ref(false)
+const logoutAction = ref<LogoutAction | null>(null)
 const revoking = ref(false)
+const logoutSheet = ref<HTMLElement | null>(null)
+const confirmLogoutButton = ref<HTMLButtonElement | null>(null)
+let logoutTrigger: HTMLElement | null = null
+
+const displayName = computed(() => profile.value?.nickname || auth.nickname || '用户')
+const accountSummary = computed(() => {
+  const username = profile.value?.username?.trim()
+  return username ? `@${username} · 当前设备已登录` : '当前设备已登录'
+})
+const logoutTitle = computed(() => (logoutAction.value === 'all' ? '退出所有设备？' : '退出当前设备？'))
+const logoutMessage = computed(() =>
+  logoutAction.value === 'all'
+    ? '该账号在手机、电脑等全部设备上的登录状态都会被撤销，所有设备都需要重新登录。'
+    : '仅结束当前设备的登录状态，其他设备不会受到影响。',
+)
 
 async function loadProfile() {
   loading.value = true
+  loadFailed.value = false
+  profile.value = null
   try {
     profile.value = await fetchMe()
+  } catch {
+    loadFailed.value = true
   } finally {
     loading.value = false
   }
@@ -26,37 +51,78 @@ async function loadProfile() {
 
 onMounted(loadProfile)
 
-async function onLogout() {
-  try {
-    await showConfirmDialog({ title: '退出登录', message: '确认退出当前账号？' })
-  } catch {
-    return // 用户取消
+function openLogoutSheet(action: LogoutAction) {
+  logoutTrigger = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  logoutAction.value = action
+  nextTick(() => confirmLogoutButton.value?.focus())
+}
+
+function closeLogoutSheet() {
+  if (!revoking.value) {
+    logoutAction.value = null
+    nextTick(() => {
+      logoutTrigger?.focus()
+      logoutTrigger = null
+    })
   }
+}
+
+function onLogoutSheetKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeLogoutSheet()
+    return
+  }
+  if (event.key !== 'Tab' || !logoutSheet.value) {
+    return
+  }
+
+  const focusable = Array.from(
+    logoutSheet.value.querySelectorAll<HTMLElement>('button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'),
+  )
+  if (focusable.length === 0) {
+    event.preventDefault()
+    logoutSheet.value.focus()
+    return
+  }
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+function clearCurrentSession(message: string) {
+  logoutAction.value = null
+  // 清理旧版本遗留的 Base64 密码；新的“记住用户名”不保存密码，可安全保留。
+  localStorage.removeItem(LEGACY_CREDENTIAL_KEY)
   auth.clear()
   chatSocket.close()
-  showToast('已退出登录')
+  showToast(message)
   router.replace('/login')
 }
 
-async function onRevokeSessions() {
-  if (revoking.value) {
+async function confirmLogout() {
+  if (!logoutAction.value || revoking.value) {
     return
   }
-  try {
-    await showConfirmDialog({
-      title: '退出所有设备',
-      message: '确认撤销该账号的全部登录状态？所有设备都需要重新登录。',
-    })
-  } catch {
-    return // 用户取消
+
+  if (logoutAction.value === 'current') {
+    clearCurrentSession('已退出当前设备')
+    return
   }
+
   revoking.value = true
   try {
     await revokeSessions()
-    auth.clear()
-    chatSocket.close()
-    showToast('所有设备已退出登录')
-    router.replace('/login')
+    clearCurrentSession('所有设备已退出登录')
+  } catch {
+    // 全部会话撤销失败时必须保留当前登录态，便于用户重试。
+    return
   } finally {
     revoking.value = false
   }
@@ -65,83 +131,675 @@ async function onRevokeSessions() {
 
 <template>
   <div class="profile-page">
-    <van-nav-bar title="我的" />
+    <header class="account-header" :aria-hidden="logoutAction ? 'true' : undefined" :inert="!!logoutAction">
+      <div>
+        <h1>我的</h1>
+        <p>账户中心</p>
+      </div>
+    </header>
 
-    <div class="content">
-      <div class="header">
-        <div class="avatar">
-          <img v-if="profile?.avatarUrl" :src="profile.avatarUrl" class="avatar-img" alt="头像" />
-          <van-icon v-else name="manager" size="36" />
+    <main class="profile-scroll" :aria-hidden="logoutAction ? 'true' : undefined" :inert="!!logoutAction">
+      <div v-if="loading" class="profile-loading" aria-busy="true" aria-label="正在加载个人资料">
+        <div class="profile-hero skeleton-hero">
+          <span class="skeleton skeleton-avatar"></span>
+          <span class="skeleton-copy">
+            <i class="skeleton skeleton-line skeleton-line-short"></i>
+            <i class="skeleton skeleton-line skeleton-line-title"></i>
+            <i class="skeleton skeleton-line"></i>
+          </span>
         </div>
-        <div class="nickname">{{ profile?.nickname || auth.nickname || '用户' }}</div>
+        <section v-for="section in 2" :key="section" class="menu-section">
+          <span class="skeleton skeleton-label"></span>
+          <div class="menu-card skeleton-card">
+            <span class="skeleton skeleton-menu-icon"></span>
+            <span class="skeleton-copy">
+              <i class="skeleton skeleton-line skeleton-line-title"></i>
+              <i class="skeleton skeleton-line"></i>
+            </span>
+          </div>
+        </section>
       </div>
 
-      <van-cell-group inset class="menu-group">
-        <van-cell title="个人信息" icon="contact" is-link clickable @click="router.push('/profile/info')" />
-      </van-cell-group>
+      <section v-else-if="loadFailed" class="state-panel" role="alert">
+        <span class="state-icon"><van-icon name="contact" /></span>
+        <h2>个人资料加载失败</h2>
+        <p>当前先不显示缓存资料，避免把异常信息当成真实资料。</p>
+        <button type="button" class="retry-button" @click="loadProfile">
+          <van-icon name="replay" />
+          重新加载
+        </button>
+      </section>
 
-      <van-cell-group inset class="menu-group">
-        <van-cell title="退出当前设备" icon="warning-o" is-link clickable @click="onLogout" />
-        <van-cell title="退出所有设备" icon="close" is-link clickable @click="onRevokeSessions" />
-      </van-cell-group>
-    </div>
+      <template v-else-if="profile">
+        <section class="profile-hero">
+          <div class="avatar-frame">
+            <UserAvatar :src="profile.avatarUrl" :name="displayName" />
+            <span class="online-dot" aria-label="当前在线"></span>
+          </div>
+          <div class="profile-name">
+            <small>服务账号</small>
+            <h2>{{ displayName }}</h2>
+            <p>{{ accountSummary }}</p>
+          </div>
+        </section>
 
-    <AppTabbar />
+        <div class="profile-content">
+          <section class="menu-section" aria-labelledby="accountInfoTitle">
+            <h2 id="accountInfoTitle">账户信息</h2>
+            <div class="menu-card">
+              <button type="button" class="menu-row" @click="router.push('/profile/info')">
+                <span class="menu-icon"><van-icon name="contact" /></span>
+                <span class="menu-copy">
+                  <strong>个人信息</strong>
+                  <small>头像、昵称、用户名与手机号</small>
+                </span>
+                <van-icon class="menu-chevron" name="arrow" />
+              </button>
+            </div>
+          </section>
+
+          <section class="menu-section" aria-labelledby="securityTitle">
+            <h2 id="securityTitle">登录与安全</h2>
+            <div class="menu-card">
+              <button type="button" class="menu-row" @click="openLogoutSheet('current')">
+                <span class="menu-icon neutral"><van-icon name="sign" /></span>
+                <span class="menu-copy">
+                  <strong>退出当前设备</strong>
+                  <small>仅结束这台设备的登录状态</small>
+                </span>
+                <van-icon class="menu-chevron" name="arrow" />
+              </button>
+              <button type="button" class="menu-row danger" @click="openLogoutSheet('all')">
+                <span class="menu-icon danger"><van-icon name="close" /></span>
+                <span class="menu-copy">
+                  <strong>退出所有设备</strong>
+                  <small>全部设备都需要重新登录</small>
+                </span>
+                <van-icon class="menu-chevron" name="arrow" />
+              </button>
+            </div>
+          </section>
+        </div>
+      </template>
+    </main>
+
+    <AppTabbar :aria-hidden="logoutAction ? 'true' : undefined" :inert="!!logoutAction" />
+
+    <Transition name="sheet">
+      <div v-if="logoutAction" class="logout-overlay" @click.self="closeLogoutSheet">
+        <section
+          ref="logoutSheet"
+          class="logout-sheet"
+          role="dialog"
+          tabindex="-1"
+          aria-modal="true"
+          aria-labelledby="logoutSheetTitle"
+          aria-describedby="logoutSheetMessage"
+          @keydown="onLogoutSheetKeydown"
+        >
+          <span class="sheet-handle" aria-hidden="true"></span>
+          <span class="sheet-icon" :class="{ danger: logoutAction === 'all' }">
+            <van-icon :name="logoutAction === 'all' ? 'close' : 'sign'" />
+          </span>
+          <h2 id="logoutSheetTitle">{{ logoutTitle }}</h2>
+          <p id="logoutSheetMessage">{{ logoutMessage }}</p>
+          <div class="sheet-actions">
+            <button type="button" class="sheet-button secondary" :disabled="revoking" @click="closeLogoutSheet">
+              取消
+            </button>
+            <button
+              ref="confirmLogoutButton"
+              type="button"
+              class="sheet-button danger"
+              :disabled="revoking"
+              @click="confirmLogout"
+            >
+              <van-loading v-if="revoking" size="17" color="#fff" />
+              <span v-else>确认退出</span>
+            </button>
+          </div>
+        </section>
+      </div>
+    </Transition>
   </div>
 </template>
 
 <style scoped>
 .profile-page {
+  --account-ink: var(--cw-ink, #142033);
+  --account-signal: var(--cw-primary, #316cff);
+  --account-signal-soft: var(--cw-primary-soft, #edf2ff);
+  --account-lake: var(--cw-success, #19a995);
+  --account-cloud: var(--cw-page-bg, #f2f5fa);
+  --account-paper: var(--cw-card-bg, #fff);
+  --account-ember: var(--cw-danger, #df5458);
+  position: relative;
   flex: 1;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
+  background: var(--account-cloud);
+  color: var(--account-ink);
 }
 
-.content {
-  flex: 1;
-  overflow-y: auto;
-  /* 底部预留 tabbar 高度，防遮挡 */
-  padding-bottom: 66px;
-}
-
-.header {
+.account-header {
+  flex: 0 0 auto;
+  min-height: 72px;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  padding: 32px 0 40px;
-  background: var(--cw-gradient-brand);
-  border-radius: 0 0 24px 24px;
-  color: #fff;
+  padding: calc(13px + env(safe-area-inset-top)) 18px 12px;
+  background: color-mix(in srgb, var(--account-paper) 94%, transparent);
+  border-bottom: 1px solid rgba(223, 229, 238, 0.8);
 }
 
-.avatar {
-  width: 64px;
-  height: 64px;
+.account-header h1,
+.account-header p {
+  margin: 0;
+}
+
+.account-header h1 {
+  font-size: 19px;
+  font-weight: 760;
+  letter-spacing: -0.02em;
+}
+
+.account-header p {
+  margin-top: 3px;
+  color: #8995a7;
+  font-size: 11px;
+}
+
+.profile-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+  padding: 16px 16px var(--cw-tabbar-space, 104px);
+}
+
+.profile-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.profile-hero {
+  position: relative;
+  overflow: hidden;
+  min-height: 108px;
+  display: grid;
+  grid-template-columns: 70px minmax(0, 1fr);
+  align-items: center;
+  gap: 15px;
+  padding: 19px;
+  border-radius: 23px;
+  background: var(--account-ink);
+  color: #fff;
+  box-shadow: 0 18px 38px rgba(20, 32, 51, 0.2);
+}
+
+.profile-hero::before {
+  content: '';
+  position: absolute;
+  right: -48px;
+  top: -75px;
+  width: 160px;
+  height: 160px;
+  border: 1px solid rgba(105, 150, 255, 0.34);
   border-radius: 50%;
-  background: #fff;
-  color: var(--cw-primary);
+  box-shadow: 0 0 0 22px rgba(49, 108, 255, 0.055);
+  pointer-events: none;
+}
+
+.avatar-frame {
+  position: relative;
+  width: 66px;
+  height: 66px;
+  overflow: visible;
+  border: 3px solid rgba(255, 255, 255, 0.78);
+  border-radius: 22px;
+  background: var(--account-signal);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+}
+
+.avatar-frame :deep(.user-avatar) {
+  --user-avatar-initials-size: 20px;
+  --user-avatar-icon-size: 27px;
+  border-radius: 19px;
+}
+
+.online-dot {
+  position: absolute;
+  right: -5px;
+  bottom: -5px;
+  width: 17px;
+  height: 17px;
+  border: 3px solid var(--account-ink);
+  border-radius: 50%;
+  background: var(--account-lake);
+}
+
+.profile-name {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.profile-name small {
+  display: block;
+  margin-bottom: 4px;
+  color: #8ea0bd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.profile-name h2,
+.profile-name p {
+  overflow: hidden;
+  margin: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-name h2 {
+  font-size: 20px;
+  letter-spacing: -0.025em;
+}
+
+.profile-name p {
+  margin-top: 7px;
+  color: #aebbd0;
+  font-size: 10px;
+}
+
+.profile-content {
+  padding-top: 2px;
+}
+
+.menu-section {
+  margin-top: 18px;
+}
+
+.menu-section > h2 {
+  margin: 0 3px 9px;
+  color: #758297;
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.menu-card {
+  overflow: hidden;
+  border: 1px solid rgba(226, 232, 241, 0.9);
+  border-radius: 17px;
+  background: var(--account-paper);
+  box-shadow: 0 7px 22px rgba(37, 55, 85, 0.055);
+}
+
+.menu-row {
+  width: 100%;
+  min-height: 66px;
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) 20px;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 0;
+  border-bottom: 1px solid #eef1f5;
+  background: var(--account-paper);
+  color: inherit;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.menu-row:last-child {
+  border-bottom: 0;
+}
+
+.menu-row:active {
+  background: #f8faff;
+}
+
+.menu-icon {
+  width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.avatar-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.nickname {
-  margin-top: 12px;
+  border-radius: 12px;
+  background: var(--account-signal-soft);
+  color: var(--account-signal);
   font-size: 18px;
-  font-weight: 600;
-  color: #fff;
 }
 
-.menu-group {
-  margin-top: 16px;
+.menu-icon.neutral {
+  background: #eff2f6;
+  color: #68768b;
+}
+
+.menu-icon.danger {
+  background: #fff0f0;
+  color: var(--account-ember);
+}
+
+.menu-copy {
+  min-width: 0;
+}
+
+.menu-copy strong,
+.menu-copy small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menu-copy strong {
+  font-size: 13px;
+  font-weight: 690;
+}
+
+.menu-copy small {
+  margin-top: 4px;
+  color: #8c98aa;
+  font-size: 10px;
+}
+
+.menu-row.danger .menu-copy strong {
+  color: #c94b4b;
+}
+
+.menu-chevron {
+  justify-self: end;
+  color: #a1aab8;
+  font-size: 17px;
+}
+
+.state-panel {
+  min-height: calc(100% - 20px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 34px 24px 56px;
+  text-align: center;
+}
+
+.state-icon {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 22px;
+  background: var(--account-signal-soft);
+  color: var(--account-signal);
+  font-size: 29px;
+  box-shadow: 0 10px 24px rgba(49, 108, 255, 0.12);
+}
+
+.state-panel h2 {
+  margin: 19px 0 0;
+  font-size: 17px;
+}
+
+.state-panel p {
+  max-width: 286px;
+  margin: 9px 0 0;
+  color: #7c899d;
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.retry-button {
+  min-width: 132px;
+  min-height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin-top: 22px;
+  padding: 0 20px;
+  border: 0;
+  border-radius: 15px;
+  background: var(--account-signal);
+  color: #fff;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: 0 12px 26px rgba(49, 108, 255, 0.2);
+  cursor: pointer;
+}
+
+.profile-loading {
+  padding-bottom: 12px;
+}
+
+.skeleton {
+  display: block;
+  overflow: hidden;
+  background: linear-gradient(90deg, #e8edf5 25%, #f5f7fb 50%, #e8edf5 75%);
+  background-size: 200% 100%;
+  animation: skeleton-wave 1.25s ease-in-out infinite;
+}
+
+.skeleton-hero::before {
+  display: none;
+}
+
+.skeleton-avatar {
+  width: 66px;
+  height: 66px;
+  border-radius: 22px;
+  opacity: 0.38;
+}
+
+.skeleton-copy {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.skeleton-line {
+  width: 88%;
+  height: 9px;
+  border-radius: 999px;
+}
+
+.skeleton-line-short {
+  width: 38%;
+  height: 7px;
+  opacity: 0.56;
+}
+
+.skeleton-line-title {
+  width: 62%;
+  height: 13px;
+}
+
+.skeleton-label {
+  width: 64px;
+  height: 10px;
+  margin: 0 3px 9px;
+  border-radius: 999px;
+}
+
+.skeleton-card {
+  min-height: 66px;
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+}
+
+.skeleton-menu-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+}
+
+.logout-overlay {
+  position: absolute;
+  z-index: 100;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 12px;
+  background: rgba(15, 25, 40, 0.45);
+  backdrop-filter: blur(3px);
+}
+
+.logout-sheet {
+  width: 100%;
+  padding: 9px 17px calc(17px + env(safe-area-inset-bottom));
+  border-radius: 24px;
+  background: var(--account-paper);
+  box-shadow: 0 22px 60px rgba(14, 25, 43, 0.25);
+  text-align: center;
+}
+
+.sheet-handle {
+  width: 38px;
+  height: 4px;
+  display: block;
+  margin: 0 auto 15px;
+  border-radius: 999px;
+  background: #d8dee8;
+}
+
+.sheet-icon {
+  width: 46px;
+  height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  background: #eff2f6;
+  color: #66758a;
+  font-size: 21px;
+}
+
+.sheet-icon.danger {
+  background: #fff0f0;
+  color: var(--account-ember);
+}
+
+.logout-sheet h2 {
+  margin: 13px 0 0;
+  font-size: 17px;
+}
+
+.logout-sheet p {
+  margin: 8px auto 0;
+  max-width: 320px;
+  color: #78869a;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.sheet-actions {
+  display: grid;
+  grid-template-columns: 1fr 1.28fr;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.sheet-button {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 15px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.sheet-button.secondary {
+  background: #eef2f7;
+  color: #59687c;
+}
+
+.sheet-button.danger {
+  background: var(--account-ember);
+  color: #fff;
+  box-shadow: 0 10px 24px rgba(223, 84, 88, 0.2);
+}
+
+.sheet-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
+}
+
+.menu-row:focus-visible,
+.retry-button:focus-visible,
+.sheet-button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.28);
+  outline-offset: -3px;
+}
+
+.sheet-enter-active,
+.sheet-leave-active {
+  transition: opacity 160ms ease;
+}
+
+.sheet-enter-active .logout-sheet,
+.sheet-leave-active .logout-sheet {
+  transition: transform 180ms ease;
+}
+
+.sheet-enter-from,
+.sheet-leave-to {
+  opacity: 0;
+}
+
+.sheet-enter-from .logout-sheet,
+.sheet-leave-to .logout-sheet {
+  transform: translateY(24px);
+}
+
+@keyframes skeleton-wave {
+  from {
+    background-position: 160% 0;
+  }
+  to {
+    background-position: -60% 0;
+  }
+}
+
+@media (max-width: 340px) {
+  .profile-scroll {
+    padding-inline: 12px;
+  }
+
+  .profile-hero {
+    grid-template-columns: 62px minmax(0, 1fr);
+    gap: 12px;
+    padding-inline: 16px;
+  }
+
+  .avatar-frame,
+  .skeleton-avatar {
+    width: 60px;
+    height: 60px;
+  }
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton,
+  .sheet-enter-active,
+  .sheet-leave-active,
+  .sheet-enter-active .logout-sheet,
+  .sheet-leave-active .logout-sheet {
+    animation: none;
+    transition: none;
+  }
 }
 </style>

--- a/customer-work-app/src/views/ProfileInfo.test.ts
+++ b/customer-work-app/src/views/ProfileInfo.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UserInfo } from '@/types/api'
+import ProfileInfoView from './ProfileInfo.vue'
+
+const { fetchMeMock, showToastMock, uploadAvatarMock } = vi.hoisted(() => ({
+  fetchMeMock: vi.fn(),
+  showToastMock: vi.fn(),
+  uploadAvatarMock: vi.fn(),
+}))
+
+vi.mock('@/api/auth', () => ({ fetchMe: fetchMeMock, uploadAvatar: uploadAvatarMock }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ back: vi.fn() }) }))
+vi.mock('vant', () => ({ showToast: showToastMock }))
+
+const UserAvatarStub = defineComponent({
+  name: 'UserAvatar',
+  props: { src: { type: String, default: '' }, name: { type: String, default: '' } },
+  setup(props) {
+    return () => h('span', { class: 'user-avatar-stub', 'data-src': props.src }, props.name)
+  },
+})
+
+const globalOptions = {
+  config: { errorHandler: vi.fn() },
+  stubs: {
+    UserAvatar: UserAvatarStub,
+    'van-icon': { template: '<i></i>' },
+    'van-loading': { template: '<span></span>' },
+  },
+}
+
+const profile: UserInfo = {
+  userId: 'user-1',
+  username: 'RichardFyoung',
+  nickname: 'RichardFyoung',
+  phone: '13800000000',
+  avatarUrl: 'https://example.test/old-avatar.png',
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+async function mountProfileInfo() {
+  const wrapper = mount(ProfileInfoView, { global: globalOptions })
+  await flushPromises()
+  return wrapper
+}
+
+async function selectAvatar(
+  wrapper: Awaited<ReturnType<typeof mountProfileInfo>>,
+  file: File,
+) {
+  const input = wrapper.get('.avatar-upload-input')
+  Object.defineProperty(input.element, 'files', { configurable: true, value: [file] })
+  await input.trigger('change')
+  await flushPromises()
+  return input
+}
+
+describe('ProfileInfo avatar upload', () => {
+  beforeEach(() => {
+    fetchMeMock.mockReset().mockResolvedValue(profile)
+    showToastMock.mockReset()
+    uploadAvatarMock.mockReset()
+  })
+
+  it('文件选择器有可读名称，并在前端拦截非图片与超限图片', async () => {
+    const wrapper = await mountProfileInfo()
+    const input = wrapper.get('.avatar-upload-input')
+    expect(input.attributes('aria-label')).toBe('更换头像')
+
+    await selectAvatar(wrapper, new File(['not an image'], 'avatar.txt', { type: 'text/plain' }))
+    await selectAvatar(
+      wrapper,
+      new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'avatar.png', { type: 'image/png' }),
+    )
+
+    expect(uploadAvatarMock).not.toHaveBeenCalled()
+    expect(showToastMock).toHaveBeenNthCalledWith(1, '仅支持 png/jpg/jpeg/gif 格式')
+    expect(showToastMock).toHaveBeenNthCalledWith(2, '图片大小不能超过 2MB')
+  })
+
+  it('合法图片上传期间禁用选择器，成功后立即更新头像', async () => {
+    const upload = deferred<string>()
+    uploadAvatarMock.mockReturnValue(upload.promise)
+    const wrapper = await mountProfileInfo()
+    const file = new File(['image'], 'avatar.png', { type: 'image/png' })
+    const input = wrapper.get('.avatar-upload-input')
+    Object.defineProperty(input.element, 'files', { configurable: true, value: [file] })
+
+    await input.trigger('change')
+    expect(input.attributes('disabled')).toBeDefined()
+
+    upload.resolve('https://example.test/new-avatar.png')
+    await flushPromises()
+
+    expect(uploadAvatarMock).toHaveBeenCalledWith(file)
+    expect(input.attributes('disabled')).toBeUndefined()
+    expect(wrapper.get('.user-avatar-stub').attributes('data-src')).toBe('https://example.test/new-avatar.png')
+    expect(showToastMock).toHaveBeenCalledWith('头像已更新')
+  })
+
+  it('上传失败会解除提交锁，且允许再次选择同一文件', async () => {
+    uploadAvatarMock.mockRejectedValueOnce(new Error('upload unavailable')).mockResolvedValueOnce('new-avatar.png')
+    const wrapper = await mountProfileInfo()
+    const file = new File(['image'], 'avatar.png', { type: 'image/png' })
+
+    const input = await selectAvatar(wrapper, file)
+    expect(input.attributes('disabled')).toBeUndefined()
+
+    await selectAvatar(wrapper, file)
+    expect(uploadAvatarMock).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('.user-avatar-stub').attributes('data-src')).toBe('new-avatar.png')
+  })
+})

--- a/customer-work-app/src/views/ProfileInfo.vue
+++ b/customer-work-app/src/views/ProfileInfo.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { showToast } from 'vant'
-import type { UploaderAfterRead, UploaderBeforeRead, UploaderFileListItem } from 'vant'
 import { fetchMe, uploadAvatar } from '@/api/auth'
+import UserAvatar from '@/components/UserAvatar.vue'
 import type { UserInfo } from '@/types/api'
 
 // 头像上传限制：与后端契约对齐（png/jpg/jpeg/gif，≤2MB），前端先校验一次减少无效上传
@@ -14,12 +14,19 @@ const router = useRouter()
 
 const profile = ref<UserInfo | null>(null)
 const loading = ref(true)
+const loadFailed = ref(false)
 const uploading = ref(false)
+
+const displayName = computed(() => profile.value?.nickname || profile.value?.username || '用户')
 
 async function loadProfile() {
   loading.value = true
+  loadFailed.value = false
+  profile.value = null
   try {
     profile.value = await fetchMe()
+  } catch {
+    loadFailed.value = true
   } finally {
     loading.value = false
   }
@@ -27,28 +34,29 @@ async function loadProfile() {
 
 onMounted(loadProfile)
 
-const beforeReadAvatar: UploaderBeforeRead = (file) => {
-  const target = Array.isArray(file) ? file[0] : file
-  if (!ACCEPTED_AVATAR_TYPES.includes(target.type)) {
+function validateAvatar(file: File): boolean {
+  if (!ACCEPTED_AVATAR_TYPES.includes(file.type)) {
     showToast('仅支持 png/jpg/jpeg/gif 格式')
     return false
   }
-  if (target.size > MAX_AVATAR_BYTES) {
+  if (file.size > MAX_AVATAR_BYTES) {
     showToast('图片大小不能超过 2MB')
     return false
   }
   return true
 }
 
-const afterReadAvatar: UploaderAfterRead = async (file) => {
-  const item = Array.isArray(file) ? file[0] : (file as UploaderFileListItem)
-  const rawFile = item.file
-  if (!rawFile) {
+async function onAvatarSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  // 允许用户在失败后再次选择同一个文件。
+  input.value = ''
+  if (!file || !validateAvatar(file)) {
     return
   }
   uploading.value = true
   try {
-    const avatarUrl = await uploadAvatar(rawFile)
+    const avatarUrl = await uploadAvatar(file)
     if (profile.value) {
       profile.value = { ...profile.value, avatarUrl }
     }
@@ -61,97 +69,443 @@ const afterReadAvatar: UploaderAfterRead = async (file) => {
 
 <template>
   <div class="profile-info-page">
-    <van-nav-bar title="个人信息" left-arrow @click-left="router.back()" />
+    <header class="detail-header">
+      <button type="button" class="back-button" aria-label="返回" @click="router.back()">
+        <van-icon name="arrow-left" />
+      </button>
+      <div>
+        <h1>个人信息</h1>
+        <p>账户资料</p>
+      </div>
+      <span class="header-spacer" aria-hidden="true"></span>
+    </header>
 
-    <div class="content">
-      <van-loading v-if="loading" class="loading" vertical>加载中...</van-loading>
-      <template v-else>
-        <div class="avatar-section">
-          <van-uploader :before-read="beforeReadAvatar" :after-read="afterReadAvatar" :max-count="1">
-            <div class="avatar-tap">
-              <img v-if="profile?.avatarUrl" :src="profile.avatarUrl" class="avatar-img" alt="头像" />
-              <van-icon v-else name="manager" size="40" />
-              <div class="avatar-badge">
-                <van-icon name="photograph" size="14" />
-              </div>
-            </div>
-          </van-uploader>
-          <div class="avatar-tip">{{ uploading ? '上传中...' : '点击更换头像' }}</div>
+    <main class="content">
+      <div v-if="loading" class="loading-state" aria-busy="true" aria-label="正在加载个人信息">
+        <span class="skeleton avatar-skeleton"></span>
+        <span class="skeleton tip-skeleton"></span>
+        <div class="field-card skeleton-card">
+          <div v-for="index in 3" :key="index" class="field-row">
+            <span class="skeleton label-skeleton"></span>
+            <span class="skeleton value-skeleton"></span>
+          </div>
         </div>
+      </div>
 
-        <van-cell-group inset>
-          <van-cell title="昵称" :value="profile?.nickname || '-'" />
-          <van-cell title="用户名" :value="profile?.username || '-'" />
-          <van-cell title="手机号" :value="profile?.phone || '-'" />
-        </van-cell-group>
+      <section v-else-if="loadFailed" class="error-state" role="alert">
+        <span class="error-icon"><van-icon name="contact" /></span>
+        <h2>资料加载失败</h2>
+        <p>暂时无法获取个人资料，请检查网络后重新加载。</p>
+        <button type="button" class="retry-button" @click="loadProfile">
+          <van-icon name="replay" />
+          重新加载
+        </button>
+      </section>
+
+      <template v-else-if="profile">
+        <section class="avatar-section">
+          <label class="avatar-upload-control">
+            <input
+              class="avatar-upload-input"
+              type="file"
+              accept="image/png,image/jpeg,image/gif"
+              :disabled="uploading"
+              aria-label="更换头像"
+              @change="onAvatarSelected"
+            />
+            <div class="avatar-tap" :aria-busy="uploading">
+              <UserAvatar :src="profile.avatarUrl" :name="displayName" />
+              <span class="avatar-badge">
+                <van-loading v-if="uploading" size="13" color="#fff" />
+                <van-icon v-else name="photograph" />
+              </span>
+            </div>
+          </label>
+          <p class="avatar-tip">
+            {{ uploading ? '正在上传头像…' : '点击头像更换 · PNG/JPG/GIF，最大 2MB' }}
+          </p>
+        </section>
+
+        <section class="readonly-section" aria-labelledby="readonlyTitle">
+          <div class="section-heading">
+            <h2 id="readonlyTitle">基本资料</h2>
+            <span>只读</span>
+          </div>
+          <div class="field-card">
+            <div class="field-row">
+              <span class="field-label">昵称</span>
+              <strong class="field-value">{{ profile.nickname || '-' }}</strong>
+            </div>
+            <div class="field-row">
+              <span class="field-label">用户名</span>
+              <strong class="field-value">{{ profile.username || '-' }}</strong>
+            </div>
+            <div class="field-row">
+              <span class="field-label">手机号</span>
+              <strong class="field-value">{{ profile.phone || '-' }}</strong>
+            </div>
+          </div>
+          <p class="readonly-tip"><van-icon name="info-o" />账号字段由系统维护，当前不可直接修改</p>
+        </section>
       </template>
-    </div>
+    </main>
   </div>
 </template>
 
 <style scoped>
 .profile-info-page {
+  --info-ink: var(--cw-ink, #142033);
+  --info-signal: var(--cw-primary, #316cff);
+  --info-signal-soft: var(--cw-primary-soft, #edf2ff);
+  --info-cloud: var(--cw-page-bg, #f2f5fa);
+  --info-paper: var(--cw-card-bg, #fff);
   flex: 1;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
+  overflow: hidden;
+  background: var(--info-cloud);
+  color: var(--info-ink);
+}
+
+.detail-header {
+  min-height: 72px;
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) 42px;
+  align-items: center;
+  padding: calc(10px + env(safe-area-inset-top)) 12px 10px;
+  border-bottom: 1px solid rgba(223, 229, 238, 0.8);
+  background: color-mix(in srgb, var(--info-paper) 94%, transparent);
+  text-align: center;
+}
+
+.detail-header h1,
+.detail-header p {
+  margin: 0;
+}
+
+.detail-header h1 {
+  font-size: 17px;
+  font-weight: 750;
+  letter-spacing: -0.015em;
+}
+
+.detail-header p {
+  margin-top: 2px;
+  color: #939eae;
+  font-size: 9px;
+}
+
+.back-button {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 13px;
+  background: transparent;
+  color: var(--info-ink);
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.back-button:active {
+  background: #eef2f7;
+}
+
+.header-spacer {
+  width: 40px;
+  height: 40px;
 }
 
 .content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  padding-bottom: 24px;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+  padding: 18px 14px calc(30px + env(safe-area-inset-bottom));
 }
 
-.loading {
-  margin-top: 40vh;
+.content::-webkit-scrollbar {
+  display: none;
 }
 
 .avatar-section {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 32px 0 24px;
+  padding: 18px 0 25px;
+}
+
+.avatar-upload-control {
+  position: relative;
+  display: inline-block;
+  border-radius: 30px;
+}
+
+.avatar-upload-input {
+  position: absolute;
+  z-index: 4;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: inherit;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.avatar-upload-input:disabled {
+  cursor: wait;
+}
+
+.avatar-upload-input:focus-visible + .avatar-tap {
+  outline: 3px solid rgba(49, 108, 255, 0.28);
+  outline-offset: 4px;
 }
 
 .avatar-tap {
   position: relative;
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  background: var(--cw-card-bg);
-  color: var(--cw-primary);
+  width: 86px;
+  height: 86px;
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
-  box-shadow: var(--cw-card-shadow);
+  overflow: visible;
+  border: 3px solid #fff;
+  border-radius: 29px;
+  background: var(--info-signal);
+  box-shadow: 0 14px 32px rgba(49, 108, 255, 0.22);
 }
 
-.avatar-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.avatar-tap :deep(.user-avatar) {
+  --user-avatar-initials-size: 25px;
+  --user-avatar-icon-size: 32px;
+  border-radius: 25px;
 }
 
 .avatar-badge {
   position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background: var(--cw-primary);
-  color: #fff;
+  z-index: 3;
+  right: -7px;
+  bottom: -7px;
+  width: 29px;
+  height: 29px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid var(--cw-card-bg);
+  border: 3px solid var(--info-cloud);
+  border-radius: 50%;
+  background: var(--info-signal);
+  color: #fff;
+  font-size: 14px;
 }
 
 .avatar-tip {
-  margin-top: 8px;
+  margin: 14px 0 0;
+  color: #79869a;
+  font-size: 11px;
+}
+
+.readonly-section {
+  margin-top: 4px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 3px 9px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #758297;
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.section-heading span {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #e9edf4;
+  color: #7b8799;
+  font-size: 9px;
+}
+
+.field-card {
+  overflow: hidden;
+  border: 1px solid #e5eaf2;
+  border-radius: 17px;
+  background: var(--info-paper);
+  box-shadow: 0 7px 22px rgba(37, 55, 85, 0.055);
+}
+
+.field-row {
+  min-height: 64px;
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 12px 15px;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.field-row:last-child {
+  border-bottom: 0;
+}
+
+.field-label {
+  color: #788599;
   font-size: 12px;
-  color: var(--cw-text-secondary);
+}
+
+.field-value {
+  overflow: hidden;
+  color: var(--info-ink);
+  text-align: right;
+  font-size: 13px;
+  font-weight: 680;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.readonly-tip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 10px 4px 0;
+  color: #919cad;
+  font-size: 10px;
+}
+
+.error-state {
+  min-height: calc(100% - 18px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 24px 46px;
+  text-align: center;
+}
+
+.error-icon {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 22px;
+  background: var(--info-signal-soft);
+  color: var(--info-signal);
+  font-size: 29px;
+  box-shadow: 0 10px 24px rgba(49, 108, 255, 0.12);
+}
+
+.error-state h2 {
+  margin: 19px 0 0;
+  font-size: 17px;
+}
+
+.error-state p {
+  max-width: 270px;
+  margin: 9px 0 0;
+  color: #7c899d;
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.retry-button {
+  min-width: 132px;
+  min-height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin-top: 22px;
+  padding: 0 20px;
+  border: 0;
+  border-radius: 15px;
+  background: var(--info-signal);
+  color: #fff;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: 0 12px 26px rgba(49, 108, 255, 0.2);
+  cursor: pointer;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 18px 0 0;
+}
+
+.skeleton {
+  display: block;
+  background: linear-gradient(90deg, #e7ecf4 25%, #f6f8fb 50%, #e7ecf4 75%);
+  background-size: 200% 100%;
+  animation: skeleton-wave 1.25s ease-in-out infinite;
+}
+
+.avatar-skeleton {
+  width: 86px;
+  height: 86px;
+  border-radius: 29px;
+}
+
+.tip-skeleton {
+  width: 178px;
+  height: 10px;
+  margin: 15px 0 27px;
+  border-radius: 999px;
+}
+
+.skeleton-card {
+  width: 100%;
+}
+
+.label-skeleton,
+.value-skeleton {
+  height: 11px;
+  border-radius: 999px;
+}
+
+.label-skeleton {
+  width: 45px;
+}
+
+.value-skeleton {
+  width: min(132px, 78%);
+  justify-self: end;
+}
+
+.back-button:focus-visible,
+.retry-button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.28);
+  outline-offset: -3px;
+}
+
+@keyframes skeleton-wave {
+  from {
+    background-position: 160% 0;
+  }
+  to {
+    background-position: -60% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
 }
 </style>

--- a/customer-work-app/src/views/Register.vue
+++ b/customer-work-app/src/views/Register.vue
@@ -26,104 +26,408 @@ async function onSubmit() {
 
 <template>
   <div class="register-page">
-    <div class="hero">
-      <div class="hero-brand">注册账号</div>
-      <div class="hero-sub">创建您的专属客服账号</div>
-    </div>
-    <div class="card">
-    <van-form @submit="onSubmit">
-      <van-cell-group inset>
-        <van-field
-          v-model="username"
-          name="username"
-          label="用户名"
-          placeholder="请输入用户名"
-          :rules="[{ required: true, message: '请输入用户名' }]"
-        />
-        <van-field
-          v-model="password"
-          type="password"
-          name="password"
-          label="密码"
-          placeholder="请输入密码"
-          :rules="[{ required: true, message: '请输入密码' }]"
-        />
-        <van-field
-          v-model="nickname"
-          name="nickname"
-          label="昵称"
-          placeholder="请输入昵称"
-          :rules="[{ required: true, message: '请输入昵称' }]"
-        />
-        <van-field
-          v-model="phone"
-          name="phone"
-          label="手机号"
-          placeholder="请输入手机号"
-          :rules="[{ required: true, message: '请输入手机号' }]"
-        />
-      </van-cell-group>
-      <div class="submit-wrap">
-        <van-button round block type="primary" native-type="submit" :loading="submitting">注册</van-button>
+    <section class="register-hero">
+      <div class="register-brand">
+        <span class="assistant-mark" aria-hidden="true"><span class="assistant-glyph"><i></i></span></span>
+        <span>
+          <strong>智能客服</strong>
+          <small>SERVICE COMPANION</small>
+        </span>
       </div>
-    </van-form>
-    <div class="link-wrap">
-      已有账号？
-      <router-link to="/login">去登录</router-link>
-    </div>
-    </div>
+      <h1>创建服务账号</h1>
+      <p>完成注册后，即可保存会话、订单与服务进度。</p>
+    </section>
+
+    <section class="register-panel">
+      <div class="panel-heading">
+        <h2>填写账户资料</h2>
+        <p>以下信息用于识别您的服务账号</p>
+      </div>
+      <van-form class="auth-form" @submit="onSubmit">
+        <div class="input-group">
+          <label for="registerUsername">用户名</label>
+          <van-field
+            id="registerUsername"
+            v-model="username"
+            class="auth-field"
+            name="username"
+            left-icon="contact"
+            placeholder="请输入用户名"
+            autocomplete="username"
+            autocapitalize="none"
+            :rules="[{ required: true, message: '请输入用户名' }]"
+          />
+        </div>
+        <div class="input-group">
+          <label for="registerPassword">密码</label>
+          <van-field
+            id="registerPassword"
+            v-model="password"
+            class="auth-field"
+            type="password"
+            name="password"
+            left-icon="lock"
+            placeholder="请输入密码"
+            autocomplete="new-password"
+            :rules="[{ required: true, message: '请输入密码' }]"
+          />
+        </div>
+        <div class="input-group">
+          <label for="registerNickname">昵称</label>
+          <van-field
+            id="registerNickname"
+            v-model="nickname"
+            class="auth-field"
+            name="nickname"
+            left-icon="smile-o"
+            placeholder="请输入昵称"
+            autocomplete="name"
+            :rules="[{ required: true, message: '请输入昵称' }]"
+          />
+        </div>
+        <div class="input-group">
+          <label for="registerPhone">手机号</label>
+          <van-field
+            id="registerPhone"
+            v-model="phone"
+            class="auth-field"
+            type="tel"
+            name="phone"
+            left-icon="phone-o"
+            placeholder="请输入手机号"
+            autocomplete="tel"
+            :rules="[{ required: true, message: '请输入手机号' }]"
+          />
+        </div>
+        <van-button
+          class="submit-button"
+          block
+          type="primary"
+          native-type="submit"
+          :loading="submitting"
+          loading-text="正在注册…"
+        >
+          注册
+        </van-button>
+      </van-form>
+      <p class="link-wrap">
+        已有账号？
+        <router-link to="/login">去登录</router-link>
+      </p>
+    </section>
   </div>
 </template>
 
 <style scoped>
 .register-page {
+  --auth-ink: var(--cw-ink, #142033);
+  --auth-signal: var(--cw-primary, #316cff);
+  --auth-paper: var(--cw-card-bg, #fff);
   flex: 1;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  background: var(--cw-page-bg);
+  background: var(--auth-paper);
+  color: var(--auth-ink);
+  scrollbar-width: none;
 }
 
-.hero {
-  background: var(--cw-gradient-brand);
+.register-page::-webkit-scrollbar {
+  display: none;
+}
+
+.register-hero {
+  position: relative;
+  min-height: 253px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  padding: calc(46px + env(safe-area-inset-top)) 28px 49px;
+  background: var(--auth-ink);
   color: #fff;
-  padding: 48px 24px 40px;
-  text-align: center;
-  border-radius: 0 0 28px 28px;
 }
 
-.hero-brand {
-  font-size: 24px;
-  font-weight: 700;
+.register-hero::before,
+.register-hero::after {
+  content: '';
+  position: absolute;
+  border: 1px solid rgba(94, 140, 255, 0.38);
+  border-radius: 50%;
+  pointer-events: none;
 }
 
-.hero-sub {
-  margin-top: 8px;
-  font-size: 13px;
-  opacity: 0.85;
+.register-hero::before {
+  width: 238px;
+  height: 238px;
+  right: -108px;
+  top: -112px;
+  box-shadow: 0 0 0 31px rgba(49, 108, 255, 0.05);
 }
 
-.card {
+.register-hero::after {
+  width: 104px;
+  height: 104px;
+  left: -59px;
+  bottom: -52px;
+}
+
+.register-brand {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 29px;
+}
+
+.assistant-mark {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: #fff;
+  color: var(--auth-signal);
+  box-shadow: 0 10px 26px rgba(13, 38, 103, 0.22);
+}
+
+.assistant-mark::before,
+.assistant-mark::after {
+  content: '';
+  position: absolute;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  animation: beacon 2.4s ease-out infinite;
+}
+
+.assistant-mark::before {
+  inset: -6px;
+}
+
+.assistant-mark::after {
+  inset: -11px;
+  animation-delay: 0.8s;
+}
+
+.assistant-glyph {
+  position: relative;
+  width: 22px;
+  height: 17px;
+  border: 2px solid currentColor;
+  border-radius: 10px 10px 9px 9px;
+}
+
+.assistant-glyph::before,
+.assistant-glyph::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.assistant-glyph::before {
+  left: 4px;
+}
+
+.assistant-glyph::after {
+  right: 4px;
+}
+
+.assistant-glyph i {
+  position: absolute;
+  left: 50%;
+  bottom: -6px;
+  width: 8px;
+  height: 7px;
+  border-left: 2px solid currentColor;
+  transform: skew(-24deg) translateX(-50%);
+}
+
+.register-brand strong,
+.register-brand small {
+  display: block;
+}
+
+.register-brand strong {
+  font-size: 14px;
+}
+
+.register-brand small {
+  margin-top: 3px;
+  color: #8fa0bb;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+}
+
+.register-hero h1,
+.register-hero p {
+  position: relative;
+  z-index: 1;
+}
+
+.register-hero h1 {
+  margin: 0;
+  font-size: 29px;
+  line-height: 1.22;
+  letter-spacing: -0.04em;
+}
+
+.register-hero p {
+  max-width: 285px;
+  margin: 9px 0 0;
+  color: #aebbd0;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.register-panel {
+  position: relative;
+  z-index: 2;
   flex: 1;
-  background: var(--cw-card-bg);
-  border-radius: var(--cw-card-radius) var(--cw-card-radius) 0 0;
-  margin-top: -20px;
-  padding-top: 24px;
-  box-shadow: var(--cw-card-shadow);
+  margin-top: -30px;
+  padding: 25px 22px calc(28px + env(safe-area-inset-bottom));
+  border-radius: 30px 30px 0 0;
+  background: var(--auth-paper);
 }
 
-.submit-wrap {
-  margin: 24px 16px 0;
+.panel-heading {
+  margin: 0 1px 21px;
+}
+
+.panel-heading h2,
+.panel-heading p {
+  margin: 0;
+}
+
+.panel-heading h2 {
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+
+.panel-heading p {
+  margin-top: 5px;
+  color: #8a95a6;
+  font-size: 10px;
+}
+
+.input-group {
+  margin-bottom: 13px;
+}
+
+.input-group > label {
+  display: block;
+  margin: 0 2px 6px;
+  color: #637087;
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.auth-field {
+  min-height: 50px;
+  padding: 7px 14px;
+  border: 1px solid #dfe5ee;
+  border-radius: 15px;
+  background: #f8fafd;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.auth-field::after {
+  display: none;
+}
+
+.auth-field:focus-within {
+  border-color: color-mix(in srgb, var(--auth-signal) 74%, #fff);
+  background: #fff;
+  box-shadow: 0 0 0 3px rgba(49, 108, 255, 0.1);
+}
+
+.auth-field :deep(.van-field__left-icon) {
+  margin-right: 10px;
+  color: #8490a3;
+  font-size: 18px;
+}
+
+.auth-field :deep(.van-field__control) {
+  color: var(--auth-ink);
+  font-size: 13px;
+}
+
+.auth-field :deep(.van-field__control::placeholder) {
+  color: #a4adba;
+}
+
+.auth-field :deep(.van-field__error-message) {
+  margin-top: 5px;
+  font-size: 10px;
+}
+
+.submit-button {
+  min-height: 50px;
+  margin-top: 9px;
+  border: 0;
+  border-radius: 16px;
+  background: var(--auth-signal);
+  font-size: 14px;
+  font-weight: 750;
+  box-shadow: 0 12px 26px rgba(49, 108, 255, 0.23);
+}
+
+.submit-button:focus-visible {
+  outline: 3px solid rgba(49, 108, 255, 0.3);
+  outline-offset: 3px;
 }
 
 .link-wrap {
+  margin: 18px 0 0;
   text-align: center;
-  margin-top: 16px;
-  padding-bottom: 24px;
-  font-size: 14px;
-  color: var(--cw-text-secondary);
+  color: #8792a3;
+  font-size: 11px;
 }
 
 .link-wrap a {
-  color: var(--cw-primary);
+  color: var(--auth-signal);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.link-wrap a:focus-visible {
+  outline: 2px solid rgba(49, 108, 255, 0.32);
+  outline-offset: 3px;
+}
+
+@keyframes beacon {
+  0% {
+    opacity: 0.34;
+    transform: scale(0.88);
+  }
+  72%,
+  100% {
+    opacity: 0;
+    transform: scale(1.08);
+  }
+}
+
+@media (max-width: 340px) {
+  .register-hero {
+    padding-inline: 22px;
+  }
+
+  .register-panel {
+    padding-inline: 17px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-mark::before,
+  .assistant-mark::after {
+    animation: none;
+    opacity: 0.18;
+  }
 }
 </style>

--- a/customer-work-app/src/views/TicketDetail.test.ts
+++ b/customer-work-app/src/views/TicketDetail.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TicketDetail } from '@/types/api'
+import TicketDetailView from './TicketDetail.vue'
+
+const { fetchTicketDetailMock } = vi.hoisted(() => ({ fetchTicketDetailMock: vi.fn() }))
+
+vi.mock('@/api/ticket', () => ({
+  closeTicket: vi.fn(),
+  confirmTicket: vi.fn(),
+  fetchTicketDetail: fetchTicketDetailMock,
+  reopenTicket: vi.fn(),
+  rejectTicket: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}))
+
+vi.mock('vant', () => ({ showToast: vi.fn() }))
+
+const detail: TicketDetail = {
+  ticket: {
+    id: 'TK-20260828-01',
+    sessionId: 'session-1',
+    userId: 'user-1',
+    title: '物流状态查询',
+    category: '订单物流',
+    priority: 'NORMAL',
+    status: 'PROCESSING',
+    assignee: '客服 07',
+    handoffReason: '需要核对物流节点',
+    resolveNote: null,
+    reopenCount: 0,
+    createdAtMs: 1_777_520_000_000,
+    updatedAtMs: 1_777_520_060_000,
+  },
+  events: [],
+}
+
+const globalOptions = {
+  stubs: {
+    'van-nav-bar': { template: '<header></header>' },
+    'van-loading': { template: '<span><slot /></span>' },
+    'van-button': { emits: ['click'], template: '<button type="button" @click="$emit(\'click\')"><slot /></button>' },
+    'van-tag': { template: '<span><slot /></span>' },
+    'van-cell-group': { template: '<section><slot /></section>' },
+    'van-cell': { template: '<div></div>' },
+    'van-steps': { template: '<section><slot /></section>' },
+    'van-step': { template: '<div><slot /></div>' },
+    'van-dialog': { template: '<div><slot /></div>' },
+    'van-field': { template: '<textarea></textarea>' },
+  },
+}
+
+describe('TicketDetail', () => {
+  beforeEach(() => {
+    fetchTicketDetailMock.mockReset()
+  })
+
+  it('加载失败时提供原地重试，并能恢复详情内容', async () => {
+    fetchTicketDetailMock.mockRejectedValueOnce(new Error('network unavailable')).mockResolvedValueOnce(detail)
+    const wrapper = mount(TicketDetailView, {
+      props: { id: detail.ticket.id },
+      global: globalOptions,
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('工单没有加载成功')
+    expect(wrapper.text()).toContain('重新加载')
+
+    await wrapper.get('.state-error button').trigger('click')
+    await flushPromises()
+
+    expect(fetchTicketDetailMock).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('h1').text()).toBe('物流状态查询')
+    expect(wrapper.text()).toContain('暂无流转记录')
+  })
+})

--- a/customer-work-app/src/views/TicketDetail.vue
+++ b/customer-work-app/src/views/TicketDetail.vue
@@ -4,7 +4,14 @@ import { useRouter } from 'vue-router'
 import { showToast } from 'vant'
 import { closeTicket, confirmTicket, fetchTicketDetail, reopenTicket, rejectTicket } from '@/api/ticket'
 import type { Ticket, TicketEvent } from '@/types/api'
-import { TICKET_STATUS_TAG_TYPE, TICKET_STATUS_TEXT } from '@/types/api'
+import {
+  ticketActorTypeText,
+  ticketCategoryText,
+  ticketEventTypeText,
+  ticketPriorityText,
+  TICKET_STATUS_TAG_TYPE,
+  TICKET_STATUS_TEXT,
+} from '@/types/api'
 
 const props = defineProps<{ id: string }>()
 const router = useRouter()
@@ -12,6 +19,7 @@ const router = useRouter()
 const ticket = ref<Ticket | null>(null)
 const events = ref<TicketEvent[]>([])
 const loading = ref(true)
+const loadError = ref('')
 
 const rejectVisible = ref(false)
 const reopenVisible = ref(false)
@@ -22,10 +30,15 @@ const ticketId = computed(() => props.id)
 
 async function loadDetail() {
   loading.value = true
+  loadError.value = ''
   try {
     const detail = await fetchTicketDetail(ticketId.value)
     ticket.value = detail.ticket
     events.value = detail.events
+  } catch {
+    ticket.value = null
+    events.value = []
+    loadError.value = '工单详情暂时无法加载，请稍后重试'
   } finally {
     loading.value = false
   }
@@ -100,41 +113,69 @@ function goChat() {
 
 <template>
   <div class="ticket-detail-page">
-    <van-nav-bar title="工单详情" left-arrow @click-left="router.back()" />
+    <van-nav-bar title="工单详情" left-arrow safe-area-inset-top @click-left="router.back()" />
     <div class="content">
-      <van-loading v-if="loading" class="loading" vertical>加载中...</van-loading>
+      <div v-if="loading" class="state-panel" role="status">
+        <van-loading color="var(--cw-primary, #1677ff)" vertical>正在加载工单…</van-loading>
+      </div>
+      <div v-else-if="loadError" class="state-panel state-error">
+        <div class="state-symbol" aria-hidden="true">!</div>
+        <strong>工单没有加载成功</strong>
+        <p>{{ loadError }}</p>
+        <van-button round type="primary" size="small" @click="loadDetail">重新加载</van-button>
+      </div>
       <template v-else-if="ticket">
-        <van-cell-group inset title="基本信息">
-          <van-cell title="工单编号" :value="`#${ticket.id}`" />
-          <van-cell title="标题" :value="ticket.title || '-'" />
-          <van-cell title="状态">
-            <template #value>
-              <van-tag :type="TICKET_STATUS_TAG_TYPE[ticket.status]">{{ TICKET_STATUS_TEXT[ticket.status] }}</van-tag>
-            </template>
-          </van-cell>
-          <van-cell title="分类" :value="ticket.category || '-'" />
-          <van-cell title="优先级" :value="ticket.priority || '-'" />
-          <van-cell title="处理人" :value="ticket.assignee || '-'" />
-          <van-cell v-if="ticket.handoffReason" title="转人工原因" :value="ticket.handoffReason" />
-          <van-cell v-if="ticket.resolveNote" title="处理说明" :value="ticket.resolveNote" />
-          <van-cell title="重开次数" :value="String(ticket.reopenCount)" />
-          <van-cell title="创建时间" :value="formatTime(ticket.createdAtMs)" />
-          <van-cell title="更新时间" :value="formatTime(ticket.updatedAtMs)" />
-        </van-cell-group>
+        <section class="ticket-hero">
+          <div class="ticket-hero-topline">
+            <span>工单 #{{ ticket.id }}</span>
+            <van-tag :type="TICKET_STATUS_TAG_TYPE[ticket.status]" plain size="medium">
+              {{ TICKET_STATUS_TEXT[ticket.status] }}
+            </van-tag>
+          </div>
+          <h1>{{ ticket.title || '服务工单' }}</h1>
+          <p>最近更新于 {{ formatTime(ticket.updatedAtMs) }}</p>
+          <div class="hero-meta">
+            <span><small>分类</small>{{ ticket.category ? ticketCategoryText(ticket.category) : '未分类' }}</span>
+            <span><small>优先级</small>{{ ticket.priority ? ticketPriorityText(ticket.priority) : '未设置' }}</span>
+            <span><small>处理人</small>{{ ticket.assignee || '待分配' }}</span>
+          </div>
+        </section>
 
-        <div class="section-title">流转记录</div>
-        <van-steps direction="vertical" :active="events.length">
-          <van-step v-for="(event, index) in events" :key="index">
-            <div class="event-type">{{ event.eventType }}</div>
-            <div v-if="event.fromStatus || event.toStatus" class="event-status">
-              {{ event.fromStatus ? TICKET_STATUS_TEXT[event.fromStatus] : '—' }}
-              →
-              {{ event.toStatus ? TICKET_STATUS_TEXT[event.toStatus] : '—' }}
-            </div>
-            <div v-if="event.note" class="event-note">{{ event.note }}</div>
-            <div class="event-time">{{ formatTime(event.createdAtMs) }} · {{ event.actorType }}</div>
-          </van-step>
-        </van-steps>
+        <section class="detail-section">
+          <div class="section-heading">
+            <span class="section-kicker">SERVICE INFO</span>
+            <h2>服务信息</h2>
+          </div>
+          <van-cell-group class="info-card" inset>
+            <van-cell v-if="ticket.handoffReason" title="转人工原因" :value="ticket.handoffReason" />
+            <van-cell v-if="ticket.resolveNote" title="处理说明" :value="ticket.resolveNote" />
+            <van-cell title="重开次数" :value="`${ticket.reopenCount} 次`" />
+            <van-cell title="创建时间" :value="formatTime(ticket.createdAtMs)" />
+            <van-cell title="更新时间" :value="formatTime(ticket.updatedAtMs)" />
+          </van-cell-group>
+        </section>
+
+        <section class="detail-section">
+          <div class="section-heading">
+            <span class="section-kicker">PROGRESS</span>
+            <h2>流转记录</h2>
+          </div>
+          <div class="timeline-card">
+            <van-steps v-if="events.length > 0" direction="vertical" :active="events.length" active-color="#1677ff">
+              <van-step v-for="(event, index) in events" :key="index">
+                <div class="event-type">{{ ticketEventTypeText(event.eventType) }}</div>
+                <div v-if="event.fromStatus || event.toStatus" class="event-status">
+                  {{ event.fromStatus ? TICKET_STATUS_TEXT[event.fromStatus] : '—' }}
+                  <span aria-hidden="true">→</span>
+                  {{ event.toStatus ? TICKET_STATUS_TEXT[event.toStatus] : '—' }}
+                </div>
+                <div v-if="event.note" class="event-note">{{ event.note }}</div>
+                <div class="event-time">{{ formatTime(event.createdAtMs) }} · {{ ticketActorTypeText(event.actorType) }}</div>
+              </van-step>
+            </van-steps>
+            <div v-else class="timeline-empty">暂无流转记录</div>
+          </div>
+        </section>
 
         <div class="actions">
           <template v-if="ticket.status === 'WAITING_CONFIRM'">
@@ -165,58 +206,227 @@ function goChat() {
 
 <style scoped>
 .ticket-detail-page {
-  flex: 1;
   display: flex;
+  min-height: 100vh;
+  min-height: 100dvh;
   flex-direction: column;
-  background: #f7f8fa;
+  background:
+    radial-gradient(circle at 92% 3%, rgba(24, 119, 242, 0.1), transparent 25%),
+    var(--cw-page-bg, #f4f7fb);
 }
 
 .content {
   flex: 1;
   overflow-y: auto;
-  padding-bottom: 24px;
+  padding: 12px 12px calc(28px + env(safe-area-inset-bottom));
 }
 
-.loading {
-  margin-top: 40vh;
+.state-panel {
+  display: flex;
+  min-height: 68vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
 }
 
-.section-title {
-  margin: 16px 16px 8px;
-  font-size: 14px;
-  color: #969799;
+.state-panel strong {
+  margin-top: 12px;
+  color: var(--cw-text-primary, #13233a);
+  font-size: 16px;
+}
+
+.state-panel p {
+  margin: 5px 0 16px;
+  color: var(--cw-text-secondary, #718096);
+  font-size: 13px;
+}
+
+.state-symbol {
+  display: grid;
+  width: 50px;
+  height: 50px;
+  place-items: center;
+  border-radius: 16px;
+  color: #fff;
+  background: #ef6d6d;
+  font-size: 24px;
+  font-weight: 800;
+  box-shadow: 0 10px 22px rgba(239, 109, 109, 0.25);
+}
+
+.ticket-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 18px;
+  border-radius: 22px;
+  color: #fff;
+  background:
+    radial-gradient(circle at 85% 8%, rgba(91, 231, 192, 0.28), transparent 34%),
+    linear-gradient(145deg, #14375f, #0b2543);
+  box-shadow: 0 18px 38px rgba(12, 38, 70, 0.18);
+}
+
+.ticket-hero::after {
+  position: absolute;
+  right: -36px;
+  bottom: -54px;
+  width: 150px;
+  height: 150px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  content: '';
+}
+
+.ticket-hero-topline {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 12px;
+  letter-spacing: 0.4px;
+}
+
+.ticket-hero h1 {
+  position: relative;
+  z-index: 1;
+  margin: 19px 0 5px;
+  font-size: 22px;
+  line-height: 1.35;
+}
+
+.ticket-hero > p {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 12px;
+}
+
+.hero-meta {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.hero-meta span {
+  min-width: 0;
+  overflow: hidden;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 13px;
+  background: rgba(255, 255, 255, 0.07);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hero-meta small {
+  display: block;
+  margin-bottom: 4px;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 10px;
+}
+
+.detail-section {
+  margin-top: 23px;
+}
+
+.section-heading {
+  margin: 0 4px 10px;
+}
+
+.section-heading h2 {
+  margin: 1px 0 0;
+  color: var(--cw-text-primary, #13233a);
+  font-size: 17px;
+}
+
+.section-kicker {
+  color: var(--cw-primary, #1677ff);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 1.6px;
+}
+
+.info-card,
+.timeline-card {
+  overflow: hidden;
+  border: 1px solid rgba(19, 35, 58, 0.06);
+  border-radius: 18px;
+  background: var(--cw-card-bg, #fff);
+  box-shadow: 0 10px 28px rgba(21, 52, 92, 0.07);
+}
+
+.info-card {
+  margin: 0;
+}
+
+.timeline-card {
+  padding: 4px 10px;
+}
+
+.timeline-empty {
+  padding: 32px 16px;
+  color: var(--cw-text-secondary, #718096);
+  font-size: 13px;
+  text-align: center;
 }
 
 .event-type {
-  font-weight: 500;
+  color: var(--cw-text-primary, #13233a);
+  font-size: 14px;
+  font-weight: 700;
 }
 
 .event-status {
   font-size: 13px;
-  color: #646566;
-  margin-top: 2px;
+  color: var(--cw-primary, #1677ff);
+  margin-top: 4px;
 }
 
 .event-note {
   font-size: 13px;
-  color: #646566;
-  margin-top: 2px;
+  color: var(--cw-text-secondary, #718096);
+  margin-top: 5px;
+  line-height: 1.5;
 }
 
 .event-time {
   font-size: 12px;
-  color: #969799;
-  margin-top: 2px;
+  color: #9aa6b6;
+  margin-top: 6px;
 }
 
 .actions {
-  margin: 20px 16px 0;
+  margin-top: 22px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+}
+
+.actions .van-button {
+  min-height: 46px;
 }
 
 .dialog-field {
   padding: 16px;
+}
+
+@media (max-width: 340px) {
+  .hero-meta {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hero-meta span:last-child {
+    grid-column: 1 / -1;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更说明 / What

将 `customer-work-app` 的消息、聊天、订单、我的、登录注册与工单详情统一升级为 Service Pulse 视觉体系，并保留原有业务链路与接口语义。

- 统一移动端信息架构、悬浮底部导航、状态色、留白与响应式布局
- 补全加载、空态、错误重试、分页竞争、WebSocket 会话、评价、登出和头像降级等交互状态
- 加强键盘焦点、语义标签、触控热区、安全区与窄屏适配
- 将“记住密码”调整为仅记住用户名，并安全迁移、清理旧本地凭据
- 为 H5 新增 Vitest 测试，并纳入前端 CI 矩阵

## 类型 / Type

- [x] feat 新功能
- [ ] fix 修复
- [ ] docs 文档
- [ ] refactor / test / chore

## 验证 / Verification

- `customer-work-app`: 10 个测试文件、27 项测试通过
- `customer-work-app`: TypeScript 检查与生产构建通过
- `customer-admin-web`: 7 个测试文件、37 项测试通过，生产构建通过
- 浏览器验收：8 个页面、390×844 与 320×568 两种视口，覆盖正常、空态、错误重试、头像降级及关键交互；无控制台错误、页面异常或横向溢出
- Maven 全项目门禁：6 个模块全部成功；3471 项测试，0 失败，0 错误，6 跳过；最终 `BUILD SUCCESS`

## 自查 / Checklist

- [x] `mvn test` 全绿（新增功能附了单元测试）
- [x] 未在代码 / 配置中硬编码任何密钥
- [x] 新增外部后端遵循“接口 + 默认实现（@ConditionalOnMissingBean）”约定（本次未新增外部后端）
- [x] 必要时更新了 README / 配置项说明
