### PR TITLE
feat(admin-web): 重构全局导航与顶部布局

### DIFF
--- a/customer-admin-web/index.html
+++ b/customer-admin-web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />

--- a/customer-admin-web/src/App.vue
+++ b/customer-admin-web/src/App.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
 import { useThemeStore } from '@/store/theme'
 
 const themeStore = useThemeStore()
-onMounted(() => themeStore.apply())
+// 在首个路由组件渲染前应用已保存的明暗模式，避免全局壳先以亮色闪现再切暗色。
+themeStore.apply()
 </script>
 
 <template>

--- a/customer-admin-web/src/components/NotificationBell.vue
+++ b/customer-admin-web/src/components/NotificationBell.vue
@@ -116,7 +116,7 @@ onUnmounted(() => {
   >
     <template #reference>
       <el-badge :value="unreadCount" :max="99" :hidden="unreadCount === 0" class="notification-badge">
-        <el-button class="bell-btn" text title="站内消息">
+        <el-button class="bell-btn" text title="站内消息" aria-label="打开站内消息">
           <el-icon :size="18"><Bell /></el-icon>
         </el-button>
       </el-badge>
@@ -130,9 +130,10 @@ onUnmounted(() => {
       </div>
       <el-empty v-if="!loading && messages.length === 0" description="暂无消息" :image-size="50" />
       <el-scrollbar v-else max-height="360px">
-        <div
+        <button
           v-for="msg in messages"
           :key="msg.id"
+          type="button"
           class="notification-item"
           @click="handleMessageClick(msg)"
         >
@@ -142,7 +143,7 @@ onUnmounted(() => {
             <div class="notification-item-content">{{ msg.content }}</div>
             <div class="notification-item-time">{{ formatRelativeTime(msg.createTime) }}</div>
           </div>
-        </div>
+        </button>
       </el-scrollbar>
     </div>
   </el-popover>
@@ -183,11 +184,17 @@ onUnmounted(() => {
 }
 
 .notification-item {
+  width: 100%;
   display: flex;
   align-items: flex-start;
   gap: 6px;
   padding: 8px 4px;
+  border: 0;
   border-bottom: 1px solid var(--el-border-color-lighter);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font: inherit;
   cursor: pointer;
 }
 

--- a/customer-admin-web/src/components/TenantSwitcher.vue
+++ b/customer-admin-web/src/components/TenantSwitcher.vue
@@ -52,6 +52,7 @@ onMounted(load)
     size="default"
     :loading="switching"
     filterable
+    aria-label="租户视角"
   >
     <template #prefix>
       <el-icon><OfficeBuilding /></el-icon>

--- a/customer-admin-web/src/layouts/AppBreadcrumb.vue
+++ b/customer-admin-web/src/layouts/AppBreadcrumb.vue
@@ -2,30 +2,13 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useMenuStore } from '@/store/menu'
-import type { MenuNode } from '@/types/api'
+import { findMenuTrail } from './navigationModel'
 
 const route = useRoute()
 const menuStore = useMenuStore()
 
-/** 按 path 精确匹配菜单树，返回从根到命中节点的名称链（分组名 + 叶子名）。 */
-function findAncestorNames(nodes: MenuNode[], path: string, trail: string[]): string[] | null {
-  for (const node of nodes) {
-    const nextTrail = [...trail, node.name]
-    if (node.path && node.path === path) {
-      return nextTrail
-    }
-    if (node.children && node.children.length > 0) {
-      const found = findAncestorNames(node.children, path, nextTrail)
-      if (found) {
-        return found
-      }
-    }
-  }
-  return null
-}
-
 const crumbs = computed(() => {
-  const found = findAncestorNames(menuStore.tree, route.path, [])
+  const found = findMenuTrail(menuStore.tree, route.fullPath, route.path)
   if (found) {
     return found
   }
@@ -33,17 +16,25 @@ const crumbs = computed(() => {
   const title = (route.meta.title as string | undefined) || (route.name ? String(route.name) : route.path)
   return [title]
 })
+
+// 两级路径已由生命周期导航 + 当前页签完整表达；只有真正的深层路径才额外占用面包屑行。
+const shouldShow = computed(() => crumbs.value.length > 2)
 </script>
 
 <template>
-  <el-breadcrumb class="app-breadcrumb" separator="/">
+  <el-breadcrumb v-if="shouldShow" class="app-breadcrumb" separator="/" aria-label="当前位置">
     <el-breadcrumb-item v-for="(name, idx) in crumbs" :key="idx">{{ name }}</el-breadcrumb-item>
   </el-breadcrumb>
 </template>
 
 <style scoped>
 .app-breadcrumb {
-  padding: 10px 16px;
-  font-size: 13px;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+  background: var(--el-bg-color);
+  font-size: 12px;
 }
 </style>

--- a/customer-admin-web/src/layouts/AppHeader.vue
+++ b/customer-admin-web/src/layouts/AppHeader.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/store/auth'
+import { useMenuStore } from '@/store/menu'
+import { useTabsStore } from '@/store/tabs'
+import { useThemeStore } from '@/store/theme'
+import GlobalCommandSearch from './GlobalCommandSearch.vue'
+import NotificationBell from '@/components/NotificationBell.vue'
+import TenantSwitcher from '@/components/TenantSwitcher.vue'
+
+const props = defineProps<{
+  compactViewport: boolean
+  overlayOpen: boolean
+  navigationCollapsed: boolean
+}>()
+const emit = defineEmits<{ navigationToggle: [event: MouseEvent] }>()
+
+const router = useRouter()
+const auth = useAuthStore()
+const menuStore = useMenuStore()
+const tabsStore = useTabsStore()
+const themeStore = useThemeStore()
+const userInitial = computed(() => (
+  (auth.nickname || auth.username || 'U').trim().slice(0, 1).toLocaleUpperCase()
+))
+
+const navigationToggleIcon = computed(() => {
+  if (props.compactViewport) return props.overlayOpen ? 'Close' : 'Expand'
+  return props.navigationCollapsed ? 'Expand' : 'Fold'
+})
+const navigationToggleLabel = computed(() => {
+  if (props.compactViewport) return props.overlayOpen ? '关闭导航菜单' : '打开导航菜单'
+  return props.navigationCollapsed ? '展开导航栏' : '收起导航栏'
+})
+
+async function handleLogout() {
+  await auth.logout()
+  menuStore.reset()
+  tabsStore.reset()
+  await router.replace({ name: 'Login' })
+}
+</script>
+
+<template>
+  <el-header class="layout-header" height="var(--cw-topbar-height)">
+    <div class="header-left">
+      <el-button
+        v-if="auth.isApproved"
+        class="icon-button navigation-toggle"
+        text
+        :icon="navigationToggleIcon"
+        :aria-label="navigationToggleLabel"
+        @click="emit('navigationToggle', $event)"
+      />
+      <span class="header-separator" aria-hidden="true" />
+      <div class="location-copy">
+        <span class="location-product">customer_work · Agent Console</span>
+        <strong>智能体运营台</strong>
+      </div>
+    </div>
+
+    <div v-if="auth.isApproved" class="header-center">
+      <GlobalCommandSearch />
+    </div>
+
+    <div class="header-right">
+      <TenantSwitcher v-if="auth.isApproved" />
+      <el-button
+        class="icon-button"
+        text
+        :icon="themeStore.isDark ? 'Sunny' : 'Moon'"
+        :title="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
+        :aria-label="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
+        @click="themeStore.toggleDark()"
+      />
+      <NotificationBell v-if="auth.isApproved" />
+      <el-dropdown trigger="click">
+        <button type="button" class="user-menu-trigger" aria-label="打开用户菜单">
+          <span class="user-avatar">{{ userInitial }}</span>
+          <span class="user-name">{{ auth.nickname }}</span>
+          <el-icon><ArrowDown /></el-icon>
+        </button>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item @click="router.push({ name: 'ChangePassword' })">修改密码</el-dropdown-item>
+            <el-dropdown-item divided @click="handleLogout">退出登录</el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+    </div>
+  </el-header>
+</template>
+
+<style scoped>
+.layout-header {
+  flex: 0 0 var(--cw-topbar-height);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 16px 0 12px;
+  background: color-mix(in srgb, var(--el-bg-color) 96%, transparent);
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.header-left,
+.header-right {
+  display: flex;
+  align-items: center;
+}
+
+.header-left {
+  flex: 0 1 auto;
+  min-width: 150px;
+  gap: 10px;
+}
+
+.header-center {
+  flex: 1;
+  min-width: 164px;
+  display: flex;
+  justify-content: center;
+  padding: 0 8px;
+}
+
+.header-right {
+  flex: 0 0 auto;
+  gap: 4px;
+}
+
+.header-right :deep(.tenant-switcher) {
+  width: 200px;
+  margin-right: 4px;
+}
+
+.icon-button {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 9px;
+  color: var(--el-text-color-regular);
+  font-size: 18px;
+}
+
+.icon-button:hover {
+  color: var(--el-color-primary);
+  background: var(--el-fill-color-light);
+}
+
+.header-separator {
+  width: 1px;
+  height: 28px;
+  background: var(--el-border-color-lighter);
+}
+
+.location-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  white-space: nowrap;
+}
+
+.location-product {
+  color: var(--el-text-color-placeholder);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.location-copy strong {
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.user-menu-trigger {
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 6px 0 4px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--el-text-color-regular);
+  cursor: pointer;
+}
+
+.user-menu-trigger:hover {
+  background: var(--el-fill-color-light);
+}
+
+.user-avatar {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  background: linear-gradient(145deg, var(--el-color-primary-light-7), var(--el-color-primary-light-9));
+  color: var(--el-color-primary-dark-2);
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.user-name {
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+@media (max-width: 1280px) {
+  .header-right :deep(.tenant-switcher) {
+    width: 174px;
+  }
+
+  .location-product {
+    display: none;
+  }
+}
+
+@media (max-width: 1120px) {
+  .user-name,
+  .header-separator {
+    display: none;
+  }
+
+  .header-left {
+    min-width: auto;
+  }
+}
+
+@media (max-width: 900px) {
+  .location-copy {
+    display: none;
+  }
+
+  .header-right :deep(.tenant-switcher) {
+    width: 150px;
+  }
+}
+</style>

--- a/customer-admin-web/src/layouts/GlobalCommandSearch.vue
+++ b/customer-admin-web/src/layouts/GlobalCommandSearch.vue
@@ -1,0 +1,426 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import type { InputInstance } from 'element-plus'
+import { useMenuStore } from '@/store/menu'
+import {
+  buildNavigationCommands,
+  buildNavigationSections,
+  searchNavigationCommands,
+} from './navigationModel'
+
+const router = useRouter()
+const menuStore = useMenuStore()
+const visible = ref(false)
+const query = ref('')
+const selectedIndex = ref(0)
+const searchInput = ref<InputInstance>()
+const triggerButton = ref<HTMLButtonElement>()
+const resultPanel = ref<HTMLElement>()
+let restoreFocusTarget: HTMLElement | null = null
+
+const sections = computed(() => buildNavigationSections(menuStore.tree))
+const commands = computed(() => buildNavigationCommands(sections.value))
+const results = computed(() => searchNavigationCommands(commands.value, query.value))
+const shortcutLabel = computed(() => (
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘ K' : 'Ctrl K'
+))
+
+watch(query, () => {
+  selectedIndex.value = 0
+})
+
+watch(results, () => {
+  selectedIndex.value = Math.min(selectedIndex.value, Math.max(results.value.length - 1, 0))
+})
+
+watch(selectedIndex, (index) => {
+  void nextTick(() => {
+    resultPanel.value
+      ?.querySelector<HTMLElement>(`#navigation-command-${index}`)
+      ?.scrollIntoView({ block: 'nearest' })
+  })
+})
+
+function focusSearch() {
+  void nextTick(() => searchInput.value?.focus())
+}
+
+function openSearch() {
+  restoreFocusTarget = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : triggerButton.value ?? null
+  visible.value = true
+  query.value = ''
+  selectedIndex.value = 0
+  focusSearch()
+}
+
+function closeSearch() {
+  visible.value = false
+}
+
+function restoreFocus() {
+  restoreFocusTarget?.focus()
+  restoreFocusTarget = null
+}
+
+async function selectResult(index: number) {
+  const command = results.value[index]
+  if (!command) return
+  closeSearch()
+  await router.push(command.path)
+}
+
+function handleSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    selectedIndex.value = results.value.length === 0
+      ? 0
+      : (selectedIndex.value + 1) % results.value.length
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    selectedIndex.value = results.value.length === 0
+      ? 0
+      : (selectedIndex.value - 1 + results.value.length) % results.value.length
+  } else if (event.key === 'Enter') {
+    event.preventDefault()
+    void selectResult(selectedIndex.value)
+  } else if (event.key === 'Escape') {
+    event.preventDefault()
+    closeSearch()
+  }
+}
+
+function handleGlobalShortcut(event: KeyboardEvent) {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === 'k') {
+    event.preventDefault()
+    visible.value ? closeSearch() : openSearch()
+  }
+}
+
+function resultMeta(index: number): string {
+  const command = results.value[index]
+  if (!command) return ''
+  const ancestors = command.trail.slice(0, -1)
+  return [command.sectionTitle, ...ancestors].join(' · ')
+}
+
+onMounted(() => window.addEventListener('keydown', handleGlobalShortcut))
+onBeforeUnmount(() => window.removeEventListener('keydown', handleGlobalShortcut))
+</script>
+
+<template>
+  <button
+    ref="triggerButton"
+    type="button"
+    class="global-search-trigger"
+    aria-label="搜索菜单、智能体或配置"
+    @click="openSearch"
+  >
+    <el-icon><Search /></el-icon>
+    <span class="global-search-placeholder">搜索菜单、智能体或配置</span>
+    <kbd>{{ shortcutLabel }}</kbd>
+  </button>
+
+  <el-dialog
+    v-model="visible"
+    class="navigation-command-dialog"
+    width="min(640px, calc(100vw - 32px))"
+    top="12vh"
+    :show-close="false"
+    :close-on-click-modal="true"
+    append-to-body
+    @open="focusSearch"
+    @closed="restoreFocus"
+  >
+    <template #header>
+      <span class="sr-only">全局导航搜索</span>
+    </template>
+
+    <div class="command-search-box">
+      <el-input
+        ref="searchInput"
+        v-model="query"
+        size="large"
+        clearable
+        autocomplete="off"
+        placeholder="输入菜单、智能体、路径或能力名称"
+        aria-label="全局导航关键词"
+        :aria-activedescendant="results[selectedIndex] ? `navigation-command-${selectedIndex}` : undefined"
+        @keydown="handleSearchKeydown"
+      >
+        <template #prefix><el-icon><Search /></el-icon></template>
+      </el-input>
+      <span class="command-escape">ESC 关闭</span>
+    </div>
+
+    <div ref="resultPanel" class="command-results" role="listbox" aria-label="导航搜索结果">
+      <button
+        v-for="(command, index) in results"
+        :id="`navigation-command-${index}`"
+        :key="command.key"
+        type="button"
+        class="command-result"
+        :class="{ 'is-selected': index === selectedIndex }"
+        role="option"
+        :aria-selected="index === selectedIndex"
+        @mouseenter="selectedIndex = index"
+        @click="selectResult(index)"
+      >
+        <span class="command-result-icon" :class="{ 'is-agent': command.dynamic }">
+          <el-icon><Cpu v-if="command.dynamic" /><Document v-else /></el-icon>
+        </span>
+        <span class="command-result-copy">
+          <span class="command-result-title">{{ command.title }}</span>
+          <span class="command-result-meta">{{ resultMeta(index) }}</span>
+        </span>
+        <span class="command-result-path">{{ command.path }}</span>
+        <el-icon class="command-enter"><Right /></el-icon>
+      </button>
+
+      <el-empty
+        v-if="results.length === 0"
+        description="没有匹配的导航入口"
+        :image-size="56"
+      />
+    </div>
+
+    <div class="command-footer" aria-hidden="true">
+      <span><kbd>↑</kbd><kbd>↓</kbd> 选择</span>
+      <span><kbd>Enter</kbd> 打开</span>
+      <span>仅搜索当前账号有权访问的入口</span>
+    </div>
+  </el-dialog>
+</template>
+
+<style scoped>
+.global-search-trigger {
+  width: min(420px, 30vw);
+  min-width: 220px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 10px 0 12px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 9px;
+  background: var(--el-fill-color-extra-light);
+  color: var(--el-text-color-secondary);
+  cursor: pointer;
+  transition: border-color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.global-search-trigger:hover {
+  border-color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 55%, var(--el-border-color));
+  background: var(--el-bg-color);
+}
+
+.global-search-placeholder {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 13px;
+}
+
+kbd {
+  min-width: 22px;
+  height: 21px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 5px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-secondary);
+  font: 11px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--el-border-color) 80%, transparent);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+:global(.navigation-command-dialog) {
+  overflow: hidden;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 14px;
+  box-shadow: 0 24px 80px rgb(15 23 42 / 24%);
+}
+
+:global(.navigation-command-dialog .el-dialog__header) {
+  height: 0;
+  padding: 0;
+  margin: 0;
+}
+
+:global(.navigation-command-dialog .el-dialog__body) {
+  padding: 12px 12px 0;
+}
+
+.command-search-box {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.command-search-box :deep(.el-input) {
+  flex: 1;
+}
+
+.command-search-box :deep(.el-input__wrapper) {
+  box-shadow: none;
+  background: transparent;
+  padding-left: 4px;
+}
+
+.command-search-box :deep(.el-input__inner) {
+  font-size: 16px;
+}
+
+.command-escape {
+  padding-right: 4px;
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.command-results {
+  max-height: min(54vh, 480px);
+  min-height: 132px;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.command-result {
+  width: 100%;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--el-text-color-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.command-result.is-selected {
+  background: var(--el-color-primary-light-9);
+}
+
+.command-result-icon {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 9px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-secondary);
+}
+
+.command-result-icon.is-agent {
+  border-color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 30%, transparent);
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
+}
+
+.command-result-copy {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.command-result-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.command-result-meta,
+.command-result-path {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.command-result-path {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.command-enter {
+  flex: 0 0 auto;
+  color: var(--el-text-color-placeholder);
+}
+
+.command-footer {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 0 -12px;
+  padding: 0 14px;
+  border-top: 1px solid var(--el-border-color-lighter);
+  background: var(--el-fill-color-extra-light);
+  color: var(--el-text-color-secondary);
+  font-size: 11px;
+}
+
+.command-footer span:last-child {
+  margin-left: auto;
+}
+
+.command-footer kbd + kbd {
+  margin-left: 3px;
+}
+
+@media (max-width: 1120px) {
+  .global-search-trigger {
+    width: min(300px, 26vw);
+    min-width: 164px;
+  }
+
+  .global-search-trigger kbd {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .command-result-path,
+  .command-footer span:last-child {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .global-search-trigger {
+    transition: none;
+  }
+}
+</style>

--- a/customer-admin-web/src/layouts/LifecycleNavigation.vue
+++ b/customer-admin-web/src/layouts/LifecycleNavigation.vue
@@ -1,0 +1,518 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { InputInstance } from 'element-plus'
+import { useMenuStore } from '@/store/menu'
+import MenuTree from './MenuTree.vue'
+import {
+  buildNavigationSections,
+  filterNavigationNodes,
+  resolveNavigationSectionKey,
+  type NavigationSectionKey,
+} from './navigationModel'
+
+const emit = defineEmits<{
+  stateChange: [state: { compactViewport: boolean; overlayOpen: boolean; collapsed: boolean }]
+  requestMainFocus: []
+}>()
+
+const route = useRoute()
+const router = useRouter()
+const menuStore = useMenuStore()
+const navigationSections = computed(() => buildNavigationSections(menuStore.tree))
+const selectedSectionKey = ref<NavigationSectionKey>('overview')
+const contextQuery = ref('')
+const compactViewport = ref(false)
+const overlayOpen = ref(false)
+const contextSearchInput = ref<InputInstance>()
+let compactViewportQuery: MediaQueryList | null = null
+let overlayTrigger: HTMLElement | null = null
+
+// SQL 通用查询页靠 defineKey 区分菜单，高亮必须保留 query；普通页面仍按 path 对齐。
+const activePath = computed(() => (route.path === '/sql/query' ? route.fullPath : route.path))
+const isNavigationCompact = computed(() => menuStore.collapsed || compactViewport.value)
+const asideWidth = computed(() => (
+  isNavigationCompact.value ? 'var(--cw-nav-rail-width)' : 'var(--cw-shell-expanded-width)'
+))
+const currentSection = computed(() => (
+  navigationSections.value.find((section) => section.key === selectedSectionKey.value)
+  ?? navigationSections.value[0]
+))
+const filteredContextNodes = computed(() => (
+  currentSection.value ? filterNavigationNodes(currentSection.value.menuNodes, contextQuery.value) : []
+))
+
+function syncSectionFromRoute() {
+  const key = resolveNavigationSectionKey(navigationSections.value, route.fullPath, route.path)
+  selectedSectionKey.value = navigationSections.value.some((section) => section.key === key)
+    ? key
+    : 'overview'
+}
+
+function focusContextSearch() {
+  void nextTick(() => contextSearchInput.value?.focus())
+}
+
+function openOverlay(trigger: HTMLElement | null) {
+  overlayTrigger = trigger
+  overlayOpen.value = true
+  focusContextSearch()
+}
+
+function closeOverlay(focusTarget: 'trigger' | 'main' | 'none' = 'trigger') {
+  overlayOpen.value = false
+  const trigger = overlayTrigger
+  overlayTrigger = null
+  if (focusTarget === 'trigger' && trigger?.isConnected) {
+    void nextTick(() => trigger.focus())
+  } else if (focusTarget === 'main') {
+    void nextTick(() => emit('requestMainFocus'))
+  }
+}
+
+// 路由变化与菜单热刷新都重新按真实树归属分区；从覆盖层完成导航时把焦点交给新页面。
+watch(() => route.fullPath, () => {
+  syncSectionFromRoute()
+  contextQuery.value = ''
+  if (overlayOpen.value) {
+    closeOverlay('main')
+  } else {
+    overlayTrigger = null
+  }
+}, { immediate: true })
+watch(() => menuStore.tree, syncSectionFromRoute)
+
+watch(
+  [compactViewport, overlayOpen, () => menuStore.collapsed],
+  ([isCompactViewport, isOverlayOpen, isCollapsed]) => {
+    emit('stateChange', {
+      compactViewport: isCompactViewport,
+      overlayOpen: isOverlayOpen,
+      collapsed: isCollapsed,
+    })
+  },
+  { immediate: true },
+)
+
+function selectSection(key: NavigationSectionKey, event: MouseEvent) {
+  selectedSectionKey.value = key
+  contextQuery.value = ''
+  if (isNavigationCompact.value) {
+    openOverlay(event.currentTarget instanceof HTMLElement ? event.currentTarget : null)
+  }
+}
+
+function toggleFromHeader(event: MouseEvent) {
+  if (compactViewport.value) {
+    if (overlayOpen.value) {
+      closeOverlay()
+    } else {
+      openOverlay(event.currentTarget instanceof HTMLElement ? event.currentTarget : null)
+    }
+    return
+  }
+  menuStore.toggleCollapsed()
+  closeOverlay('none')
+}
+
+function updateCompactViewport(event: MediaQueryListEvent | MediaQueryList) {
+  compactViewport.value = event.matches
+  if (!event.matches) {
+    closeOverlay('none')
+  }
+}
+
+function handleEscape(event: KeyboardEvent) {
+  if (!event.defaultPrevented && event.key === 'Escape' && overlayOpen.value) {
+    event.preventDefault()
+    closeOverlay()
+  }
+}
+
+onMounted(() => {
+  compactViewportQuery = window.matchMedia('(max-width: 1023px)')
+  updateCompactViewport(compactViewportQuery)
+  compactViewportQuery.addEventListener('change', updateCompactViewport)
+  window.addEventListener('keydown', handleEscape)
+})
+
+onBeforeUnmount(() => {
+  compactViewportQuery?.removeEventListener('change', updateCompactViewport)
+  window.removeEventListener('keydown', handleEscape)
+})
+
+defineExpose({ toggleFromHeader })
+</script>
+
+<template>
+  <el-aside
+    :width="asideWidth"
+    class="layout-aside"
+    :class="{ 'is-compact': isNavigationCompact }"
+  >
+    <div class="primary-rail">
+      <button
+        class="rail-brand"
+        type="button"
+        title="返回首页"
+        aria-label="返回首页"
+        @click="router.push('/home')"
+      >
+        <span class="logo-mark">CW</span>
+      </button>
+
+      <nav class="rail-nav" aria-label="智能体生命周期导航">
+        <button
+          v-for="section in navigationSections"
+          :key="section.key"
+          type="button"
+          class="rail-item"
+          :class="{ 'is-active': selectedSectionKey === section.key }"
+          :title="section.label"
+          :aria-current="selectedSectionKey === section.key ? 'true' : undefined"
+          aria-controls="lifecycle-context-menu"
+          :aria-expanded="selectedSectionKey === section.key && (!isNavigationCompact || overlayOpen)"
+          @click="selectSection(section.key, $event)"
+        >
+          <el-icon class="rail-icon"><component :is="section.icon" /></el-icon>
+          <span class="rail-label">{{ section.label }}</span>
+        </button>
+      </nav>
+    </div>
+
+    <section
+      v-show="!isNavigationCompact || overlayOpen"
+      id="lifecycle-context-menu"
+      class="context-pane"
+      :class="{ 'is-overlay': isNavigationCompact }"
+      :aria-label="currentSection ? `${currentSection.title}菜单` : '上下文菜单'"
+    >
+      <div v-if="currentSection" class="context-head">
+        <div class="context-eyebrow">CUSTOMER WORK</div>
+        <div class="context-title-row">
+          <strong>{{ currentSection.title }}</strong>
+          <span class="context-count">{{ currentSection.itemCount }}</span>
+        </div>
+        <el-button
+          v-if="isNavigationCompact"
+          class="context-close"
+          text
+          :icon="'Close'"
+          aria-label="关闭上下文菜单"
+          @click="closeOverlay()"
+        />
+      </div>
+
+      <div v-if="currentSection" class="context-search-wrap">
+        <el-input
+          ref="contextSearchInput"
+          v-model="contextQuery"
+          class="context-search"
+          :placeholder="currentSection.searchPlaceholder"
+          clearable
+          :aria-label="currentSection.searchPlaceholder"
+        >
+          <template #prefix><el-icon><Search /></el-icon></template>
+        </el-input>
+      </div>
+
+      <div class="context-scroll">
+        <el-menu
+          v-if="filteredContextNodes.length > 0"
+          class="context-menu"
+          :default-active="activePath"
+          router
+          unique-opened
+        >
+          <MenuTree :nodes="filteredContextNodes" />
+        </el-menu>
+        <el-empty v-else description="没有匹配的入口" :image-size="52" />
+      </div>
+    </section>
+  </el-aside>
+
+  <button
+    v-if="isNavigationCompact && overlayOpen"
+    type="button"
+    class="navigation-backdrop"
+    aria-label="关闭上下文菜单"
+    @click="closeOverlay()"
+  />
+</template>
+
+<style scoped>
+.layout-aside {
+  --cw-rail-bg: #0b1728;
+  --cw-rail-hover: #15263c;
+  height: 100%;
+  display: flex;
+  position: relative;
+  z-index: 1200;
+  overflow: visible;
+  background: var(--cw-rail-bg);
+  border-right: 1px solid var(--el-border-color-lighter);
+  transition: width 180ms ease-out;
+}
+
+.primary-rail {
+  width: var(--cw-nav-rail-width);
+  height: 100%;
+  flex: 0 0 var(--cw-nav-rail-width);
+  display: flex;
+  flex-direction: column;
+  background: var(--cw-rail-bg);
+  color: #b7c5d8;
+}
+
+.rail-brand {
+  width: var(--cw-nav-rail-width);
+  height: var(--cw-topbar-height);
+  flex: 0 0 var(--cw-topbar-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid rgb(255 255 255 / 8%);
+  background: transparent;
+  cursor: pointer;
+}
+
+.logo-mark {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: linear-gradient(145deg, #5a78ff, #3c5ee8);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  box-shadow: 0 7px 18px rgb(58 86 210 / 32%);
+}
+
+.rail-nav {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 8px;
+  overflow-y: auto;
+}
+
+.rail-item {
+  width: 56px;
+  min-height: 55px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 7px 4px 6px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: #91a1b7;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.rail-item:hover {
+  background: var(--cw-rail-hover);
+  color: #e6edf7;
+}
+
+.rail-item.is-active {
+  background: rgb(79 110 247 / 17%);
+  color: #fff;
+}
+
+.rail-item.is-active::after {
+  content: '';
+  width: 3px;
+  height: 24px;
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  border-radius: 3px 0 0 3px;
+  background: #6f8aff;
+  transform: translateY(-50%);
+}
+
+.rail-icon {
+  font-size: 19px;
+}
+
+.rail-label {
+  font-size: 11px;
+  line-height: 16px;
+  letter-spacing: 0.02em;
+}
+
+.context-pane {
+  width: var(--cw-context-nav-width);
+  min-width: var(--cw-context-nav-width);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-primary);
+  box-shadow: 1px 0 0 var(--el-border-color-lighter);
+}
+
+.context-pane.is-overlay {
+  width: 220px;
+  min-width: 220px;
+  position: absolute;
+  inset: 0 auto 0 var(--cw-nav-rail-width);
+  z-index: 2;
+  box-shadow: 14px 0 36px rgb(15 23 42 / 18%);
+}
+
+.context-head {
+  min-height: var(--cw-topbar-height);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.context-eyebrow {
+  color: var(--el-text-color-placeholder);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.context-title-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.context-title-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.context-count {
+  min-width: 20px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-secondary);
+  font-size: 10px;
+}
+
+.context-close {
+  position: absolute;
+  top: 16px;
+  right: 8px;
+}
+
+.context-search-wrap {
+  padding: 12px 10px 8px;
+}
+
+.context-search :deep(.el-input__wrapper) {
+  border-radius: 8px;
+  background: var(--el-fill-color-extra-light);
+  box-shadow: 0 0 0 1px var(--el-border-color-lighter) inset;
+}
+
+.context-search :deep(.el-input__inner) {
+  font-size: 12px;
+}
+
+.context-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 2px 8px 14px;
+}
+
+.context-menu {
+  border-right: 0;
+  background: transparent;
+  --el-menu-bg-color: transparent;
+  --el-menu-hover-bg-color: var(--el-fill-color-light);
+  --el-menu-active-color: var(--el-text-color-primary);
+  --el-menu-text-color: var(--el-text-color-regular);
+}
+
+.context-menu :deep(.el-menu-item),
+.context-menu :deep(.el-sub-menu__title) {
+  min-width: 0;
+  height: 40px;
+  position: relative;
+  margin: 2px 0;
+  border-radius: 8px;
+  line-height: 40px;
+  font-size: 13px;
+}
+
+.context-menu :deep(.el-menu-item .el-icon),
+.context-menu :deep(.el-sub-menu__title .el-icon) {
+  color: var(--el-text-color-secondary) !important;
+}
+
+.context-menu :deep(.el-menu-item span),
+.context-menu :deep(.el-sub-menu__title span) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.context-menu :deep(.el-menu-item.is-active) {
+  background: var(--el-color-primary-light-9);
+  color: var(--el-text-color-primary);
+  font-weight: 600;
+}
+
+.context-menu :deep(.el-menu-item.is-active::before) {
+  content: '';
+  width: 2px;
+  height: 22px;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  border-radius: 0 2px 2px 0;
+  background: var(--theme-primary, var(--el-color-primary));
+  transform: translateY(-50%);
+}
+
+.navigation-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1180;
+  padding: 0;
+  border: 0;
+  background: rgb(15 23 42 / 18%);
+  cursor: default;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .layout-aside,
+  .rail-item {
+    transition: none;
+  }
+}
+</style>

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -1,117 +1,83 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useAuthStore } from '@/store/auth'
-import { useMenuStore } from '@/store/menu'
 import { useTabsStore } from '@/store/tabs'
-import { useThemeStore } from '@/store/theme'
-import MenuTree from './MenuTree.vue'
+import LifecycleNavigation from './LifecycleNavigation.vue'
+import AppHeader from './AppHeader.vue'
 import TabsBar from './TabsBar.vue'
 import AppBreadcrumb from './AppBreadcrumb.vue'
 import FooterCopyright from '@/components/FooterCopyright.vue'
-import NotificationBell from '@/components/NotificationBell.vue'
-import TenantSwitcher from '@/components/TenantSwitcher.vue'
 
-const router = useRouter()
+interface LifecycleNavigationHandle {
+  toggleFromHeader: (event: MouseEvent) => void
+}
+
 const route = useRoute()
 const auth = useAuthStore()
-const menuStore = useMenuStore()
 const tabsStore = useTabsStore()
-const themeStore = useThemeStore()
+const lifecycleNavigation = ref<LifecycleNavigationHandle>()
+const mainContent = ref<{ $el: HTMLElement }>()
+const navigationState = reactive({
+  compactViewport: false,
+  overlayOpen: false,
+  collapsed: false,
+})
 
-// SQL 通用查询页（/sql/query）是所有报表菜单共用的同一个路由 path，靠 defineKey 区分不同菜单项，
-// 用 route.path 高亮时几十个报表菜单会全部一起高亮；此时改取 route.fullPath（含 query），
-// 与菜单节点 node.path 里存的 /sql/query?defineKey=xxx 完整链接对齐，其它页面维持原样按 path 高亮。
-const activePath = computed(() => (route.path === '/sql/query' ? route.fullPath : route.path))
-const asideWidth = computed(() => menuStore.collapsed ? '64px' : '220px')
 // 工作区需要接管 el-main 的剩余高度来承载内部滚动；只按精确路由名收口，避免表格、表单页受影响。
 const isWorkspaceRoute = computed(() => route.name === 'Workspace')
 
-// MainLayout 只在 Layout 的子路由下挂载（登录页/改密页在其外层），路由一变化就落一个标签，
-// 已存在的标签只切激活态、不重复追加。
+// MainLayout 只负责壳层编排：路由变化落标签，导航归属与焦点生命周期由 LifecycleNavigation 自己维护。
 watch(() => route.fullPath, () => tabsStore.openTab(route), { immediate: true })
 
-async function handleLogout() {
-  await auth.logout()
-  menuStore.reset()
-  tabsStore.reset()
-  await router.replace({ name: 'Login' })
+function updateNavigationState(state: typeof navigationState) {
+  Object.assign(navigationState, state)
+}
+
+function handleNavigationToggle(event: MouseEvent) {
+  lifecycleNavigation.value?.toggleFromHeader(event)
+}
+
+function focusMainContent() {
+  void nextTick(() => mainContent.value?.$el.focus())
 }
 </script>
 
 <template>
-  <el-container class="layout">
-    <el-aside :width="asideWidth" class="layout-aside" :class="{ collapsed: menuStore.collapsed }">
-      <div class="logo">
-        <span class="logo-mark">CW</span>
-        <span v-show="!menuStore.collapsed" class="logo-text">customer_work</span>
-      </div>
-      <!-- 深色品牌侧边栏：配色走 .layout-aside 上的 CSS 变量（不用 props 传色，props 方式
-           已被 EP 标记废弃且无法参与明暗切换的变量级联） -->
-      <el-menu
-        :default-active="activePath"
-        :collapse="menuStore.collapsed"
-        :collapse-transition="true"
-        router
-        unique-opened
-      >
-        <MenuTree :nodes="menuStore.tree" :collapsed="menuStore.collapsed" />
-      </el-menu>
-    </el-aside>
-    <el-container class="layout-content">
-      <el-header class="layout-header">
-        <div class="header-left">
-          <el-button
-            v-if="auth.isApproved"
-            class="collapse-btn"
-            text
-            :icon="menuStore.collapsed ? 'Expand' : 'Fold'"
-            @click="menuStore.toggleCollapsed"
-          />
-        </div>
-        <div class="header-right">
-          <TenantSwitcher v-if="auth.isApproved" />
-          <el-button
-            class="collapse-btn"
-            text
-            :icon="themeStore.isDark ? 'Sunny' : 'Moon'"
-            :title="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
-            @click="themeStore.toggleDark()"
-          />
-          <NotificationBell v-if="auth.isApproved" />
-          <el-dropdown>
-            <span class="user-info">{{ auth.nickname }}<el-icon><ArrowDown /></el-icon></span>
-          <template #dropdown>
-            <el-dropdown-menu>
-              <el-dropdown-item @click="router.push({ name: 'ChangePassword' })">修改密码</el-dropdown-item>
-              <el-dropdown-item @click="handleLogout">退出登录</el-dropdown-item>
-            </el-dropdown-menu>
-            </template>
-          </el-dropdown>
-        </div>
-      </el-header>
+  <el-container class="layout" direction="horizontal">
+    <LifecycleNavigation
+      ref="lifecycleNavigation"
+      @state-change="updateNavigationState"
+      @request-main-focus="focusMainContent"
+    />
+
+    <el-container class="layout-content" direction="vertical">
+      <AppHeader
+        :compact-viewport="navigationState.compactViewport"
+        :overlay-open="navigationState.overlayOpen"
+        :navigation-collapsed="navigationState.collapsed"
+        @navigation-toggle="handleNavigationToggle"
+      />
       <TabsBar v-if="auth.isApproved" />
       <AppBreadcrumb v-if="auth.isApproved" />
       <el-main
+        ref="mainContent"
         class="layout-main"
+        tabindex="-1"
         :class="{
           'layout-main--home': route.name === 'Home',
           'layout-main--workspace': isWorkspaceRoute,
         }"
       >
-        <!-- 只精确缓存 WorkspaceView：TabsBar 让"已打开的标签"在视觉上常驻，但底下的路由组件此前没配
-             keep-alive，标签切走再切回其实是整个组件重新 mount——WorkspaceView 里的对话/VibeCoding
-             面板state 全在组件本地 ref，一销毁就清空，进行中的 SSE 流也被 onUnmounted 里的 abortStream
-             打断。这里不做成全局 include（tabsStore.tabs 覆盖的其它页面，如表格/表单页，未必对"数据
-             保持不刷新重进"这件事做过设计，贸然全量 keep-alive 影响面不可控），只精确点名
-             WorkspaceView，需要时再按同样方式给其它页面加白名单。 -->
+        <!-- 只精确缓存 WorkspaceView：不要给 component 增加 fullPath key，也不要因主导航切换卸载
+             router-view；否则切页会中断进行中的 SSE，并丢失对话或 VibeCoding 状态。 -->
         <router-view v-slot="{ Component }">
           <keep-alive :include="['WorkspaceView']">
             <component :is="Component" />
           </keep-alive>
         </router-view>
       </el-main>
-      <el-footer class="layout-footer" height="36px">
+      <el-footer class="layout-footer" height="var(--cw-footer-height)">
         <FooterCopyright />
       </el-footer>
     </el-container>
@@ -121,6 +87,8 @@ async function handleLogout() {
 <style scoped>
 .layout {
   height: 100%;
+  position: relative;
+  overflow: hidden;
 }
 
 .layout-content {
@@ -128,103 +96,14 @@ async function handleLogout() {
   min-height: 0;
 }
 
-.layout-aside {
-  /* 品牌深色侧边栏：明暗两态保持同一深色，不随模式切换 */
-  --cw-aside-bg: #001529;
-  background: var(--cw-aside-bg);
-  display: flex;
-  flex-direction: column;
-  transition: width 0.28s ease-in-out;
-  overflow-x: hidden;
-  /* el-menu 配色（替代已废弃的 background-color/text-color/active-text-color props） */
-  --el-menu-bg-color: var(--cw-aside-bg);
-  --el-menu-text-color: #c9d1d9;
-  --el-menu-active-color: #fff;
-  --el-menu-hover-bg-color: rgba(255, 255, 255, 0.08);
-  --el-menu-border-color: transparent;
-}
-
-.layout-aside.collapsed {
-  --el-menu-icon-width: 24px;
-}
-
-.logo {
-  height: 56px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  flex-shrink: 0;
-  padding: 0 12px;
-}
-
-.logo-mark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  background: linear-gradient(135deg, #409eff, #79bbff);
-  color: #fff;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0;
-  flex-shrink: 0;
-}
-
-.logo-text {
-  color: #fff;
-  font-weight: 600;
-  font-size: 15px;
-  white-space: nowrap;
-  overflow: hidden;
-  transition: opacity 0.28s ease-in-out;
-}
-
-.layout-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: var(--el-bg-color);
-  border-bottom: 1px solid var(--el-border-color-lighter);
-  padding: 0 16px;
-}
-
-.header-left {
-  display: flex;
-  align-items: center;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.collapse-btn {
-  font-size: 18px;
-  color: var(--el-text-color-regular);
-  padding: 8px;
-}
-
-.collapse-btn:hover {
-  color: var(--el-color-primary);
-  background: var(--el-fill-color-light);
-}
-
-.user-info {
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
 .layout-main {
   min-width: 0;
   min-height: 0;
   background: var(--el-bg-color-page);
+}
+
+.layout-main:focus {
+  outline: none;
 }
 
 .layout-main--home {
@@ -245,24 +124,18 @@ async function handleLogout() {
 }
 
 .layout-footer {
+  flex: 0 0 var(--cw-footer-height);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0;
   background: var(--el-bg-color);
   border-top: 1px solid var(--el-border-color-lighter);
-  padding: 0;
 }
 
 @media (max-width: 900px) {
   .layout-main--workspace {
     padding: 8px;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .layout-aside,
-  .logo-text {
-    transition: none;
   }
 }
 </style>

--- a/customer-admin-web/src/layouts/MenuTree.vue
+++ b/customer-admin-web/src/layouts/MenuTree.vue
@@ -3,29 +3,16 @@ import type { MenuNode } from '@/types/api'
 
 defineProps<{ nodes: MenuNode[]; collapsed?: boolean }>()
 
-// 按 perm_code 给系统管理 / AI 配置的叶子菜单个性化配色（图标名本身来自后端 sys_permission.icon
-// 种子数据，见 V5__menu_icons.sql）；未命中的节点（分组节点、动态智能体节点）不着色，继承菜单默认
-// 文字颜色，不强行统一风格。
-const ICON_COLORS: Record<string, string> = {
-  system: '#5B8FF9',
-  aiconfig: '#8B5CF6',
-  workspace: '#14B8A6',
-  user: '#409EFF',
-  role: '#9B59B6',
-  log: '#E6A23C',
-  model: '#13C2C2',
-  mcp: '#6554C0',
-  skill: '#52C41A',
-  agent: '#EB2F96',
-}
-
-function iconColor(permCode: string | null): string | undefined {
-  return permCode ? ICON_COLORS[permCode] : undefined
+/** 动态智能体 id 与权限 id 来自两张表，视觉扁平后可能碰撞，key 必须带来源域。 */
+function nodeKey(node: MenuNode): string {
+  return node.dynamic
+    ? `agent:${node.agentCode || node.id}`
+    : `menu:${node.id}`
 }
 </script>
 
 <template>
-  <template v-for="node in nodes" :key="node.id">
+  <template v-for="node in nodes" :key="nodeKey(node)">
     <el-sub-menu
       v-if="node.children && node.children.length > 0"
       :index="node.path || String(node.id)"
@@ -33,7 +20,7 @@ function iconColor(permCode: string | null): string | undefined {
     >
       <template #title>
         <img v-if="node.iconType === 'image' && node.icon" :src="node.icon" alt="" class="menu-icon-img" />
-        <el-icon v-else :style="{ color: iconColor(node.permCode) }"><component :is="node.icon || 'Folder'" /></el-icon>
+        <el-icon v-else><component :is="node.icon || 'Folder'" /></el-icon>
         <span v-show="!collapsed">{{ node.name }}</span>
       </template>
       <MenuTree :nodes="node.children" :collapsed="collapsed" />
@@ -44,7 +31,7 @@ function iconColor(permCode: string | null): string | undefined {
       :title="node.name"
     >
       <img v-if="node.iconType === 'image' && node.icon" :src="node.icon" alt="" class="menu-icon-img" />
-      <el-icon v-else :style="{ color: iconColor(node.permCode) }"><component :is="node.icon || 'Document'" /></el-icon>
+      <el-icon v-else><component :is="node.icon || 'Document'" /></el-icon>
       <span v-show="!collapsed">{{ node.name }}</span>
     </el-menu-item>
   </template>

--- a/customer-admin-web/src/layouts/TabsBar.vue
+++ b/customer-admin-web/src/layouts/TabsBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTabsStore } from '@/store/tabs'
 import type { TabsPaneContext, TabPaneName } from 'element-plus'
@@ -9,9 +9,9 @@ const tabsStore = useTabsStore()
 
 function handleTabClick(pane: TabsPaneContext) {
   const key = pane.paneName
-  const tab = tabsStore.tabs.find((t) => t.key === key)
+  const tab = tabsStore.tabs.find((item) => item.key === key)
   if (tab) {
-    router.push(tab.fullPath)
+    void router.push(tab.fullPath)
   }
 }
 
@@ -19,65 +19,142 @@ function handleTabRemove(paneName: TabPaneName) {
   tabsStore.closeTab(String(paneName))
 }
 
-// 右键上下文菜单：定位到具体被右键的标签靠事件委托 + DOM 顺序对齐 tabsStore.tabs（Element Plus
-// 的 el-tab-pane 不是实际渲染节点，拿不到 paneName，只能反查 .el-tabs__item 在导航条里的下标）。
 const menuVisible = ref(false)
 const menuX = ref(0)
 const menuY = ref(0)
 const menuTargetKey = ref('')
+const contextMenu = ref<HTMLElement>()
+let contextTriggerItem: HTMLElement | null = null
+type MenuFocusTarget = 'none' | 'trigger' | 'active'
+
+function tabKeyFromItem(item: HTMLElement): string | undefined {
+  return item.querySelector<HTMLElement>('[data-tab-key]')?.dataset.tabKey
+}
+
+function openContextMenu(item: HTMLElement, x: number, y: number) {
+  const key = tabKeyFromItem(item)
+  if (!key || !tabsStore.tabs.some((tab) => tab.key === key)) return
+  menuTargetKey.value = key
+  menuX.value = Math.min(x, window.innerWidth - 150)
+  menuY.value = Math.min(y, window.innerHeight - 132)
+  contextTriggerItem = item
+  menuVisible.value = true
+  void nextTick(() => contextMenu.value?.querySelector<HTMLButtonElement>('button:not(:disabled)')?.focus())
+}
 
 function onTabsContextMenu(event: MouseEvent) {
   const item = (event.target as HTMLElement).closest('.el-tabs__item') as HTMLElement | null
-  if (!item) {
-    return
-  }
+  if (!item) return
   event.preventDefault()
-  const nav = item.parentElement
-  const items = nav ? Array.from(nav.querySelectorAll('.el-tabs__item')) : []
-  const index = items.indexOf(item)
-  const tab = tabsStore.tabs[index]
-  if (!tab) {
-    return
-  }
-  menuTargetKey.value = tab.key
-  menuX.value = event.clientX
-  menuY.value = event.clientY
-  menuVisible.value = true
+  openContextMenu(item, event.clientX, event.clientY)
 }
 
-function closeMenu() {
+function onTabsKeydown(event: KeyboardEvent) {
+  if (!(event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10'))) return
+  const item = (event.target as HTMLElement).closest('.el-tabs__item') as HTMLElement | null
+  if (!item) return
+  event.preventDefault()
+  const rect = item.getBoundingClientRect()
+  openContextMenu(item, rect.left, rect.bottom + 4)
+}
+
+function findTabItem(key: string): HTMLElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLElement>('.el-tabs__item'))
+    .find((item) => tabKeyFromItem(item) === key)
+}
+
+function focusTab(key: string) {
+  void nextTick(() => findTabItem(key)?.focus())
+}
+
+function closeMenu(focusTarget: MenuFocusTarget = 'none') {
   menuVisible.value = false
+  const trigger = contextTriggerItem
+  contextTriggerItem = null
+  if (focusTarget === 'trigger' && trigger?.isConnected) {
+    void nextTick(() => trigger.focus())
+  } else if (focusTarget === 'active') {
+    focusTab(tabsStore.activeKey)
+  }
+}
+
+function handleWindowDismiss() {
+  closeMenu()
+}
+
+function handleMenuKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu('trigger')
+    return
+  }
+
+  if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+  const items = Array.from(
+    contextMenu.value?.querySelectorAll<HTMLButtonElement>('button:not(:disabled)') ?? [],
+  )
+  if (items.length === 0) return
+  event.preventDefault()
+  const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement)
+  const nextIndex = event.key === 'Home'
+    ? 0
+    : event.key === 'End'
+      ? items.length - 1
+      : event.key === 'ArrowUp'
+        ? (currentIndex <= 0 ? items.length - 1 : currentIndex - 1)
+        : (currentIndex + 1) % items.length
+  items[nextIndex]?.focus()
+}
+
+function handleMenuFocusout(event: FocusEvent) {
+  const nextTarget = event.relatedTarget
+  if (!(nextTarget instanceof Node) || !contextMenu.value?.contains(nextTarget)) {
+    closeMenu()
+  }
 }
 
 function doClose() {
   tabsStore.closeTab(menuTargetKey.value)
-  closeMenu()
+  closeMenu('active')
 }
 
 function doCloseOthers() {
   tabsStore.closeOthers(menuTargetKey.value)
-  closeMenu()
+  closeMenu('trigger')
 }
 
 function doCloseToRight() {
   tabsStore.closeToRight(menuTargetKey.value)
-  closeMenu()
+  closeMenu('trigger')
 }
 
-const targetTab = () => tabsStore.tabs.find((t) => t.key === menuTargetKey.value)
+const targetTab = () => tabsStore.tabs.find((tab) => tab.key === menuTargetKey.value)
 const canClose = () => targetTab()?.closable ?? false
-const canCloseOthers = () => tabsStore.tabs.some((t) => t.closable && t.key !== menuTargetKey.value)
+const canCloseOthers = () => tabsStore.tabs.some((tab) => tab.closable && tab.key !== menuTargetKey.value)
 const canCloseToRight = () => {
-  const idx = tabsStore.tabs.findIndex((t) => t.key === menuTargetKey.value)
-  return idx !== -1 && idx < tabsStore.tabs.length - 1
+  const index = tabsStore.tabs.findIndex((tab) => tab.key === menuTargetKey.value)
+  return index !== -1 && index < tabsStore.tabs.length - 1
 }
 
-onMounted(() => window.addEventListener('click', closeMenu))
-onBeforeUnmount(() => window.removeEventListener('click', closeMenu))
+onMounted(() => {
+  window.addEventListener('click', handleWindowDismiss)
+  window.addEventListener('resize', handleWindowDismiss)
+  window.addEventListener('blur', handleWindowDismiss)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('click', handleWindowDismiss)
+  window.removeEventListener('resize', handleWindowDismiss)
+  window.removeEventListener('blur', handleWindowDismiss)
+})
 </script>
 
 <template>
-  <div class="tabs-bar-wrapper" @contextmenu="onTabsContextMenu">
+  <div
+    class="tabs-bar-wrapper"
+    @contextmenu="onTabsContextMenu"
+    @keydown="onTabsKeydown"
+  >
     <el-tabs
       v-model="tabsStore.activeKey"
       type="card"
@@ -89,88 +166,166 @@ onBeforeUnmount(() => window.removeEventListener('click', closeMenu))
         v-for="tab in tabsStore.tabs"
         :key="tab.key"
         :name="tab.key"
-        :label="tab.title"
         :closable="tab.closable"
-      />
+      >
+        <template #label>
+          <span class="tab-label" :data-tab-key="tab.key">{{ tab.title }}</span>
+        </template>
+      </el-tab-pane>
     </el-tabs>
 
-    <ul
+    <div
       v-if="menuVisible"
+      ref="contextMenu"
       class="tab-context-menu"
-      :style="{ left: menuX + 'px', top: menuY + 'px' }"
+      role="menu"
+      aria-label="页签操作"
+      :style="{ left: `${menuX}px`, top: `${menuY}px` }"
       @click.stop
+      @keydown="handleMenuKeydown"
+      @focusout="handleMenuFocusout"
     >
-      <li :class="{ disabled: !canClose() }" @click="canClose() && doClose()">关闭</li>
-      <li :class="{ disabled: !canCloseOthers() }" @click="canCloseOthers() && doCloseOthers()">关闭其他</li>
-      <li :class="{ disabled: !canCloseToRight() }" @click="canCloseToRight() && doCloseToRight()">关闭右侧</li>
-    </ul>
+      <button type="button" role="menuitem" :disabled="!canClose()" @click="doClose">关闭</button>
+      <button type="button" role="menuitem" :disabled="!canCloseOthers()" @click="doCloseOthers">关闭其他</button>
+      <button type="button" role="menuitem" :disabled="!canCloseToRight()" @click="doCloseToRight">关闭右侧</button>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.tabs-bar-wrapper {
+  height: var(--cw-tabs-height);
+  position: relative;
+  flex: 0 0 var(--cw-tabs-height);
+  overflow: hidden;
+  background: var(--el-bg-color);
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
 .tabs-bar {
-  padding: 8px 16px 0;
+  height: var(--cw-tabs-height);
+  padding: 5px 14px 0;
   background: var(--el-bg-color);
 }
 
 .tabs-bar :deep(.el-tabs__header) {
+  height: 35px;
   margin: 0;
+  border-bottom: 0;
+}
+
+.tabs-bar :deep(.el-tabs__nav-wrap),
+.tabs-bar :deep(.el-tabs__nav-scroll),
+.tabs-bar :deep(.el-tabs__nav) {
+  height: 35px;
 }
 
 .tabs-bar :deep(.el-tabs__nav) {
-  border: none;
+  border: 0;
+  gap: 4px;
 }
 
 .tabs-bar :deep(.el-tabs__item) {
-  border: 1px solid var(--el-border-color);
-  border-radius: 4px 4px 0 0;
-  margin-right: 4px;
-  height: 32px;
-  line-height: 32px;
+  height: 31px;
+  position: relative;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 8px 8px 0 0;
+  background: transparent;
+  color: var(--el-text-color-secondary);
+  line-height: 31px;
+  font-size: 12px;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.tabs-bar :deep(.el-tabs__item + .el-tabs__item) {
+  border-left: 1px solid transparent;
+}
+
+.tabs-bar :deep(.el-tabs__item:hover) {
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-primary);
 }
 
 .tabs-bar :deep(.el-tabs__item.is-active) {
-  color: var(--el-color-primary);
+  border-color: var(--el-border-color-lighter);
+  border-bottom-color: var(--el-bg-color);
+  background: var(--el-bg-color);
+  color: var(--el-text-color-primary);
   font-weight: 600;
 }
 
-.tabs-bar-wrapper {
-  position: relative;
+.tabs-bar :deep(.el-tabs__item.is-active::before) {
+  content: '';
+  height: 2px;
+  position: absolute;
+  inset: -1px 8px auto;
+  border-radius: 0 0 2px 2px;
+  background: var(--theme-primary, var(--el-color-primary));
 }
 
-.tab-context-menu {
-  position: fixed;
-  z-index: 2000;
-  min-width: 100px;
-  padding: 4px 0;
-  margin: 0;
-  list-style: none;
-  background: var(--el-bg-color);
-  border: 1px solid var(--el-border-color);
-  border-radius: 4px;
-  box-shadow: 0 2px 12px rgb(0 0 0 / 10%);
+.tabs-bar :deep(.el-tabs__item .is-icon-close) {
+  opacity: 0;
+  transition: opacity 120ms ease;
 }
 
-.tab-context-menu li {
-  padding: 6px 16px;
-  font-size: 13px;
-  color: var(--el-text-color-regular);
-  cursor: pointer;
+.tabs-bar :deep(.el-tabs__item:hover .is-icon-close),
+.tabs-bar :deep(.el-tabs__item.is-active .is-icon-close),
+.tabs-bar :deep(.el-tabs__item:focus-visible .is-icon-close) {
+  opacity: 1;
+}
+
+.tab-label {
+  display: inline-block;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
   white-space: nowrap;
 }
 
-.tab-context-menu li:hover {
-  background: var(--el-fill-color-light);
-  color: var(--el-color-primary);
+.tab-context-menu {
+  min-width: 132px;
+  position: fixed;
+  z-index: 2200;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 5px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 9px;
+  background: var(--el-bg-color-overlay);
+  box-shadow: 0 12px 30px rgb(15 23 42 / 16%);
 }
 
-.tab-context-menu li.disabled {
+.tab-context-menu button {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--el-text-color-regular);
+  text-align: left;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.tab-context-menu button:hover:not(:disabled),
+.tab-context-menu button:focus-visible:not(:disabled) {
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-primary);
+}
+
+.tab-context-menu button:disabled {
   color: var(--el-text-color-placeholder);
   cursor: not-allowed;
 }
 
-.tab-context-menu li.disabled:hover {
-  background: transparent;
-  color: var(--el-text-color-placeholder);
+@media (prefers-reduced-motion: reduce) {
+  .tabs-bar :deep(.el-tabs__item),
+  .tabs-bar :deep(.el-tabs__item .is-icon-close) {
+    transition: none;
+  }
 }
 </style>

--- a/customer-admin-web/src/layouts/navigationModel.test.ts
+++ b/customer-admin-web/src/layouts/navigationModel.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest'
+import type { MenuNode } from '@/types/api'
+import {
+  buildNavigationCommands,
+  buildNavigationSections,
+  filterNavigationNodes,
+  findMenuTrail,
+  resolveNavigationSectionKey,
+  searchNavigationCommands,
+  type NavigationCommand,
+} from './navigationModel'
+
+function node(overrides: Partial<MenuNode> & Pick<MenuNode, 'id' | 'name'>): MenuNode {
+  return {
+    path: null,
+    icon: null,
+    iconType: 'library',
+    permCode: null,
+    sort: null,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children: [],
+    ...overrides,
+  }
+}
+
+function fixtureTree(): MenuNode[] {
+  return [
+    node({
+      id: 1,
+      name: '系统管理',
+      path: '/system',
+      permCode: 'system',
+      children: [node({ id: 10, name: '用户管理', path: '/system/user', permCode: 'user' })],
+    }),
+    node({
+      id: 2,
+      name: 'AI 配置',
+      path: '/aiconfig',
+      permCode: 'aiconfig',
+      children: [node({ id: 20, name: '模型配置', path: '/aiconfig/model', permCode: 'model' })],
+    }),
+    node({
+      id: 3,
+      name: '智能体工作区',
+      path: '/workspace',
+      permCode: 'workspace',
+      children: [node({
+        id: 300,
+        name: 'OA 考勤与周报',
+        path: '/workspace/oa-assistant',
+        icon: '/agent-icon.png',
+        iconType: 'image',
+        agentCode: 'oa-assistant',
+        capabilities: ['chat', 'vibecoding'],
+        dynamic: true,
+      })],
+    }),
+    node({
+      id: 160,
+      name: '我的工作台',
+      permCode: 'workbench',
+      children: [
+        node({ id: 150, name: '开发者工具箱', path: '/system/devtools', permCode: 'devtools' }),
+        node({
+          id: 123,
+          name: '资金对账',
+          path: '/sql/query?defineKey=repayment',
+          permCode: 'audit:view',
+        }),
+        node({
+          id: 124,
+          name: '库存报表',
+          path: '/sql/query?defineKey=inventory',
+          permCode: 'inventory:view',
+        }),
+      ],
+    }),
+    node({
+      id: 270,
+      name: '监控大屏',
+      path: '/monitor',
+      permCode: 'monitor:view',
+      children: [node({
+        id: 194,
+        name: '智能体耗时统计',
+        path: '/system/agent-call-stats',
+        permCode: 'agent-call-stats:view',
+      })],
+    }),
+    node({ id: 999, name: '未来能力', path: '/future/overview', permCode: 'future' }),
+  ]
+}
+
+describe('buildNavigationSections', () => {
+  it('按稳定权限码分组、提升动态智能体，同时不改写后端原树', () => {
+    const tree = fixtureTree()
+    const originalWorkspaceChildren = tree[2].children
+
+    const sections = buildNavigationSections(tree)
+
+    expect(sections.map((section) => section.key)).toEqual(['overview', 'agents', 'build', 'operate', 'settings'])
+    const agents = sections.find((section) => section.key === 'agents')!
+    expect(agents.menuNodes).toBe(originalWorkspaceChildren)
+    expect(agents.menuNodes[0]).toMatchObject({
+      path: '/workspace/oa-assistant',
+      agentCode: 'oa-assistant',
+      capabilities: ['chat', 'vibecoding'],
+      dynamic: true,
+      iconType: 'image',
+    })
+    expect(tree[2].children).toBe(originalWorkspaceChildren)
+    expect(tree[2].children).toHaveLength(1)
+  })
+
+  it('未知一级菜单进入总览兜底且不丢失，空权限分区不占导航位', () => {
+    const sections = buildNavigationSections(fixtureTree())
+    expect(sections.find((section) => section.key === 'overview')?.menuNodes.map((item) => item.name))
+      .toEqual(['首页', '我的工作台', '未来能力'])
+    expect(sections.some((section) => section.key === 'operate')).toBe(true)
+    expect(sections.some((section) => section.key === 'govern')).toBe(false)
+  })
+
+  it('没有启用中的智能体时保留 workspace 空态入口', () => {
+    const tree = [node({ id: 3, name: '智能体工作区', path: '/workspace', permCode: 'workspace' })]
+    const agents = buildNavigationSections(tree).find((section) => section.key === 'agents')!
+    expect(agents.itemCount).toBe(0)
+    expect(agents.menuNodes).toEqual(tree)
+  })
+
+  it('标准 workspace 与未来一级入口同分区时，提升智能体但不丢未来入口', () => {
+    const workspace = node({
+      id: 3,
+      name: '智能体工作区',
+      path: '/workspace',
+      permCode: 'workspace',
+      children: [node({
+        id: 301,
+        name: 'OA 助手',
+        path: '/workspace/oa-assistant',
+        agentCode: 'oa-assistant',
+        dynamic: true,
+      })],
+    })
+    const futureEntry = node({ id: 302, name: '智能体市场', path: '/workspace/market' })
+
+    const agents = buildNavigationSections([workspace, futureEntry]).find((section) => section.key === 'agents')!
+
+    expect(agents.menuNodes.map((item) => item.name)).toEqual(['OA 助手', '智能体市场'])
+    expect(agents.itemCount).toBe(2)
+  })
+
+  it('十个真实一级菜单按输入顺序映射到固定六类', () => {
+    const roots = [
+      node({ id: 270, name: '监控大屏', path: '/monitor', permCode: 'monitor:view' }),
+      node({ id: 1, name: '系统管理', path: '/system', permCode: 'system' }),
+      node({ id: 2, name: 'AI 配置', path: '/aiconfig', permCode: 'aiconfig' }),
+      node({ id: 3, name: '智能体工作区', path: '/workspace', permCode: 'workspace' }),
+      node({ id: 4, name: 'Projects', path: '/project', permCode: 'project' }),
+      node({ id: 231, name: '运营闭环', path: '/ops', permCode: 'ops' }),
+      node({ id: 110, name: 'SQL配置管理', permCode: 'sql-config' }),
+      node({ id: 160, name: '我的工作台', permCode: 'workbench' }),
+      node({ id: 130, name: '客服工单', path: '/ticket', permCode: 'ticket' }),
+      node({ id: 204, name: '内容风控', path: '/contentguard', permCode: 'contentguard' }),
+    ]
+
+    const sections = buildNavigationSections(roots)
+
+    expect(sections.map((section) => section.key)).toEqual([
+      'overview', 'agents', 'build', 'operate', 'govern', 'settings',
+    ])
+    expect(sections.find((section) => section.key === 'build')?.sourceNodes.map((item) => item.permCode))
+      .toEqual(['aiconfig', 'project', 'sql-config'])
+    expect(sections.find((section) => section.key === 'operate')?.sourceNodes.map((item) => item.permCode))
+      .toEqual(['monitor:view', 'ops', 'ticket'])
+  })
+
+  it('菜单热刷新后基于新树重算，不复用旧分区', () => {
+    const before = buildNavigationSections([node({ id: 1, name: '系统管理', permCode: 'system' })])
+    const after = buildNavigationSections([node({ id: 204, name: '内容风控', permCode: 'contentguard' })])
+    expect(before.some((section) => section.key === 'settings')).toBe(true)
+    expect(before.some((section) => section.key === 'govern')).toBe(false)
+    expect(after.some((section) => section.key === 'settings')).toBe(false)
+    expect(after.some((section) => section.key === 'govern')).toBe(true)
+  })
+})
+
+describe('resolveNavigationSectionKey', () => {
+  it.each([
+    ['/workspace/oa-assistant', '/workspace/oa-assistant', 'agents'],
+    ['/aiconfig/model', '/aiconfig/model', 'build'],
+    ['/sql/query?defineKey=repayment', '/sql/query', 'overview'],
+    ['/system/devtools', '/system/devtools', 'overview'],
+    ['/system/agent-call-stats', '/system/agent-call-stats', 'operate'],
+    ['/system/user', '/system/user', 'settings'],
+  ])('将 %s 归入 %s', (fullPath, path, expected) => {
+    const sections = buildNavigationSections(fixtureTree())
+    expect(resolveNavigationSectionKey(sections, fullPath, path)).toBe(expected)
+  })
+
+  it('未知路由回到总览兜底', () => {
+    const sections = buildNavigationSections(fixtureTree())
+    expect(resolveNavigationSectionKey(sections, '/unknown', '/unknown')).toBe('overview')
+  })
+
+  it.each([
+    ['/workspace/new-agent', 'agents'],
+    ['/project/new', 'build'],
+    ['/ops/new', 'operate'],
+    ['/contentguard/new', 'govern'],
+    ['/system/new', 'settings'],
+    ['/workbench/new', 'overview'],
+  ])('菜单树尚未包含 %s 时按路径安全兜底', (path, expected) => {
+    expect(resolveNavigationSectionKey(buildNavigationSections([]), path, path)).toBe(expected)
+  })
+})
+
+describe('filterNavigationNodes', () => {
+  it('命中后代时只克隆祖先路径，不修改输入树', () => {
+    const tree = fixtureTree()
+    const filtered = filterNavigationNodes(tree, '模型')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].name).toBe('AI 配置')
+    expect(filtered[0].children.map((child) => child.name)).toEqual(['模型配置'])
+    expect(tree[1].children).toHaveLength(1)
+  })
+
+  it('父节点直接命中时保留完整子树', () => {
+    const filtered = filterNavigationNodes(fixtureTree(), 'AI 配置')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].children.map((child) => child.name)).toEqual(['模型配置'])
+  })
+
+  it('空查询复用原树引用，完全无匹配时返回空列表', () => {
+    const tree = fixtureTree()
+    expect(filterNavigationNodes(tree, '   ')).toBe(tree)
+    expect(filterNavigationNodes(tree, '不存在的菜单')).toEqual([])
+  })
+})
+
+describe('navigation commands', () => {
+  it('只输出可导航结果，动态智能体和 SQL 完整 query 均保留', () => {
+    const commands = buildNavigationCommands(buildNavigationSections(fixtureTree()))
+    expect(commands.some((command) => command.title === 'AI 配置')).toBe(false)
+    expect(commands.find((command) => command.title === 'OA 考勤与周报')).toMatchObject({
+      path: '/workspace/oa-assistant',
+      dynamic: true,
+    })
+    expect(commands.find((command) => command.title === '资金对账')?.path)
+      .toBe('/sql/query?defineKey=repayment')
+    expect(commands.find((command) => command.title === '库存报表')?.path)
+      .toBe('/sql/query?defineKey=inventory')
+  })
+
+  it('支持大小写、祖先标题和能力关键词，并按标题匹配优先', () => {
+    const commands = buildNavigationCommands(buildNavigationSections(fixtureTree()))
+    expect(searchNavigationCommands(commands, '  OA  ')[0].title).toBe('OA 考勤与周报')
+    expect(searchNavigationCommands(commands, '我的工作台').map((command) => command.title))
+      .toContain('资金对账')
+    expect(searchNavigationCommands(commands, 'VIBECODING')[0].title).toBe('OA 考勤与周报')
+  })
+
+  it('支持多关键词全匹配、空结果和自定义上限', () => {
+    const commands = buildNavigationCommands(buildNavigationSections(fixtureTree()))
+    expect(searchNavigationCommands(commands, 'OA chat').map((command) => command.title))
+      .toEqual(['OA 考勤与周报'])
+    expect(searchNavigationCommands(commands, '不存在的入口')).toEqual([])
+    expect(searchNavigationCommands(commands, '', 1)).toHaveLength(1)
+  })
+
+  it('workspace 无动态智能体时仍可搜索空态入口，同路径命令保留第一项', () => {
+    const emptyWorkspace = node({ id: 3, name: '智能体工作区', path: '/workspace', permCode: 'workspace' })
+    const duplicatePathRoots = [
+      node({ id: 501, name: '未来入口 A', path: '/future/shared' }),
+      node({ id: 502, name: '未来入口 B', path: '/future/shared' }),
+    ]
+
+    const commands = buildNavigationCommands(buildNavigationSections([emptyWorkspace, ...duplicatePathRoots]))
+
+    expect(commands.find((command) => command.path === '/workspace')?.title).toBe('智能体工作区')
+    expect(commands.filter((command) => command.path === '/future/shared')).toHaveLength(1)
+    expect(commands.find((command) => command.path === '/future/shared')?.title).toBe('未来入口 A')
+  })
+
+  it('标题精确、前缀、包含和元数据命中按明确权重排序', () => {
+    const command = (key: string, title: string, trail: string[] = []): NavigationCommand => ({
+      key,
+      title,
+      path: `/${key}`,
+      sectionKey: 'overview',
+      sectionTitle: '工作总览',
+      trail,
+      dynamic: false,
+      keywords: '',
+    })
+    const commands = [
+      command('metadata', 'Console', ['Agent Operations']),
+      command('contains', 'Smart Agent'),
+      command('prefix', 'Agent Builder'),
+      command('exact', 'Agent'),
+    ]
+
+    expect(searchNavigationCommands(commands, 'agent').map((item) => item.key))
+      .toEqual(['exact', 'prefix', 'contains', 'metadata'])
+  })
+})
+
+describe('findMenuTrail', () => {
+  it('SQL 报表优先按 fullPath 返回完整祖先链', () => {
+    expect(findMenuTrail(
+      fixtureTree(),
+      '/sql/query?defineKey=repayment',
+      '/sql/query',
+    )).toEqual(['我的工作台', '资金对账'])
+  })
+
+  it('SQL 报表严格区分 defineKey，未知 query 不误命中第一项', () => {
+    expect(findMenuTrail(
+      fixtureTree(),
+      '/sql/query?defineKey=inventory',
+      '/sql/query',
+    )).toEqual(['我的工作台', '库存报表'])
+    expect(findMenuTrail(
+      fixtureTree(),
+      '/sql/query?defineKey=unknown',
+      '/sql/query',
+    )).toBeNull()
+  })
+})

--- a/customer-admin-web/src/layouts/navigationModel.ts
+++ b/customer-admin-web/src/layouts/navigationModel.ts
@@ -1,0 +1,284 @@
+import type { MenuNode } from '@/types/api'
+
+/**
+ * 全局导航按智能体生命周期重新分组。这里仅改变展示结构，原始菜单节点仍由后端完成权限剪枝、
+ * 对外部署过滤和动态智能体注入，前端不得在此补权限或制造新业务路由。
+ */
+export type NavigationSectionKey =
+  | 'overview'
+  | 'agents'
+  | 'build'
+  | 'operate'
+  | 'govern'
+  | 'settings'
+
+interface NavigationSectionDefinition {
+  key: NavigationSectionKey
+  label: string
+  title: string
+  icon: string
+  searchPlaceholder: string
+}
+
+export interface NavigationSection extends NavigationSectionDefinition {
+  /** 后端原始一级节点，用于按当前路由反推生命周期分区。 */
+  sourceNodes: MenuNode[]
+  /** 上下文菜单实际展示的节点；智能体分区会把 workspace 的动态子节点提升一层。 */
+  menuNodes: MenuNode[]
+  /** 导航轨上展示的业务入口数量。 */
+  itemCount: number
+}
+
+export interface NavigationCommand {
+  key: string
+  title: string
+  path: string
+  sectionKey: NavigationSectionKey
+  sectionTitle: string
+  trail: string[]
+  dynamic: boolean
+  keywords: string
+}
+
+const SECTION_DEFINITIONS: readonly NavigationSectionDefinition[] = [
+  { key: 'overview', label: '总览', title: '工作总览', icon: 'Grid', searchPlaceholder: '查找工作入口' },
+  { key: 'agents', label: '智能体', title: '智能体工作区', icon: 'Cpu', searchPlaceholder: '查找智能体' },
+  { key: 'build', label: '构建', title: '构建与配置', icon: 'Tools', searchPlaceholder: '查找构建能力' },
+  { key: 'operate', label: '运营', title: '监控与运营', icon: 'DataAnalysis', searchPlaceholder: '查找运营能力' },
+  { key: 'govern', label: '治理', title: '安全治理', icon: 'Lock', searchPlaceholder: '查找治理能力' },
+  { key: 'settings', label: '设置', title: '平台设置', icon: 'Setting', searchPlaceholder: '查找系统设置' },
+]
+
+/** 后端一级菜单的稳定权限码到生命周期分区的映射，不依赖可编辑的中文名称。 */
+const ROOT_SECTION_BY_PERM_CODE: Readonly<Record<string, NavigationSectionKey>> = {
+  workbench: 'overview',
+  workspace: 'agents',
+  aiconfig: 'build',
+  project: 'build',
+  'sql-config': 'build',
+  'monitor:view': 'operate',
+  ops: 'operate',
+  ticket: 'operate',
+  contentguard: 'govern',
+  system: 'settings',
+}
+
+const HOME_NODE: MenuNode = {
+  id: -1,
+  name: '首页',
+  path: '/home',
+  icon: 'House',
+  iconType: 'library',
+  permCode: '__home',
+  sort: -1,
+  agentCode: null,
+  capabilities: null,
+  dynamic: false,
+  children: [],
+}
+
+function sectionKeyForPath(path: string): NavigationSectionKey {
+  if (path.startsWith('/workspace')) return 'agents'
+  if (path.startsWith('/aiconfig') || path.startsWith('/project') || path.startsWith('/sql')) return 'build'
+  if (path.startsWith('/monitor') || path.startsWith('/ops') || path.startsWith('/ticket')) return 'operate'
+  if (path.startsWith('/contentguard')) return 'govern'
+  if (path.startsWith('/system')) return 'settings'
+  return 'overview'
+}
+
+function sectionKeyForRoot(node: MenuNode): NavigationSectionKey {
+  if (node.permCode && ROOT_SECTION_BY_PERM_CODE[node.permCode]) {
+    return ROOT_SECTION_BY_PERM_CODE[node.permCode]
+  }
+
+  // 管理员可在菜单管理中新增一级目录。权限码尚未纳入映射时，按路径做保守归类；仍无法识别的
+  // 节点进入“总览”兜底，既保持六类信息架构，也确保新功能不会因前端发布节奏落后而被静默隐藏。
+  return sectionKeyForPath(node.path ?? '')
+}
+
+/**
+ * 把后端菜单树映射为生命周期导航。函数不修改传入节点，菜单热刷新后可直接重新计算。
+ */
+export function buildNavigationSections(tree: MenuNode[]): NavigationSection[] {
+  const sourceBuckets = new Map<NavigationSectionKey, MenuNode[]>()
+  for (const definition of SECTION_DEFINITIONS) {
+    sourceBuckets.set(definition.key, [])
+  }
+  for (const node of tree) {
+    sourceBuckets.get(sectionKeyForRoot(node))?.push(node)
+  }
+
+  return SECTION_DEFINITIONS.flatMap((definition) => {
+    const sourceNodes = sourceBuckets.get(definition.key) ?? []
+    let menuNodes = sourceNodes
+    let itemCount = sourceNodes.length
+
+    if (definition.key === 'overview') {
+      menuNodes = [HOME_NODE, ...sourceNodes]
+      itemCount = menuNodes.length
+    } else if (definition.key === 'agents') {
+      const canonicalWorkspace = sourceNodes.length === 1 && sourceNodes[0].permCode === 'workspace'
+        ? sourceNodes[0]
+        : null
+      if (canonicalWorkspace && canonicalWorkspace.children.length > 0) {
+        // 真实后端的标准形态直接复用只读 children 引用，避免每次 computed 求值制造新数组。
+        menuNodes = canonicalWorkspace.children
+        itemCount = canonicalWorkspace.children.length
+      } else {
+        const visibleNodes: MenuNode[] = []
+        let visibleEntryCount = 0
+        for (const node of sourceNodes) {
+          const children = node.children ?? []
+          if (node.permCode === 'workspace' && children.length > 0) {
+            // 标准 workspace 根节点只负责承载动态智能体，提升一层避免重复层级。
+            visibleNodes.push(...children)
+            visibleEntryCount += children.length
+          } else {
+            // 未来新增的 /workspace/** 一级入口仍要保留，不能因与标准 workspace 同分区而被 flatMap 丢掉。
+            visibleNodes.push(node)
+            if (node.permCode !== 'workspace') visibleEntryCount += 1
+          }
+        }
+        // 尚无启用中的智能体时保留 /workspace 空态入口，但计数仍为 0。
+        menuNodes = visibleNodes
+        itemCount = visibleEntryCount
+      }
+    }
+
+    const shouldShow = definition.key === 'overview' || sourceNodes.length > 0
+    return shouldShow ? [{ ...definition, sourceNodes, menuNodes, itemCount }] : []
+  })
+}
+
+function menuPathMatches(nodePath: string | null, fullPath: string, path: string): boolean {
+  if (!nodePath) return false
+  if (nodePath === fullPath) return true
+  // 带 query 的 SQL 报表必须按 fullPath 精确匹配，不能退化成裸 path 后让多个报表一起激活。
+  return !nodePath.includes('?') && nodePath === path
+}
+
+function containsPath(nodes: MenuNode[], fullPath: string, path: string): boolean {
+  return nodes.some((node) => (
+    menuPathMatches(node.path, fullPath, path)
+    || (node.children?.length > 0 && containsPath(node.children, fullPath, path))
+  ))
+}
+
+/** 按当前完整路由反推生命周期分区，先信任后端树的真实归属，再用路径前缀兜底。 */
+export function resolveNavigationSectionKey(
+  sections: NavigationSection[],
+  fullPath: string,
+  path: string,
+): NavigationSectionKey {
+  if (path === '/home') return 'overview'
+  const matched = sections.find((section) => containsPath(section.sourceNodes, fullPath, path))
+  if (matched) return matched.key
+
+  return sectionKeyForPath(path)
+}
+
+function nodeMatchesQuery(node: MenuNode, normalizedQuery: string): boolean {
+  const searchable = [
+    node.name,
+    node.path,
+    node.permCode,
+    node.agentCode,
+    ...(node.capabilities ?? []),
+  ].filter(Boolean).join(' ').toLocaleLowerCase()
+  return searchable.includes(normalizedQuery)
+}
+
+/** 上下文菜单过滤：命中父节点时保留完整子树，命中后代时只克隆祖先路径，不改写原树。 */
+export function filterNavigationNodes(nodes: MenuNode[], query: string): MenuNode[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  if (!normalizedQuery) return nodes
+
+  return nodes.flatMap((node) => {
+    if (nodeMatchesQuery(node, normalizedQuery)) return [node]
+    const children = filterNavigationNodes(node.children ?? [], normalizedQuery)
+    return children.length > 0 ? [{ ...node, children }] : []
+  })
+}
+
+/** 查找菜单祖先链；SQL 报表先匹配完整 query，普通页面再按 path 匹配。 */
+export function findMenuTrail(
+  nodes: MenuNode[],
+  fullPath: string,
+  path: string,
+  trail: string[] = [],
+): string[] | null {
+  for (const node of nodes) {
+    const nextTrail = [...trail, node.name]
+    if (menuPathMatches(node.path, fullPath, path)) return nextTrail
+    const found = findMenuTrail(node.children ?? [], fullPath, path, nextTrail)
+    if (found) return found
+  }
+  return null
+}
+
+function collectCommands(
+  nodes: MenuNode[],
+  section: NavigationSection,
+  trail: string[],
+  commands: NavigationCommand[],
+) {
+  for (const node of nodes) {
+    const nextTrail = [...trail, node.name]
+    const hasChildren = (node.children?.length ?? 0) > 0
+    // 目录节点在 router 中没有对应组件，不作为搜索结果；workspace 空态是预注册的真实路由。
+    if (node.path && (!hasChildren || node.permCode === 'workspace')) {
+      commands.push({
+        key: `${section.key}:${node.id}:${node.path}`,
+        title: node.name,
+        path: node.path,
+        sectionKey: section.key,
+        sectionTitle: section.title,
+        trail: nextTrail,
+        dynamic: node.dynamic,
+        keywords: [node.permCode, node.agentCode, ...(node.capabilities ?? [])].filter(Boolean).join(' '),
+      })
+    }
+    collectCommands(node.children ?? [], section, nextTrail, commands)
+  }
+}
+
+/** 生成真实可导航的命令列表，同一路径只保留第一项，避免提升智能体节点后产生重复结果。 */
+export function buildNavigationCommands(sections: NavigationSection[]): NavigationCommand[] {
+  const commands: NavigationCommand[] = []
+  for (const section of sections) {
+    collectCommands(section.menuNodes, section, [], commands)
+  }
+  const firstCommandByPath = new Map<string, NavigationCommand>()
+  for (const command of commands) {
+    if (!firstCommandByPath.has(command.path)) {
+      firstCommandByPath.set(command.path, command)
+    }
+  }
+  return Array.from(firstCommandByPath.values())
+}
+
+/** 简单、可预测的关键词排序：标题精确/前缀优先，其次才是祖先、路径和能力字段命中。 */
+export function searchNavigationCommands(
+  commands: NavigationCommand[],
+  query: string,
+  limit = 12,
+): NavigationCommand[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  if (!normalizedQuery) return commands.slice(0, limit)
+  const terms = normalizedQuery.split(/\s+/).filter(Boolean)
+
+  return commands
+    .map((command) => {
+      const title = command.title.toLocaleLowerCase()
+      const haystack = [title, command.sectionTitle, command.trail.join(' '), command.path, command.keywords]
+        .join(' ')
+        .toLocaleLowerCase()
+      if (!terms.every((term) => haystack.includes(term))) return null
+      const score = title === normalizedQuery ? 100 : title.startsWith(normalizedQuery) ? 60 : title.includes(normalizedQuery) ? 40 : 10
+      return { command, score }
+    })
+    .filter((item): item is { command: NavigationCommand; score: number } => item !== null)
+    .sort((left, right) => right.score - left.score || left.command.title.localeCompare(right.command.title, 'zh-CN'))
+    .slice(0, limit)
+    .map((item) => item.command)
+}

--- a/customer-admin-web/src/style.css
+++ b/customer-admin-web/src/style.css
@@ -11,5 +11,19 @@ body,
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'HarmonyOS Sans SC', 'PingFang SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  color: var(--el-text-color-primary);
+  background: var(--el-bg-color-page);
+}
+
+:where(button, a, [role='menuitem'], [tabindex]):focus-visible {
+  outline: 2px solid var(--cw-focus-ring, var(--el-color-primary));
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
 }

--- a/customer-admin-web/src/theme.css
+++ b/customer-admin-web/src/theme.css
@@ -5,6 +5,13 @@
  */
 
 :root {
+  --cw-nav-rail-width: 72px;
+  --cw-context-nav-width: 180px;
+  --cw-shell-expanded-width: calc(var(--cw-nav-rail-width) + var(--cw-context-nav-width));
+  --cw-topbar-height: 64px;
+  --cw-tabs-height: 40px;
+  --cw-footer-height: 36px;
+  --cw-focus-ring: var(--theme-primary, var(--el-color-primary));
   /* 全局圆角从 4px 提到 6px，弹窗更圆润 */
   --el-border-radius-base: 6px;
   --el-dialog-border-radius: 10px;

--- a/customer-admin-web/src/views/system/DevToolboxView.vue
+++ b/customer-admin-web/src/views/system/DevToolboxView.vue
@@ -84,9 +84,11 @@ watch(
 
 <style scoped>
 .devtoolbox-page {
+  height: 100%;
+  min-height: 0;
   display: flex;
   gap: 16px;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 .devtoolbox-sidebar {
@@ -99,7 +101,8 @@ watch(
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 8px;
   padding: 12px;
-  height: calc(100vh - 140px);
+  height: 100%;
+  min-height: 0;
 }
 
 .devtoolbox-search {
@@ -108,6 +111,7 @@ watch(
 
 .devtoolbox-list {
   flex: 1;
+  min-height: 0;
 }
 
 .devtoolbox-item {
@@ -148,6 +152,8 @@ watch(
 .devtoolbox-panel {
   flex: 1;
   min-width: 0;
+  min-height: 0;
+  overflow: auto;
 }
 
 .panel-title {


### PR DESCRIPTION
## 变更说明

- 将原有单列树形菜单重构为「生命周期导航轨 + 上下文菜单」，按总览、智能体、构建、运营、治理、设置六类组织后端权限菜单。
- 重构顶部栏，整合全局权限内搜索、租户视角、主题、站内消息和用户入口；同步优化标签栏、面包屑和焦点可访问性。
- 保留后端菜单树作为路由、权限和动态智能体的唯一事实来源；保留 Workspace 精确 `keep-alive`，避免切页中断会话或丢失草稿。
- 支持桌面折叠、窄屏覆盖层、暗色模式、键盘搜索及页签上下文菜单，并补齐导航模型边界测试。

## 验证结果

- 管理端 Node 24：Vitest 8 个文件、66 条测试全部通过；生产构建通过。
- H5 Node 24：Vitest 10 个文件、27 条测试全部通过；生产构建通过。
- 真实 Chromium 验收：12 个场景全部通过，覆盖六类菜单映射、折叠/窄屏、全局搜索、Workspace 草稿保活、页签键盘菜单、暗色刷新、通知单例和动态智能体深链；unexpected API、console、page、network error 均为 0。
- JDK 17 Maven 全量门禁：6 个模块 `BUILD SUCCESS`；`customer-admin-server` 1556 条测试（0 failure / 0 error / 1 skipped），另含 `customer-channel` 80 条、`customer-gateway` 1 条。按本地环境约定排除需要 Redis 密码的 `RedisSessionPersistenceTest`。
- `git diff --check` 与凭据检查通过。
- 独立代码质量复审、测试覆盖复核和安全审计均无阻塞问题。

## 兼容性说明

- 已变基到最新 `main`（包含 PR #161 的 H5 重构）；最新上游变更仅涉及 H5 与 CI，本次业务改动仅涉及 `customer-admin-web`。
- 未新增或升级依赖，未修改后端、数据库迁移或权限协议。
