### PR TITLE
feat(admin): redesign authentication experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,13 +161,24 @@ jobs:
         working-directory: ${{ matrix.project }}
         run: npm ci
 
-      - name: Run frontend unit tests
+      - name: Run frontend tests
         working-directory: ${{ matrix.project }}
         run: npm test
 
       - name: Type-check and build
         working-directory: ${{ matrix.project }}
         run: npm run build
+
+      - name: Upload frontend test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.project }}-test-results
+          path: |
+            ${{ matrix.project }}/test-results
+            ${{ matrix.project }}/playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
 
   deployment-smoke:
     runs-on: ubuntu-latest

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
@@ -64,7 +64,8 @@ public class AuthController {
             registrationGuard.selfServiceEnabled(),
             registrationGuard.captchaRequired(),
             registrationGuard.emailRequired(),
-            registrationGuard.emailVerificationRequired()));
+            registrationGuard.emailVerificationRequired(),
+            registrationGuard.emailCodeResendCooldownSeconds()));
     }
 
     /**
@@ -113,9 +114,11 @@ public class AuthController {
      *                                 否则用在注册那一步
      * @param emailRequired            是否必须填邮箱
      * @param emailVerificationRequired 是否需要邮箱验证码（决定注册表单渲染"获取验证码"按钮）
+     * @param emailCodeCooldownSeconds 同一邮箱两次发码之间的服务端冷却时间（秒）
      */
     public record RegisterOptionsVO(boolean selfServiceEnabled, boolean captchaRequired,
-                                    boolean emailRequired, boolean emailVerificationRequired) {
+                                    boolean emailRequired, boolean emailVerificationRequired,
+                                    int emailCodeCooldownSeconds) {
     }
 
     /** OA 域账号（LDAP/AD）单点登录，与上面的账号密码登录入口共存，前端登录页 Tab 切换。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/email/EmailVerificationService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/email/EmailVerificationService.java
@@ -101,7 +101,7 @@ public class EmailVerificationService {
         }
         EmailVerificationCode stored = store.get(email);
         if (stored == null) {
-            throw new BizException(ResultCode.EMAIL_CODE_INVALID, "验证码已过期，请重新获取");
+            throw new BizException(ResultCode.EMAIL_CODE_REISSUE_REQUIRED);
         }
         if (!stored.code().equals(input.trim())) {
             int maxAttempts = properties.getEmailVerification().getMaxAttempts();
@@ -109,7 +109,7 @@ public class EmailVerificationService {
             if (failed.attempts() >= maxAttempts) {
                 store.invalidate(email);
                 log.info("email verification code invalidated after {} failed attempts", maxAttempts);
-                throw new BizException(ResultCode.EMAIL_CODE_INVALID, "验证码错误次数过多，请重新获取");
+                throw new BizException(ResultCode.EMAIL_CODE_REISSUE_REQUIRED);
             }
             store.save(email, failed);
             throw new BizException(ResultCode.EMAIL_CODE_INVALID);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationGuard.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationGuard.java
@@ -78,6 +78,11 @@ public class RegistrationGuard {
         return publicDeployment.isEnabled() || properties.getEmailVerification().isEnabled();
     }
 
+    /** 前端发码按钮应与服务端使用同一重发冷却时间，避免配置变化后出现假倒计时。 */
+    public int emailCodeResendCooldownSeconds() {
+        return properties.getEmailVerification().getResendCooldownSeconds();
+    }
+
     /** 自助注册总开关，关闭时只能由管理员预建账号。 */
     public boolean selfServiceEnabled() {
         return properties.isSelfServiceEnabled();

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -37,8 +37,9 @@ public enum ResultCode {
     SQL_NOT_READONLY(30008, "仅允许只读 SELECT/WITH 查询"),
     SQL_PARAM_INVALID(30009, "SQL 查询参数不合法"),
     CAPTCHA_INVALID(30010, "图形验证码错误或已过期"),
-    EMAIL_CODE_INVALID(30012, "邮箱验证码错误或已过期"),
     PASSWORD_TOO_WEAK(30011, "密码强度不足，请至少包含字母与数字且不少于 8 位"),
+    EMAIL_CODE_INVALID(30012, "邮箱验证码错误"),
+    EMAIL_CODE_REISSUE_REQUIRED(30013, "邮箱验证码已失效，请重新获取"),
 
     // 4xxxx 外部依赖类
     MODEL_TEST_TIMEOUT(40001, "模型连通性测试超时"),

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerRegisterOptionsTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerRegisterOptionsTest.java
@@ -1,0 +1,87 @@
+package com.richard.fyoung.customeradmin.auth.controller;
+
+import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuard;
+import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
+import com.richard.fyoung.customeradmin.auth.service.AuthService;
+import com.richard.fyoung.customeradmin.config.SaTokenConfig;
+import com.richard.fyoung.customeradmin.system.user.service.UserRegistrationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = AuthControllerRegisterOptionsTest.WebMvcTestConfig.class)
+class AuthControllerRegisterOptionsTest {
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    @Autowired
+    private RegistrationGuard registrationGuard;
+
+    @Test
+    void registerOptions_shouldExposeTheCompleteAnonymousRegistrationJsonContract() throws Exception {
+        when(registrationGuard.selfServiceEnabled()).thenReturn(true);
+        when(registrationGuard.captchaRequired()).thenReturn(true);
+        when(registrationGuard.emailRequired()).thenReturn(false);
+        when(registrationGuard.emailVerificationRequired()).thenReturn(true);
+        when(registrationGuard.emailCodeResendCooldownSeconds()).thenReturn(37);
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
+
+        mockMvc.perform(get("/api/auth/register-options").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.message").value("ok"))
+            .andExpect(jsonPath("$.data.selfServiceEnabled").value(true))
+            .andExpect(jsonPath("$.data.captchaRequired").value(true))
+            .andExpect(jsonPath("$.data.emailRequired").value(false))
+            .andExpect(jsonPath("$.data.emailVerificationRequired").value(true))
+            .andExpect(jsonPath("$.data.emailCodeCooldownSeconds").value(37));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableWebMvc
+    @Import({AuthController.class, SaTokenConfig.class})
+    static class WebMvcTestConfig {
+
+        @Bean
+        AuthService authService() {
+            return mock(AuthService.class);
+        }
+
+        @Bean
+        UserRegistrationService userRegistrationService() {
+            return mock(UserRegistrationService.class);
+        }
+
+        @Bean
+        RegistrationGuard registrationGuard() {
+            return mock(RegistrationGuard.class);
+        }
+
+        @Bean
+        RegistrationGuardProperties registrationGuardProperties() {
+            return new RegistrationGuardProperties();
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/email/EmailVerificationServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/email/EmailVerificationServiceTest.java
@@ -96,7 +96,7 @@ class EmailVerificationServiceTest {
         // 同一份码不能注册两个账号
         assertNull(store.get(EMAIL));
         BizException replay = assertThrows(BizException.class, () -> service.verify(EMAIL, code));
-        assertEquals(ResultCode.EMAIL_CODE_INVALID, replay.getResultCode());
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, replay.getResultCode());
     }
 
     /**
@@ -109,10 +109,14 @@ class EmailVerificationServiceTest {
     void verify_shouldAllowRetriesUntilMaxAttemptsThenInvalidate() {
         service.sendCode(EMAIL, IP);
         String code = store.get(EMAIL).code();
+        String wrongCode = wrongCodeFor(code);
         int maxAttempts = properties.getEmailVerification().getMaxAttempts();
 
         for (int i = 0; i < maxAttempts - 1; i++) {
-            assertThrows(BizException.class, () -> service.verify(EMAIL, "000000"));
+            BizException retryable = assertThrows(BizException.class,
+                () -> service.verify(EMAIL, wrongCode));
+            assertEquals(ResultCode.EMAIL_CODE_INVALID, retryable.getResultCode(),
+                "未耗尽尝试次数时客户端应允许继续输入当前验证码");
             assertNotNull(store.get(EMAIL), "未达上限前验证码应当仍然有效");
         }
         // 中途输对仍然算数
@@ -123,24 +127,54 @@ class EmailVerificationServiceTest {
     void verify_shouldInvalidateCodeAfterMaxFailedAttempts() {
         service.sendCode(EMAIL, IP);
         String code = store.get(EMAIL).code();
+        String wrongCode = wrongCodeFor(code);
+        int maxAttempts = properties.getEmailVerification().getMaxAttempts();
 
-        for (int i = 0; i < properties.getEmailVerification().getMaxAttempts(); i++) {
-            assertThrows(BizException.class, () -> service.verify(EMAIL, "000000"));
+        for (int i = 0; i < maxAttempts - 1; i++) {
+            BizException retryable = assertThrows(BizException.class,
+                () -> service.verify(EMAIL, wrongCode));
+            assertEquals(ResultCode.EMAIL_CODE_INVALID, retryable.getResultCode());
         }
+        BizException exhausted = assertThrows(BizException.class,
+            () -> service.verify(EMAIL, wrongCode));
 
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, exhausted.getResultCode(),
+            "次数耗尽后客户端必须引导重新获取验证码");
         assertNull(store.get(EMAIL), "失败次数耗尽后验证码必须作废");
         BizException error = assertThrows(BizException.class, () -> service.verify(EMAIL, code));
-        assertEquals(ResultCode.EMAIL_CODE_INVALID, error.getResultCode());
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, error.getResultCode());
+    }
+
+    @Test
+    void verify_shouldRequireReissueWhenCodeDoesNotExist() {
+        BizException error = assertThrows(BizException.class,
+            () -> service.verify(EMAIL, "123456"));
+
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, error.getResultCode());
+    }
+
+    @Test
+    void verify_shouldRequireReissueWhenCodeExpired() {
+        store.save(EMAIL, new EmailVerificationCode("123456", 0, System.currentTimeMillis() - 1));
+
+        BizException error = assertThrows(BizException.class,
+            () -> service.verify(EMAIL, "123456"));
+
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, error.getResultCode());
+        assertNull(store.get(EMAIL));
     }
 
     /** 失败重写不得续期，否则不断试错就能让验证码永不过期，正好方便暴力猜码。 */
     @Test
     void verify_shouldKeepOriginalExpiryWhenRecordingFailure() {
         service.sendCode(EMAIL, IP);
+        String code = store.get(EMAIL).code();
         long expireAtBefore = store.get(EMAIL).expireAtMs();
 
-        assertThrows(BizException.class, () -> service.verify(EMAIL, "000000"));
+        BizException error = assertThrows(BizException.class,
+            () -> service.verify(EMAIL, wrongCodeFor(code)));
 
+        assertEquals(ResultCode.EMAIL_CODE_INVALID, error.getResultCode());
         assertEquals(expireAtBefore, store.get(EMAIL).expireAtMs());
     }
 
@@ -230,5 +264,9 @@ class EmailVerificationServiceTest {
     void normalize_shouldLowercaseAndTrim() {
         assertEquals("richard@example.com", EmailVerificationService.normalize("  Richard@Example.COM "));
         assertNull(EmailVerificationService.normalize(null));
+    }
+
+    private String wrongCodeFor(String code) {
+        return "000000".equals(code) ? "111111" : "000000";
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationEmailVerificationFlowTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationEmailVerificationFlowTest.java
@@ -71,7 +71,7 @@ class RegistrationEmailVerificationFlowTest {
             STRONG_PASSWORD, STRONG_PASSWORD));
     }
 
-    /** 没有邮箱验证码就注册不了——这正是"填了别人的邮箱"这条路被堵死的地方。 */
+    /** 空输入属于可修正的表单错误，不应误导客户端认为必须重新发码。 */
     @Test
     void admit_shouldRejectWithoutEmailCode() {
         BizException error = assertThrows(BizException.class,
@@ -80,7 +80,7 @@ class RegistrationEmailVerificationFlowTest {
         assertEquals(ResultCode.EMAIL_CODE_INVALID, error.getResultCode());
     }
 
-    /** 一个邮箱收到的码不能拿去注册另一个邮箱。 */
+    /** 目标邮箱没有签发记录时，客户端必须引导重新获取，而不是继续重试当前码。 */
     @Test
     void admit_shouldRejectCodeIssuedForAnotherAddress() {
         guard.sendEmailCode(EMAIL, null, null, IP);
@@ -90,7 +90,43 @@ class RegistrationEmailVerificationFlowTest {
             () -> guard.admit(IP, null, null, "someone-else@example.com", code,
                 STRONG_PASSWORD, STRONG_PASSWORD));
 
-        assertEquals(ResultCode.EMAIL_CODE_INVALID, error.getResultCode());
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, error.getResultCode());
+    }
+
+    /** 普通输错仍可继续尝试当前验证码，不应要求用户重复收信。 */
+    @Test
+    void admit_shouldKeepCurrentCodeRetryableAfterOrdinaryMismatch() {
+        guard.sendEmailCode(EMAIL, null, null, IP);
+        String code = emailStore.get(EMAIL).code();
+
+        BizException mismatch = assertThrows(BizException.class,
+            () -> guard.admit(IP, null, null, EMAIL, wrongCodeFor(code),
+                STRONG_PASSWORD, STRONG_PASSWORD));
+
+        assertEquals(ResultCode.EMAIL_CODE_INVALID, mismatch.getResultCode());
+        assertDoesNotThrow(() -> guard.admit(IP, null, null, EMAIL, code,
+            STRONG_PASSWORD, STRONG_PASSWORD));
+    }
+
+    /** 尝试次数耗尽后当前码已销毁，客户端必须切换到重新发码流程。 */
+    @Test
+    void admit_shouldRequireReissueAfterAttemptsExhausted() {
+        guard.sendEmailCode(EMAIL, null, null, IP);
+        String code = emailStore.get(EMAIL).code();
+        String wrongCode = wrongCodeFor(code);
+        int maxAttempts = properties.getEmailVerification().getMaxAttempts();
+
+        for (int i = 0; i < maxAttempts - 1; i++) {
+            BizException retryable = assertThrows(BizException.class,
+                () -> guard.admit(IP, null, null, EMAIL, wrongCode,
+                    STRONG_PASSWORD, STRONG_PASSWORD));
+            assertEquals(ResultCode.EMAIL_CODE_INVALID, retryable.getResultCode());
+        }
+        BizException exhausted = assertThrows(BizException.class,
+            () -> guard.admit(IP, null, null, EMAIL, wrongCode,
+                STRONG_PASSWORD, STRONG_PASSWORD));
+
+        assertEquals(ResultCode.EMAIL_CODE_REISSUE_REQUIRED, exhausted.getResultCode());
     }
 
     /**
@@ -211,5 +247,9 @@ class RegistrationEmailVerificationFlowTest {
         }
         captchaStore.save(challenge.captchaId(), answer, properties.getCaptcha().getTtlSeconds());
         return answer.toUpperCase(Locale.ROOT);
+    }
+
+    private String wrongCodeFor(String code) {
+        return "000000".equals(code) ? "111111" : "000000";
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationGuardTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationGuardTest.java
@@ -56,6 +56,13 @@ class RegistrationGuardTest {
         assertDoesNotThrow(() -> guard.admit(IP, null, null, null, null, STRONG_PASSWORD, STRONG_PASSWORD));
     }
 
+    @Test
+    void emailCodeCooldown_shouldExposeTheServerConfigurationToTheLoginPage() {
+        properties.getEmailVerification().setResendCooldownSeconds(37);
+
+        assertEquals(37, guard.emailCodeResendCooldownSeconds());
+    }
+
     /**
      * 对外部署强制图形码、邮箱与邮箱验证码，且不看 {@code admin.registration.*} 的开关。
      *

--- a/customer-admin-web/.gitignore
+++ b/customer-admin-web/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+playwright-report
+test-results
 *.local
 
 # Editor directories and files

--- a/customer-admin-web/package-lock.json
+++ b/customer-admin-web/package-lock.json
@@ -22,6 +22,7 @@
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/markdown-it": "^14.1.2",
         "@types/node": "^24.13.2",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -233,6 +234,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmmirror.com/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2010,9 +2027,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -2136,10 +2153,57 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmmirror.com/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2156,7 +2220,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/customer-admin-web/package.json
+++ b/customer-admin-web/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "npm run test:unit && npm run test:e2e",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",
@@ -24,6 +26,7 @@
     "vue-router": "^4.6.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.13.2",
     "@vitejs/plugin-vue": "^6.0.7",

--- a/customer-admin-web/playwright.config.ts
+++ b/customer-admin-web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test'
+import { LOGIN_E2E_ORIGIN, LOGIN_E2E_PORT } from './tests/e2e/loginTestEnvironment'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  // 使用独立后缀，避免 Vitest 把 Playwright 用例当作单元测试收集。
+  testMatch: '**/*.e2e.ts',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: LOGIN_E2E_ORIGIN,
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chrome',
+      // GitHub ubuntu-latest 与本机均已有 Chrome，避免 CI 每次额外下载浏览器。
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${LOGIN_E2E_PORT} --strictPort`,
+    url: `${LOGIN_E2E_ORIGIN}/login?redirect=/home`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+})

--- a/customer-admin-web/src/components/FooterCopyright.vue
+++ b/customer-admin-web/src/components/FooterCopyright.vue
@@ -1,11 +1,5 @@
-<script setup lang="ts">
-defineProps<{
-  dark?: boolean
-}>()
-</script>
-
 <template>
-  <div class="footer-copyright" :class="{ dark }">
+  <div class="footer-copyright">
     <span>© customer_work · owlzhangfq@gmail.com</span>
   </div>
 </template>
@@ -16,14 +10,13 @@ defineProps<{
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 100%;
+  height: auto;
+  min-height: var(--cw-footer-height, 36px);
+  flex: none;
+  box-sizing: border-box;
   padding: 0 16px;
   font-size: 12px;
   line-height: 1;
   color: var(--el-text-color-secondary);
-}
-
-.footer-copyright.dark {
-  color: rgba(255, 255, 255, 0.55);
 }
 </style>

--- a/customer-admin-web/src/layouts/LifecycleNavigation.vue
+++ b/customer-admin-web/src/layouts/LifecycleNavigation.vue
@@ -242,8 +242,8 @@ defineExpose({ toggleFromHeader })
 
 <style scoped>
 .layout-aside {
-  --cw-rail-bg: #0b1728;
-  --cw-rail-hover: #15263c;
+  --cw-rail-bg: var(--cw-brand-ink);
+  --cw-rail-hover: var(--cw-brand-ink-hover);
   height: 100%;
   display: flex;
   position: relative;
@@ -285,7 +285,7 @@ defineExpose({ toggleFromHeader })
   align-items: center;
   justify-content: center;
   border-radius: 10px;
-  background: linear-gradient(145deg, #5a78ff, #3c5ee8);
+  background: linear-gradient(145deg, var(--cw-brand-logo-start), var(--cw-brand-logo-end));
   color: #fff;
   font-size: 12px;
   font-weight: 800;
@@ -340,7 +340,7 @@ defineExpose({ toggleFromHeader })
   right: -8px;
   top: 50%;
   border-radius: 3px 0 0 3px;
-  background: #6f8aff;
+  background: var(--cw-brand-signal);
   transform: translateY(-50%);
 }
 

--- a/customer-admin-web/src/router/index.ts
+++ b/customer-admin-web/src/router/index.ts
@@ -77,8 +77,12 @@ router.beforeEach(async (to) => {
   if (!auth.isLoggedIn) {
     return { name: 'Login', query: { redirect: to.fullPath } }
   }
-  if (auth.forceChangePassword && to.name !== 'ChangePassword') {
-    return { name: 'ChangePassword' }
+  if (auth.forceChangePassword) {
+    if (to.name !== 'ChangePassword') {
+      return { name: 'ChangePassword' }
+    }
+    // 强制改密是独立的最小登录态，不应提前加载权限与菜单；改密成功并重新登录后再进入正常链路。
+    return true
   }
   // 待审核/已拒绝账号即使手工输入已知地址，也只能停留在首页。真正的数据权限仍由后端
   // UserRoleResolver + 接口权限校验兜底；这里负责把前端可见范围收敛到“首页 + 品牌 Logo”。

--- a/customer-admin-web/src/theme.css
+++ b/customer-admin-web/src/theme.css
@@ -12,6 +12,11 @@
   --cw-tabs-height: 40px;
   --cw-footer-height: 36px;
   --cw-focus-ring: var(--theme-primary, var(--el-color-primary));
+  --cw-brand-ink: #0b1728;
+  --cw-brand-ink-hover: #15263c;
+  --cw-brand-logo-start: #5a78ff;
+  --cw-brand-logo-end: #3c5ee8;
+  --cw-brand-signal: #6f8aff;
   /* 全局圆角从 4px 提到 6px，弹窗更圆润 */
   --el-border-radius-base: 6px;
   --el-dialog-border-radius: 10px;

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -92,6 +92,8 @@ export interface RegisterOptionsVO {
   emailRequired: boolean
   /** 是否需要邮箱验证码 */
   emailVerificationRequired: boolean
+  /** 服务端配置的同邮箱发码冷却秒数；可选以兼容滚动升级期间的旧服务端。 */
+  emailCodeCooldownSeconds?: number
 }
 
 /** 一次验证码挑战；image 是 PNG 的 data URI，直接塞进 <img src> */

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -1,23 +1,37 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { FormInstance, FormRules } from 'element-plus'
-import { fetchCaptcha, fetchRegisterOptions, login, register, sendRegisterEmailCode, ssoLogin } from '@/api/auth'
+import { fetchRegisterOptions, login, ssoLogin } from '@/api/auth'
 import { fetchLoginCarouselUrls } from '@/api/login-image'
+import FooterCopyright from '@/components/FooterCopyright.vue'
 import { useAuthStore } from '@/store/auth'
 import { useMenuStore } from '@/store/menu'
-import FooterCopyright from '@/components/FooterCopyright.vue'
-import type { RegisterOptionsVO, RegisterRequest } from '@/types/api'
+import { useThemeStore } from '@/store/theme'
+import type { LoginResponse, RegisterOptionsVO } from '@/types/api'
+import { chooseButtonTextColor } from '@/utils/themeContrast'
+import LoginBrandStage from './LoginBrandStage.vue'
+import RegisterPanel from './RegisterPanel.vue'
+import {
+  createLoginSubmission,
+  getLoginModePresentation,
+  shouldShowRegisterEntry,
+  type LoginMode,
+} from './loginPageModel'
 
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 const menuStore = useMenuStore()
+const themeStore = useThemeStore()
 
+const authSurfaceRef = ref<HTMLElement>()
 const authPanel = ref<'login' | 'register'>('login')
-
-/** local：账号密码登录（数据库） / sso：OA 域账号登录（LDAP/AD） */
-const loginMode = ref<'local' | 'sso'>('local')
+const loginMode = ref<LoginMode>('local')
+const modePresentation = computed(() => getLoginModePresentation(loginMode.value))
+const localModePresentation = getLoginModePresentation('local')
+const ssoModePresentation = getLoginModePresentation('sso')
+const primaryTextColor = computed(() => chooseButtonTextColor(themeStore.primaryColor))
 
 const formRef = ref<FormInstance>()
 const submitting = ref(false)
@@ -27,235 +41,138 @@ const rules: FormRules = {
   password: [{ required: true, message: '请输入密码', trigger: 'blur' }],
 }
 
-const registerFormRef = ref<FormInstance>()
-const registerSubmitting = ref(false)
-const registerForm = reactive<RegisterRequest>({
-  username: '',
-  nickname: '',
-  email: '',
-  password: '',
-  confirmPassword: '',
-  captchaId: '',
-  captcha: '',
-  emailCode: '',
-})
-
-// 本实例是否开放注册、是否要求验证码与邮箱：由后端按部署形态给出，
-// 对外开放实例上这两项是强制的，前端不做本地判断（判断了也会被后端再拦一次）。
+// 注册能力必须由匿名接口成功确认；接口未返回时按关闭处理，避免先展示再被服务端拒绝。
+const registerOptionsLoaded = ref(false)
 const registerOptions = ref<RegisterOptionsVO>({
-  selfServiceEnabled: true,
+  selfServiceEnabled: false,
   captchaRequired: false,
   emailRequired: false,
   emailVerificationRequired: false,
 })
-const captchaImage = ref('')
-const captchaLoading = ref(false)
+const canRegister = computed(() => shouldShowRegisterEntry(
+  loginMode.value,
+  registerOptionsLoaded.value,
+  registerOptions.value.selfServiceEnabled,
+))
 
-// 邮箱验证码：发码后按冷却时间倒计时，避免用户反复点击——每一次点击都是一封真实的邮件
-const emailCodeSending = ref(false)
-const emailCodeCountdown = ref(0)
-let emailCodeTimer: ReturnType<typeof setInterval> | undefined
+// 后台仍可配置多张登录图；接口不可用时用首页同源客服视觉兜底。
+const bgImages = ref<string[]>(['/home-cover.jpg'])
 
-function startEmailCodeCountdown(seconds: number) {
-  emailCodeCountdown.value = seconds
-  clearEmailCodeTimer()
-  emailCodeTimer = setInterval(() => {
-    emailCodeCountdown.value -= 1
-    if (emailCodeCountdown.value <= 0) {
-      clearEmailCodeTimer()
-    }
-  }, 1000)
-}
-
-function clearEmailCodeTimer() {
-  if (emailCodeTimer) {
-    clearInterval(emailCodeTimer)
-    emailCodeTimer = undefined
-  }
-}
-
-// 定时器不随组件销毁自动停止，离开登录页后继续跑会一直持有闭包
-onBeforeUnmount(clearEmailCodeTimer)
-
-async function handleSendEmailCode() {
-  // 只校验邮箱与图形码这两项：整表校验会因为密码还没填而拦下发码
-  const emailValid = await registerFormRef.value?.validateField('email').then(() => true).catch(() => false)
-  if (!emailValid) {
-    return
-  }
-  if (registerOptions.value.captchaRequired && !registerForm.captcha) {
-    ElMessage.warning('请先填写图形验证码')
-    return
-  }
-  emailCodeSending.value = true
-  try {
-    const ttlSeconds = await sendRegisterEmailCode({
-      email: registerForm.email as string,
-      captchaId: registerForm.captchaId,
-      captcha: registerForm.captcha,
-    })
-    ElMessage.success(`验证码已发送，${Math.round(ttlSeconds / 60)} 分钟内有效`)
-    // 冷却按服务端的 60 秒走；这里只是不让用户空点，真正的限制在服务端
-    startEmailCodeCountdown(60)
-  } catch (error) {
-    // 图形码是一次性的，无论因为什么失败都已作废，必须换一张
-    await refreshCaptcha()
-    throw error
-  } finally {
-    emailCodeSending.value = false
-  }
-}
-
-async function refreshCaptcha() {
-  if (!registerOptions.value.captchaRequired) {
-    return
-  }
-  captchaLoading.value = true
-  try {
-    const challenge = await fetchCaptcha()
-    registerForm.captchaId = challenge.captchaId
-    registerForm.captcha = ''
-    captchaImage.value = challenge.image
-  } finally {
-    captchaLoading.value = false
-  }
-}
-const registerRules: FormRules = {
-  username: [
-    { required: true, message: '请输入用户名', trigger: 'blur' },
-    { min: 3, max: 32, message: '用户名长度为 3 至 32 位', trigger: 'blur' },
-    { pattern: /^[A-Za-z0-9._-]+$/, message: '仅支持字母、数字、点、下划线和短横线', trigger: 'blur' },
-  ],
-  nickname: [{ max: 64, message: '昵称不能超过 64 位', trigger: 'blur' }],
-  captcha: [
-    {
-      validator: (_rule, value, callback) => {
-        callback(registerOptions.value.captchaRequired && !value ? new Error('请输入图形验证码') : undefined)
-      },
-      trigger: 'blur',
-    },
-  ],
-  emailCode: [
-    {
-      validator: (_rule, value, callback) => {
-        callback(registerOptions.value.emailVerificationRequired && !value
-          ? new Error('请输入邮箱验证码') : undefined)
-      },
-      trigger: 'blur',
-    },
-  ],
-  email: [
-    {
-      validator: (_rule, value, callback) => {
-        if (!value) {
-          callback(registerOptions.value.emailRequired ? new Error('请输入邮箱') : undefined)
-          return
-        }
-        callback(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ? undefined : new Error('邮箱格式不正确'))
-      },
-      trigger: 'blur',
-    },
-  ],
-  password: [
-    { required: true, message: '请输入密码', trigger: 'blur' },
-    { min: 8, max: 64, message: '密码长度为 8 至 64 位', trigger: 'blur' },
-    {
-      // 与后端 PasswordPolicy 保持同一条规则：够长 + 字母数字混合。
-      // 前端先拦一道只是为了少一次往返，真正的判定在服务端。
-      pattern: /^(?=.*[A-Za-z])(?=.*\d).+$/,
-      message: '密码需同时包含字母与数字',
-      trigger: 'blur',
-    },
-  ],
-  confirmPassword: [
-    { required: true, message: '请再次输入密码', trigger: 'blur' },
-    {
-      validator: (_rule, value, callback) => {
-        if (value !== registerForm.password) {
-          callback(new Error('两次输入的密码不一致'))
-          return
-        }
-        callback()
-      },
-      trigger: 'blur',
-    },
-  ],
-}
-
-// “记住我”只记住用户名 + 是否勾选（不在前端存明文密码）；密码本身交给浏览器自带的密码管理器
-// 记住（表单已加 autocomplete 属性），后端登录态有效期见 applyRememberedUsername 配套的 rememberMe 参数。
 const REMEMBER_KEY_PREFIX = 'admin-remember-username-'
 
-function loadRememberedUsername(mode: 'local' | 'sso') {
+function loadRememberedUsername(mode: LoginMode) {
   const saved = localStorage.getItem(REMEMBER_KEY_PREFIX + mode)
-  if (saved) {
-    form.username = saved
-    form.rememberMe = true
-  } else {
-    form.username = ''
-    form.rememberMe = false
+  form.username = saved || ''
+  form.rememberMe = Boolean(saved)
+}
+
+async function resetAuthScroll() {
+  await nextTick()
+  if (authSurfaceRef.value) {
+    authSurfaceRef.value.scrollTop = 0
+  }
+  const documentScroller = document.scrollingElement
+  if (documentScroller) {
+    documentScroller.scrollTop = 0
   }
 }
 
-function switchMode(mode: 'local' | 'sso') {
+async function switchMode(mode: LoginMode) {
+  if (submitting.value || loginMode.value === mode) {
+    return
+  }
   loginMode.value = mode
   form.password = ''
   loadRememberedUsername(mode)
   formRef.value?.clearValidate()
+  await resetAuthScroll()
+}
+
+async function handleModeKeydown(event: KeyboardEvent) {
+  if (submitting.value) {
+    return
+  }
+  if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+    return
+  }
+  event.preventDefault()
+  const nextMode: LoginMode = event.key === 'ArrowLeft' || event.key === 'Home' ? 'local' : 'sso'
+  await switchMode(nextMode)
+  await nextTick()
+  document.getElementById(`login-mode-${nextMode}`)?.focus()
 }
 
 async function openRegister() {
+  if (submitting.value || !canRegister.value) {
+    return
+  }
   authPanel.value = 'register'
-  registerFormRef.value?.clearValidate()
-  await refreshCaptcha()
+  await resetAuthScroll()
 }
 
-function backToLogin() {
+async function backToLogin(username?: string) {
   authPanel.value = 'login'
   loginMode.value = 'local'
+  form.password = ''
+  if (username) {
+    form.username = username
+    form.rememberMe = false
+  } else {
+    loadRememberedUsername('local')
+  }
   formRef.value?.clearValidate()
+  await resetAuthScroll()
 }
 
-loadRememberedUsername(loginMode.value)
-
-// 登录页轮播背景图：先用 public/ 下的内置默认图兜底，挂载后实时拉取后台
-// "系统管理 › 登录页图片"上传的启用图（免鉴权接口，见后端 LoginImagePublicController）；
-// 拉取失败或列表为空时保持默认图，登录页永远有背景可展示。
-const DEFAULT_BG_IMAGES = ['/A1.jpg', '/A2.jpg', '/A3.jpg']
-const bgImages = ref<string[]>(DEFAULT_BG_IMAGES)
-
-onMounted(async () => {
+async function loadLoginImages() {
   try {
     const urls = await fetchLoginCarouselUrls()
     if (urls.length > 0) {
       bgImages.value = urls
     }
   } catch {
-    // 后端不可用时静默保持默认图，不打扰登录
+    // 后端不可用时静默使用内置图，不干扰身份验证主流程。
   }
+}
+
+async function loadRegisterOptions() {
   try {
     registerOptions.value = await fetchRegisterOptions()
+    registerOptionsLoaded.value = true
   } catch {
-    // 拿不到部署形态时保持默认（开放注册、不强制验证码）：
-    // 真正的强制在服务端，这里只影响表单要不要渲染验证码框
+    registerOptionsLoaded.value = false
   }
-})
+}
 
 async function handleSubmit() {
-  const valid = await formRef.value?.validate().catch(() => false)
-  if (!valid) {
+  if (submitting.value) {
     return
   }
   submitting.value = true
   try {
-    const result = loginMode.value === 'local' ? await login(form) : await ssoLogin(form)
-    const rememberKey = REMEMBER_KEY_PREFIX + loginMode.value
-    if (form.rememberMe) {
-      localStorage.setItem(rememberKey, form.username)
+    const valid = await formRef.value?.validate().catch(() => false)
+    if (!valid) {
+      return
+    }
+    // 请求发出后，界面仍可能因脚本触发变化；后续处理必须绑定本次提交身份。
+    const submission = createLoginSubmission(loginMode.value, form)
+    let result: LoginResponse
+    try {
+      result = submission.mode === 'local'
+        ? await login(submission.credentials)
+        : await ssoLogin(submission.credentials)
+    } catch {
+      // 请求层已展示业务或网络错误，组件只负责恢复可提交状态。
+      return
+    }
+    const rememberKey = REMEMBER_KEY_PREFIX + submission.mode
+    if (submission.credentials.rememberMe) {
+      localStorage.setItem(rememberKey, submission.credentials.username)
     } else {
       localStorage.removeItem(rememberKey)
     }
-    auth.applyLoginResult(result, form.username)
+    // 必须应用完整登录结果，保留昵称、强制改密与账号审核状态。
+    auth.applyLoginResult(result, submission.credentials.username)
     if (result.forceChangePassword) {
       ElMessage.warning('首次登录请先修改密码')
       await router.replace({ name: 'ChangePassword' })
@@ -269,410 +186,426 @@ async function handleSubmit() {
   }
 }
 
-async function handleRegister() {
-  const valid = await registerFormRef.value?.validate().catch(() => false)
-  if (!valid) {
-    return
-  }
-  registerSubmitting.value = true
-  try {
-    const username = registerForm.username
-    await register(registerForm)
-    ElMessage.success('注册成功，请登录后等待管理员审核')
-    registerFormRef.value?.resetFields()
-    clearEmailCodeTimer()
-    emailCodeCountdown.value = 0
-    backToLogin()
-    form.username = username
-    form.password = ''
-  } catch (error) {
-    // 开了邮箱验证时，图形码是在「获取验证码」那一步用掉的，注册失败与它无关；
-    // 邮箱验证码也不刷新——用户名重复这类失败并不作废它，逼人重新收信只会多发一封邮件。
-    // 没开邮箱验证时，图形码刚刚被这次提交消费掉，必须换一张，
-    // 否则用户改完再提交会拿到一个"验证码错误"的二次失败。
-    if (!registerOptions.value.emailVerificationRequired) {
-      await refreshCaptcha()
-    }
-    throw error
-  } finally {
-    registerSubmitting.value = false
-  }
-}
+loadRememberedUsername(loginMode.value)
+
+onMounted(() => {
+  // 图片与注册能力互不依赖，并行加载，慢图片不会阻塞注册入口判断。
+  void Promise.allSettled([loadLoginImages(), loadRegisterOptions()])
+})
 </script>
 
 <template>
-  <div class="login-page">
-    <div class="bg-carousel">
-      <el-carousel height="100%" :interval="2000" arrow="never" indicator-position="none">
-        <el-carousel-item v-for="img in bgImages" :key="img">
-          <div class="bg-slide" :style="{ backgroundImage: `url(${img})` }" />
-        </el-carousel-item>
-      </el-carousel>
-      <div class="bg-overlay" />
-    </div>
-    <el-card class="login-card">
-      <template #header>
-        <div class="login-title">智能体客服后台管理系统</div>
-      </template>
-      <div class="access-flow" aria-label="账号开通流程">
-        <span>注册账号</span>
-        <i />
-        <span>管理员审核</span>
-        <i />
-        <span>开通菜单</span>
+  <main class="login-page">
+    <LoginBrandStage :images="bgImages" />
+
+    <section ref="authSurfaceRef" class="auth-surface" data-login-scroll aria-label="身份验证">
+      <div class="auth-toolbar">
+        <span class="secure-context"><i aria-hidden="true" /> 安全登录</span>
+        <el-button
+          circle
+          plain
+          :icon="themeStore.isDark ? 'Sunny' : 'Moon'"
+          :aria-label="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
+          :title="themeStore.isDark ? '切换到亮色模式' : '切换到暗色模式'"
+          @click="themeStore.toggleDark()"
+        />
       </div>
-      <div v-if="authPanel === 'login'" class="login-tabs">
-        <div
-          class="login-tab"
-          :class="{ active: loginMode === 'local' }"
-          @click="switchMode('local')"
+
+      <div class="auth-content">
+        <section
+          v-if="authPanel === 'login'"
+          id="login-panel"
+          class="auth-panel"
+          role="tabpanel"
+          :aria-labelledby="`login-mode-${loginMode}`"
         >
-          账号密码登录
-        </div>
-        <div
-          class="login-tab"
-          :class="{ active: loginMode === 'sso' }"
-          @click="switchMode('sso')"
-        >
-          OA 登录
-        </div>
-      </div>
-      <el-form
-        v-if="authPanel === 'login'"
-        ref="formRef"
-        :model="form"
-        :rules="rules"
-        @keyup.enter="handleSubmit"
-        @submit.prevent
-      >
-        <el-form-item prop="username">
-          <el-input
-            v-model="form.username"
-            :placeholder="loginMode === 'local' ? '用户名' : 'OA 账号（如 RichardFyoung）'"
-            size="large"
-            autocomplete="username"
-            :prefix-icon="'User'"
-          />
-        </el-form-item>
-        <el-form-item prop="password">
-          <el-input
-            v-model="form.password"
-            type="password"
-            :placeholder="loginMode === 'local' ? '密码' : 'OA 密码'"
-            size="large"
-            show-password
-            autocomplete="current-password"
-            :prefix-icon="'Lock'"
-          />
-        </el-form-item>
-        <el-form-item>
-          <el-checkbox v-model="form.rememberMe">记住我（7 天内免登录）</el-checkbox>
-        </el-form-item>
-        <el-form-item>
-          <el-button type="primary" size="large" style="width: 100%" :loading="submitting" @click="handleSubmit">
-            登录
-          </el-button>
-        </el-form-item>
-        <div v-if="loginMode === 'local' && registerOptions.selfServiceEnabled" class="panel-switch">
-          还没有账号？<el-button link type="primary" @click="openRegister">立即注册</el-button>
-        </div>
-      </el-form>
-      <el-form
-        v-else
-        ref="registerFormRef"
-        :model="registerForm"
-        :rules="registerRules"
-        @keyup.enter="handleRegister"
-        @submit.prevent
-      >
-        <div class="register-heading">
-          <strong>注册本地账号</strong>
-          <span>
-            {{
-              registerOptions.emailVerificationRequired
-                ? '需先验证邮箱，注册后可登录查看审核状态，菜单将在管理员分配角色后开通。'
-                : '注册后可登录查看审核状态，菜单将在管理员分配角色后开通。'
-            }}
-          </span>
-        </div>
-        <el-form-item prop="username">
-          <el-input
-            v-model="registerForm.username"
-            placeholder="用户名（3-32 位）"
-            size="large"
-            autocomplete="username"
-            :prefix-icon="'User'"
-          />
-        </el-form-item>
-        <el-form-item prop="nickname">
-          <el-input
-            v-model="registerForm.nickname"
-            placeholder="昵称（选填）"
-            size="large"
-            autocomplete="name"
-            :prefix-icon="'Postcard'"
-          />
-        </el-form-item>
-        <el-form-item prop="email">
-          <el-input
-            v-model="registerForm.email"
-            :placeholder="registerOptions.emailRequired ? '邮箱（接收审核结果）' : '邮箱（选填）'"
-            size="large"
-            autocomplete="email"
-            :prefix-icon="'Message'"
-          />
-        </el-form-item>
-        <el-form-item v-if="registerOptions.captchaRequired" prop="captcha">
-          <div class="captcha-row">
-            <el-input
-              v-model="registerForm.captcha"
-              placeholder="图形验证码"
-              size="large"
-              maxlength="8"
-              autocomplete="off"
-              :prefix-icon="'Key'"
-            />
-            <!-- 点击图片换一张：图形码是一次性的，看不清时不该逼人重填整张表 -->
-            <img
-              v-if="captchaImage"
-              class="captcha-image"
-              :src="captchaImage"
-              alt="点击刷新验证码"
-              title="点击刷新"
-              @click="refreshCaptcha"
-            />
-            <el-button v-else size="large" :loading="captchaLoading" @click="refreshCaptcha">
-              获取
-            </el-button>
-          </div>
-        </el-form-item>
-        <el-form-item v-if="registerOptions.emailVerificationRequired" prop="emailCode">
-          <div class="captcha-row">
-            <el-input
-              v-model="registerForm.emailCode"
-              placeholder="邮箱验证码"
-              size="large"
-              maxlength="8"
-              autocomplete="one-time-code"
-              :prefix-icon="'Message'"
-            />
-            <!-- 倒计时期间禁用：每一次点击都是一封真实的邮件，服务端还有 60 秒冷却与每日总量 -->
-            <el-button
-              class="email-code-button"
-              size="large"
-              :loading="emailCodeSending"
-              :disabled="emailCodeCountdown > 0"
-              @click="handleSendEmailCode"
+          <header class="login-heading">
+            <p class="eyebrow">customer_work · Agent Console</p>
+            <h1>{{ modePresentation.title }}</h1>
+            <p>{{ modePresentation.description }}</p>
+          </header>
+
+          <div class="mode-switch" role="tablist" aria-label="登录方式">
+            <button
+              id="login-mode-local"
+              type="button"
+              role="tab"
+              :class="{ active: loginMode === 'local' }"
+              :aria-selected="loginMode === 'local'"
+              :disabled="submitting"
+              aria-controls="login-panel"
+              :tabindex="loginMode === 'local' ? 0 : -1"
+              @click="switchMode('local')"
+              @keydown="handleModeKeydown"
             >
-              {{ emailCodeCountdown > 0 ? `${emailCodeCountdown} 秒后重发` : '获取验证码' }}
-            </el-button>
+              {{ localModePresentation.label }}
+            </button>
+            <button
+              id="login-mode-sso"
+              type="button"
+              role="tab"
+              :class="{ active: loginMode === 'sso' }"
+              :aria-selected="loginMode === 'sso'"
+              :disabled="submitting"
+              aria-controls="login-panel"
+              :tabindex="loginMode === 'sso' ? 0 : -1"
+              @click="switchMode('sso')"
+              @keydown="handleModeKeydown"
+            >
+              {{ ssoModePresentation.label }}
+            </button>
           </div>
-        </el-form-item>
-        <el-form-item prop="password">
-          <el-input
-            v-model="registerForm.password"
-            type="password"
-            placeholder="密码（至少 8 位，含字母与数字）"
-            size="large"
-            show-password
-            autocomplete="new-password"
-            :prefix-icon="'Lock'"
-          />
-        </el-form-item>
-        <el-form-item prop="confirmPassword">
-          <el-input
-            v-model="registerForm.confirmPassword"
-            type="password"
-            placeholder="再次输入密码"
-            size="large"
-            show-password
-            autocomplete="new-password"
-            :prefix-icon="'Lock'"
-          />
-        </el-form-item>
-        <el-form-item>
-          <el-button
-            type="primary"
-            size="large"
-            style="width: 100%"
-            :loading="registerSubmitting"
-            @click="handleRegister"
-          >
-            提交注册
-          </el-button>
-        </el-form-item>
-        <div class="panel-switch">
-          已有账号？<el-button link type="primary" @click="backToLogin">返回登录</el-button>
-        </div>
-      </el-form>
-    </el-card>
-    <FooterCopyright dark />
-  </div>
+
+          <el-form ref="formRef" class="login-form" :model="form" :rules="rules" @submit.prevent="handleSubmit">
+            <label class="field-label" for="login-username">{{ modePresentation.usernameLabel }}</label>
+            <el-form-item prop="username">
+              <el-input
+                id="login-username"
+                v-model="form.username"
+                size="large"
+                autocomplete="username"
+                :placeholder="modePresentation.usernamePlaceholder"
+                :prefix-icon="'User'"
+                :disabled="submitting"
+              />
+            </el-form-item>
+
+            <label class="field-label" for="login-password">{{ modePresentation.passwordLabel }}</label>
+            <el-form-item prop="password">
+              <el-input
+                id="login-password"
+                v-model="form.password"
+                type="password"
+                size="large"
+                show-password
+                autocomplete="current-password"
+                :placeholder="modePresentation.passwordPlaceholder"
+                :prefix-icon="'Lock'"
+                :disabled="submitting"
+              />
+            </el-form-item>
+
+            <div class="remember-row">
+              <el-checkbox v-model="form.rememberMe" :disabled="submitting">保持登录</el-checkbox>
+              <span>延长登录状态；本机仅保存用户名</span>
+            </div>
+
+            <el-button
+              native-type="submit"
+              type="primary"
+              size="large"
+              class="primary-action"
+              :style="{ '--login-primary-text': primaryTextColor }"
+              :loading="submitting"
+            >
+              {{ loginMode === 'local' ? '进入运营台' : '使用 OA 账号登录' }}
+            </el-button>
+          </el-form>
+
+          <p v-if="loginMode === 'sso'" class="mode-note">
+            OA 身份由企业目录校验，首次登录会关联后台身份。
+          </p>
+
+          <div v-if="canRegister" class="register-entry">
+            <span>还没有本地账号？</span>
+            <el-button link type="primary" :disabled="submitting" @click="openRegister">创建账号</el-button>
+            <small>注册后由管理员审核并分配菜单权限</small>
+          </div>
+        </section>
+
+        <RegisterPanel
+          v-else
+          class="auth-panel"
+          :options="registerOptions"
+          :primary-text-color="primaryTextColor"
+          @back="backToLogin()"
+          @complete="backToLogin"
+          @request-scroll-top="resetAuthScroll"
+        />
+      </div>
+
+      <FooterCopyright />
+    </section>
+  </main>
 </template>
 
 <style scoped>
-.captcha-row {
-  display: flex;
-  gap: 8px;
-  width: 100%;
-  align-items: center;
-}
-
-.email-code-button {
-  flex-shrink: 0;
-  min-width: 108px;
-}
-
-.captcha-image {
-  height: 40px;
-  width: 120px;
-  border-radius: 4px;
-  cursor: pointer;
-  flex-shrink: 0;
-  border: 1px solid var(--el-border-color);
-}
-
 .login-page {
-  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 560px;
+  display: grid;
+  grid-template-columns: minmax(0, 58fr) minmax(500px, 42fr);
+  overflow: hidden;
+  background: var(--el-bg-color-page);
+}
+
+.auth-surface {
+  min-width: 0;
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background:
+    radial-gradient(circle at 100% 0%, var(--el-color-primary-light-9) 0%, transparent 31%),
+    var(--el-bg-color);
+  color: var(--el-text-color-primary);
+  scrollbar-gutter: stable;
+}
+
+.auth-toolbar {
+  min-height: var(--cw-topbar-height, 64px);
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 18px;
+  box-sizing: border-box;
+  padding: 12px clamp(24px, 3vw, 42px) 0;
+}
+
+.secure-context {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.secure-context i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--el-color-success);
+  box-shadow: 0 0 0 4px var(--el-color-success-light-9);
+}
+
+.auth-content {
+  width: 100%;
+  min-height: 0;
+  flex: 1 0 auto;
+  display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
+  box-sizing: border-box;
+  padding: 26px clamp(34px, 4.2vw, 64px) 30px;
 }
 
-/* 背景轮播层：铺满整页，垫在登录卡片和页脚之下。深灰渐变作为兜底——背景图加载失败也不会白屏。
-   inset:0 只是撑出了"视觉上"的高度，CSS 百分比高度解析认的是父元素显式声明的 height 属性
-   （不认 inset 撑出来的隐式高度）——不显式补一个 height:100%，el-carousel 的 height="100%"
-   会算成 0，导致轮播完全不可见（只剩兜底渐变）。 */
-.bg-carousel {
-  position: absolute;
-  inset: 0;
-  height: 100%;
+.auth-panel {
   width: 100%;
-  z-index: 0;
-  background: linear-gradient(135deg, #1f2937, #4b5563);
+  max-width: 440px;
+  margin-block: auto;
 }
 
-/* el-carousel 组件本身只把 height="100%" 这个 prop 透传给 .el-carousel__container，根节点
-   .el-carousel 自己不带任何高度样式——即便父级 .bg-carousel 有了显式高度，根节点 auto 高度
-   在只有一个百分比高度子节点的情况下仍会被解析为 0（子节点撑不起 auto 高度的父节点），
-   容器和 .el-carousel__item 的 100% 高度就跟着全部塌成 0。显式补上根节点高度打破这层循环。 */
-.bg-carousel :deep(.el-carousel) {
-  height: 100%;
+.login-heading {
+  margin-bottom: 26px;
 }
 
-/* cover 铺满整屏不留空，与屏幕宽高比不一致的部分会被裁切（竖版图在横屏上会切掉上下）。
-   不做 Ken Burns 缩放动画：背景层是先光栅化再按 transform 拉伸，慢速放大必然发虚。 */
-.bg-slide {
-  width: 100%;
-  height: 100%;
-  background-size: cover;
-  background-position: center;
-}
-
-/* 深色渐变遮罩：保证登录卡片和页脚文字在任意风景图上都有足够对比度可读 */
-.bg-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.55) 0%, rgba(15, 23, 42, 0.35) 50%, rgba(15, 23, 42, 0.65) 100%);
-}
-
-.login-card {
-  position: relative;
-  z-index: 1;
-  width: 390px;
-  margin-bottom: auto;
-  margin-top: auto;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(6px);
-}
-
-/* 暗色模式下毛玻璃卡片跟随变深，与内部表单控件的暗色保持一致 */
-html.dark .login-card {
-  background: rgba(20, 20, 20, 0.88);
-}
-
-.login-title {
-  text-align: center;
-  font-size: 18px;
-  font-weight: 600;
-}
-
-.access-flow {
-  display: grid;
-  grid-template-columns: auto 1fr auto 1fr auto;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 14px;
-  color: var(--el-text-color-secondary);
+.eyebrow {
+  margin: 0 0 9px;
+  color: var(--el-color-primary);
   font-size: 12px;
-  white-space: nowrap;
+  font-weight: 700;
+  letter-spacing: 0.08em;
 }
 
-.access-flow i {
-  height: 1px;
-  background: var(--el-border-color);
+.login-heading h1 {
+  margin: 0;
+  color: var(--el-text-color-primary);
+  font-size: clamp(30px, 2.5vw, 38px);
+  line-height: 1.2;
+  letter-spacing: -0.03em;
 }
 
-.login-tabs {
-  display: flex;
-  margin-bottom: 16px;
-  border-bottom: 1px solid var(--el-border-color);
-}
-
-.login-tab {
-  flex: 1;
-  text-align: center;
-  padding: 8px 0;
-  cursor: pointer;
+.login-heading > p:last-child {
+  margin: 10px 0 0;
   color: var(--el-text-color-secondary);
   font-size: 14px;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s;
-}
-
-.login-tab.active {
-  color: var(--el-color-primary);
-  border-bottom-color: var(--el-color-primary);
-  font-weight: 600;
-}
-
-.register-heading {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin: 2px 0 16px;
-}
-
-.register-heading strong {
-  color: var(--el-text-color-primary);
-  font-size: 16px;
-}
-
-.register-heading span {
-  color: var(--el-text-color-secondary);
-  font-size: 12px;
   line-height: 1.6;
 }
 
-.panel-switch {
-  margin-top: -4px;
+.mode-switch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin-bottom: 24px;
+  padding: 4px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 11px;
+  background: var(--el-fill-color-extra-light);
+}
+
+.mode-switch button {
+  min-height: 38px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--el-text-color-secondary);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: background-color 160ms ease-out, color 160ms ease-out, box-shadow 160ms ease-out;
+}
+
+.mode-switch button.active {
+  background: var(--el-bg-color);
+  color: var(--el-color-primary);
+  box-shadow: var(--cw-card-shadow);
+}
+
+.mode-switch button:disabled {
+  cursor: wait;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--el-text-color-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.login-form :deep(.el-form-item) {
+  margin-bottom: 18px;
+}
+
+.login-form :deep(.el-input__wrapper) {
+  min-height: 46px;
+}
+
+.remember-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin: -2px 0 20px;
+}
+
+.remember-row span {
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+}
+
+.auth-panel :deep(.primary-action) {
+  width: 100%;
+  min-height: 46px;
+  --el-button-text-color: var(--login-primary-text);
+  --el-button-hover-text-color: var(--login-primary-text);
+  --el-button-active-text-color: var(--login-primary-text);
+}
+
+.mode-note {
+  margin: 14px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.6;
   text-align: center;
+}
+
+.register-entry {
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: center;
+  align-items: center;
+  column-gap: 4px;
+  margin-top: 21px;
   color: var(--el-text-color-secondary);
   font-size: 13px;
 }
 
-@media (max-width: 480px) {
-  .login-card {
-    width: calc(100% - 32px);
+.register-entry small {
+  grid-column: 1 / -1;
+  margin-top: 3px;
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+  text-align: center;
+}
+
+@media (max-width: 1200px) and (min-width: 1024px) {
+  .login-page {
+    grid-template-columns: minmax(0, 54fr) minmax(480px, 46fr);
+  }
+
+  .auth-content {
+    padding-inline: 30px;
   }
 }
 
-/* FooterCopyright 是子组件，scoped 样式默认不穿透，显式提到背景遮罩之上 */
-.login-page :deep(.footer-copyright) {
-  position: relative;
-  z-index: 1;
+@media (min-width: 900px) and (max-height: 720px) {
+  .auth-toolbar {
+    min-height: 52px;
+  }
+
+  .auth-content {
+    padding-block: 16px 18px;
+  }
+
+  .login-heading {
+    margin-bottom: 18px;
+  }
+
+  .mode-switch {
+    margin-bottom: 18px;
+  }
+}
+
+@media (max-width: 899px) {
+  .login-page {
+    height: auto;
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+  }
+
+  .auth-surface {
+    height: auto;
+    min-height: calc(100svh - 210px);
+    overflow: visible;
+    scrollbar-gutter: auto;
+  }
+
+  .auth-toolbar {
+    min-height: 54px;
+    padding: 10px 24px 0;
+  }
+
+  .auth-content {
+    min-height: auto;
+    align-items: flex-start;
+    padding: 18px 28px 34px;
+  }
+
+  .auth-panel {
+    margin-block: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .secure-context {
+    display: none;
+  }
+
+  .auth-toolbar {
+    min-height: 48px;
+    padding-inline: 20px;
+  }
+
+  .auth-content {
+    padding: 14px 20px 30px;
+  }
+
+  .login-heading {
+    margin-bottom: 20px;
+  }
+
+  .remember-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/login/LoginBrandStage.vue
+++ b/customer-admin-web/src/views/login/LoginBrandStage.vue
@@ -1,0 +1,646 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = defineProps<{
+  images: string[]
+}>()
+
+const carouselRef = ref<{ setActiveItem: (index: number) => void }>()
+const activeImageIndex = ref(0)
+const manuallyPaused = ref(false)
+const pointerPaused = ref(false)
+const focusPaused = ref(false)
+const prefersReducedMotion = ref(false)
+let reducedMotionQuery: MediaQueryList | undefined
+
+const displayImages = computed(() => props.images.map((image) => image.trim()).filter(Boolean))
+const hasMultipleImages = computed(() => displayImages.value.length > 1)
+const shouldAutoplay = computed(() => (
+  hasMultipleImages.value
+  && !manuallyPaused.value
+  && !pointerPaused.value
+  && !focusPaused.value
+  && !prefersReducedMotion.value
+))
+
+function syncReducedMotion(event: MediaQueryListEvent | MediaQueryList) {
+  prefersReducedMotion.value = event.matches
+}
+
+function selectImage(index: number) {
+  activeImageIndex.value = index
+  manuallyPaused.value = true
+  carouselRef.value?.setActiveItem(index)
+}
+
+function toggleAutoplay() {
+  if (!prefersReducedMotion.value) {
+    manuallyPaused.value = !manuallyPaused.value
+  }
+}
+
+onMounted(() => {
+  reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+  syncReducedMotion(reducedMotionQuery)
+  reducedMotionQuery.addEventListener('change', syncReducedMotion)
+})
+
+onBeforeUnmount(() => {
+  reducedMotionQuery?.removeEventListener('change', syncReducedMotion)
+})
+</script>
+
+<template>
+  <section
+    class="brand-stage"
+    aria-labelledby="brand-stage-title"
+    @mouseenter="pointerPaused = true"
+    @mouseleave="pointerPaused = false"
+    @focusin="focusPaused = true"
+    @focusout="focusPaused = false"
+  >
+    <div class="brand-media" aria-hidden="true">
+      <el-carousel
+        v-if="hasMultipleImages"
+        ref="carouselRef"
+        height="100%"
+        :autoplay="shouldAutoplay"
+        :interval="8000"
+        :pause-on-hover="false"
+        arrow="never"
+        indicator-position="none"
+        @change="activeImageIndex = $event"
+      >
+        <el-carousel-item v-for="image in displayImages" :key="image">
+          <div class="brand-image" :style="{ backgroundImage: `url(${JSON.stringify(image)})` }" />
+        </el-carousel-item>
+      </el-carousel>
+      <div
+        v-else-if="displayImages[0]"
+        class="brand-image"
+        :style="{ backgroundImage: `url(${JSON.stringify(displayImages[0])})` }"
+      />
+      <div class="brand-scrim" />
+    </div>
+
+    <div class="brand-content">
+      <header class="brand-header">
+        <span class="brand-mark" aria-hidden="true">CW</span>
+        <span class="brand-identity">
+          <strong>customer_work</strong>
+          <small>Agent Console</small>
+        </span>
+      </header>
+
+      <div class="brand-message">
+        <p class="brand-kicker">智能体运营台</p>
+        <h1 id="brand-stage-title">让每一次智能服务，<br>都有迹可循。</h1>
+        <p class="brand-summary">
+          从意图识别到最终回复，在一条清晰链路中完成知识、工具与安全能力的协同。
+        </p>
+      </div>
+
+      <div class="execution-trace" aria-label="智能体执行轨迹示意">
+        <div class="trace-heading">
+          <span>执行轨迹</span>
+          <small>示意链路</small>
+        </div>
+        <ol>
+          <li>
+            <span class="trace-node" aria-hidden="true" />
+            <span><small>INTENT</small><strong>识别意图</strong></span>
+          </li>
+          <li>
+            <span class="trace-node" aria-hidden="true" />
+            <span><small>KNOWLEDGE</small><strong>检索知识</strong></span>
+          </li>
+          <li>
+            <span class="trace-node" aria-hidden="true" />
+            <span><small>GUARD</small><strong>安全校验</strong></span>
+          </li>
+          <li>
+            <span class="trace-node" aria-hidden="true" />
+            <span><small>TOOL</small><strong>调用工具</strong></span>
+          </li>
+          <li class="is-complete">
+            <span class="trace-node" aria-hidden="true">✓</span>
+            <span><small>ANSWER</small><strong>生成回复</strong></span>
+          </li>
+        </ol>
+      </div>
+
+      <div v-if="hasMultipleImages" class="carousel-controls" aria-label="品牌背景图控制">
+        <button
+          class="motion-toggle"
+          type="button"
+          :disabled="prefersReducedMotion"
+          :aria-pressed="manuallyPaused"
+          :title="prefersReducedMotion ? '已遵循系统的减少动态效果设置' : undefined"
+          @click="toggleAutoplay"
+        >
+          <svg v-if="!manuallyPaused && !prefersReducedMotion" viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M4.5 3.25h2.25v9.5H4.5zm4.75 0h2.25v9.5H9.25z" />
+          </svg>
+          <svg v-else viewBox="0 0 16 16" aria-hidden="true">
+            <path d="m5 3 7 5-7 5z" />
+          </svg>
+          <span>
+            {{ prefersReducedMotion ? '自动切换已关闭' : manuallyPaused ? '继续轮播' : '暂停轮播' }}
+          </span>
+        </button>
+
+        <div class="carousel-dots" role="group" aria-label="选择品牌背景图">
+          <button
+            v-for="(_image, index) in displayImages"
+            :key="index"
+            type="button"
+            :class="{ 'is-active': activeImageIndex === index }"
+            :aria-label="`查看第 ${index + 1} 张品牌背景图`"
+            :aria-current="activeImageIndex === index ? 'true' : undefined"
+            @click="selectImage(index)"
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.brand-stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 560px;
+  overflow: hidden;
+  color: #fff;
+  background: var(--cw-brand-ink);
+  isolation: isolate;
+}
+
+.brand-media,
+.brand-scrim {
+  position: absolute;
+  inset: 0;
+}
+
+.brand-media {
+  z-index: -1;
+  background:
+    radial-gradient(circle at 72% 20%, rgba(111, 138, 255, 0.22), transparent 34%),
+    var(--cw-brand-ink);
+}
+
+.brand-media :deep(.el-carousel),
+.brand-media :deep(.el-carousel__container),
+.brand-image {
+  width: 100%;
+  height: 100%;
+}
+
+.brand-image {
+  background-position: 62% center;
+  background-size: cover;
+}
+
+.brand-scrim {
+  background:
+    linear-gradient(90deg, rgba(11, 23, 40, 0.97) 0%, rgba(11, 23, 40, 0.88) 48%, rgba(11, 23, 40, 0.68) 100%),
+    linear-gradient(180deg, rgba(11, 23, 40, 0.22) 0%, rgba(11, 23, 40, 0.58) 100%);
+}
+
+.brand-content {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-rows: auto 1fr auto auto;
+  gap: 30px;
+  height: 100%;
+  padding: clamp(28px, 4vw, 54px) clamp(30px, 5vw, 72px) 34px;
+}
+
+.brand-header {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: fit-content;
+}
+
+.brand-mark {
+  display: inline-flex;
+  flex: 0 0 34px;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: linear-gradient(145deg, var(--cw-brand-logo-start), var(--cw-brand-logo-end));
+  box-shadow: 0 10px 24px rgba(60, 94, 232, 0.28);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.brand-identity {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+}
+
+.brand-identity strong {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.brand-identity small {
+  margin-top: 3px;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.brand-message {
+  align-self: center;
+  max-width: 620px;
+  margin-top: 8px;
+}
+
+.brand-kicker {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0 0 18px;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0.16em;
+}
+
+.brand-kicker::before {
+  width: 26px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--cw-brand-signal);
+  content: '';
+}
+
+.brand-message h1 {
+  max-width: 580px;
+  margin: 0;
+  font-size: clamp(36px, 4.1vw, 58px);
+  font-weight: 720;
+  line-height: 1.16;
+  letter-spacing: -0.045em;
+  text-wrap: balance;
+}
+
+.brand-summary {
+  max-width: 500px;
+  margin: 22px 0 0;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 14px;
+  line-height: 1.85;
+}
+
+.execution-trace {
+  max-width: 680px;
+  padding: 17px 18px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 14px;
+  background: rgba(7, 16, 29, 0.48);
+  box-shadow: 0 20px 48px rgba(2, 8, 23, 0.18);
+  backdrop-filter: blur(10px);
+}
+
+.trace-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 15px;
+}
+
+.trace-heading > span {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.trace-heading small {
+  color: rgba(255, 255, 255, 0.43);
+  font-size: 10px;
+}
+
+.execution-trace ol {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.execution-trace li {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.execution-trace li:not(:last-child)::after {
+  position: absolute;
+  top: 8px;
+  left: 17px;
+  width: calc(100% - 13px);
+  height: 1px;
+  background: linear-gradient(90deg, rgba(111, 138, 255, 0.65), rgba(111, 138, 255, 0.13));
+  content: '';
+}
+
+.trace-node {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  flex: 0 0 16px;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 4px solid rgba(111, 138, 255, 0.32);
+  border-radius: 50%;
+  background: var(--cw-brand-signal);
+  color: #08201e;
+  font-size: 9px;
+  font-weight: 900;
+}
+
+.execution-trace li > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.execution-trace small {
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.38);
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  text-overflow: ellipsis;
+}
+
+.execution-trace strong {
+  margin-top: 2px;
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.execution-trace .is-complete .trace-node {
+  border-color: rgba(45, 212, 191, 0.24);
+  background: #2dd4bf;
+}
+
+.carousel-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 30px;
+}
+
+.motion-toggle,
+.carousel-dots button {
+  appearance: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+}
+
+.motion-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 30px;
+  padding: 5px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(4, 12, 23, 0.36);
+  color: rgba(255, 255, 255, 0.66);
+  font: inherit;
+  font-size: 11px;
+}
+
+.motion-toggle:hover:not(:disabled) {
+  border-color: rgba(255, 255, 255, 0.28);
+  color: #fff;
+}
+
+.motion-toggle:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.motion-toggle svg {
+  width: 13px;
+  height: 13px;
+  fill: currentColor;
+}
+
+.motion-toggle:focus-visible,
+.carousel-dots button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
+
+.carousel-dots {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.carousel-dots button {
+  width: 20px;
+  height: 4px;
+  padding: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.24);
+  transition: width 180ms ease, background-color 180ms ease;
+}
+
+.carousel-dots button.is-active {
+  width: 34px;
+  background: var(--cw-brand-signal);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .brand-header,
+  .brand-message,
+  .execution-trace {
+    animation: brand-reveal 560ms both cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .brand-message {
+    animation-delay: 80ms;
+  }
+
+  .execution-trace {
+    animation-delay: 160ms;
+  }
+}
+
+@keyframes brand-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1160px) {
+  .brand-content {
+    padding-right: 34px;
+    padding-left: 34px;
+  }
+
+  .brand-message h1 {
+    font-size: clamp(34px, 4vw, 48px);
+  }
+
+  .execution-trace {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .execution-trace ol {
+    gap: 7px;
+  }
+}
+
+@media (min-width: 900px) and (max-width: 1023px) {
+  .brand-content {
+    grid-template-rows: auto 1fr auto;
+    gap: 22px;
+    padding: 30px 30px 24px;
+  }
+
+  .brand-message {
+    align-self: center;
+  }
+
+  .brand-message h1 {
+    font-size: clamp(38px, 4.8vw, 46px);
+  }
+
+  .brand-summary {
+    font-size: 13px;
+  }
+
+  .execution-trace {
+    display: none;
+  }
+}
+
+@media (max-width: 899px) {
+  .brand-stage {
+    height: 210px;
+    min-height: 210px;
+  }
+
+  .brand-content {
+    grid-template-rows: auto 1fr auto;
+    gap: 12px;
+    padding: 20px clamp(22px, 6vw, 54px) 16px;
+  }
+
+  .brand-message {
+    align-self: end;
+    margin-top: 0;
+  }
+
+  .brand-kicker {
+    margin-bottom: 8px;
+    font-size: 11px;
+  }
+
+  .brand-message h1 {
+    font-size: clamp(28px, 5.5vw, 38px);
+    line-height: 1.12;
+  }
+
+  .brand-summary,
+  .execution-trace {
+    display: none;
+  }
+
+  .carousel-controls {
+    position: absolute;
+    right: clamp(22px, 6vw, 54px);
+    bottom: 16px;
+  }
+
+  .motion-toggle {
+    margin-right: 12px;
+  }
+}
+
+@media (max-width: 560px) {
+  .brand-stage {
+    height: 204px;
+    min-height: 204px;
+  }
+
+  .brand-content {
+    padding: 16px 20px 14px;
+  }
+
+  .brand-identity small,
+  .motion-toggle span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .brand-message h1 {
+    font-size: clamp(27px, 8.3vw, 34px);
+  }
+
+  .carousel-controls {
+    right: 20px;
+    bottom: 14px;
+  }
+
+  .motion-toggle {
+    width: 30px;
+    justify-content: center;
+    margin-right: 8px;
+    padding: 5px;
+  }
+
+  .carousel-dots button {
+    width: 14px;
+  }
+
+  .carousel-dots button.is-active {
+    width: 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brand-stage *,
+  .brand-stage *::before,
+  .brand-stage *::after,
+  .brand-media :deep(*) {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+</style>

--- a/customer-admin-web/src/views/login/RegisterPanel.vue
+++ b/customer-admin-web/src/views/login/RegisterPanel.vue
@@ -1,0 +1,813 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import type { FormInstance, FormRules } from 'element-plus'
+import { fetchCaptcha, register, sendRegisterEmailCode } from '@/api/auth'
+import type { RegisterOptionsVO } from '@/types/api'
+import {
+  buildEmailCodeRequestPayload,
+  buildRegistrationPayload,
+  calculateCountdownSeconds,
+  getEmailCodeRequestValidationFields,
+  getRegisterStepPresentationFields,
+  getRegisterVerificationPlan,
+  getRegistrationStepValidationFields,
+  isCaptchaConsumedByEmailCodeRequest,
+  isCaptchaConsumedByRegistration,
+  REGISTER_ACCOUNT_STEP,
+  REGISTER_SECURITY_STEP,
+  resolveEmailCodeCooldownSeconds,
+  shouldHandleRegisterEnter,
+  shouldClearEmailCodeAfterRegistrationFailure,
+  usesEmailCodeForRegistration,
+  type RegisterFormData,
+  type RegisterStep,
+} from './loginPageModel'
+
+const props = defineProps<{
+  options: RegisterOptionsVO
+  primaryTextColor: string
+}>()
+
+const emit = defineEmits<{
+  back: []
+  complete: [username: string]
+  'request-scroll-top': []
+}>()
+
+const formRef = ref<FormInstance>()
+const step = ref<RegisterStep>(REGISTER_ACCOUNT_STEP)
+const state = ref<'form' | 'success'>('form')
+const submittedUsername = ref('')
+const navigationPending = ref(false)
+const submitting = ref(false)
+const captchaImage = ref('')
+const captchaLoading = ref(false)
+const emailCodeSending = ref(false)
+const emailCodeCountdown = ref(0)
+const issuedEmail = ref('')
+let emailCodeTimer: ReturnType<typeof setInterval> | undefined
+let emailCodeCooldownDeadline = 0
+let disposed = false
+let captchaRequestGeneration = 0
+let emailCodeRequestGeneration = 0
+let registerRequestGeneration = 0
+
+const form = reactive<RegisterFormData>({
+  username: '',
+  nickname: '',
+  email: '',
+  password: '',
+  confirmPassword: '',
+  captchaId: '',
+  captcha: '',
+  emailCode: '',
+})
+
+const verificationPlan = computed(() => getRegisterVerificationPlan(props.options))
+const showCaptcha = computed(() => verificationPlan.value.presentationFields.includes('captcha'))
+const showEmailCode = computed(() => verificationPlan.value.presentationFields.includes('emailCode'))
+const captchaUsedForEmailCode = computed(() => (
+  isCaptchaConsumedByEmailCodeRequest(verificationPlan.value)
+))
+const operationPending = computed(() => (
+  navigationPending.value
+  || submitting.value
+  || emailCodeSending.value
+))
+const verificationRequestPending = computed(() => operationPending.value || captchaLoading.value)
+const registrationPending = computed(() => operationPending.value || captchaLoading.value)
+const emailCodeCooldownSeconds = computed(() => (
+  resolveEmailCodeCooldownSeconds(props.options.emailCodeCooldownSeconds)
+))
+
+const rules: FormRules = {
+  username: [
+    { required: true, message: '请输入用户名', trigger: 'blur' },
+    { min: 3, max: 32, message: '用户名长度为 3 至 32 位', trigger: 'blur' },
+    { pattern: /^[A-Za-z0-9._-]+$/, message: '仅支持字母、数字、点、下划线和短横线', trigger: 'blur' },
+  ],
+  nickname: [{ max: 64, message: '昵称不能超过 64 位', trigger: 'blur' }],
+  email: [
+    {
+      validator: (_rule, value, callback) => {
+        if (!value) {
+          callback(props.options.emailRequired || props.options.emailVerificationRequired
+            ? new Error('请输入邮箱') : undefined)
+          return
+        }
+        callback(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ? undefined : new Error('邮箱格式不正确'))
+      },
+      trigger: 'blur',
+    },
+  ],
+  captcha: [
+    {
+      validator: (_rule, value, callback) => {
+        callback(showCaptcha.value && !value ? new Error('请输入图形验证码') : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  emailCode: [
+    {
+      validator: (_rule, value, callback) => {
+        if (showEmailCode.value && !value) {
+          callback(new Error('请输入邮箱验证码'))
+          return
+        }
+        callback(showEmailCode.value && issuedEmail.value !== form.email
+          ? new Error('请先向当前邮箱发送验证码')
+          : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  password: [
+    { required: true, message: '请输入密码', trigger: 'blur' },
+    { min: 8, max: 64, message: '密码长度为 8 至 64 位', trigger: 'blur' },
+    {
+      // 与后端 PasswordPolicy 保持同一条基础规则，弱口令的最终判定仍由服务端负责。
+      pattern: /^(?=.*[A-Za-z])(?=.*\d).+$/,
+      message: '密码需同时包含字母与数字',
+      trigger: 'blur',
+    },
+  ],
+  confirmPassword: [
+    { required: true, message: '请再次输入密码', trigger: 'blur' },
+    {
+      validator: (_rule, value, callback) => {
+        callback(value === form.password ? undefined : new Error('两次输入的密码不一致'))
+      },
+      trigger: 'blur',
+    },
+  ],
+}
+
+function clearEmailCodeTimer() {
+  if (emailCodeTimer) {
+    clearInterval(emailCodeTimer)
+    emailCodeTimer = undefined
+  }
+}
+
+function clearIssuedEmailCode() {
+  issuedEmail.value = ''
+  form.emailCode = ''
+  if (!disposed) {
+    formRef.value?.clearValidate('emailCode')
+  }
+}
+
+function clearEmailVerificationState() {
+  clearIssuedEmailCode()
+  emailCodeCooldownDeadline = 0
+  emailCodeCountdown.value = 0
+  clearEmailCodeTimer()
+}
+
+function clearCaptchaChallenge() {
+  form.captchaId = ''
+  form.captcha = ''
+  captchaImage.value = ''
+  if (!disposed) {
+    formRef.value?.clearValidate('captcha')
+  }
+}
+
+function clearRegistrationData() {
+  form.username = ''
+  form.nickname = ''
+  form.email = ''
+  form.password = ''
+  form.confirmPassword = ''
+  clearCaptchaChallenge()
+  clearEmailVerificationState()
+}
+
+function updateEmailCodeCountdown() {
+  if (disposed) {
+    return
+  }
+  emailCodeCountdown.value = calculateCountdownSeconds(emailCodeCooldownDeadline, Date.now())
+  if (emailCodeCountdown.value === 0) {
+    emailCodeCooldownDeadline = 0
+    clearEmailCodeTimer()
+  }
+}
+
+function startEmailCodeCountdown() {
+  clearEmailCodeTimer()
+  emailCodeCooldownDeadline = Date.now() + emailCodeCooldownSeconds.value * 1000
+  updateEmailCodeCountdown()
+  if (emailCodeCountdown.value > 0 && !disposed) {
+    emailCodeTimer = setInterval(updateEmailCodeCountdown, 1000)
+  }
+}
+
+async function scrollToTop() {
+  await nextTick()
+  if (!disposed) {
+    emit('request-scroll-top')
+  }
+}
+
+async function refreshCaptcha() {
+  if (disposed || !showCaptcha.value || captchaLoading.value) {
+    return
+  }
+  const generation = ++captchaRequestGeneration
+  captchaLoading.value = true
+  try {
+    const challenge = await fetchCaptcha()
+    if (disposed || generation !== captchaRequestGeneration) {
+      return
+    }
+    form.captchaId = challenge.captchaId
+    form.captcha = ''
+    captchaImage.value = challenge.image
+    formRef.value?.clearValidate('captcha')
+  } catch {
+    // 请求层已展示服务端错误；保留可重试入口，不把异步异常泄漏到 Vue 事件循环。
+    if (!disposed && generation === captchaRequestGeneration) {
+      clearCaptchaChallenge()
+    }
+  } finally {
+    if (!disposed && generation === captchaRequestGeneration) {
+      captchaLoading.value = false
+    }
+  }
+}
+
+async function validateFields(fields: readonly string[]) {
+  if (!formRef.value) {
+    return false
+  }
+  const results = await Promise.all(fields.map((field) => (
+    formRef.value!.validateField(field).then(() => true).catch(() => false)
+  )))
+  return !disposed && results.every(Boolean)
+}
+
+async function goToSecurityStep() {
+  if (disposed || operationPending.value) {
+    return
+  }
+  navigationPending.value = true
+  try {
+    const valid = await validateFields(getRegisterStepPresentationFields(
+      REGISTER_ACCOUNT_STEP,
+      verificationPlan.value,
+    ))
+    if (!valid || disposed) {
+      return
+    }
+    step.value = REGISTER_SECURITY_STEP
+    await scrollToTop()
+  } finally {
+    if (!disposed) {
+      navigationPending.value = false
+    }
+  }
+}
+
+async function goToAccountStep() {
+  if (disposed || operationPending.value) {
+    return
+  }
+  navigationPending.value = true
+  try {
+    step.value = REGISTER_ACCOUNT_STEP
+    await scrollToTop()
+  } finally {
+    if (!disposed) {
+      navigationPending.value = false
+    }
+  }
+}
+
+function backToLogin() {
+  if (!operationPending.value) {
+    clearRegistrationData()
+    emit('back')
+  }
+}
+
+async function handleSendEmailCode() {
+  if (disposed || verificationRequestPending.value || emailCodeCountdown.value > 0) {
+    return
+  }
+  emailCodeSending.value = true
+  const generation = ++emailCodeRequestGeneration
+  try {
+    const valid = await validateFields(getEmailCodeRequestValidationFields(verificationPlan.value))
+    if (!valid || disposed || generation !== emailCodeRequestGeneration) {
+      return
+    }
+    const payload = buildEmailCodeRequestPayload(form, verificationPlan.value)
+    const ttlSeconds = await sendRegisterEmailCode(payload)
+    if (disposed || generation !== emailCodeRequestGeneration || form.email !== payload.email) {
+      return
+    }
+    issuedEmail.value = payload.email
+    form.emailCode = ''
+    formRef.value?.clearValidate('emailCode')
+    if (captchaUsedForEmailCode.value) {
+      // 图形码是一次性挑战；发码成功后丢弃旧凭据，确需重发时再由用户获取新挑战。
+      clearCaptchaChallenge()
+    }
+    ElMessage.success(`验证码已发送，${Math.max(1, Math.round(ttlSeconds / 60))} 分钟内有效`)
+    startEmailCodeCountdown()
+  } catch {
+    if (!disposed) {
+      // 发码失败后服务端可能已使旧邮箱码失效；只清空凭据，保留既有发码冷却。
+      clearIssuedEmailCode()
+      // 图形码一次性消费；发码失败后清空旧挑战，由用户按需重新获取。
+      if (isCaptchaConsumedByEmailCodeRequest(verificationPlan.value)) {
+        clearCaptchaChallenge()
+      }
+    }
+  } finally {
+    if (!disposed) {
+      emailCodeSending.value = false
+    }
+  }
+}
+
+async function handleRegister() {
+  if (disposed || registrationPending.value) {
+    return
+  }
+  submitting.value = true
+  const generation = ++registerRequestGeneration
+  try {
+    // 最终提交重新覆盖两步字段；邮箱模式不再校验发码时已消费的图形码。
+    const accountValid = await validateFields(getRegistrationStepValidationFields(
+      REGISTER_ACCOUNT_STEP,
+      verificationPlan.value,
+    ))
+    if (!accountValid || disposed || generation !== registerRequestGeneration) {
+      if (!disposed) {
+        step.value = REGISTER_ACCOUNT_STEP
+        await scrollToTop()
+      }
+      return
+    }
+    const securityValid = await validateFields(getRegistrationStepValidationFields(
+      REGISTER_SECURITY_STEP,
+      verificationPlan.value,
+    ))
+    if (!securityValid || disposed || generation !== registerRequestGeneration) {
+      return
+    }
+    const payload = buildRegistrationPayload(form, verificationPlan.value)
+    const username = form.username
+    await register(payload)
+    if (disposed || generation !== registerRequestGeneration) {
+      return
+    }
+    submittedUsername.value = username
+    // 成功页只保留展示所需用户名，立即缩短密码与一次性验证码在内存中的暴露窗口。
+    clearRegistrationData()
+    state.value = 'success'
+    clearEmailCodeTimer()
+    emailCodeCountdown.value = 0
+    await scrollToTop()
+  } catch (error) {
+    // 只有已通过验证码核验的冲突或结果未知的异常才按“已消费”收敛；前置校验失败与普通输错允许原地修正。
+    if (!disposed
+      && usesEmailCodeForRegistration(verificationPlan.value)
+      && shouldClearEmailCodeAfterRegistrationFailure(error)) {
+      clearIssuedEmailCode()
+    }
+    // 邮箱验证关闭时，图形码由最终注册请求消费；失败后清空并由用户按需重新获取。
+    if (!disposed && isCaptchaConsumedByRegistration(verificationPlan.value)) {
+      clearCaptchaChallenge()
+    }
+  } finally {
+    if (!disposed && generation === registerRequestGeneration) {
+      submitting.value = false
+    }
+  }
+}
+
+function handleEnter(event: KeyboardEvent) {
+  const targetInsideButton = Boolean((event.target as HTMLElement | null)?.closest('button'))
+  if (!shouldHandleRegisterEnter(event, targetInsideButton, operationPending.value)) {
+    return
+  }
+  event.preventDefault()
+  if (step.value === REGISTER_ACCOUNT_STEP) {
+    void goToSecurityStep()
+    return
+  }
+  void handleRegister()
+}
+
+function completeRegistration() {
+  if (!operationPending.value) {
+    emit('complete', submittedUsername.value)
+  }
+}
+
+onMounted(refreshCaptcha)
+watch(() => form.email, () => {
+  emailCodeRequestGeneration += 1
+  clearEmailVerificationState()
+}, { flush: 'sync' })
+onBeforeUnmount(() => {
+  disposed = true
+  captchaRequestGeneration += 1
+  emailCodeRequestGeneration += 1
+  registerRequestGeneration += 1
+  clearRegistrationData()
+})
+</script>
+
+<template>
+  <section
+    class="register-panel"
+    aria-labelledby="register-title"
+    :style="{ '--login-primary-text': primaryTextColor }"
+  >
+    <template v-if="state === 'form'">
+      <div class="panel-heading register-panel-heading">
+        <div>
+          <p class="eyebrow">创建本地账号</p>
+          <h1 id="register-title">加入智能体运营台</h1>
+          <p>完成注册后即可登录查看审核状态，管理员审核并分配角色后需重新登录。</p>
+        </div>
+        <el-button class="back-login" link :disabled="operationPending" @click="backToLogin">返回登录</el-button>
+      </div>
+
+      <ol class="register-steps" aria-label="注册步骤">
+        <li
+          :class="{ active: step === REGISTER_ACCOUNT_STEP, complete: step === REGISTER_SECURITY_STEP }"
+          :aria-current="step === REGISTER_ACCOUNT_STEP ? 'step' : undefined"
+        >
+          <span>1</span>
+          <div><strong>账号资料</strong><small>建立身份信息</small></div>
+        </li>
+        <li
+          :class="{ active: step === REGISTER_SECURITY_STEP }"
+          :aria-current="step === REGISTER_SECURITY_STEP ? 'step' : undefined"
+        >
+          <span>2</span>
+          <div><strong>安全验证</strong><small>设置登录凭据</small></div>
+        </li>
+      </ol>
+
+      <el-form
+        ref="formRef"
+        class="register-form"
+        :model="form"
+        :rules="rules"
+        :disabled="operationPending"
+        :aria-busy="operationPending"
+        @keydown.enter="handleEnter"
+        @submit.prevent
+      >
+        <!-- v-show 保留两步字段注册；最终提交按后端实际消费字段重新校验。 -->
+        <div v-show="step === REGISTER_ACCOUNT_STEP" class="form-step" aria-labelledby="register-account-step">
+          <h2 id="register-account-step" class="sr-only">账号资料</h2>
+          <label class="field-label" for="register-username">用户名 <span>必填</span></label>
+          <el-form-item prop="username">
+            <el-input id="register-username" v-model="form.username" size="large" autocomplete="username" placeholder="3-32 位，支持字母、数字及 . _ -" :prefix-icon="'User'" />
+          </el-form-item>
+
+          <label class="field-label" for="register-nickname">昵称 <span>选填</span></label>
+          <el-form-item prop="nickname">
+            <el-input id="register-nickname" v-model="form.nickname" size="large" autocomplete="name" placeholder="你希望被如何称呼" :prefix-icon="'Postcard'" />
+          </el-form-item>
+
+          <label class="field-label" for="register-email">邮箱 <span>{{ options.emailRequired || options.emailVerificationRequired ? '必填' : '选填' }}</span></label>
+          <el-form-item prop="email">
+            <el-input id="register-email" v-model="form.email" size="large" autocomplete="email" :placeholder="options.emailRequired || options.emailVerificationRequired ? '用于验证身份与接收审核结果' : '用于接收审核结果'" :prefix-icon="'Message'" />
+          </el-form-item>
+
+          <el-button
+            type="primary"
+            size="large"
+            class="primary-action"
+            :disabled="operationPending"
+            @click="goToSecurityStep"
+          >
+            下一步
+          </el-button>
+        </div>
+
+        <div v-show="step === REGISTER_SECURITY_STEP" class="form-step" aria-labelledby="register-security-step">
+          <h2 id="register-security-step" class="sr-only">安全验证</h2>
+
+          <template v-if="showCaptcha">
+            <label class="field-label" for="register-captcha">
+              图形验证码 <span>{{ captchaUsedForEmailCode ? '发码/重发时必填' : '必填' }}</span>
+            </label>
+            <el-form-item prop="captcha">
+              <div class="verification-row">
+                <el-input id="register-captcha" v-model="form.captcha" size="large" maxlength="16" autocomplete="off" placeholder="请输入图中字符" :prefix-icon="'Key'" />
+                <button v-if="captchaImage" type="button" class="captcha-challenge" aria-label="刷新图形验证码" :disabled="verificationRequestPending" @click="refreshCaptcha">
+                  <img :src="captchaImage" alt="图形验证码" />
+                  <span>换一张</span>
+                </button>
+                <el-button v-else class="captcha-fallback" size="large" :loading="captchaLoading" @click="refreshCaptcha">获取验证码</el-button>
+              </div>
+            </el-form-item>
+          </template>
+
+          <template v-if="showEmailCode">
+            <label class="field-label" for="register-email-code">邮箱验证码 <span>必填</span></label>
+            <el-form-item prop="emailCode">
+              <div class="verification-row">
+                <el-input id="register-email-code" v-model="form.emailCode" size="large" maxlength="16" inputmode="numeric" autocomplete="one-time-code" placeholder="请输入邮件中的验证码" :prefix-icon="'Message'" />
+                <el-button class="email-code-button" size="large" :loading="emailCodeSending" :disabled="verificationRequestPending || emailCodeCountdown > 0" @click="handleSendEmailCode">
+                  {{ emailCodeCountdown > 0 ? `${emailCodeCountdown} 秒后重发` : '发送验证码' }}
+                </el-button>
+              </div>
+            </el-form-item>
+          </template>
+
+          <label class="field-label" for="register-password">密码 <span>必填</span></label>
+          <el-form-item prop="password">
+            <el-input id="register-password" v-model="form.password" type="password" size="large" show-password autocomplete="new-password" placeholder="至少 8 位，同时包含字母与数字" :prefix-icon="'Lock'" />
+          </el-form-item>
+
+          <label class="field-label" for="register-confirm-password">确认密码 <span>必填</span></label>
+          <el-form-item prop="confirmPassword">
+            <el-input id="register-confirm-password" v-model="form.confirmPassword" type="password" size="large" show-password autocomplete="new-password" placeholder="再次输入登录密码" :prefix-icon="'Lock'" />
+          </el-form-item>
+
+          <div class="step-actions">
+            <el-button size="large" :disabled="operationPending" @click="goToAccountStep">上一步</el-button>
+            <el-button
+              type="primary"
+              size="large"
+              class="primary-action"
+              :loading="submitting"
+              :disabled="registrationPending"
+              @click="handleRegister"
+            >
+              提交注册
+            </el-button>
+          </div>
+        </div>
+      </el-form>
+    </template>
+
+    <div v-else class="registration-success" aria-live="polite">
+      <div class="success-mark" aria-hidden="true"><el-icon><CircleCheckFilled /></el-icon></div>
+      <p class="eyebrow">账号已创建</p>
+      <h1 id="register-title">注册成功，{{ submittedUsername }}</h1>
+      <p>现在可以登录查看审核状态。管理员完成审核并分配角色后，请重新登录以加载已开通菜单。</p>
+      <el-button
+        type="primary"
+        size="large"
+        class="primary-action"
+        :disabled="operationPending"
+        @click="completeRegistration"
+      >
+        返回登录
+      </el-button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.register-panel,
+.register-form,
+.form-step {
+  width: 100%;
+}
+
+.panel-heading {
+  margin-bottom: 22px;
+}
+
+.register-panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--el-color-primary);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+h1 {
+  margin: 0;
+  color: var(--el-text-color-primary);
+  font-size: clamp(26px, 2.2vw, 34px);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.panel-heading p:last-child,
+.registration-success > p:last-of-type {
+  max-width: 460px;
+  margin: 10px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.back-login {
+  flex: none;
+  margin-top: 20px;
+}
+
+.register-steps {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin: 0 0 22px;
+  padding: 0;
+  list-style: none;
+}
+
+.register-steps li {
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 10px;
+  background: var(--el-fill-color-extra-light);
+  color: var(--el-text-color-secondary);
+}
+
+.register-steps li > span {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  background: var(--el-fill-color-dark);
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.register-steps li.active {
+  border-color: var(--el-color-primary-light-5);
+  background: var(--el-color-primary-light-9);
+  color: var(--el-text-color-primary);
+}
+
+.register-steps li.active > span,
+.register-steps li.complete > span {
+  background: var(--el-color-primary);
+  color: var(--login-primary-text, #fff);
+}
+
+.register-steps strong,
+.register-steps small {
+  display: block;
+}
+
+.register-steps strong {
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.register-steps small {
+  margin-top: 3px;
+  color: var(--el-text-color-secondary);
+  font-size: 11px;
+}
+
+.field-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 7px;
+  color: var(--el-text-color-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.field-label span {
+  color: var(--el-text-color-placeholder);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.register-form :deep(.el-form-item) {
+  margin-bottom: 16px;
+}
+
+.register-form :deep(.el-input__wrapper) {
+  min-height: 44px;
+}
+
+.verification-row {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  width: 100%;
+}
+
+.captcha-challenge {
+  width: 124px;
+  min-height: 44px;
+  flex: none;
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--el-border-color);
+  border-radius: var(--el-border-radius-base);
+  background: var(--el-bg-color);
+  cursor: pointer;
+}
+
+.captcha-challenge img {
+  width: 100%;
+  height: 100%;
+  min-height: 42px;
+  display: block;
+  object-fit: cover;
+}
+
+.captcha-challenge span {
+  position: absolute;
+  right: 4px;
+  bottom: 3px;
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: rgba(11, 23, 40, 0.78);
+  color: #fff;
+  font-size: 10px;
+}
+
+.captcha-fallback,
+.email-code-button {
+  min-width: 124px;
+  flex: none;
+}
+
+.step-actions {
+  display: grid;
+  grid-template-columns: 112px 1fr;
+  gap: 10px;
+}
+
+.registration-success {
+  width: 100%;
+  padding: 18px 0;
+}
+
+.success-mark {
+  width: 54px;
+  height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 22px;
+  border-radius: 16px;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success);
+  font-size: 28px;
+}
+
+.registration-success .primary-action {
+  margin-top: 28px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
+@media (max-width: 480px) {
+  .register-panel-heading {
+    gap: 10px;
+  }
+
+  .register-steps small {
+    display: none;
+  }
+
+  .verification-row {
+    gap: 8px;
+  }
+
+  .captcha-challenge,
+  .captcha-fallback,
+  .email-code-button {
+    min-width: 108px;
+    width: 108px;
+    padding-inline: 8px;
+  }
+}
+</style>

--- a/customer-admin-web/src/views/login/loginPageModel.test.ts
+++ b/customer-admin-web/src/views/login/loginPageModel.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildEmailCodeRequestPayload,
+  buildRegistrationPayload,
+  calculateCountdownSeconds,
+  createLoginSubmission,
+  getEmailCodeRequestValidationFields,
+  getLoginModePresentation,
+  getRegisterStepPresentationFields,
+  getRegisterVerificationPlan,
+  getRegistrationStepValidationFields,
+  isCaptchaConsumedByEmailCodeRequest,
+  isCaptchaConsumedByRegistration,
+  REGISTER_ACCOUNT_STEP,
+  REGISTER_SECURITY_STEP,
+  resolveEmailCodeCooldownSeconds,
+  shouldHandleRegisterEnter,
+  shouldClearEmailCodeAfterRegistrationFailure,
+  shouldShowRegisterEntry,
+  usesEmailCodeForRegistration,
+  type RegisterField,
+  type RegisterFormData,
+  type RegisterVerificationOptions,
+} from './loginPageModel'
+
+describe('getLoginModePresentation', () => {
+  it('本地账号使用本地身份文案', () => {
+    expect(getLoginModePresentation('local')).toEqual({
+      label: '本地账号',
+      title: '欢迎回来',
+      description: '使用本地账号进入智能体运营台。',
+      usernameLabel: '用户名',
+      usernamePlaceholder: '请输入用户名',
+      passwordLabel: '密码',
+      passwordPlaceholder: '请输入密码',
+    })
+  })
+
+  it('OA 账号使用企业目录文案且不复用本地字段提示', () => {
+    const local = getLoginModePresentation('local')
+    const sso = getLoginModePresentation('sso')
+
+    expect(sso).toEqual({
+      label: 'OA 账号',
+      title: 'OA 账号登录',
+      description: '使用企业目录账号验证身份。',
+      usernameLabel: 'OA 账号',
+      usernamePlaceholder: '请输入 OA 账号',
+      passwordLabel: 'OA 密码',
+      passwordPlaceholder: '请输入 OA 密码',
+    })
+    expect(sso.usernameLabel).not.toBe(local.usernameLabel)
+    expect(sso.passwordLabel).not.toBe(local.passwordLabel)
+  })
+})
+
+describe('createLoginSubmission', () => {
+  it('冻结登录模式与凭据快照，且请求凭据不混入 mode', () => {
+    const form = { username: 'richard', password: 'Secret123', rememberMe: true }
+
+    const submission = createLoginSubmission('local', form)
+    form.username = 'changed'
+    form.password = 'Changed456'
+    form.rememberMe = false
+
+    expect(submission).toEqual({
+      mode: 'local',
+      credentials: { username: 'richard', password: 'Secret123', rememberMe: true },
+    })
+    expect(submission.credentials).not.toHaveProperty('mode')
+    expect(Object.isFrozen(submission)).toBe(true)
+    expect(Object.isFrozen(submission.credentials)).toBe(true)
+  })
+})
+
+describe('shouldShowRegisterEntry', () => {
+  it.each([
+    ['后端能力尚未加载', 'local', false, true],
+    ['后端关闭自助注册', 'local', true, false],
+    ['OA 模式', 'sso', true, true],
+  ] as const)('%s时 fail-closed 隐藏注册入口', (_label, mode, optionsLoaded, selfServiceEnabled) => {
+    expect(shouldShowRegisterEntry(mode, optionsLoaded, selfServiceEnabled)).toBe(false)
+  })
+
+  it('仅本地模式且后端明确开放时显示注册入口', () => {
+    expect(shouldShowRegisterEntry('local', true, true)).toBe(true)
+  })
+})
+
+describe('注册选项契约', () => {
+  const form: RegisterFormData = {
+    username: 'richard',
+    nickname: 'Richard',
+    email: 'richard@example.com',
+    password: 'Secret123',
+    confirmPassword: 'Secret123',
+    captchaId: 'captcha-id',
+    captcha: 'ABCD',
+    emailCode: '246810',
+  }
+  const baseRegistrationPayload = {
+    username: 'richard',
+    nickname: 'Richard',
+    email: 'richard@example.com',
+    password: 'Secret123',
+    confirmPassword: 'Secret123',
+  }
+  const cases: ReadonlyArray<{
+    name: string
+    options: RegisterVerificationOptions
+    presentationFields: readonly RegisterField[]
+    emailCodeRequestFields: readonly RegisterField[]
+    registrationFields: readonly RegisterField[]
+    emailCodePayload: Record<string, string>
+    registrationPayload: Record<string, string>
+    captchaConsumedByEmailCodeRequest: boolean
+    captchaConsumedByRegistration: boolean
+    emailCodeUsedForRegistration: boolean
+  }> = [
+    {
+      name: '无需验证码',
+      options: { captchaRequired: false, emailVerificationRequired: false },
+      presentationFields: [],
+      emailCodeRequestFields: [],
+      registrationFields: [],
+      emailCodePayload: { email: 'richard@example.com' },
+      registrationPayload: baseRegistrationPayload,
+      captchaConsumedByEmailCodeRequest: false,
+      captchaConsumedByRegistration: false,
+      emailCodeUsedForRegistration: false,
+    },
+    {
+      name: '图形验证码保护最终注册',
+      options: { captchaRequired: true, emailVerificationRequired: false },
+      presentationFields: ['captcha'],
+      emailCodeRequestFields: [],
+      registrationFields: ['captcha'],
+      emailCodePayload: { email: 'richard@example.com' },
+      registrationPayload: {
+        ...baseRegistrationPayload,
+        captchaId: 'captcha-id',
+        captcha: 'ABCD',
+      },
+      captchaConsumedByEmailCodeRequest: false,
+      captchaConsumedByRegistration: true,
+      emailCodeUsedForRegistration: false,
+    },
+    {
+      name: '最终注册只校验邮箱验证码',
+      options: { captchaRequired: false, emailVerificationRequired: true },
+      presentationFields: ['emailCode'],
+      emailCodeRequestFields: [],
+      registrationFields: ['emailCode'],
+      emailCodePayload: { email: 'richard@example.com' },
+      registrationPayload: { ...baseRegistrationPayload, emailCode: '246810' },
+      captchaConsumedByEmailCodeRequest: false,
+      captchaConsumedByRegistration: false,
+      emailCodeUsedForRegistration: true,
+    },
+    {
+      name: '图形验证码只保护发码且最终只校验邮箱验证码',
+      options: { captchaRequired: true, emailVerificationRequired: true },
+      presentationFields: ['captcha', 'emailCode'],
+      emailCodeRequestFields: ['captcha'],
+      registrationFields: ['emailCode'],
+      emailCodePayload: {
+        email: 'richard@example.com',
+        captchaId: 'captcha-id',
+        captcha: 'ABCD',
+      },
+      registrationPayload: { ...baseRegistrationPayload, emailCode: '246810' },
+      captchaConsumedByEmailCodeRequest: true,
+      captchaConsumedByRegistration: false,
+      emailCodeUsedForRegistration: true,
+    },
+  ]
+
+  it.each(cases)('$name', ({
+    options,
+    presentationFields,
+    emailCodeRequestFields,
+    registrationFields,
+    emailCodePayload,
+    registrationPayload,
+    captchaConsumedByEmailCodeRequest,
+    captchaConsumedByRegistration,
+    emailCodeUsedForRegistration,
+  }) => {
+    expect(getRegisterVerificationPlan(options)).toEqual({
+      presentationFields,
+      emailCodeRequestFields,
+      registrationFields,
+    })
+    const plan = getRegisterVerificationPlan(options)
+    const accountFields = getRegisterStepPresentationFields(REGISTER_ACCOUNT_STEP, plan)
+    const securityPresentationFields = getRegisterStepPresentationFields(REGISTER_SECURITY_STEP, plan)
+    const finalAccountFields = getRegistrationStepValidationFields(REGISTER_ACCOUNT_STEP, plan)
+    const finalSecurityFields = getRegistrationStepValidationFields(REGISTER_SECURITY_STEP, plan)
+
+    expect(accountFields).toEqual(['username', 'nickname', 'email'])
+    expect(securityPresentationFields).toEqual(['password', 'confirmPassword', ...presentationFields])
+    expect(getEmailCodeRequestValidationFields(plan)).toEqual(['email', ...emailCodeRequestFields])
+    expect(finalAccountFields).toEqual(['username', 'nickname', 'email'])
+    expect(finalSecurityFields).toEqual(['password', 'confirmPassword', ...registrationFields])
+    expect(buildEmailCodeRequestPayload(form, plan)).toEqual(emailCodePayload)
+    expect(buildRegistrationPayload(form, plan)).toEqual(registrationPayload)
+    expect(isCaptchaConsumedByEmailCodeRequest(plan)).toBe(captchaConsumedByEmailCodeRequest)
+    expect(isCaptchaConsumedByRegistration(plan)).toBe(captchaConsumedByRegistration)
+    expect(usesEmailCodeForRegistration(plan)).toBe(emailCodeUsedForRegistration)
+    expect(accountFields.filter((field) => securityPresentationFields.includes(field))).toEqual([])
+  })
+
+  it('空的选填昵称与邮箱归一化为 null，且不混入未启用的验证字段', () => {
+    const plan = getRegisterVerificationPlan({
+      captchaRequired: false,
+      emailVerificationRequired: false,
+    })
+
+    expect(buildRegistrationPayload({
+      ...form,
+      nickname: '',
+      email: '',
+    }, plan)).toEqual({
+      username: 'richard',
+      nickname: null,
+      email: null,
+      password: 'Secret123',
+      confirmPassword: 'Secret123',
+    })
+  })
+})
+
+describe('shouldClearEmailCodeAfterRegistrationFailure', () => {
+  it.each([
+    ['用户名或邮箱冲突发生在验证码核验之后', { code: 30004, message: '用户名已存在' }, true],
+    ['普通邮箱码输错仍允许直接修正', { code: 30012, message: '邮箱验证码错误' }, false],
+    ['新服务端用独立错误码要求重新获取', { code: 30013, message: '邮箱验证码已失效，请重新获取' }, true],
+    ['旧服务端过期文案仍能要求重新获取', { code: 30012, message: '验证码已过期，请重新获取' }, true],
+    ['旧服务端次数耗尽文案仍能要求重新获取', { code: 30012, message: '验证码错误次数过多，请重新获取' }, true],
+    ['参数错误发生在验证码核验之前', { code: 30001, message: '参数校验失败' }, false],
+    ['弱口令发生在验证码核验之前', { code: 30011, message: '密码强度不足' }, false],
+    ['注册限流发生在验证码核验之前', { code: 40051, message: '注册请求过于频繁' }, false],
+    ['非 2xx Axios 错误同样读取 response.data', {
+      response: { data: { code: 30004, message: '该邮箱已注册' } },
+    }, true],
+    ['未知网络结果按可能已消费收敛', new Error('Network Error'), true],
+  ] as const)('%s', (_label, error, expected) => {
+    expect(shouldClearEmailCodeAfterRegistrationFailure(error)).toBe(expected)
+  })
+})
+
+describe('shouldHandleRegisterEnter', () => {
+  it('普通输入框 Enter 推进状态机', () => {
+    expect(shouldHandleRegisterEnter(
+      { isComposing: false, repeat: false, keyCode: 13 },
+      false,
+      false,
+    )).toBe(true)
+  })
+
+  it.each([
+    ['IME composing', { isComposing: true, repeat: false, keyCode: 13 }, false, false],
+    ['IME legacy keyCode', { isComposing: false, repeat: false, keyCode: 229 }, false, false],
+    ['长按重复', { isComposing: false, repeat: true, keyCode: 13 }, false, false],
+    ['按钮自身', { isComposing: false, repeat: false, keyCode: 13 }, true, false],
+    ['异步处理中', { isComposing: false, repeat: false, keyCode: 13 }, false, true],
+  ] as const)('%s 不推进状态机', (_name, event, targetInsideButton, operationPending) => {
+    expect(shouldHandleRegisterEnter(event, targetInsideButton, operationPending)).toBe(false)
+  })
+})
+
+describe('calculateCountdownSeconds', () => {
+  it('从截止时间重算，事件循环延迟不会累计漂移', () => {
+    const deadline = 66_000
+
+    expect(calculateCountdownSeconds(deadline, 1_000)).toBe(65)
+    expect(calculateCountdownSeconds(deadline, 2_350)).toBe(64)
+    expect(calculateCountdownSeconds(deadline, 66_000)).toBe(0)
+    expect(calculateCountdownSeconds(deadline, 120_000)).toBe(0)
+  })
+
+  it.each([
+    ['旧服务端缺省字段', undefined, 60],
+    ['服务端自定义冷却', 37, 37],
+    ['服务端关闭冷却', 0, 0],
+    ['服务端非正值统一视为关闭', -1, 0],
+  ] as const)('%s', (_name, configuredSeconds, expected) => {
+    expect(resolveEmailCodeCooldownSeconds(configuredSeconds)).toBe(expected)
+  })
+})

--- a/customer-admin-web/src/views/login/loginPageModel.ts
+++ b/customer-admin-web/src/views/login/loginPageModel.ts
@@ -1,0 +1,337 @@
+import type { EmailCodeRequest, RegisterRequest } from '@/types/api'
+
+export type LoginMode = 'local' | 'sso'
+
+export interface LoginModePresentation {
+  label: string
+  title: string
+  description: string
+  usernameLabel: string
+  usernamePlaceholder: string
+  passwordLabel: string
+  passwordPlaceholder: string
+}
+
+const LOGIN_MODE_PRESENTATIONS: Readonly<Record<LoginMode, Readonly<LoginModePresentation>>> = {
+  local: {
+    label: '本地账号',
+    title: '欢迎回来',
+    description: '使用本地账号进入智能体运营台。',
+    usernameLabel: '用户名',
+    usernamePlaceholder: '请输入用户名',
+    passwordLabel: '密码',
+    passwordPlaceholder: '请输入密码',
+  },
+  sso: {
+    label: 'OA 账号',
+    title: 'OA 账号登录',
+    description: '使用企业目录账号验证身份。',
+    usernameLabel: 'OA 账号',
+    usernamePlaceholder: '请输入 OA 账号',
+    passwordLabel: 'OA 密码',
+    passwordPlaceholder: '请输入 OA 密码',
+  },
+}
+
+export function getLoginModePresentation(mode: LoginMode): Readonly<LoginModePresentation> {
+  return LOGIN_MODE_PRESENTATIONS[mode]
+}
+
+export interface LoginFormData {
+  username: string
+  password: string
+  rememberMe: boolean
+}
+
+export interface LoginSubmission {
+  readonly mode: LoginMode
+  readonly credentials: Readonly<LoginFormData>
+}
+
+/**
+ * 登录请求发出前冻结身份模式与凭据快照，避免 await 期间的表单变化污染后续记忆账号和登录态处理。
+ */
+export function createLoginSubmission(
+  mode: LoginMode,
+  form: Readonly<LoginFormData>,
+): Readonly<LoginSubmission> {
+  const credentials = Object.freeze({
+    username: form.username,
+    password: form.password,
+    rememberMe: form.rememberMe,
+  })
+  return Object.freeze({ mode, credentials })
+}
+
+/**
+ * 注册入口必须以后端能力接口成功返回为前提，接口未完成或失败时按关闭处理。
+ */
+export function shouldShowRegisterEntry(
+  mode: LoginMode,
+  optionsLoaded: boolean,
+  selfServiceEnabled: boolean,
+): boolean {
+  return mode === 'local' && optionsLoaded && selfServiceEnabled
+}
+
+export type RegisterVerificationField = 'captcha' | 'emailCode'
+
+export interface RegisterVerificationOptions {
+  captchaRequired: boolean
+  emailVerificationRequired: boolean
+}
+
+/**
+ * 图形验证码和邮箱验证码分别保护不同动作，不能只按“是否显示”合并处理。
+ */
+export interface RegisterVerificationPlan {
+  /** 安全验证步骤需要展示的字段。 */
+  presentationFields: readonly RegisterVerificationField[]
+  /** 发送邮箱验证码前需要校验的字段。 */
+  emailCodeRequestFields: readonly RegisterVerificationField[]
+  /** 最终提交注册时需要校验的字段。 */
+  registrationFields: readonly RegisterVerificationField[]
+}
+
+const CAPTCHA_FIELD: RegisterVerificationField = 'captcha'
+const EMAIL_CODE_FIELD: RegisterVerificationField = 'emailCode'
+
+export function getRegisterVerificationPlan(
+  options: RegisterVerificationOptions,
+): RegisterVerificationPlan {
+  if (options.emailVerificationRequired) {
+    return {
+      presentationFields: options.captchaRequired
+        ? [CAPTCHA_FIELD, EMAIL_CODE_FIELD]
+        : [EMAIL_CODE_FIELD],
+      emailCodeRequestFields: options.captchaRequired ? [CAPTCHA_FIELD] : [],
+      registrationFields: [EMAIL_CODE_FIELD],
+    }
+  }
+
+  return {
+    presentationFields: options.captchaRequired ? [CAPTCHA_FIELD] : [],
+    emailCodeRequestFields: [],
+    registrationFields: options.captchaRequired ? [CAPTCHA_FIELD] : [],
+  }
+}
+
+export const REGISTER_ACCOUNT_STEP = 1 as const
+export const REGISTER_SECURITY_STEP = 2 as const
+export type RegisterStep = typeof REGISTER_ACCOUNT_STEP | typeof REGISTER_SECURITY_STEP
+
+export type RegisterField =
+  | 'username'
+  | 'nickname'
+  | 'email'
+  | 'password'
+  | 'confirmPassword'
+  | RegisterVerificationField
+
+const REGISTER_ACCOUNT_FIELDS: readonly RegisterField[] = ['username', 'nickname', 'email']
+const REGISTER_SECURITY_FIELDS: readonly RegisterField[] = ['password', 'confirmPassword']
+
+/**
+ * 页面分步仅负责决定展示哪些控件，不能被最终注册校验直接复用。
+ * 邮箱验证模式下，图形码在发码后已消费，但仍需保留控件供重发。
+ */
+export function getRegisterStepPresentationFields(
+  step: RegisterStep,
+  plan: RegisterVerificationPlan,
+): readonly RegisterField[] {
+  if (step === REGISTER_ACCOUNT_STEP) {
+    return REGISTER_ACCOUNT_FIELDS
+  }
+
+  return [
+    ...REGISTER_SECURITY_FIELDS,
+    ...plan.presentationFields,
+  ]
+}
+
+/** 发送邮箱验证码时的完整校验集合。 */
+export function getEmailCodeRequestValidationFields(
+  plan: RegisterVerificationPlan,
+): readonly RegisterField[] {
+  return ['email', ...plan.emailCodeRequestFields]
+}
+
+/** 发码请求是否会消费图形码；无论成功失败，旧挑战都不能再次使用。 */
+export function isCaptchaConsumedByEmailCodeRequest(
+  plan: RegisterVerificationPlan,
+): boolean {
+  return plan.emailCodeRequestFields.includes(CAPTCHA_FIELD)
+}
+
+/**
+ * 最终注册按步骤校验，邮箱验证模式只要求邮箱验证码，不再校验已消费的图形码。
+ */
+export function getRegistrationStepValidationFields(
+  step: RegisterStep,
+  plan: RegisterVerificationPlan,
+): readonly RegisterField[] {
+  if (step === REGISTER_ACCOUNT_STEP) {
+    return REGISTER_ACCOUNT_FIELDS
+  }
+
+  return [
+    ...REGISTER_SECURITY_FIELDS,
+    ...plan.registrationFields,
+  ]
+}
+
+/** 最终注册请求是否会消费图形码；失败后旧挑战同样失效。 */
+export function isCaptchaConsumedByRegistration(
+  plan: RegisterVerificationPlan,
+): boolean {
+  return plan.registrationFields.includes(CAPTCHA_FIELD)
+}
+
+/** 最终注册是否使用邮箱验证码；失败后能否继续复用由服务端错误结果决定。 */
+export function usesEmailCodeForRegistration(
+  plan: RegisterVerificationPlan,
+): boolean {
+  return plan.registrationFields.includes(EMAIL_CODE_FIELD)
+}
+
+const PARAM_INVALID_CODE = 30001
+const PARAM_MISSING_CODE = 30002
+const RESOURCE_DUPLICATE_CODE = 30004
+const PASSWORD_TOO_WEAK_CODE = 30011
+const EMAIL_CODE_INVALID_CODE = 30012
+const EMAIL_CODE_REISSUE_REQUIRED_CODE = 30013
+const FEATURE_NOT_AVAILABLE_CODE = 40050
+const REGISTER_TOO_FREQUENT_CODE = 40051
+const EMAIL_CODE_REISSUE_HINT = '请重新获取'
+
+interface RegistrationFailureBody {
+  code?: unknown
+  message?: unknown
+  response?: {
+    data?: unknown
+  }
+}
+
+function registrationFailureBody(error: unknown): RegistrationFailureBody | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined
+  }
+  const candidate = error as RegistrationFailureBody
+  const responseData = candidate.response?.data
+  return responseData && typeof responseData === 'object'
+    ? responseData as RegistrationFailureBody
+    : candidate
+}
+
+/**
+ * 注册失败不等于邮箱码已消费：表单、弱口令与限流发生在邮箱码核验之前，普通输错也允许继续尝试。
+ * 唯一键冲突发生在核验通过之后；未知的网络/服务端结果无法证明凭据仍有效，按已消费收敛。
+ */
+export function shouldClearEmailCodeAfterRegistrationFailure(error: unknown): boolean {
+  const body = registrationFailureBody(error)
+  const code = typeof body?.code === 'number' ? body.code : undefined
+  if (code === RESOURCE_DUPLICATE_CODE) {
+    return true
+  }
+  if (code === EMAIL_CODE_REISSUE_REQUIRED_CODE) {
+    return true
+  }
+  if (code === EMAIL_CODE_INVALID_CODE) {
+    // 兼容尚未升级独立 30013 错误码的旧服务端；新服务端不再依赖中文文案判定。
+    return typeof body?.message === 'string' && body.message.includes(EMAIL_CODE_REISSUE_HINT)
+  }
+  if ([
+    PARAM_INVALID_CODE,
+    PARAM_MISSING_CODE,
+    PASSWORD_TOO_WEAK_CODE,
+    FEATURE_NOT_AVAILABLE_CODE,
+    REGISTER_TOO_FREQUENT_CODE,
+  ].includes(code ?? Number.NaN)) {
+    return false
+  }
+  return true
+}
+
+export interface RegisterFormData {
+  username: string
+  nickname: string
+  email: string
+  password: string
+  confirmPassword: string
+  captchaId: string
+  captcha: string
+  emailCode: string
+}
+
+/** 生产发码请求与契约测试共用同一个载荷构造入口。 */
+export function buildEmailCodeRequestPayload(
+  form: Readonly<RegisterFormData>,
+  plan: RegisterVerificationPlan,
+): EmailCodeRequest {
+  if (plan.emailCodeRequestFields.includes(CAPTCHA_FIELD)) {
+    return {
+      email: form.email,
+      captchaId: form.captchaId,
+      captcha: form.captcha,
+    }
+  }
+
+  return { email: form.email }
+}
+
+/** 生产注册请求与契约测试共用同一个载荷构造入口。 */
+export function buildRegistrationPayload(
+  form: Readonly<RegisterFormData>,
+  plan: RegisterVerificationPlan,
+): RegisterRequest {
+  const payload: RegisterRequest = {
+    username: form.username,
+    nickname: form.nickname || null,
+    email: form.email || null,
+    password: form.password,
+    confirmPassword: form.confirmPassword,
+  }
+
+  if (plan.registrationFields.includes(CAPTCHA_FIELD)) {
+    payload.captchaId = form.captchaId
+    payload.captcha = form.captcha
+  }
+  if (plan.registrationFields.includes(EMAIL_CODE_FIELD)) {
+    payload.emailCode = form.emailCode
+  }
+
+  return payload
+}
+
+export interface RegisterEnterEventState {
+  isComposing: boolean
+  repeat: boolean
+  keyCode: number
+}
+
+/** 输入法合成、长按重复和按钮自身的 Enter 都不能推进注册状态机。 */
+export function shouldHandleRegisterEnter(
+  event: Readonly<RegisterEnterEventState>,
+  targetInsideButton: boolean,
+  operationPending: boolean,
+): boolean {
+  return !event.isComposing
+    && event.keyCode !== 229
+    && !event.repeat
+    && !targetInsideButton
+    && !operationPending
+}
+
+/** 倒计时始终从截止时间重算，后台标签页节流后也不会累计漂移。 */
+export function calculateCountdownSeconds(deadline: number, now: number): number {
+  return Math.max(0, Math.ceil((deadline - now) / 1000))
+}
+
+export const DEFAULT_EMAIL_CODE_COOLDOWN_SECONDS = 60
+
+/**
+ * 旧服务端未返回该字段时保持 60 秒兼容值；0 与负数按服务端语义表示关闭冷却。
+ */
+export function resolveEmailCodeCooldownSeconds(configuredSeconds?: number): number {
+  return Math.max(0, configuredSeconds ?? DEFAULT_EMAIL_CODE_COOLDOWN_SECONDS)
+}

--- a/customer-admin-web/tests/e2e/login.e2e.ts
+++ b/customer-admin-web/tests/e2e/login.e2e.ts
@@ -1,0 +1,871 @@
+import { expect, test, type Page } from '@playwright/test'
+import type { LoginResponse, RegisterOptionsVO } from '../../src/types/api'
+import { LOGIN_E2E_ORIGIN } from './loginTestEnvironment'
+
+const LOGIN_PATH = '/login?redirect=/home'
+const LOGIN_IMAGES_API = `${LOGIN_E2E_ORIGIN}/api/login-images/list`
+const REGISTER_OPTIONS_API = `${LOGIN_E2E_ORIGIN}/api/auth/register-options`
+const CAPTCHA_API = `${LOGIN_E2E_ORIGIN}/api/auth/captcha`
+const EMAIL_CODE_API = `${LOGIN_E2E_ORIGIN}/api/auth/email-code`
+const REGISTER_API = `${LOGIN_E2E_ORIGIN}/api/auth/register`
+const LOCAL_LOGIN_API = `${LOGIN_E2E_ORIGIN}/api/auth/login`
+const SSO_LOGIN_API = `${LOGIN_E2E_ORIGIN}/api/auth/sso-login`
+const PERMISSIONS_API = `${LOGIN_E2E_ORIGIN}/api/auth/permissions`
+const MENU_ROUTES_API = `${LOGIN_E2E_ORIGIN}/api/menu/routes`
+const MENU_VERSION_API = `${LOGIN_E2E_ORIGIN}/api/menu/version`
+const CURRENT_TENANT_VIEW_API = `${LOGIN_E2E_ORIGIN}/api/tenant/current-view`
+const UNREAD_MESSAGE_COUNT_API = `${LOGIN_E2E_ORIGIN}/api/message/unread-count`
+const TEST_BUSINESS_REJECTION_CODE = 40000
+const RESOURCE_DUPLICATE_CODE = 30004
+const PASSWORD_TOO_WEAK_CODE = 30011
+const EMAIL_CODE_INVALID_CODE = 30012
+const EMAIL_CODE_REISSUE_REQUIRED_CODE = 30013
+const TEST_CAPTCHA_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9WnWQAAAAASUVORK5CYII='
+
+const REGISTER_OPTIONS: RegisterOptionsVO = {
+  selfServiceEnabled: true,
+  captchaRequired: false,
+  emailRequired: false,
+  emailVerificationRequired: false,
+  emailCodeCooldownSeconds: 60,
+}
+
+interface PendingLoginRequest {
+  url: string
+  body: Record<string, unknown>
+  release: () => void
+}
+
+function successResult<T>(data: T) {
+  return { code: 0, message: 'success', data }
+}
+
+async function mockLoginBootstrap(page: Page, options: RegisterOptionsVO = REGISTER_OPTIONS) {
+  // 只拦截浏览器真正访问的后端 URL；不能使用 **/api/**，否则会误伤 Vite 的 /src/api/*.ts。
+  await page.route(LOGIN_IMAGES_API, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(successResult([])),
+    })
+  })
+  await page.route(REGISTER_OPTIONS_API, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(successResult(options)),
+    })
+  })
+}
+
+async function mockAuthenticatedBootstrap(page: Page, onRequest?: (url: string) => void) {
+  const endpoints: ReadonlyArray<readonly [string, unknown]> = [
+    [PERMISSIONS_API, []],
+    [MENU_ROUTES_API, []],
+    [MENU_VERSION_API, 1],
+  ]
+  for (const [url, data] of endpoints) {
+    await page.route(url, async (route) => {
+      onRequest?.(route.request().url())
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult(data)),
+      })
+    })
+  }
+  // /home 布局挂载后会精确读取这两个顶栏状态；避免 E2E 意外访问本机 8082 后端。
+  await page.route(CURRENT_TENANT_VIEW_API, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(successResult({
+        userTenantId: 'default',
+        effectiveTenantId: 'default',
+        crossTenantAuthority: false,
+      })),
+    })
+  })
+  await page.route(UNREAD_MESSAGE_COUNT_API, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(successResult(0)),
+    })
+  })
+}
+
+function successfulLoginResult(forceChangePassword = false): LoginResponse {
+  return {
+    token: forceChangePassword ? 'force-change-token' : 'local-login-token',
+    nickname: 'Richard',
+    forceChangePassword,
+    approvalStatus: 'APPROVED',
+    approvalRemark: null,
+  }
+}
+
+async function captureRejectedLogin(page: Page, url: string): Promise<{
+  requestCaptured: Promise<PendingLoginRequest>
+}> {
+  let captureRequest!: (request: PendingLoginRequest) => void
+  const requestCaptured = new Promise<PendingLoginRequest>((resolve) => {
+    captureRequest = resolve
+  })
+
+  await page.route(url, async (route) => {
+    let releaseResponse!: () => void
+    const responseReleased = new Promise<void>((resolve) => {
+      releaseResponse = resolve
+    })
+    captureRequest({
+      url: route.request().url(),
+      body: route.request().postDataJSON() as Record<string, unknown>,
+      release: releaseResponse,
+    })
+    await responseReleased
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: TEST_BUSINESS_REJECTION_CODE,
+        message: 'E2E 登录分流验证',
+        data: null,
+      }),
+    })
+  })
+
+  // 包一层对象，避免 async 返回值把内部 Promise 自动展开并在请求发出前形成死锁。
+  return { requestCaptured }
+}
+
+async function suppressExpectedLoginRejection(page: Page) {
+  await page.addInitScript((expectedCode) => {
+    window.addEventListener('unhandledrejection', (event) => {
+      const reason = event.reason as { code?: unknown } | null
+      if (reason?.code === expectedCode) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+      }
+    })
+  }, TEST_BUSINESS_REJECTION_CODE)
+}
+
+async function openLogin(page: Page) {
+  await mockLoginBootstrap(page)
+  await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '创建账号' })).toBeVisible()
+}
+
+async function documentScrollTop(page: Page) {
+  return page.evaluate(() => document.scrollingElement?.scrollTop ?? 0)
+}
+
+async function scrollDocumentToBottom(page: Page) {
+  return page.evaluate(() => {
+    const scroller = document.scrollingElement
+    if (!scroller) {
+      return 0
+    }
+    scroller.scrollTop = scroller.scrollHeight
+    return scroller.scrollTop
+  })
+}
+
+async function expectDocumentAtTop(page: Page) {
+  await expect.poll(() => documentScrollTop(page)).toBe(0)
+}
+
+async function expectAuthSurfaceFits(page: Page, viewportWidth: number) {
+  const authSurface = page.locator('[data-login-scroll]')
+  const layout = await authSurface.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    overflowY: getComputedStyle(element).overflowY,
+  }))
+
+  expect(layout.overflowY).toBe('auto')
+  expect(layout.scrollHeight).toBeLessThanOrEqual(layout.clientHeight + 1)
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(viewportWidth)
+}
+
+async function fillRegisterAccountStep(page: Page) {
+  await page.locator('#register-username').fill('richard.ui')
+  await page.locator('#register-nickname').fill('Richard')
+  await page.locator('#register-email').fill('richard@example.com')
+}
+
+async function openRegisterSecurityStep(page: Page, options: RegisterOptionsVO) {
+  await mockLoginBootstrap(page, options)
+  await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' })
+  await page.getByRole('button', { name: '创建账号' }).click()
+  await fillRegisterAccountStep(page)
+  await page.getByRole('button', { name: '下一步' }).click()
+  await expect(page.locator('#register-password')).toBeVisible()
+}
+
+interface EmailRegistrationHarness {
+  emailCodeRequestCount: number
+  registrationPayloads: Record<string, unknown>[]
+}
+
+async function prepareEmailCodeOnlyRegistration(
+  page: Page,
+  responseForAttempt: (attempt: number) => unknown,
+): Promise<EmailRegistrationHarness> {
+  const harness: EmailRegistrationHarness = {
+    emailCodeRequestCount: 0,
+    registrationPayloads: [],
+  }
+  await page.route(EMAIL_CODE_API, async (route) => {
+    harness.emailCodeRequestCount += 1
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(successResult(300)),
+    })
+  })
+  await page.route(REGISTER_API, async (route) => {
+    harness.registrationPayloads.push(route.request().postDataJSON() as Record<string, unknown>)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(responseForAttempt(harness.registrationPayloads.length)),
+    })
+  })
+  await openRegisterSecurityStep(page, {
+    selfServiceEnabled: true,
+    captchaRequired: false,
+    emailRequired: true,
+    emailVerificationRequired: true,
+    emailCodeCooldownSeconds: 60,
+  })
+  await page.getByRole('button', { name: '发送验证码' }).click()
+  await expect(page.locator('#register-email-code')).toBeEnabled()
+  await page.locator('#register-password').fill('Password123')
+  await page.locator('#register-confirm-password').fill('Password123')
+  return harness
+}
+
+test.describe('桌面登录布局', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('主操作无需滚动，键盘可切换模式，登录请求严格按身份分流', async ({ page }) => {
+    // 业务失败是本用例刻意构造的终态，只抑制对应测试错误，避免 Vite 把含虚拟密码的表单快照写进 CI 日志。
+    await suppressExpectedLoginRejection(page)
+    await openLogin(page)
+
+    await expect(page.getByRole('button', { name: '进入运营台' })).toBeInViewport()
+    await expect(page.getByRole('button', { name: '创建账号' })).toBeInViewport()
+    await expect(page.getByText('© customer_work · owlzhangfq@gmail.com')).toBeInViewport()
+    await expectAuthSurfaceFits(page, 1280)
+
+    const localTab = page.getByRole('tab', { name: '本地账号' })
+    const ssoTab = page.getByRole('tab', { name: 'OA 账号' })
+    await localTab.focus()
+    await page.keyboard.press('ArrowRight')
+    await expect(ssoTab).toBeFocused()
+    await expect(ssoTab).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByRole('heading', { name: 'OA 账号登录' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '创建账号' })).toHaveCount(0)
+
+    await page.keyboard.press('Home')
+    await expect(localTab).toBeFocused()
+    await expect(localTab).toHaveAttribute('aria-selected', 'true')
+
+    const localCapture = await captureRejectedLogin(page, LOCAL_LOGIN_API)
+    await page.locator('#login-username').fill('local.richard')
+    await page.locator('#login-password').fill('Local1234')
+    await page.getByRole('checkbox', { name: '保持登录' })
+      .evaluate((element: HTMLInputElement) => element.click())
+    await expect(page.getByRole('checkbox', { name: '保持登录' })).toBeChecked()
+    await page.getByRole('button', { name: '进入运营台' }).click()
+
+    const localRequest = await localCapture.requestCaptured
+    try {
+      expect(localRequest.url).toBe(LOCAL_LOGIN_API)
+      expect(localRequest.body).toMatchObject({ username: 'local.richard', rememberMe: true })
+      await expect(localTab).toBeDisabled()
+      await expect(ssoTab).toBeDisabled()
+    } finally {
+      localRequest.release()
+    }
+    await expect(localTab).toBeEnabled()
+    await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}${LOGIN_PATH}`)
+
+    await ssoTab.click()
+    const ssoCapture = await captureRejectedLogin(page, SSO_LOGIN_API)
+    await page.locator('#login-username').fill('oa.richard')
+    await page.locator('#login-password').fill('Sso12345')
+    await expect(page.getByRole('checkbox', { name: '保持登录' })).not.toBeChecked()
+    await page.getByRole('button', { name: '使用 OA 账号登录' }).click()
+
+    const ssoRequest = await ssoCapture.requestCaptured
+    try {
+      expect(ssoRequest.url).toBe(SSO_LOGIN_API)
+      expect(ssoRequest.body).toMatchObject({ username: 'oa.richard', rememberMe: false })
+      await expect(localTab).toBeDisabled()
+      await expect(ssoTab).toBeDisabled()
+    } finally {
+      ssoRequest.release()
+    }
+    await expect(ssoTab).toBeEnabled()
+    await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}${LOGIN_PATH}`)
+  })
+})
+
+test.describe('登录成功状态机', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('本地普通登录持久化完整状态、记住用户名并完成 redirect=/home', async ({ page }) => {
+    const bootstrapRequests: string[] = []
+    let loginPayload: Record<string, unknown> | undefined
+
+    await mockAuthenticatedBootstrap(page, (url) => bootstrapRequests.push(url))
+    await page.route(LOCAL_LOGIN_API, async (route) => {
+      loginPayload = route.request().postDataJSON() as Record<string, unknown>
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult(successfulLoginResult())),
+      })
+    })
+    await openLogin(page)
+
+    await page.locator('#login-username').fill('local.richard')
+    await page.locator('#login-password').fill('Local1234')
+    await page.getByRole('checkbox', { name: '保持登录' })
+      .evaluate((element: HTMLInputElement) => element.click())
+    await page.getByRole('button', { name: '进入运营台' }).click()
+
+    await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}/home`)
+    expect(loginPayload).toEqual({
+      username: 'local.richard',
+      password: 'Local1234',
+      rememberMe: true,
+    })
+    expect(bootstrapRequests).toEqual([
+      PERMISSIONS_API,
+      MENU_ROUTES_API,
+      MENU_VERSION_API,
+    ])
+    expect(await page.evaluate(() => ({
+      token: localStorage.getItem('admin-token'),
+      nickname: localStorage.getItem('admin-nickname'),
+      username: localStorage.getItem('admin-username'),
+      forceChangePassword: localStorage.getItem('admin-force-change-password'),
+      approvalStatus: localStorage.getItem('admin-approval-status'),
+      approvalRemark: localStorage.getItem('admin-approval-remark'),
+      rememberedUsername: localStorage.getItem('admin-remember-username-local'),
+      rememberedSsoUsername: localStorage.getItem('admin-remember-username-sso'),
+    }))).toEqual({
+      token: 'local-login-token',
+      nickname: 'Richard',
+      username: 'local.richard',
+      forceChangePassword: 'false',
+      approvalStatus: 'APPROVED',
+      approvalRemark: null,
+      rememberedUsername: 'local.richard',
+      rememberedSsoUsername: null,
+    })
+  })
+
+  test('forceChangePassword 强制进入改密页且不启动菜单 bootstrap', async ({ page }) => {
+    const bootstrapRequests: string[] = []
+
+    await mockAuthenticatedBootstrap(page, (url) => bootstrapRequests.push(url))
+    await page.route(LOCAL_LOGIN_API, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult(successfulLoginResult(true))),
+      })
+    })
+    await openLogin(page)
+
+    await page.locator('#login-username').fill('first.login')
+    await page.locator('#login-password').fill('Local1234')
+    await page.getByRole('button', { name: '进入运营台' }).click()
+
+    await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}/change-password`)
+    await expect(page.getByText('首次登录请修改密码', { exact: true })).toBeVisible()
+    expect(bootstrapRequests).toEqual([])
+    expect(await page.evaluate(() => ({
+      token: localStorage.getItem('admin-token'),
+      username: localStorage.getItem('admin-username'),
+      forceChangePassword: localStorage.getItem('admin-force-change-password'),
+      rememberedUsername: localStorage.getItem('admin-remember-username-local'),
+    }))).toEqual({
+      token: 'force-change-token',
+      username: 'first.login',
+      forceChangePassword: 'true',
+      rememberedUsername: null,
+    })
+  })
+})
+
+test.describe('原始紧凑视口', () => {
+  test.use({ viewport: { width: 916, height: 664 } })
+
+  test('登录与两步注册的主操作无需内部滚动即可使用', async ({ page }) => {
+    await openLogin(page)
+
+    await expect(page.getByRole('button', { name: '进入运营台' })).toBeInViewport()
+    await expect(page.getByRole('button', { name: '创建账号' })).toBeInViewport()
+    await expect(page.getByText('© customer_work · owlzhangfq@gmail.com')).toBeInViewport()
+    await expectAuthSurfaceFits(page, 916)
+
+    await page.getByRole('button', { name: '创建账号' }).click()
+    await expect(page.getByRole('heading', { name: '加入智能体运营台' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '返回登录' })).toBeInViewport()
+    await expect(page.getByRole('button', { name: '下一步' })).toBeInViewport()
+    await expectAuthSurfaceFits(page, 916)
+
+    await fillRegisterAccountStep(page)
+    await page.getByRole('button', { name: '下一步' }).click()
+    await expect(page.locator('#register-password')).toBeVisible()
+    await expect(page.getByRole('button', { name: '上一步' })).toBeInViewport()
+    await expect(page.getByRole('button', { name: '提交注册' })).toBeInViewport()
+    await expectAuthSurfaceFits(page, 916)
+  })
+})
+
+test.describe('邮箱验证码异步状态', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('邮箱与图形码完整注册只提交 emailCode，成功后返回登录并预填账号', async ({ page }) => {
+    let captchaRequestCount = 0
+    let emailCodePayload: Record<string, unknown> | undefined
+    let registrationPayload: Record<string, unknown> | undefined
+
+    await page.route(CAPTCHA_API, async (route) => {
+      captchaRequestCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult({
+          captchaId: `captcha-${captchaRequestCount}`,
+          image: TEST_CAPTCHA_IMAGE,
+          ttlSeconds: 300,
+        })),
+      })
+    })
+    await page.route(EMAIL_CODE_API, async (route) => {
+      emailCodePayload = route.request().postDataJSON() as Record<string, unknown>
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult(300)),
+      })
+    })
+    await page.route(REGISTER_API, async (route) => {
+      registrationPayload = route.request().postDataJSON() as Record<string, unknown>
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult(null)),
+      })
+    })
+    await openRegisterSecurityStep(page, {
+      selfServiceEnabled: true,
+      captchaRequired: true,
+      emailRequired: true,
+      emailVerificationRequired: true,
+      emailCodeCooldownSeconds: 37,
+    })
+
+    await expect(page.getByRole('button', { name: '刷新图形验证码' })).toBeVisible()
+    await page.locator('#register-captcha').fill('AB12')
+    await page.getByRole('button', { name: '发送验证码' }).click()
+
+    await expect(page.getByRole('button', { name: /^(37|36) 秒后重发$/ })).toBeDisabled()
+    await expect(page.locator('#register-email-code')).toBeEnabled()
+    await expect(page.locator('#register-password')).toBeEnabled()
+    await expect(page.getByRole('button', { name: '提交注册' })).toBeEnabled()
+    await expect(page.getByRole('button', { name: '获取验证码' })).toBeVisible()
+    await page.locator('#register-email-code').fill('123456')
+    await page.locator('#register-password').fill('Password123')
+    await page.locator('#register-confirm-password').fill('Password123')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByRole('heading', { name: '注册成功，richard.ui' })).toBeVisible()
+    expect(emailCodePayload).toEqual({
+      email: 'richard@example.com',
+      captchaId: 'captcha-1',
+      captcha: 'AB12',
+    })
+    expect(registrationPayload).toEqual({
+      username: 'richard.ui',
+      nickname: 'Richard',
+      email: 'richard@example.com',
+      password: 'Password123',
+      confirmPassword: 'Password123',
+      emailCode: '123456',
+    })
+    expect(registrationPayload).not.toHaveProperty('captcha')
+    expect(registrationPayload).not.toHaveProperty('captchaId')
+    expect(captchaRequestCount).toBe(1)
+
+    await page.getByRole('button', { name: '返回登录' }).click()
+    await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
+    await expect(page.locator('#login-username')).toHaveValue('richard.ui')
+    await expect(page.locator('#login-password')).toHaveValue('')
+    await expect(page.getByRole('checkbox', { name: '保持登录' })).not.toBeChecked()
+  })
+
+  test('发码失败清空已消费挑战，邮箱变化撤销旧邮箱的验证码状态', async ({ page }) => {
+    let captchaRequestCount = 0
+    const emailCodePayloads: Record<string, unknown>[] = []
+
+    await page.route(CAPTCHA_API, async (route) => {
+      captchaRequestCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult({
+          captchaId: `captcha-${captchaRequestCount}`,
+          image: TEST_CAPTCHA_IMAGE,
+          ttlSeconds: 300,
+        })),
+      })
+    })
+    await page.route(EMAIL_CODE_API, async (route) => {
+      emailCodePayloads.push(route.request().postDataJSON() as Record<string, unknown>)
+      const response = emailCodePayloads.length === 1
+        ? { code: TEST_BUSINESS_REJECTION_CODE, message: 'E2E 发码失败', data: null }
+        : successResult(300)
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      })
+    })
+    await openRegisterSecurityStep(page, {
+      selfServiceEnabled: true,
+      captchaRequired: true,
+      emailRequired: true,
+      emailVerificationRequired: true,
+      emailCodeCooldownSeconds: 37,
+    })
+
+    await expect(page.getByRole('button', { name: '刷新图形验证码' })).toBeVisible()
+    await page.locator('#register-captcha').fill('AB12')
+    await page.getByRole('button', { name: '发送验证码' }).click()
+
+    await expect(page.getByText('E2E 发码失败', { exact: true })).toBeVisible()
+    await expect(page.locator('#register-captcha')).toHaveValue('')
+    await expect(page.locator('#register-email-code')).toHaveValue('')
+    await expect(page.getByRole('button', { name: '获取验证码' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '发送验证码' })).toBeEnabled()
+
+    await page.getByRole('button', { name: '获取验证码' }).click()
+    await expect(page.getByRole('button', { name: '刷新图形验证码' })).toBeVisible()
+    await page.locator('#register-captcha').fill('CD34')
+    await page.getByRole('button', { name: '发送验证码' }).click()
+    await expect(page.getByRole('button', { name: /^(37|36) 秒后重发$/ })).toBeDisabled()
+    await page.locator('#register-email-code').fill('123456')
+
+    await page.getByRole('button', { name: '上一步' }).click()
+    await page.locator('#register-email').fill('changed@example.com')
+    await page.getByRole('button', { name: '下一步' }).click()
+
+    await expect(page.locator('#register-email-code')).toHaveValue('')
+    await expect(page.getByRole('button', { name: '发送验证码' })).toBeEnabled()
+    await expect(page.getByRole('button', { name: '获取验证码' })).toBeVisible()
+    expect(emailCodePayloads).toEqual([
+      {
+        email: 'richard@example.com',
+        captchaId: 'captcha-1',
+        captcha: 'AB12',
+      },
+      {
+        email: 'richard@example.com',
+        captchaId: 'captcha-2',
+        captcha: 'CD34',
+      },
+    ])
+  })
+})
+
+test.describe('注册失败恢复', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('邮箱验证码注册业务失败后清空一次性凭据，并可重新发码成功重试', async ({ page }) => {
+    let captchaRequestCount = 0
+    let emailCodeRequestCount = 0
+    const registrationPayloads: Record<string, unknown>[] = []
+
+    await page.route(CAPTCHA_API, async (route) => {
+      captchaRequestCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult({
+          captchaId: `captcha-${captchaRequestCount}`,
+          image: TEST_CAPTCHA_IMAGE,
+          ttlSeconds: 300,
+        })),
+      })
+    })
+    await page.route(EMAIL_CODE_API, async (route) => {
+      emailCodeRequestCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult(300)),
+      })
+    })
+    await page.route(REGISTER_API, async (route) => {
+      registrationPayloads.push(route.request().postDataJSON() as Record<string, unknown>)
+      const response = registrationPayloads.length === 1
+        ? { code: RESOURCE_DUPLICATE_CODE, message: 'E2E 用户名已存在', data: null }
+        : successResult(null)
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      })
+    })
+    await openRegisterSecurityStep(page, {
+      selfServiceEnabled: true,
+      captchaRequired: true,
+      emailRequired: true,
+      emailVerificationRequired: true,
+      emailCodeCooldownSeconds: 2,
+    })
+
+    await page.locator('#register-captcha').fill('OLD1')
+    await page.getByRole('button', { name: '发送验证码' }).click()
+    await expect(page.getByRole('button', { name: /^(2|1) 秒后重发$/ })).toBeDisabled()
+    await page.locator('#register-email-code').fill('111111')
+    await page.locator('#register-password').fill('Password123')
+    await page.locator('#register-confirm-password').fill('Password123')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByText('E2E 用户名已存在', { exact: true })).toBeVisible()
+    await expect(page.locator('#register-email-code')).toHaveValue('')
+    await expect(page.getByRole('button', { name: /^(2|1) 秒后重发$/ })).toBeDisabled()
+    await expect(page.getByRole('button', { name: '获取验证码' })).toBeVisible()
+    expect(registrationPayloads).toHaveLength(1)
+    expect(registrationPayloads[0]).toMatchObject({ emailCode: '111111' })
+
+    await page.getByRole('button', { name: '获取验证码' }).click()
+    await expect(page.getByRole('button', { name: '刷新图形验证码' })).toBeVisible()
+    await page.locator('#register-captcha').fill('NEW2')
+    await expect(page.getByRole('button', { name: '发送验证码' })).toBeEnabled({ timeout: 3_500 })
+    await page.getByRole('button', { name: '发送验证码' }).click()
+    await expect(page.getByRole('button', { name: /^(2|1) 秒后重发$/ })).toBeDisabled()
+    await page.locator('#register-email-code').fill('222222')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByRole('heading', { name: '注册成功，richard.ui' })).toBeVisible()
+    expect(registrationPayloads).toHaveLength(2)
+    expect(registrationPayloads[1]).toMatchObject({ emailCode: '222222' })
+    expect(registrationPayloads[1]).not.toHaveProperty('captcha')
+    expect(registrationPayloads[1]).not.toHaveProperty('captchaId')
+    expect(captchaRequestCount).toBe(2)
+    expect(emailCodeRequestCount).toBe(2)
+  })
+
+  test('邮箱验证码普通输错后保留凭据状态，可直接改正并重试', async ({ page }) => {
+    const harness = await prepareEmailCodeOnlyRegistration(page, (attempt) => (
+      attempt === 1
+        ? { code: EMAIL_CODE_INVALID_CODE, message: '邮箱验证码错误', data: null }
+        : successResult(null)
+    ))
+
+    await page.locator('#register-email-code').fill('000000')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByText('邮箱验证码错误', { exact: true })).toBeVisible()
+    await expect(page.locator('#register-email-code')).toHaveValue('000000')
+    await page.locator('#register-email-code').fill('123456')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByRole('heading', { name: '注册成功，richard.ui' })).toBeVisible()
+    expect(harness.emailCodeRequestCount).toBe(1)
+    expect(harness.registrationPayloads.map((payload) => payload.emailCode)).toEqual(['000000', '123456'])
+  })
+
+  test('邮箱验证码失效错误码清空一次性凭据，并保留服务端冷却', async ({ page }) => {
+    const harness = await prepareEmailCodeOnlyRegistration(page, () => ({
+      code: EMAIL_CODE_REISSUE_REQUIRED_CODE,
+      message: '邮箱验证码已失效，请重新获取',
+      data: null,
+    }))
+
+    await page.locator('#register-email-code').fill('123456')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByText('邮箱验证码已失效，请重新获取', { exact: true })).toBeVisible()
+    await expect(page.locator('#register-email-code')).toHaveValue('')
+    await expect(page.getByRole('button', { name: /^(60|59) 秒后重发$/ })).toBeDisabled()
+    expect(harness.emailCodeRequestCount).toBe(1)
+    expect(harness.registrationPayloads).toHaveLength(1)
+  })
+
+  test('服务端弱口令拒绝发生在邮箱码核验前，可修改密码并复用原验证码', async ({ page }) => {
+    const harness = await prepareEmailCodeOnlyRegistration(page, (attempt) => (
+      attempt === 1
+        ? { code: PASSWORD_TOO_WEAK_CODE, message: 'E2E 弱口令黑名单', data: null }
+        : successResult(null)
+    ))
+
+    await page.locator('#register-email-code').fill('123456')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByText('E2E 弱口令黑名单', { exact: true })).toBeVisible()
+    await expect(page.locator('#register-email-code')).toHaveValue('123456')
+    await page.locator('#register-password').fill('SaferPassword456')
+    await page.locator('#register-confirm-password').fill('SaferPassword456')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByRole('heading', { name: '注册成功，richard.ui' })).toBeVisible()
+    expect(harness.emailCodeRequestCount).toBe(1)
+    expect(harness.registrationPayloads).toHaveLength(2)
+    expect(harness.registrationPayloads[1]).toMatchObject({
+      password: 'SaferPassword456',
+      confirmPassword: 'SaferPassword456',
+      emailCode: '123456',
+    })
+  })
+
+  test('纯图形码注册业务失败后清空挑战，并仅允许新挑战参与重试', async ({ page }) => {
+    let captchaRequestCount = 0
+    const registrationPayloads: Record<string, unknown>[] = []
+
+    await page.route(CAPTCHA_API, async (route) => {
+      captchaRequestCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult({
+          captchaId: `captcha-${captchaRequestCount}`,
+          image: TEST_CAPTCHA_IMAGE,
+          ttlSeconds: 300,
+        })),
+      })
+    })
+    await page.route(REGISTER_API, async (route) => {
+      registrationPayloads.push(route.request().postDataJSON() as Record<string, unknown>)
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: TEST_BUSINESS_REJECTION_CODE,
+          message: 'E2E 注册业务失败',
+          data: null,
+        }),
+      })
+    })
+    await openRegisterSecurityStep(page, {
+      selfServiceEnabled: true,
+      captchaRequired: true,
+      emailRequired: false,
+      emailVerificationRequired: false,
+      emailCodeCooldownSeconds: 60,
+    })
+
+    await expect(page.getByRole('button', { name: '刷新图形验证码' })).toBeVisible()
+    await page.locator('#register-captcha').fill('OLD1')
+    await page.locator('#register-password').fill('Password123')
+    await page.locator('#register-confirm-password').fill('Password123')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect(page.getByText('E2E 注册业务失败', { exact: true })).toBeVisible()
+    await expect(page.locator('#register-captcha')).toHaveValue('')
+    await expect(page.getByRole('button', { name: '获取验证码' })).toBeVisible()
+    expect(registrationPayloads).toHaveLength(1)
+    expect(registrationPayloads[0]).toMatchObject({
+      captchaId: 'captcha-1',
+      captcha: 'OLD1',
+    })
+
+    await page.getByRole('button', { name: '获取验证码' }).click()
+    await expect(page.getByRole('button', { name: '刷新图形验证码' })).toBeVisible()
+    await page.locator('#register-captcha').fill('NEW2')
+    await page.getByRole('button', { name: '提交注册' }).click()
+
+    await expect.poll(() => registrationPayloads.length).toBe(2)
+    expect(registrationPayloads[1]).toMatchObject({
+      captchaId: 'captcha-2',
+      captcha: 'NEW2',
+    })
+    expect(registrationPayloads[1]).not.toHaveProperty('emailCode')
+    expect(captchaRequestCount).toBe(2)
+  })
+})
+
+test.describe('注册入口能力', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('注册选项业务失败时 fail-closed，仍保留本地登录能力', async ({ page }) => {
+    await page.route(LOGIN_IMAGES_API, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(successResult([])),
+      })
+    })
+    await page.route(REGISTER_OPTIONS_API, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: TEST_BUSINESS_REJECTION_CODE,
+          message: 'E2E 注册能力不可用',
+          data: null,
+        }),
+      })
+    })
+
+    await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' })
+
+    await expect(page.getByText('E2E 注册能力不可用', { exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: '创建账号' })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '进入运营台' })).toBeEnabled()
+  })
+})
+
+test.describe('移动端整页滚动', () => {
+  test.use({ viewport: { width: 390, height: 720 } })
+
+  test('模式与注册步骤切换回顶，且不产生嵌套或横向滚动', async ({ page }) => {
+    await openLogin(page)
+
+    const authSurface = page.locator('[data-login-scroll]')
+    expect(await authSurface.evaluate((element) => getComputedStyle(element).overflowY)).toBe('visible')
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390)
+
+    const initialBottom = await scrollDocumentToBottom(page)
+    expect(initialBottom).toBeGreaterThan(0)
+    await page.locator('#login-mode-sso').evaluate((element: HTMLButtonElement) => element.click())
+    await expect(page.getByRole('heading', { name: 'OA 账号登录' })).toBeVisible()
+    await expectDocumentAtTop(page)
+
+    await page.locator('#login-mode-local').evaluate((element: HTMLButtonElement) => element.click())
+    await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
+    await page.getByRole('button', { name: '创建账号' }).click()
+    await expect(page.getByRole('heading', { name: '加入智能体运营台' })).toBeVisible()
+    await expectDocumentAtTop(page)
+
+    await fillRegisterAccountStep(page)
+
+    const accountStepBottom = await scrollDocumentToBottom(page)
+    expect(accountStepBottom).toBeGreaterThan(0)
+    await page.getByRole('button', { name: '下一步' }).evaluate((element: HTMLButtonElement) => element.click())
+    await expect(page.locator('#register-password')).toBeVisible()
+    await expectDocumentAtTop(page)
+
+    const securityStepBottom = await scrollDocumentToBottom(page)
+    expect(securityStepBottom).toBeGreaterThan(0)
+    await page.getByRole('button', { name: '上一步' }).evaluate((element: HTMLButtonElement) => element.click())
+    await expect(page.locator('#register-username')).toBeVisible()
+    await expectDocumentAtTop(page)
+
+    expect(await authSurface.evaluate((element) => element.scrollTop)).toBe(0)
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390)
+  })
+})

--- a/customer-admin-web/tests/e2e/loginTestEnvironment.ts
+++ b/customer-admin-web/tests/e2e/loginTestEnvironment.ts
@@ -1,0 +1,2 @@
+export const LOGIN_E2E_PORT = 4174
+export const LOGIN_E2E_ORIGIN = `http://127.0.0.1:${LOGIN_E2E_PORT}`


