### PR TITLE
feat(admin-web): redesign workspace empty state

### DIFF
--- a/customer-admin-web/src/components/workspace/WorkspaceConversationEmptyState.test.ts
+++ b/customer-admin-web/src/components/workspace/WorkspaceConversationEmptyState.test.ts
@@ -1,0 +1,70 @@
+import { createSSRApp } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import WorkspaceConversationEmptyState from './WorkspaceConversationEmptyState.vue'
+import chatPanelSource from '@/views/workspace/ChatPanel.vue?raw'
+import vibeCodingPanelSource from '@/views/workspace/VibeCodingPanel.vue?raw'
+
+const PANEL_SOURCES = [
+  ['ChatPanel', chatPanelSource],
+  ['VibeCodingPanel', vibeCodingPanelSource],
+] as const
+
+async function renderEmptyState(assistantName = 'Java助手'): Promise<string> {
+  return renderToString(createSSRApp(WorkspaceConversationEmptyState, { assistantName }))
+}
+
+/** 只取消息容器到输入区之间的模板，避免 VibeCoding 产物栏自身的 el-empty 干扰断言。 */
+function messageRegion(source: string): string {
+  const start = source.indexOf('ref="scrollRef"')
+  const end = source.indexOf('<div class="composer-wrap">', start)
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('WorkspaceConversationEmptyState', () => {
+  it('统一展示精确的任务起点与通用任务文案', async () => {
+    const html = await renderEmptyState()
+
+    expect(html).toContain('>从一个任务开始</h2>')
+    expect(html).toContain('描述目标，或直接补充资料、上下文和约束。')
+    expect(html).toContain('例如：梳理需求 · 定位问题 · 完成一个可验证的结果')
+    expect(html).not.toContain('从一个 Java 任务开始')
+    expect(html).not.toContain('重构长方法')
+    expect(html).not.toContain('补充单元测试')
+  })
+
+  it('动态展示当前助手名称，技术标识不写死 Java', async () => {
+    const html = await renderEmptyState('OA考勤助手')
+
+    expect(html).toContain('AGENT WORKBENCH / READY')
+    expect(html).toContain('OA考勤助手 · READY')
+    expect(html).not.toContain('Java助手')
+    expect(html).not.toContain('JAVA WORKBENCH')
+    expect(html).not.toContain('JAVA ASSISTANT')
+  })
+
+  it('让技术装饰层退出无障碍树', async () => {
+    const html = await renderEmptyState()
+
+    expect(html).toContain('aria-hidden="true"')
+    expect(html).toContain('context.read();')
+    expect(html).toContain('intent.resolve();')
+    expect(html).toContain('answer.verify();')
+  })
+})
+
+describe('工作区 Panel 空态接线契约', () => {
+  it.each(PANEL_SOURCES)('%s 接入共享空态并透传当前助手名称', (_label, source) => {
+    const messages = messageRegion(source)
+
+    expect(messages).toContain('<WorkspaceConversationEmptyState')
+    expect(messages).toContain(':assistant-name="assistantName"')
+    expect(messages).toContain("'is-empty'")
+    expect(messages).not.toContain('<el-empty')
+    expect(messages).toContain('class="message-row"')
+    expect(source).not.toContain('开始和智能体对话吧')
+    expect(source).not.toContain('描述你想让智能体生成/修改的代码')
+  })
+})

--- a/customer-admin-web/src/components/workspace/WorkspaceConversationEmptyState.vue
+++ b/customer-admin-web/src/components/workspace/WorkspaceConversationEmptyState.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+defineProps<{ assistantName: string }>()
+
+const LINE_NUMBERS = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
+</script>
+
+<template>
+  <section class="workspace-empty-state">
+    <div class="workspace-empty-state__status" aria-hidden="true">
+      <span class="workspace-empty-state__status-dot" />
+      AGENT WORKBENCH / READY
+    </div>
+
+    <div class="workspace-empty-state__blueprint" aria-hidden="true">
+      <div class="workspace-empty-state__line-numbers">
+        <span v-for="line in LINE_NUMBERS" :key="line">{{ line }}</span>
+      </div>
+      <span class="workspace-empty-state__indent-guide workspace-empty-state__indent-guide--first" />
+      <span class="workspace-empty-state__indent-guide workspace-empty-state__indent-guide--second" />
+      <span class="workspace-empty-state__indent-guide workspace-empty-state__indent-guide--third" />
+      <span class="workspace-empty-state__scope-line" />
+      <span class="workspace-empty-state__scope-token workspace-empty-state__scope-token--open">{</span>
+      <span class="workspace-empty-state__scope-token workspace-empty-state__scope-token--close">}</span>
+      <code class="workspace-empty-state__ghost-code">context.read();
+intent.resolve();
+answer.verify();</code>
+    </div>
+
+    <div class="workspace-empty-state__content">
+      <div class="workspace-empty-state__eyebrow" aria-hidden="true">
+        <span class="workspace-empty-state__eyebrow-name">{{ assistantName }} · READY</span>
+      </div>
+      <h2 class="workspace-empty-state__title">从一个任务开始</h2>
+      <p class="workspace-empty-state__lead">
+        描述目标，或直接补充资料、上下文和约束。我会先理解任务，再给出可验证的处理建议。
+      </p>
+      <p class="workspace-empty-state__example">
+        <span aria-hidden="true">//</span>
+        例如：梳理需求 · 定位问题 · 完成一个可验证的结果
+      </p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.workspace-empty-state {
+  --empty-state-muted: color-mix(in srgb, var(--el-text-color-primary) 72%, var(--el-bg-color));
+  --empty-state-quiet: color-mix(in srgb, var(--el-text-color-primary) 68%, var(--el-bg-color));
+  --empty-state-line: color-mix(in srgb, var(--el-border-color) 48%, transparent);
+  --empty-state-accent: var(--theme-primary, var(--el-color-primary));
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  overflow: hidden;
+  color: var(--el-text-color-primary);
+  pointer-events: none;
+  isolation: isolate;
+}
+
+.workspace-empty-state::before {
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  background: linear-gradient(180deg, color-mix(in srgb, #fff 34%, transparent), transparent 38%);
+  content: '';
+}
+
+:global(html.dark) .workspace-empty-state::before {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--el-fill-color-light) 34%, transparent), transparent 42%);
+}
+
+.workspace-empty-state__status {
+  position: absolute;
+  z-index: 2;
+  top: 24px;
+  left: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--empty-state-muted);
+  font-family: 'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.11em;
+}
+
+.workspace-empty-state__status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--el-color-success);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--el-color-success) 10%, transparent);
+}
+
+.workspace-empty-state__blueprint {
+  position: absolute;
+  z-index: 1;
+  inset: 54px 40px 32px 34px;
+  color: var(--empty-state-muted);
+  user-select: none;
+  pointer-events: none;
+}
+
+.workspace-empty-state__line-numbers {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: grid;
+  grid-template-rows: repeat(12, 24px);
+  width: 24px;
+  color: var(--empty-state-quiet);
+  font-family: 'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+  font-size: 9px;
+  font-weight: 500;
+  line-height: 24px;
+  text-align: right;
+}
+
+.workspace-empty-state__indent-guide {
+  position: absolute;
+  width: 1px;
+  background: var(--empty-state-line);
+}
+
+.workspace-empty-state__indent-guide--first {
+  top: 0;
+  bottom: 0;
+  left: 46px;
+}
+
+.workspace-empty-state__indent-guide--second {
+  top: 24px;
+  bottom: 24px;
+  left: 70px;
+}
+
+.workspace-empty-state__indent-guide--third {
+  top: 48px;
+  bottom: 48px;
+  left: 94px;
+}
+
+.workspace-empty-state__scope-line {
+  position: absolute;
+  top: 71px;
+  left: 94px;
+  width: min(216px, 34%);
+  height: 191px;
+  border: 1px solid var(--empty-state-line);
+  border-right: 0;
+  border-radius: 10px 0 0 10px;
+}
+
+.workspace-empty-state__scope-token {
+  position: absolute;
+  left: 107px;
+  color: color-mix(in srgb, var(--empty-state-accent) 38%, transparent);
+  font-family: 'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.workspace-empty-state__scope-token--open {
+  top: 61px;
+}
+
+.workspace-empty-state__scope-token--close {
+  top: 252px;
+}
+
+.workspace-empty-state__ghost-code {
+  position: absolute;
+  top: 24px;
+  right: 6px;
+  color: color-mix(in srgb, var(--el-text-color-secondary) 14%, transparent);
+  font-family: 'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 2.15;
+  text-align: left;
+  white-space: pre;
+}
+
+.workspace-empty-state__content {
+  position: absolute;
+  z-index: 3;
+  top: clamp(112px, 28%, 176px);
+  left: 50%;
+  width: min(620px, calc(100% - 96px));
+  transform: translateX(-50%);
+  text-align: left;
+}
+
+.workspace-empty-state__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  max-width: 100%;
+  margin-bottom: 12px;
+  color: var(--empty-state-muted);
+  font-family: 'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 1;
+  letter-spacing: 0.1em;
+}
+
+.workspace-empty-state__eyebrow-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-empty-state__eyebrow::before {
+  width: 8px;
+  height: 14px;
+  border-radius: 2px;
+  background: var(--empty-state-accent);
+  content: '';
+  animation: workspace-empty-state-caret 1s step-end 2;
+}
+
+.workspace-empty-state__title {
+  margin: 0;
+  color: var(--el-text-color-primary);
+  font-size: 26px;
+  font-weight: 680;
+  line-height: 1.34;
+  letter-spacing: -0.025em;
+}
+
+.workspace-empty-state__lead {
+  max-width: 570px;
+  margin: 9px 0 0;
+  color: var(--empty-state-muted);
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+.workspace-empty-state__example {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 17px 0 0;
+  color: var(--empty-state-quiet);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.workspace-empty-state__example span {
+  color: color-mix(in srgb, var(--empty-state-accent) 62%, transparent);
+  font-family: 'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', Menlo, Consolas, monospace;
+  font-weight: 650;
+}
+
+@keyframes workspace-empty-state-caret {
+  50% {
+    opacity: 0.18;
+  }
+}
+
+@container conversation-canvas (max-width: 900px) {
+  .workspace-empty-state__status {
+    top: 20px;
+    left: 22px;
+  }
+
+  .workspace-empty-state__blueprint {
+    inset: 50px 28px 28px 22px;
+  }
+
+  .workspace-empty-state__content {
+    top: clamp(104px, 25%, 148px);
+    width: min(560px, calc(100% - 64px));
+  }
+
+  .workspace-empty-state__title {
+    font-size: 24px;
+  }
+}
+
+@container conversation-canvas (max-width: 620px) {
+  .workspace-empty-state__status {
+    top: 17px;
+    left: 18px;
+    font-size: 9px;
+  }
+
+  .workspace-empty-state__blueprint {
+    inset: 46px 18px 24px 12px;
+  }
+
+  .workspace-empty-state__indent-guide--third,
+  .workspace-empty-state__ghost-code {
+    display: none;
+  }
+
+  .workspace-empty-state__content {
+    top: clamp(96px, 23%, 126px);
+    width: calc(100% - 48px);
+  }
+
+  .workspace-empty-state__eyebrow {
+    margin-bottom: 10px;
+    font-size: 9px;
+  }
+
+  .workspace-empty-state__title {
+    font-size: 22px;
+  }
+
+  .workspace-empty-state__lead {
+    font-size: 13px;
+    line-height: 1.7;
+  }
+
+  .workspace-empty-state__example {
+    margin-top: 14px;
+    line-height: 1.7;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-empty-state__eyebrow::before {
+    animation: none;
+  }
+}
+</style>

--- a/customer-admin-web/src/styles/workspace-conversation.css
+++ b/customer-admin-web/src/styles/workspace-conversation.css
@@ -4,6 +4,7 @@
   --conversation-composer-padding: 10px 24px 14px;
   --conversation-user-bubble-max-width: 72%;
   --conversation-toolbar-wrap: nowrap;
+  --conversation-empty-canvas: color-mix(in srgb, var(--el-fill-color-lighter) 72%, var(--el-bg-color));
   position: relative;
   display: grid;
   width: 100%;
@@ -17,6 +18,8 @@
 .workspace-conversation .chat-column {
   display: flex;
   flex-direction: column;
+  container-name: conversation-canvas;
+  container-type: inline-size;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -24,20 +27,21 @@
 }
 
 .workspace-conversation .messages {
+  position: relative;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: var(--conversation-messages-padding);
   background-color: var(--el-bg-color);
-  background-image: repeating-linear-gradient(
-    90deg,
-    transparent 0,
-    transparent 31px,
-    color-mix(in srgb, var(--el-border-color-lighter) 24%, transparent) 32px
-  );
   scrollbar-color: var(--el-border-color) transparent;
   scrollbar-width: thin;
+}
+
+.workspace-conversation .messages.is-empty {
+  overflow: hidden;
+  padding: 0;
+  background-color: var(--conversation-empty-canvas);
 }
 
 .workspace-conversation .messages::-webkit-scrollbar {
@@ -123,6 +127,13 @@
   flex: 0 0 auto;
   padding: var(--conversation-composer-padding);
   background: linear-gradient(transparent, color-mix(in srgb, var(--el-bg-color) 96%, transparent) 24%);
+}
+
+.workspace-conversation .messages.is-empty + .composer-wrap {
+  background: linear-gradient(
+    transparent,
+    color-mix(in srgb, var(--conversation-empty-canvas) 96%, transparent) 24%
+  );
 }
 
 .workspace-conversation .composer-shell {

--- a/customer-admin-web/src/views/workspace/ChatPanel.vue
+++ b/customer-admin-web/src/views/workspace/ChatPanel.vue
@@ -10,6 +10,7 @@ import ExecutionModeSelect from '@/components/ExecutionModeSelect.vue'
 import PlanConfirmCard from '@/components/PlanConfirmCard.vue'
 import AttachmentPendingList from '@/components/attachment/AttachmentPendingList.vue'
 import MessageAttachments from '@/components/attachment/MessageAttachments.vue'
+import WorkspaceConversationEmptyState from '@/components/workspace/WorkspaceConversationEmptyState.vue'
 import { useThemeStore } from '@/store/theme'
 import '@/styles/workspace-conversation.css'
 import {
@@ -18,7 +19,7 @@ import {
 } from '@/store/chatConversations'
 import type { PlanCard } from '@/utils/planCard'
 
-const props = defineProps<{ agentCode: string; initialSessionId?: string }>()
+const props = defineProps<{ agentCode: string; assistantName: string; initialSessionId?: string }>()
 
 /**
  * 会话状态全部在 Pinia store（chatConversations）里，本组件只是"当前正在看哪个会话"的视图：
@@ -190,7 +191,12 @@ defineExpose({ newSession })
 <template>
   <div class="chat-panel workspace-conversation" :class="{ 'is-history-collapsed': historyCollapsed }">
     <div class="chat-column">
-      <div ref="scrollRef" class="messages" v-loading="historyLoading">
+      <div
+        ref="scrollRef"
+        class="messages"
+        :class="{ 'is-empty': (active?.messages.length ?? 0) === 0 }"
+        v-loading="historyLoading"
+      >
         <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
           <div class="bubble">
             <AssistantResponse
@@ -216,7 +222,10 @@ defineExpose({ newSession })
             />
           </div>
         </div>
-        <el-empty v-if="(active?.messages.length ?? 0) === 0" description="开始和智能体对话吧" />
+        <WorkspaceConversationEmptyState
+          v-if="(active?.messages.length ?? 0) === 0"
+          :assistant-name="assistantName"
+        />
       </div>
       <div class="composer-wrap">
         <div class="composer-shell">

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -23,6 +23,7 @@ import PlanConfirmCard from '@/components/PlanConfirmCard.vue'
 import VibeCodingToolsDrawer from '@/components/VibeCodingToolsDrawer.vue'
 import AttachmentPendingList from '@/components/attachment/AttachmentPendingList.vue'
 import MessageAttachments from '@/components/attachment/MessageAttachments.vue'
+import WorkspaceConversationEmptyState from '@/components/workspace/WorkspaceConversationEmptyState.vue'
 import { useThemeStore } from '@/store/theme'
 import '@/styles/workspace-conversation.css'
 import {
@@ -48,7 +49,7 @@ import 'highlight.js/styles/github.css'
 const REVIEW_POLL_INTERVAL_MS = 5000
 const MAX_REVIEW_POLL_COUNT = 40
 
-const props = defineProps<{ agentCode: string; initialSessionId?: string }>()
+const props = defineProps<{ agentCode: string; assistantName: string; initialSessionId?: string }>()
 
 /**
  * 会话状态全部在 Pinia store（vibeConversations）里，本组件只是视图：切页面、切智能体、组件销毁
@@ -574,7 +575,12 @@ defineExpose({ newSession })
   <div class="vibecoding-panel workspace-conversation" :class="{ 'is-history-collapsed': historyCollapsed }">
     <!-- 左列：对话区 -->
     <div class="chat-column">
-      <div ref="scrollRef" class="messages" v-loading="historyLoading">
+      <div
+        ref="scrollRef"
+        class="messages"
+        :class="{ 'is-empty': (active?.messages.length ?? 0) === 0 }"
+        v-loading="historyLoading"
+      >
         <div v-for="(msg, index) in active?.messages ?? []" :key="index" class="message-row" :class="msg.role">
           <div class="bubble">
             <AssistantResponse
@@ -660,7 +666,10 @@ defineExpose({ newSession })
             />
           </div>
         </div>
-        <el-empty v-if="(active?.messages.length ?? 0) === 0" description="描述你想让智能体生成/修改的代码" />
+        <WorkspaceConversationEmptyState
+          v-if="(active?.messages.length ?? 0) === 0"
+          :assistant-name="assistantName"
+        />
       </div>
       <div class="composer-wrap">
         <div class="composer-shell">

--- a/customer-admin-web/src/views/workspace/WorkspaceView.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceView.vue
@@ -40,6 +40,7 @@ function findNode(nodes: MenuNode[], agentCode: string): MenuNode | null {
 }
 
 const agentNode = computed(() => findNode(menuStore.tree, props.agentCode))
+const agentDisplayName = computed(() => agentNode.value?.name ?? props.agentCode)
 const supportsVibeCoding = computed(() => agentNode.value?.capabilities?.includes('vibecoding') ?? false)
 
 // 主题色/新建会话工具栏上提到 Tab 上方后，"新建会话"要按当前激活的 Tab 分发到对应面板
@@ -137,7 +138,7 @@ watch(
       <div class="agent-identity">
         <span class="agent-mark" aria-hidden="true">&lt;/&gt;</span>
         <div class="agent-copy">
-          <h1 class="agent-title">{{ agentNode?.name ?? agentCode }}</h1>
+          <h1 class="agent-title">{{ agentDisplayName }}</h1>
           <div class="agent-meta">
             <span>智能体工作台</span>
             <span class="meta-separator" aria-hidden="true">/</span>
@@ -170,10 +171,22 @@ watch(
              不加 :key 的话切换智能体时 ChatPanel 内部的 messages/sessionId 状态会跟着串到下一个
              智能体身上。加 :key 强制按 agentCode 重建实例，天然顺带把上一个智能体未结束的 SSE
              流也一起 abort 掉（复用 ChatPanel 自己 onUnmounted 里已有的 abortStream 逻辑）。 -->
-        <ChatPanel ref="chatPanelRef" :key="agentCode" :agent-code="agentCode" :initial-session-id="initialSessionId" />
+        <ChatPanel
+          ref="chatPanelRef"
+          :key="agentCode"
+          :agent-code="agentCode"
+          :assistant-name="agentDisplayName"
+          :initial-session-id="initialSessionId"
+        />
       </el-tab-pane>
       <el-tab-pane v-if="supportsVibeCoding" label="VibeCoding" name="vibecoding">
-        <VibeCodingPanel ref="vibeCodingPanelRef" :key="agentCode" :agent-code="agentCode" :initial-session-id="initialSessionId" />
+        <VibeCodingPanel
+          ref="vibeCodingPanelRef"
+          :key="agentCode"
+          :agent-code="agentCode"
+          :assistant-name="agentDisplayName"
+          :initial-session-id="initialSessionId"
+        />
       </el-tab-pane>
     </el-tabs>
   </div>


### PR DESCRIPTION
## Summary

- replace the default empty boxes in Chat and VibeCoding with one shared task-oriented workbench canvas
- use the exact title “从一个任务开始” and show the active agent name without leaking Java-specific branding to other agents
- support light/dark themes, narrow conversation containers, reduced motion, and automatic return to the normal message canvas

## Verification

- customer-admin-web: npm test — 9 files, 71 tests passed
- customer-admin-web: npm run build — passed
- Maven full gate: 3471 tests, 0 failures, 0 errors, 6 skipped — BUILD SUCCESS
- browser acceptance: Chat and VibeCoding empty states, dark theme, 515px conversation container, reduced motion, and empty-to-12-message transition verified