### PR TITLE
fix(vibecoding): preserve tenant context in Git Assistant

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/entity/AiCodingAuditLog.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/entity/AiCodingAuditLog.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -61,4 +62,12 @@ public class AiCodingAuditLog {
     /** 操作开始时间戳（毫秒），仅用于进程内计算耗时，不落库。 */
     @TableField(exist = false)
     private transient long startMillis;
+
+    /**
+     * 审计开始时的租户快照，仅用于跨异步线程恢复上下文，不直接映射 tenant_id 列。
+     * tenant_id 仍由全局租户拦截器统一写入，避免出现第二套隔离规则。
+     */
+    @TableField(exist = false)
+    @JsonIgnore
+    private transient String tenantContextId;
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorder.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorder.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.workspace.audit.service;
 
 import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
 import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
@@ -30,10 +31,12 @@ public class AiCodingAuditRecorder {
     @Async
     public void persist(AiCodingAuditLog entry) {
         try {
-            if (entry.getCreateTime() == null) {
-                entry.setCreateTime(LocalDateTime.now());
-            }
-            auditLogMapper.insert(entry);
+            TenantContext.runWith(entry.getTenantContextId(), () -> {
+                if (entry.getCreateTime() == null) {
+                    entry.setCreateTime(LocalDateTime.now());
+                }
+                auditLogMapper.insert(entry);
+            });
         } catch (Exception e) {
             log.error("persist ai coding audit log failed, code={}, operation={}, agentCode={}, sessionId={}",
                 "AI-CODING-AUDIT-PERSIST-FAIL", entry.getOperation(), entry.getAgentCode(), entry.getSessionId(), e);

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditService.java
@@ -12,6 +12,7 @@ import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
 import com.richard.fyoung.customeradmin.workspace.audit.dto.AiCodingAuditQuery;
 import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
 import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.model.ChatUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +61,8 @@ public class AiCodingAuditService {
         entry.setAgentCode(agentCode);
         entry.setSessionId(sessionId);
         entry.setStartMillis(System.currentTimeMillis());
+        // finish/Recorder 都可能运行在异步线程；租户必须在请求同步段与操作人一起捕获
+        entry.setTenantContextId(TenantContext.get());
         try {
             if (StpUtil.isLogin()) {
                 entry.setUserId(StpUtil.getLoginIdAsLong());
@@ -76,7 +79,13 @@ public class AiCodingAuditService {
         entry.setDurationMs(System.currentTimeMillis() - entry.getStartMillis());
         entry.setResult(errorCode == null ? AiCodingAuditLog.RESULT_SUCCESS : AiCodingAuditLog.RESULT_FAILURE);
         entry.setErrorCode(errorCode);
-        recorder.persist(entry);
+        try {
+            recorder.persist(entry);
+        } catch (Exception e) {
+            // @Async 代理提交任务时也可能同步失败；审计是旁路，不能覆盖 Git 助手的业务结果
+            log.error("submit ai coding audit persist task failed, code={}, operation={}, agentCode={}, sessionId={}",
+                "AI-CODING-AUDIT-SUBMIT-FAIL", entry.getOperation(), entry.getAgentCode(), entry.getSessionId(), e);
+        }
     }
 
     /** 结束一次审计（异常形式）：{@code error} 为空视为成功，否则沿 cause 链解析错误码。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantService.java
@@ -24,6 +24,11 @@ import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewResult;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewTaskVO;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.entity.CodeReviewTask;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.mapper.CodeReviewTaskMapper;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentity;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentityContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -50,6 +55,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -138,7 +144,8 @@ public class GitAssistantService {
         Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         // 审计条目在请求线程同步段创建（操作人依赖 Sa-Token ThreadLocal），异步链路里只补结果
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.GIT_DIFF_SUMMARY, agentCode, sessionId);
-        return CompletableFuture.supplyAsync(() -> {
+        GitAssistantExecutionContext executionContext = captureExecutionContext(agentCode, sessionId);
+        return supplyAsyncWithContext(executionContext, () -> {
             String diff = gitWorkspaceService.diffAgainstBaseline(workspace);
             List<String> changedFiles = gitWorkspaceService.changedFilesAgainstBaseline(workspace);
             if (changedFiles.isEmpty()) {
@@ -150,7 +157,7 @@ public class GitAssistantService {
                     + truncateDiff(diff));
             auditService.applyUsage(audit, outcome.usage());
             return new GitDiffSummary(outcome.text(), changedFiles);
-        }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .exceptionally(ex -> rethrow(ex, ResultCode.GIT_ASSISTANT_AI_FAILED, "GIT_DIFF_SUMMARY_FAIL", agentCode, sessionId))
             .whenComplete((result, error) -> auditService.finish(audit, error));
     }
@@ -160,7 +167,8 @@ public class GitAssistantService {
         requireVibeCodingCapable(agentCode);
         Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.COMMIT_MESSAGE, agentCode, sessionId);
-        return CompletableFuture.supplyAsync(() -> {
+        GitAssistantExecutionContext executionContext = captureExecutionContext(agentCode, sessionId);
+        return supplyAsyncWithContext(executionContext, () -> {
             String diff = requireNonEmptyDiff(workspace);
             Model model = agentInstanceFactory.buildModelForAgent(agentCode);
             String prompt = "conventional".equals(style)
@@ -172,7 +180,7 @@ public class GitAssistantService {
             ModelCallOutcome outcome = callModelOnce(model, prompt);
             auditService.applyUsage(audit, outcome.usage());
             return new CommitMessageResponse(outcome.text());
-        }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .exceptionally(ex -> rethrow(ex, ResultCode.GIT_ASSISTANT_AI_FAILED, "GIT_COMMIT_MESSAGE_FAIL", agentCode, sessionId))
             .whenComplete((result, error) -> auditService.finish(audit, error));
     }
@@ -182,7 +190,8 @@ public class GitAssistantService {
         requireVibeCodingCapable(agentCode);
         Path workspace = workspaceManager.resolveSessionWorkspace(agentCode, sessionId);
         AiCodingAuditLog audit = auditService.begin(AiCodingOperation.PR_DESCRIPTION, agentCode, sessionId);
-        return CompletableFuture.supplyAsync(() -> {
+        GitAssistantExecutionContext executionContext = captureExecutionContext(agentCode, sessionId);
+        return supplyAsyncWithContext(executionContext, () -> {
             String diff = requireNonEmptyDiff(workspace);
             List<String> changedFiles = gitWorkspaceService.changedFilesAgainstBaseline(workspace);
             Model model = agentInstanceFactory.buildModelForAgent(agentCode);
@@ -193,7 +202,7 @@ public class GitAssistantService {
             ModelCallOutcome outcome = callModelOnce(model, prompt);
             auditService.applyUsage(audit, outcome.usage());
             return new PrDescriptionResponse(outcome.text());
-        }, GIT_ASSISTANT_EXECUTOR).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }).orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .exceptionally(ex -> rethrow(ex, ResultCode.GIT_ASSISTANT_AI_FAILED, "GIT_PR_DESCRIPTION_FAIL", agentCode, sessionId))
             .whenComplete((result, error) -> auditService.finish(audit, error));
     }
@@ -227,16 +236,17 @@ public class GitAssistantService {
         Long taskId = task.getId();
         log.info("code review task submitted, taskId={}, agentCode={}, sessionId={}", taskId, agentCode, sessionId);
 
-        CompletableFuture.supplyAsync(() -> doReview(agentCode, diff, audit), GIT_ASSISTANT_EXECUTOR)
+        GitAssistantExecutionContext executionContext = captureExecutionContext(agentCode, sessionId);
+        supplyAsyncWithContext(executionContext, () -> doReview(agentCode, diff, audit))
             .orTimeout(AI_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .whenComplete((result, error) -> {
+            .whenComplete((result, error) -> executionContext.runWith(() -> {
                 auditService.finish(audit, error);
                 if (error == null) {
                     completeReviewTask(taskId, agentCode, userId, result);
                 } else {
                     failReviewTask(taskId, agentCode, userId, error);
                 }
-            });
+            }));
         return taskId;
     }
 
@@ -264,6 +274,39 @@ public class GitAssistantService {
     }
 
     // ---------------------- private helpers ----------------------
+
+    /**
+     * 请求进入异步边界前捕获三类调用上下文：租户决定数据隔离，配额主体决定 token 归属，
+     * 调用身份决定 Agent 授权与审计。三者必须作为同一份不可变快照传播，不能在工作线程重新推断。
+     */
+    private GitAssistantExecutionContext captureExecutionContext(String agentCode, String sessionId) {
+        AgentInvocationIdentity identity = AgentInvocationIdentityContext.get();
+        if (identity != null) {
+            identity = identity.forInvocation(identity.channelCode(), sessionId, agentCode);
+        }
+        return new GitAssistantExecutionContext(TenantContext.require(), QuotaSubjectContext.get(), identity);
+    }
+
+    private <T> CompletableFuture<T> supplyAsyncWithContext(
+            GitAssistantExecutionContext executionContext, Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(() -> executionContext.callWith(supplier), GIT_ASSISTANT_EXECUTOR);
+    }
+
+    private record GitAssistantExecutionContext(String tenantId, QuotaSubject quotaSubject,
+                                                AgentInvocationIdentity invocationIdentity) {
+
+        private <T> T callWith(Supplier<T> action) {
+            return TenantContext.callWith(tenantId, () -> QuotaSubjectContext.callWith(quotaSubject,
+                () -> AgentInvocationIdentityContext.callWith(invocationIdentity, action)));
+        }
+
+        private void runWith(Runnable action) {
+            callWith(() -> {
+                action.run();
+                return null;
+            });
+        }
+    }
 
     /**
      * 审查计算主体（在异步线程执行）：diff 已在同步段校验非空。模型输出 JSON 解析失败时降级（§4.2.3）

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorderTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditRecorderTest.java
@@ -2,12 +2,25 @@ package com.richard.fyoung.customeradmin.workspace.audit.service;
 
 import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
 import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -29,6 +42,11 @@ class AiCodingAuditRecorderTest {
         recorder = new AiCodingAuditRecorder(mapper);
     }
 
+    @AfterEach
+    void clearTenantContext() {
+        TenantContext.clear();
+    }
+
     @Test
     void persist_shouldInsert_andBackfillCreateTime() {
         AiCodingAuditLog entry = new AiCodingAuditLog();
@@ -40,9 +58,84 @@ class AiCodingAuditRecorderTest {
     }
 
     @Test
+    void persist_shouldRestoreCapturedTenantAroundMapperInsert() {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        entry.setTenantContextId("tenant-a");
+        AtomicReference<String> insertTenant = new AtomicReference<>();
+        when(mapper.insert(entry)).thenAnswer(invocation -> {
+            insertTenant.set(TenantContext.get());
+            return 1;
+        });
+
+        TenantContext.runWith("worker-previous", () -> {
+            recorder.persist(entry);
+            assertEquals("worker-previous", TenantContext.get(),
+                "异步线程原有上下文必须在落库后恢复");
+        });
+
+        assertEquals("tenant-a", insertTenant.get(),
+            "Mapper insert 必须运行在审计开始时捕获的租户下");
+    }
+
+    @Test
+    void persist_shouldRestoreCapturedTenantThroughSpringAsyncProxy() throws Exception {
+        try (AnnotationConfigApplicationContext context =
+                 new AnnotationConfigApplicationContext(AsyncTestConfig.class)) {
+            AiCodingAuditLogMapper asyncMapper = context.getBean(AiCodingAuditLogMapper.class);
+            AtomicReference<String> insertTenant = new AtomicReference<>();
+            CountDownLatch inserted = new CountDownLatch(1);
+            when(asyncMapper.insert(any(AiCodingAuditLog.class))).thenAnswer(invocation -> {
+                insertTenant.set(TenantContext.get());
+                inserted.countDown();
+                return 1;
+            });
+            AiCodingAuditLog entry = new AiCodingAuditLog();
+            entry.setTenantContextId("tenant-a");
+            TenantContext.set("caller-tenant");
+
+            context.getBean(AiCodingAuditRecorder.class).persist(entry);
+            TenantContext.clear();
+
+            assertTrue(inserted.await(2, TimeUnit.SECONDS), "@Async 审计应在超时前完成落库");
+            assertEquals("tenant-a", insertTenant.get(), "@Async 代理后的真实工作线程必须恢复租户快照");
+        }
+    }
+
+    @Test
     void persist_shouldSwallowPersistenceFailure() {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        entry.setTenantContextId("tenant-a");
         when(mapper.insert(any(AiCodingAuditLog.class))).thenThrow(new RuntimeException("db down"));
 
-        assertDoesNotThrow(() -> recorder.persist(new AiCodingAuditLog()));
+        TenantContext.runWith("worker-previous", () -> {
+            assertDoesNotThrow(() -> recorder.persist(entry));
+            assertEquals("worker-previous", TenantContext.get(),
+                "Mapper 异常也不能污染异步线程后续任务的租户上下文");
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableAsync
+    static class AsyncTestConfig {
+
+        @Bean
+        AiCodingAuditLogMapper auditLogMapper() {
+            return mock(AiCodingAuditLogMapper.class);
+        }
+
+        @Bean
+        AiCodingAuditRecorder auditRecorder(AiCodingAuditLogMapper auditLogMapper) {
+            return new AiCodingAuditRecorder(auditLogMapper);
+        }
+
+        @Bean
+        ThreadPoolTaskExecutor taskExecutor() {
+            ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+            executor.setCorePoolSize(1);
+            executor.setMaxPoolSize(1);
+            executor.setQueueCapacity(8);
+            executor.setThreadNamePrefix("audit-test-");
+            return executor;
+        }
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/audit/service/AiCodingAuditServiceTest.java
@@ -2,6 +2,7 @@ package com.richard.fyoung.customeradmin.workspace.audit.service;
 
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.page.PageResult;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
@@ -9,9 +10,11 @@ import com.richard.fyoung.customeradmin.workspace.audit.AiCodingOperation;
 import com.richard.fyoung.customeradmin.workspace.audit.dto.AiCodingAuditQuery;
 import com.richard.fyoung.customeradmin.workspace.audit.entity.AiCodingAuditLog;
 import com.richard.fyoung.customeradmin.workspace.audit.mapper.AiCodingAuditLogMapper;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.model.ChatUsage;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,10 +24,13 @@ import java.util.List;
 import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +57,11 @@ class AiCodingAuditServiceTest {
         service = new AiCodingAuditService(recorder, mapper);
     }
 
+    @AfterEach
+    void clearTenantContext() {
+        TenantContext.clear();
+    }
+
     // ===== begin：条目构建 =====
 
     @Test
@@ -64,6 +75,38 @@ class AiCodingAuditServiceTest {
         assertTrue(entry.getStartMillis() > 0);
         assertNull(entry.getUserId());
         assertNull(entry.getUsername());
+    }
+
+    @Test
+    void begin_shouldCaptureTenantForDeferredPersistence() {
+        TenantContext.set("tenant-a");
+
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.GIT_DIFF_SUMMARY, "coder", "s1");
+        TenantContext.clear();
+        service.finish(entry, (String) null);
+
+        ArgumentCaptor<AiCodingAuditLog> captor = ArgumentCaptor.forClass(AiCodingAuditLog.class);
+        verify(recorder).persist(captor.capture());
+        assertEquals("tenant-a", captor.getValue().getTenantContextId(),
+            "审计结束时请求线程可能已释放，必须使用 begin 时的租户快照");
+    }
+
+    @Test
+    void tenantContextSnapshot_shouldNotMapToDatabaseColumn() {
+        assertTrue(TableInfoHelper.getTableInfo(AiCodingAuditLog.class).getFieldList().stream()
+            .noneMatch(field -> "tenantContextId".equals(field.getProperty())),
+            "租户快照只用于进程内传播，不能生成额外 SQL 列");
+    }
+
+    @Test
+    void tenantContextSnapshot_shouldNotSerializeToAuditApiResponse() throws Exception {
+        AiCodingAuditLog entry = new AiCodingAuditLog();
+        entry.setTenantContextId("tenant-a");
+
+        String json = new ObjectMapper().writeValueAsString(entry);
+
+        assertFalse(json.contains("tenantContextId"),
+            "租户快照是内部传播字段，不能改变审计分页 API 契约");
     }
 
     // ===== finish：结果补全与落库 =====
@@ -89,6 +132,15 @@ class AiCodingAuditServiceTest {
         verify(recorder).persist(captor.capture());
         assertEquals(AiCodingAuditLog.RESULT_FAILURE, captor.getValue().getResult());
         assertEquals("VIBECODING_STREAM_CANCEL", captor.getValue().getErrorCode());
+    }
+
+    @Test
+    void finish_shouldNotPropagateAsyncTaskSubmissionFailure() {
+        AiCodingAuditLog entry = service.begin(AiCodingOperation.GIT_DIFF_SUMMARY, "coder", "s1");
+        doThrow(new IllegalStateException("executor rejected")).when(recorder).persist(entry);
+
+        assertDoesNotThrow(() -> service.finish(entry, (String) null),
+            "审计线程池拒绝任务不能覆盖 Git 助手的业务结果");
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/vibecoding/service/GitAssistantServiceTest.java
@@ -17,11 +17,17 @@ import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewResult;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.dto.ReviewTaskVO;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.entity.CodeReviewTask;
 import com.richard.fyoung.customeradmin.workspace.vibecoding.mapper.CodeReviewTaskMapper;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentity;
+import com.richard.fyoung.customerwork.safety.security.AgentInvocationIdentityContext;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubject;
+import com.richard.fyoung.customerwork.safety.subjectquota.QuotaSubjectContext;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,10 +37,13 @@ import reactor.core.publisher.Flux;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,6 +85,7 @@ class GitAssistantServiceTest {
 
     @BeforeEach
     void setUp() {
+        TenantContext.set("tenant-test");
         agentMapper = mock(AiAgentMapper.class);
         agentInstanceFactory = mock(AdminAgentInstanceFactory.class);
         workspaceManager = mock(AgentWorkspaceManager.class);
@@ -89,6 +99,13 @@ class GitAssistantServiceTest {
 
         when(workspaceManager.resolveSessionWorkspace(anyString(), anyString())).thenReturn(sessionWorkspace);
         when(agentInstanceFactory.buildModelForAgent(anyString())).thenReturn(model);
+    }
+
+    @AfterEach
+    void clearRequestContexts() {
+        TenantContext.clear();
+        QuotaSubjectContext.clear();
+        AgentInvocationIdentityContext.clear();
     }
 
     /** mock 的 insert 不会回填自增 id，异步链路要用 taskId 回写，故 stub 成插入即赋 id。 */
@@ -155,6 +172,47 @@ class GitAssistantServiceTest {
 
         assertEquals("新增了 Foo 类。", summary.summary());
         assertEquals(List.of("Foo.java"), summary.changedFiles());
+    }
+
+    @Test
+    void diffSummary_shouldPropagateRequestContextsToAsyncModelBuild() {
+        when(agentMapper.selectOne(any())).thenReturn(vibeCodingAgent());
+        when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
+            .thenReturn("diff --git a/Foo.java b/Foo.java\n+class Foo {}");
+        when(gitWorkspaceService.changedFilesAgainstBaseline(sessionWorkspace)).thenReturn(List.of("Foo.java"));
+        mockModelReply("新增了 Foo 类。");
+
+        QuotaSubject quotaSubject = QuotaSubject.adminUser("7");
+        AgentInvocationIdentity identity = new AgentInvocationIdentity(
+            "tenant-a", quotaSubject.type(), quotaSubject.id(), true)
+            .withChannel(AgentInvocationIdentity.CHANNEL_ADMIN);
+        TenantContext.set("tenant-a");
+        QuotaSubjectContext.set(quotaSubject);
+        AgentInvocationIdentityContext.set(identity);
+        AtomicReference<String> workerTenant = new AtomicReference<>();
+        AtomicReference<QuotaSubject> workerQuotaSubject = new AtomicReference<>();
+        AtomicReference<AgentInvocationIdentity> workerIdentity = new AtomicReference<>();
+        when(agentInstanceFactory.buildModelForAgent("coder")).thenAnswer(invocation -> {
+            workerTenant.set(TenantContext.get());
+            workerQuotaSubject.set(QuotaSubjectContext.get());
+            workerIdentity.set(AgentInvocationIdentityContext.get());
+            return model;
+        });
+
+        CompletableFuture<GitDiffSummary> future = service.diffSummary("coder", "s1");
+        TenantContext.clear();
+        QuotaSubjectContext.clear();
+        AgentInvocationIdentityContext.clear();
+        future.join();
+
+        assertEquals("tenant-a", workerTenant.get());
+        assertSame(quotaSubject, workerQuotaSubject.get());
+        assertEquals("tenant-a", workerIdentity.get().tenantId());
+        assertEquals(quotaSubject.type(), workerIdentity.get().subjectType());
+        assertEquals(quotaSubject.id(), workerIdentity.get().subjectId());
+        assertEquals(AgentInvocationIdentity.CHANNEL_ADMIN, workerIdentity.get().channelCode());
+        assertEquals("s1", workerIdentity.get().sessionId());
+        assertEquals("coder", workerIdentity.get().agentCode());
     }
 
     // ===== commit message =====
@@ -250,6 +308,11 @@ class GitAssistantServiceTest {
         when(gitWorkspaceService.diffAgainstBaseline(sessionWorkspace))
             .thenReturn("diff --git a/Foo.java b/Foo.java\n+String sql = \"select * where id=\"+id;");
         stubReviewTaskInsertAssignsId(99L);
+        AtomicReference<String> updateTenant = new AtomicReference<>();
+        when(reviewTaskMapper.updateById(any(CodeReviewTask.class))).thenAnswer(invocation -> {
+            updateTenant.set(TenantContext.get());
+            return 1;
+        });
         // 模型在 JSON 外还夹了 Markdown 代码块标记，解析器应能剥离
         mockModelReply("```json\n{\"issues\":[{\"severity\":\"CRITICAL\",\"file\":\"Foo.java\",\"line\":1,"
             + "\"category\":\"SECURITY\",\"message\":\"SQL 注入\",\"suggestion\":\"用参数化查询\"}],"
@@ -264,6 +327,7 @@ class GitAssistantServiceTest {
         assertEquals(1, result.issues().size());
         assertEquals("CRITICAL", result.issues().get(0).severity());
         assertEquals("SECURITY", result.issues().get(0).category());
+        assertEquals("tenant-test", updateTenant.get(), "Review 异步回写必须恢复请求租户");
         // 成功站内信：接收人=提交人、bizType=CODE_REVIEW、bizId=taskId、link 携带 reviewTask=taskId
         verify(siteMessageService, timeout(2000)).send(eq(7L), eq("AI 代码审查完成"), anyString(),
             eq("CODE_REVIEW"), eq("99"), contains("reviewTask=99"));


### PR DESCRIPTION
## 问题

Git 助手在原始 `CompletableFuture` 与 Spring `@Async` 两处异步边界后丢失请求线程中的租户上下文，导致 MyBatis 租户拦截器抛出 `TenantContextMissingException`，同时异步审计写入也会失败。

## 修复

- 在进入 Git 助手异步任务前冻结租户、配额主体与调用身份，并在模型调用和 Review 完成回调中恢复、最终清理上下文。
- 在 AI Coding 审计记录中携带仅供进程内使用的租户快照，并在真实 `@Async` 工作线程中恢复租户后写库。
- 将审计任务提交失败保持为旁路故障，避免影响 Git 助手主链路。
- 增加线程上下文传递、恢复、异步代理执行和 Review 数据库回调的回归测试。

## 验证

- 定向测试：34 个测试通过，0 失败，0 错误。
- 全量门禁：6 个 Maven 模块全部 `SUCCESS`，最终 `BUILD SUCCESS`，耗时 4 分 57 秒。
- 隔离启动：修复后端在 18082 端口健康检查为 `UP`；浏览器可正常加载目标 VibeCoding 会话、产物文件和 20 条历史会话。
- 未触发真实 Git 助手模型调用；该操作会向配置的外部模型服务商发送工作区代码差异，需要单独的数据发送授权。