### PR DESCRIPTION
## Summary

- replace the oversized nested-scroll login modal with a responsive split authentication surface that keeps the primary actions visible at the original 916 x 664 viewport and uses document scrolling on mobile
- separate local and OA identity modes, add an accessible two-step self-registration flow, and preserve complete login state including remember-me, redirects, account approval, and forced-password-change routing
- align captcha and email-code lifecycle with the backend: expose the configured resend cooldown, distinguish retryable failures from `EMAIL_CODE_REISSUE_REQUIRED`, preserve active cooldowns, and fail closed when registration capabilities cannot be confirmed
- add reusable brand/theme surfaces plus Vitest and Chrome Playwright coverage, and collect browser diagnostics on CI failures

## Verification

- customer-admin-web: `npm test` — 10 Vitest files / 104 unit tests and 13 Playwright scenarios passed on latest `main`
- customer-admin-web: `CI=1 npm run test:e2e` — 13 passed
- customer-admin-web: `npm run build` — passed
- customer-admin-web: `npm audit --registry=https://registry.npmjs.org --audit-level=high` — 0 vulnerabilities
- customer-admin-server focused email-code/register-options contract tests — 45 tests passed
- Maven full gate: 3477 tests, 0 failures, 0 errors, 6 skipped — `BUILD SUCCESS`
- browser acceptance: desktop, 916 x 664 compact viewport, mobile document scrolling, dark mode, local/OA switching, login success, forced password change, full registration, and failure recovery verified
