### PR TITLE
feat(auth): 登录拖动验证码与 3 秒轮播

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
@@ -4,19 +4,23 @@ import cn.dev33.satoken.stp.StpUtil;
 import com.richard.fyoung.customeradmin.auth.dto.ChangePasswordRequest;
 import com.richard.fyoung.customeradmin.auth.dto.EmailCodeRequest;
 import com.richard.fyoung.customeradmin.auth.dto.LoginRequest;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaChallengeResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaProofResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaVerifyRequest;
 import com.richard.fyoung.customeradmin.auth.dto.LoginResponse;
 import com.richard.fyoung.customeradmin.auth.dto.RegisterRequest;
 import com.richard.fyoung.customeradmin.auth.dto.SsoLoginRequest;
 import com.richard.fyoung.customeradmin.auth.guard.CaptchaChallenge;
 import com.richard.fyoung.customeradmin.auth.guard.ClientIpResolver;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
 import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuard;
-import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
 import com.richard.fyoung.customeradmin.auth.service.AuthService;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.system.user.service.UserRegistrationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,20 +40,40 @@ public class AuthController {
     private final AuthService authService;
     private final UserRegistrationService userRegistrationService;
     private final RegistrationGuard registrationGuard;
-    private final RegistrationGuardProperties registrationProperties;
+    private final ClientIpResolver clientIpResolver;
+    private final LoginCaptchaService loginCaptchaService;
 
     public AuthController(AuthService authService, UserRegistrationService userRegistrationService,
                           RegistrationGuard registrationGuard,
-                          RegistrationGuardProperties registrationProperties) {
+                          ClientIpResolver clientIpResolver,
+                          LoginCaptchaService loginCaptchaService) {
         this.authService = authService;
         this.userRegistrationService = userRegistrationService;
         this.registrationGuard = registrationGuard;
-        this.registrationProperties = registrationProperties;
+        this.clientIpResolver = clientIpResolver;
+        this.loginCaptchaService = loginCaptchaService;
     }
 
     @PostMapping("/login")
-    public Result<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-        return Result.success(authService.login(request));
+    public Result<LoginResponse> login(@Valid @RequestBody LoginRequest request,
+                                       HttpServletRequest httpRequest) {
+        ClientContext client = clientContextOf(httpRequest);
+        return Result.success(authService.login(request, client.ip(), client.userAgent()));
+    }
+
+    /** 下发登录滑块 challenge；签发限流、TTL 与指纹绑定均由独立服务负责。 */
+    @PostMapping("/login-captcha/challenge")
+    public Result<LoginCaptchaChallengeResponse> loginCaptchaChallenge(HttpServletRequest httpRequest) {
+        ClientContext client = clientContextOf(httpRequest);
+        return Result.success(loginCaptchaService.issueChallenge(client.ip(), client.userAgent()));
+    }
+
+    /** 校验一次滑动轨迹并签发仅能消费一次的登录 proof。 */
+    @PostMapping("/login-captcha/verify")
+    public Result<LoginCaptchaProofResponse> verifyLoginCaptcha(
+        @Valid @RequestBody LoginCaptchaVerifyRequest request, HttpServletRequest httpRequest) {
+        ClientContext client = clientContextOf(httpRequest);
+        return Result.success(loginCaptchaService.verify(request, client.ip(), client.userAgent()));
     }
 
     /**
@@ -103,7 +127,15 @@ public class AuthController {
 
     /** 来源 IP 解析口径与限流、登录锁定共用一处实现。 */
     private String clientIpOf(HttpServletRequest request) {
-        return ClientIpResolver.resolve(request, registrationProperties.isTrustForwardedHeader());
+        return clientIpResolver.resolve(request);
+    }
+
+    /** 登录链路只解析一次来源上下文，验证码绑定、锁定与日志共享同一份值。 */
+    private ClientContext clientContextOf(HttpServletRequest request) {
+        return new ClientContext(clientIpOf(request), request.getHeader(HttpHeaders.USER_AGENT));
+    }
+
+    private record ClientContext(String ip, String userAgent) {
     }
 
     /**
@@ -123,8 +155,10 @@ public class AuthController {
 
     /** OA 域账号（LDAP/AD）单点登录，与上面的账号密码登录入口共存，前端登录页 Tab 切换。 */
     @PostMapping("/sso-login")
-    public Result<LoginResponse> ssoLogin(@Valid @RequestBody SsoLoginRequest request) {
-        return Result.success(authService.ssoLogin(request));
+    public Result<LoginResponse> ssoLogin(@Valid @RequestBody SsoLoginRequest request,
+                                          HttpServletRequest httpRequest) {
+        ClientContext client = clientContextOf(httpRequest);
+        return Result.success(authService.ssoLogin(request, client.ip(), client.userAgent()));
     }
 
     @OperationLog(operation = "登出")

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaChallengeResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaChallengeResponse.java
@@ -1,0 +1,5 @@
+package com.richard.fyoung.customeradmin.auth.dto;
+
+/** 登录滑块 challenge。 */
+public record LoginCaptchaChallengeResponse(String challengeId, int ttlSeconds) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProofResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProofResponse.java
@@ -1,0 +1,5 @@
+package com.richard.fyoung.customeradmin.auth.dto;
+
+/** 登录滑块核验通过后签发的一次性 proof。 */
+public record LoginCaptchaProofResponse(String proof, int ttlSeconds) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProtocol.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProtocol.java
@@ -1,0 +1,29 @@
+package com.richard.fyoung.customeradmin.auth.dto;
+
+/**
+ * 登录滑块前后端共同遵守的固定协议边界。
+ *
+ * <p>这些值决定请求结构与交互行为，不作为运行期配置开放；修改时必须同步前端并按接口变更评审。
+ * 运维侧只允许调整 TTL、签发限流和进程内容量等不改变协议的数据。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public final class LoginCaptchaProtocol {
+
+    public static final int TRACK_MIN_X = 0;
+    public static final int TRACK_MAX_X = 1_000;
+    public static final int TRACK_MIN_Y = -1_000;
+    public static final int TRACK_MAX_Y = 1_000;
+    public static final int MIN_POINTS = 6;
+    public static final int MAX_POINTS = 80;
+    public static final long MIN_DURATION_MS = 300L;
+    public static final long MAX_DURATION_MS = 8_000L;
+    public static final int START_X_MAX = 20;
+    public static final int END_X_MIN = 980;
+    public static final int MIN_DISTINCT_X = 5;
+    public static final int MIN_INTERMEDIATE_POINTS = 4;
+    public static final long MAX_INITIAL_TIME_MS = 100L;
+
+    private LoginCaptchaProtocol() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaVerifyRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaVerifyRequest.java
@@ -1,0 +1,18 @@
+package com.richard.fyoung.customeradmin.auth.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/** 登录滑块轨迹核验请求。 */
+public record LoginCaptchaVerifyRequest(
+    @NotBlank(message = "challengeId 不能为空")
+    @Size(max = 128, message = "challengeId 长度不能超过 128") String challengeId,
+    @NotNull(message = "trajectory 不能为空")
+    @Size(min = LoginCaptchaProtocol.MIN_POINTS, max = LoginCaptchaProtocol.MAX_POINTS,
+        message = "trajectory 点数必须在 6 到 80 之间")
+    List<@Valid SliderTrackPoint> trajectory) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginRequest.java
@@ -1,14 +1,19 @@
 package com.richard.fyoung.customeradmin.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /**
  * 登录请求。
  * @author owlzhangfq@gmail.com
  */
 public record LoginRequest(
-    @NotBlank(message = "username 不能为空") String username,
-    @NotBlank(message = "password 不能为空") String password,
+    @NotBlank(message = "username 不能为空")
+    @Size(max = 64, message = "username 长度不能超过 64") String username,
+    @NotBlank(message = "password 不能为空")
+    @Size(max = 64, message = "password 长度不能超过 64") String password,
     /** 记住我：默认/缺失时视为 false，为 true 时登录态有效期延长到 admin.remember-me-timeout-seconds 配置值。 */
-    Boolean rememberMe) {
+    Boolean rememberMe,
+    @NotBlank(message = "captchaProof 不能为空")
+    @Size(max = 256, message = "captchaProof 长度不能超过 256") String captchaProof) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/SliderTrackPoint.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/SliderTrackPoint.java
@@ -1,0 +1,20 @@
+package com.richard.fyoung.customeradmin.auth.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
+
+/**
+ * 滑块轨迹采样点。X 使用 0..1000 归一化坐标，Y 是相对按下点的偏移，T 是相对毫秒数。
+ * @author owlzhangfq@gmail.com
+ */
+public record SliderTrackPoint(
+    @Min(value = LoginCaptchaProtocol.TRACK_MIN_X, message = "x 不能小于 0")
+    @Max(value = LoginCaptchaProtocol.TRACK_MAX_X, message = "x 不能大于 1000")
+    int x,
+    @Min(value = LoginCaptchaProtocol.TRACK_MIN_Y, message = "y 不能小于 -1000")
+    @Max(value = LoginCaptchaProtocol.TRACK_MAX_Y, message = "y 不能大于 1000")
+    int y,
+    @PositiveOrZero(message = "t 不能为负数")
+    long t) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/SsoLoginRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/SsoLoginRequest.java
@@ -1,14 +1,19 @@
 package com.richard.fyoung.customeradmin.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /**
  * OA 域账号（LDAP/AD）单点登录请求。
  * @author owlzhangfq@gmail.com
  */
 public record SsoLoginRequest(
-    @NotBlank(message = "username 不能为空") String username,
-    @NotBlank(message = "password 不能为空") String password,
+    @NotBlank(message = "username 不能为空")
+    @Size(max = 256, message = "username 长度不能超过 256") String username,
+    @NotBlank(message = "password 不能为空")
+    @Size(max = 256, message = "password 长度不能超过 256") String password,
     /** 记住我：默认/缺失时视为 false，为 true 时登录态有效期延长到 admin.remember-me-timeout-seconds 配置值。 */
-    Boolean rememberMe) {
+    Boolean rememberMe,
+    @NotBlank(message = "captchaProof 不能为空")
+    @Size(max = 256, message = "captchaProof 长度不能超过 256") String captchaProof) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfig.java
@@ -12,9 +12,11 @@ import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 /**
  * 注册与登录防滥用能力的装配。
@@ -23,13 +25,14 @@ import org.springframework.context.annotation.Configuration;
  * （它只有 {@code @ConfigurationProperties}，没有 {@code @Component}），删掉会在启动时报
  * {@code NoSuchBeanDefinitionException}——本项目在批量重构配置类时踩过这个坑。</p>
  *
- * <p>计数器与验证码存储都遵循同一个降级方向：Redis 可用则用 Redis（多副本共享），
- * 不可用退进程内而不是放行。防滥用能力不能因为基础设施抖动就整体消失。</p>
+ * <p>计数器与注册验证码延续原有 Redis 运行期降级策略。登录滑块更严格：仅在启动时
+ * 没有 Redisson Bean 才选用进程内存储；一旦选用 Redis，请求期异常直接失败关闭，
+ * 防止 challenge/proof 因跨存储切换而复活。</p>
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
 @Configuration
-@EnableConfigurationProperties(RegistrationGuardProperties.class)
+@EnableConfigurationProperties({RegistrationGuardProperties.class, LoginCaptchaProperties.class})
 public class AuthGuardConfig {
 
     /** Redis 键前缀与配额计数器一致，靠各自的业务键前缀区分用途。 */
@@ -67,6 +70,40 @@ public class AuthGuardConfig {
     public CaptchaService captchaService(CaptchaStore captchaStore,
                                          RegistrationGuardProperties properties) {
         return new CaptchaService(captchaStore, properties.getCaptcha());
+    }
+
+    /** 转发头只有在直接连接方命中显式可信代理网段时才参与来源 IP 解析。 */
+    @Bean
+    public ClientIpResolver clientIpResolver(RegistrationGuardProperties properties,
+                                             ServerProperties serverProperties) {
+        ServerProperties.Tomcat.Remoteip remoteIp = serverProperties.getTomcat().getRemoteip();
+        if (serverProperties.getForwardHeadersStrategy() != ServerProperties.ForwardHeadersStrategy.NONE
+            || StringUtils.hasText(remoteIp.getRemoteIpHeader())
+            || StringUtils.hasText(remoteIp.getProtocolHeader())) {
+            throw new IllegalStateException(
+                "container forward-header handling must remain disabled; ClientIpResolver is the only trust boundary");
+        }
+        return new ClientIpResolver(properties);
+    }
+
+    @Bean
+    public LoginCaptchaStore loginCaptchaStore(ObjectProvider<RedissonClient> redissonProvider,
+                                               LoginCaptchaProperties properties) {
+        InMemoryLoginCaptchaStore inMemory = new InMemoryLoginCaptchaStore(
+            properties.getMaxInMemoryEntries(), java.time.Clock.systemUTC());
+        RedissonClient redisson = redissonProvider.getIfAvailable();
+        if (redisson == null) {
+            log.info("login captcha store uses in-process mode (no RedissonClient at startup)");
+            return inMemory;
+        }
+        return new RedissonLoginCaptchaStore(redisson);
+    }
+
+    @Bean
+    public LoginCaptchaService loginCaptchaService(LoginCaptchaStore loginCaptchaStore,
+                                                   LoginCaptchaProperties properties,
+                                                   WindowCounter authGuardWindowCounter) {
+        return new LoginCaptchaService(loginCaptchaStore, properties, authGuardWindowCounter);
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/ClientIpResolver.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/ClientIpResolver.java
@@ -2,15 +2,23 @@ package com.richard.fyoung.customeradmin.auth.guard;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.util.StringUtils;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
 
 /**
- * 取请求的来源 IP，用于按 IP 的注册限流与登录锁定。
+ * 解析用于匿名接口限流、验证码绑定与登录锁定的可信来源 IP。
  *
- * <p>{@code X-Forwarded-For} 是逗号分隔的链路，最左边是原始客户端。是否采信由
- * {@code admin.registration.trust-forwarded-header} 决定——见该属性的说明，
- * 它的正确性依赖反向代理"覆写而非追加"这个部署前提。</p>
+ * <p>转发头本身由客户端控制，只有直接连接方命中显式可信代理 CIDR 时才可读取。
+ * X-Forwarded-For 按“客户端, 代理1, 代理2”排列，因此从右向左剥离可信代理，
+ * 取第一个不可信地址；伪造在最左侧的地址不会被采信。</p>
+ *
+ * <p>任何格式异常、过长、跳数过多或全链均为可信代理时都回退到直接连接地址。
+ * IP 与 CIDR 解析只接受 literal，不做 DNS 查询。</p>
  * @author owlzhangfq@gmail.com
  */
 public final class ClientIpResolver {
@@ -18,55 +26,236 @@ public final class ClientIpResolver {
     private static final String HEADER_FORWARDED_FOR = "X-Forwarded-For";
     private static final String HEADER_REAL_IP = "X-Real-IP";
     private static final String UNKNOWN = "unknown";
+    private static final int MAX_FORWARDED_HEADER_LENGTH = 2_048;
+    private static final int MAX_FORWARDED_HOPS = 16;
+    private static final int MAX_IP_LITERAL_LENGTH = 64;
 
-    private ClientIpResolver() {
+    private final boolean trustForwardedHeader;
+    private final List<IpSubnet> trustedProxySubnets;
+
+    public ClientIpResolver(RegistrationGuardProperties properties) {
+        this(Objects.requireNonNull(properties, "properties").isTrustForwardedHeader(),
+            properties.getTrustedProxyCidrs());
     }
 
-    /** 解析来源 IP；拿不到时返回固定串，让限流退化为"全体共用一个桶"而不是放行。 */
-    public static String resolve(HttpServletRequest request, boolean trustForwardedHeader) {
+    ClientIpResolver(boolean trustForwardedHeader, List<String> trustedProxyCidrs) {
+        this.trustForwardedHeader = trustForwardedHeader;
+        this.trustedProxySubnets = parseSubnets(trustedProxyCidrs);
+        if (trustForwardedHeader && trustedProxySubnets.isEmpty()) {
+            throw new IllegalArgumentException(
+                "trustedProxyCidrs must not be empty when forwarded headers are trusted");
+        }
+    }
+
+    /** 拿不到合法直连地址时返回固定串，让限流退化为全体共用一个桶而不是放行。 */
+    public String resolve(HttpServletRequest request) {
         if (request == null) {
             return UNKNOWN;
         }
-        if (trustForwardedHeader) {
-            String forwarded = firstAddress(request.getHeader(HEADER_FORWARDED_FOR));
-            if (isUsable(forwarded)) {
-                return forwarded;
-            }
-            String realIp = request.getHeader(HEADER_REAL_IP);
-            if (isUsable(realIp)) {
-                return realIp.trim();
-            }
+        IpAddress remoteAddress = parseLiteral(request.getRemoteAddr());
+        if (remoteAddress == null) {
+            return UNKNOWN;
         }
-        String remote = request.getRemoteAddr();
-        return isUsable(remote) ? remote.trim() : UNKNOWN;
+        if (!trustForwardedHeader || !isTrustedProxy(remoteAddress)) {
+            return remoteAddress.canonical();
+        }
+
+        Enumeration<String> forwardedFor = request.getHeaders(HEADER_FORWARDED_FOR);
+        if (forwardedFor != null && forwardedFor.hasMoreElements()) {
+            return resolveForwardedChain(forwardedFor, remoteAddress);
+        }
+
+        Enumeration<String> realIpValues = request.getHeaders(HEADER_REAL_IP);
+        if (realIpValues == null || !realIpValues.hasMoreElements()) {
+            return remoteAddress.canonical();
+        }
+        String realIp = realIpValues.nextElement();
+        if (realIpValues.hasMoreElements() || !StringUtils.hasText(realIp)) {
+            return remoteAddress.canonical();
+        }
+        IpAddress realAddress = parseLiteral(realIp.trim());
+        if (realAddress == null || isTrustedProxy(realAddress)) {
+            return remoteAddress.canonical();
+        }
+        return realAddress.canonical();
     }
 
-    /**
-     * 从当前请求上下文解析来源 IP，供拿不到 {@code HttpServletRequest} 参数的调用方使用。
-     *
-     * @return 来源 IP；不在 Web 请求线程上（调度线程、异步回调）返回 {@code null}，
-     *         由调用方决定是记空还是跳过——限流路径不该走这个重载
-     */
-    public static String fromCurrentRequest(boolean trustForwardedHeader) {
-        ServletRequestAttributes attrs =
-            (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        if (attrs == null) {
+    private String resolveForwardedChain(Enumeration<String> headerValues, IpAddress remoteAddress) {
+        List<IpAddress> hops = new ArrayList<>();
+        int totalLength = 0;
+        while (headerValues.hasMoreElements()) {
+            String headerValue = headerValues.nextElement();
+            if (headerValue == null) {
+                return remoteAddress.canonical();
+            }
+            int separatorLength = hops.isEmpty() ? 0 : 1;
+            if (headerValue.length() > MAX_FORWARDED_HEADER_LENGTH - totalLength - separatorLength) {
+                return remoteAddress.canonical();
+            }
+            totalLength += headerValue.length() + separatorLength;
+            String[] rawHops = headerValue.split(",", -1);
+            if (hops.size() + rawHops.length > MAX_FORWARDED_HOPS) {
+                return remoteAddress.canonical();
+            }
+            for (String rawHop : rawHops) {
+                IpAddress hop = parseLiteral(rawHop.trim());
+                if (hop == null) {
+                    return remoteAddress.canonical();
+                }
+                hops.add(hop);
+            }
+        }
+        for (int index = hops.size() - 1; index >= 0; index--) {
+            IpAddress hop = hops.get(index);
+            if (!isTrustedProxy(hop)) {
+                return hop.canonical();
+            }
+        }
+        return remoteAddress.canonical();
+    }
+
+    private boolean isTrustedProxy(IpAddress address) {
+        return trustedProxySubnets.stream().anyMatch(subnet -> subnet.contains(address));
+    }
+
+    private static List<IpSubnet> parseSubnets(List<String> rawCidrs) {
+        if (rawCidrs == null || rawCidrs.isEmpty()) {
+            return List.of();
+        }
+        List<IpSubnet> parsed = new ArrayList<>(rawCidrs.size());
+        for (String rawCidr : rawCidrs) {
+            if (!StringUtils.hasText(rawCidr)) {
+                continue;
+            }
+            parsed.add(parseSubnet(rawCidr.trim()));
+        }
+        return List.copyOf(parsed);
+    }
+
+    private static IpSubnet parseSubnet(String cidr) {
+        int slash = cidr.indexOf('/');
+        if (slash <= 0 || slash != cidr.lastIndexOf('/') || slash == cidr.length() - 1) {
+            throw invalidCidr(cidr);
+        }
+        IpAddress network = parseLiteral(cidr.substring(0, slash));
+        String rawPrefix = cidr.substring(slash + 1);
+        if (network == null || !isAsciiDigits(rawPrefix)) {
+            throw invalidCidr(cidr);
+        }
+        int prefixLength;
+        try {
+            prefixLength = Integer.parseInt(rawPrefix);
+        } catch (NumberFormatException e) {
+            throw invalidCidr(cidr);
+        }
+        int addressBits = network.bytes().length * Byte.SIZE;
+        if (prefixLength <= 0 || prefixLength > addressBits) {
+            throw invalidCidr(cidr);
+        }
+        return new IpSubnet(network.bytes(), prefixLength);
+    }
+
+    private static IllegalArgumentException invalidCidr(String cidr) {
+        return new IllegalArgumentException("invalid trusted proxy CIDR: " + cidr);
+    }
+
+    private static IpAddress parseLiteral(String rawValue) {
+        if (!StringUtils.hasText(rawValue)) {
             return null;
         }
-        String resolved = resolve(attrs.getRequest(), trustForwardedHeader);
-        return UNKNOWN.equals(resolved) ? null : resolved;
-    }
-
-    private static String firstAddress(String headerValue) {
-        if (!StringUtils.hasText(headerValue)) {
+        String value = rawValue.trim();
+        if (value.length() > MAX_IP_LITERAL_LENGTH || !value.equals(rawValue)) {
             return null;
         }
-        int comma = headerValue.indexOf(',');
-        return (comma < 0 ? headerValue : headerValue.substring(0, comma)).trim();
+        byte[] bytes = value.indexOf(':') >= 0 ? parseIpv6(value) : parseIpv4(value);
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            return new IpAddress(bytes, InetAddress.getByAddress(bytes).getHostAddress());
+        } catch (UnknownHostException impossible) {
+            throw new IllegalStateException("validated IP bytes are invalid", impossible);
+        }
     }
 
-    /** 代理链路里 unknown 是常见占位值，当成拿不到处理。 */
-    private static boolean isUsable(String value) {
-        return StringUtils.hasText(value) && !UNKNOWN.equalsIgnoreCase(value.trim());
+    private static byte[] parseIpv4(String value) {
+        String[] segments = value.split("\\.", -1);
+        if (segments.length != 4) {
+            return null;
+        }
+        byte[] bytes = new byte[4];
+        for (int index = 0; index < segments.length; index++) {
+            String segment = segments[index];
+            if (segment.isEmpty() || segment.length() > 3 || !isAsciiDigits(segment)
+                || segment.length() > 1 && segment.charAt(0) == '0') {
+                return null;
+            }
+            int valuePart = Integer.parseInt(segment);
+            if (valuePart > 255) {
+                return null;
+            }
+            bytes[index] = (byte) valuePart;
+        }
+        return bytes;
+    }
+
+    private static byte[] parseIpv6(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            boolean hexadecimal = current >= '0' && current <= '9'
+                || current >= 'a' && current <= 'f'
+                || current >= 'A' && current <= 'F';
+            if (!hexadecimal && current != ':' && current != '.') {
+                return null;
+            }
+        }
+        int lastColon = value.lastIndexOf(':');
+        if (value.indexOf('.') >= 0
+            && (lastColon < 0 || parseIpv4(value.substring(lastColon + 1)) == null)) {
+            return null;
+        }
+        try {
+            return InetAddress.getByName(value).getAddress();
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    private static boolean isAsciiDigits(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (current < '0' || current > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private record IpAddress(byte[] bytes, String canonical) {
+    }
+
+    private record IpSubnet(byte[] network, int prefixLength) {
+
+        private boolean contains(IpAddress address) {
+            byte[] candidate = address.bytes();
+            if (candidate.length != network.length) {
+                return false;
+            }
+            int wholeBytes = prefixLength / Byte.SIZE;
+            for (int index = 0; index < wholeBytes; index++) {
+                if (candidate[index] != network[index]) {
+                    return false;
+                }
+            }
+            int remainingBits = prefixLength % Byte.SIZE;
+            if (remainingBits == 0) {
+                return true;
+            }
+            int mask = 0xFF << (Byte.SIZE - remainingBits);
+            return (candidate[wholeBytes] & mask) == (network[wholeBytes] & mask);
+        }
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStore.java
@@ -1,0 +1,105 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * 登录滑块的进程内存储，供没有 Redisson Bean 的单实例部署在启动时选用。
+ *
+ * <p>消费通过 {@link ConcurrentHashMap#compute(Object, java.util.function.BiFunction)} 完成，
+ * 同一键的指纹判断与删除不可被并发请求拆开。challenge/proof 各自用容量锁串行完成
+ * “清理过期项—检查上限—写入”，避免不同 key 并发突破硬容量上限。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public class InMemoryLoginCaptchaStore implements LoginCaptchaStore {
+
+    private static final int DEFAULT_MAX_ENTRIES = 10_000;
+
+    private final Map<String, ChallengeState> challenges = new ConcurrentHashMap<>();
+    private final Map<String, ProofState> proofs = new ConcurrentHashMap<>();
+    private final Object challengeCapacityLock = new Object();
+    private final Object proofCapacityLock = new Object();
+    private final int maxEntries;
+    private final Clock clock;
+
+    public InMemoryLoginCaptchaStore() {
+        this(DEFAULT_MAX_ENTRIES, Clock.systemUTC());
+    }
+
+    InMemoryLoginCaptchaStore(int maxEntries, Clock clock) {
+        if (maxEntries <= 0) {
+            throw new IllegalArgumentException("maxEntries must be positive");
+        }
+        this.maxEntries = maxEntries;
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    @Override
+    public void saveChallenge(String challengeId, ChallengeState state, int ttlSeconds) {
+        synchronized (challengeCapacityLock) {
+            purgeExpired(challenges, ChallengeState::expireAtMs);
+            save(challenges, challengeId, state);
+        }
+    }
+
+    @Override
+    public ConsumeResult<ChallengeState> consumeChallenge(String challengeId, String fingerprint) {
+        return consume(challenges, challengeId, fingerprint,
+            ChallengeState::fingerprint, ChallengeState::expireAtMs);
+    }
+
+    @Override
+    public void saveProof(String proofHash, ProofState state, int ttlSeconds) {
+        synchronized (proofCapacityLock) {
+            purgeExpired(proofs, ProofState::expireAtMs);
+            save(proofs, proofHash, state);
+        }
+    }
+
+    @Override
+    public ConsumeResult<ProofState> consumeProof(String proofHash, String fingerprint) {
+        return consume(proofs, proofHash, fingerprint, ProofState::fingerprint, ProofState::expireAtMs);
+    }
+
+    private <T> void save(Map<String, T> values, String key, T state) {
+        if (!values.containsKey(key) && values.size() >= maxEntries) {
+            throw new IllegalStateException("login captcha in-memory store capacity exceeded");
+        }
+        values.put(key, state);
+    }
+
+    private <T> ConsumeResult<T> consume(Map<String, T> values, String key, String fingerprint,
+                                         Function<T, String> fingerprintOf,
+                                         Function<T, Long> expireAtOf) {
+        AtomicReference<T> matched = new AtomicReference<>();
+        AtomicBoolean fingerprintMismatch = new AtomicBoolean(false);
+        long now = clock.millis();
+        values.computeIfPresent(key, (ignored, state) -> {
+            if (expireAtOf.apply(state) <= now) {
+                return null;
+            }
+            if (!Objects.equals(fingerprintOf.apply(state), fingerprint)) {
+                fingerprintMismatch.set(true);
+                return state;
+            }
+            matched.set(state);
+            return null;
+        });
+        if (matched.get() != null) {
+            return ConsumeResult.matched(matched.get());
+        }
+        return fingerprintMismatch.get()
+            ? ConsumeResult.fingerprintMismatch()
+            : ConsumeResult.notFound();
+    }
+
+    private <T> void purgeExpired(Map<String, T> values, Function<T, Long> expireAtOf) {
+        long now = clock.millis();
+        values.entrySet().removeIf(entry -> expireAtOf.apply(entry.getValue()) <= now);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaProperties.java
@@ -1,0 +1,53 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 登录滑块验证码参数。
+ *
+ * <p>登录滑块与注册图形验证码是两份独立凭据：前者保护密码与 LDAP 认证入口，
+ * 后者保护匿名注册及邮件发送，不能共用开关、存储或错误码。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "admin.login-captcha")
+public class LoginCaptchaProperties {
+
+    /** challenge 有效期（秒）。 */
+    @Positive
+    private int challengeTtlSeconds = 120;
+
+    /** 登录 proof 有效期（秒）。 */
+    @Positive
+    private int proofTtlSeconds = 120;
+
+    /** 单个来源 IP 在窗口内最多签发的 challenge 数。 */
+    @Positive
+    private int maxIssuePerWindow = 30;
+
+    /** 单个来源 IP 在窗口内最多提交的轨迹校验次数。 */
+    @Positive
+    private int maxVerifyPerWindow = 120;
+
+    /** 单个来源 IP 在窗口内最多尝试消费的登录 proof 次数。 */
+    @Positive
+    private int maxProofConsumePerWindow = 120;
+
+    /** challenge 签发、轨迹校验和 proof 消费共用的限流窗口（秒）。 */
+    @Positive
+    private int rateLimitWindowSeconds = 3600;
+
+    /** 进程内模式下 challenge 与 proof 各自允许驻留的最大条数。 */
+    @Positive
+    private int maxInMemoryEntries = 10_000;
+
+    /** 参与指纹计算的 User-Agent 最大字符数。 */
+    @Positive
+    private int maxUserAgentLength = 512;
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaService.java
@@ -1,0 +1,281 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaChallengeResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaProofResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaProtocol;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaVerifyRequest;
+import com.richard.fyoung.customeradmin.auth.dto.SliderTrackPoint;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 登录滑块的 challenge → proof → 登录消费链路。
+ *
+ * <p>proof 是 32 字节随机数的 Base64URL 表达；存储只接收其 SHA-256 摘要。
+ * challenge 与 proof 都绑定来源 IP 和归一化 User-Agent 的摘要，并且只能成功消费一次。</p>
+ *
+ * <p>这套基础轨迹约束能拦截直接绕过、重放与简单瞬移，不宣称能够识别人类：
+ * 客户端轨迹本身没有服务端秘密，脚本仍可构造满足约束的数据。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class LoginCaptchaService {
+
+    private static final String ISSUE_RATE_KEY_PREFIX = "admin:login-captcha:issue:";
+    private static final String VERIFY_RATE_KEY_PREFIX = "admin:login-captcha:verify:";
+    private static final String PROOF_CONSUME_RATE_KEY_PREFIX = "admin:login-captcha:consume:";
+    private static final String UNKNOWN_CLIENT = "unknown";
+    private static final int CHALLENGE_ID_BYTES = 16;
+    private static final int PROOF_BYTES = 32;
+    private static final int MAX_IP_LENGTH = 128;
+
+    private final LoginCaptchaStore store;
+    private final LoginCaptchaProperties properties;
+    private final WindowCounter counter;
+    private final Clock clock;
+    private final SecureRandom random;
+
+    public LoginCaptchaService(LoginCaptchaStore store, LoginCaptchaProperties properties,
+                               WindowCounter counter) {
+        this(store, properties, counter, Clock.systemUTC(), new SecureRandom());
+    }
+
+    LoginCaptchaService(LoginCaptchaStore store, LoginCaptchaProperties properties,
+                        WindowCounter counter, Clock clock, SecureRandom random) {
+        this.store = store;
+        this.properties = properties;
+        this.counter = counter;
+        this.clock = clock;
+        this.random = random;
+    }
+
+    /** 签发独立 challenge；按来源 IP 做滑动窗口限流。 */
+    public LoginCaptchaChallengeResponse issueChallenge(String clientIp, String userAgent) {
+        String normalizedIp = normalize(clientIp, MAX_IP_LENGTH);
+        requireRateLimit(ISSUE_RATE_KEY_PREFIX, normalizedIp, properties.getMaxIssuePerWindow());
+
+        long now = clock.millis();
+        long expireAtMs = expireAt(now, properties.getChallengeTtlSeconds());
+        String challengeId = randomToken(CHALLENGE_ID_BYTES);
+        LoginCaptchaStore.ChallengeState state = new LoginCaptchaStore.ChallengeState(
+            fingerprint(clientIp, userAgent), now, expireAtMs);
+        try {
+            store.saveChallenge(challengeId, state, properties.getChallengeTtlSeconds());
+        } catch (Exception e) {
+            log.error("login captcha challenge persistence failed, code={}",
+                "LOGIN-CAPTCHA-CHALLENGE-PERSIST-FAIL", e);
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
+        return new LoginCaptchaChallengeResponse(challengeId, properties.getChallengeTtlSeconds());
+    }
+
+    /** 原子消费 challenge，轨迹满足约束后签发一次性 proof。 */
+    public LoginCaptchaProofResponse verify(LoginCaptchaVerifyRequest request,
+                                            String clientIp, String userAgent) {
+        if (request == null || !validToken(request.challengeId(), CHALLENGE_ID_BYTES)) {
+            throw invalid();
+        }
+        requireRateLimit(VERIFY_RATE_KEY_PREFIX, normalize(clientIp, MAX_IP_LENGTH),
+            properties.getMaxVerifyPerWindow());
+        String fingerprint = fingerprint(clientIp, userAgent);
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState> consumed;
+        try {
+            consumed = store.consumeChallenge(request.challengeId().trim(), fingerprint);
+        } catch (Exception e) {
+            log.error("login captcha challenge consume failed, code={}",
+                "LOGIN-CAPTCHA-CHALLENGE-CONSUME-FAIL", e);
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
+        if (consumed.status() != LoginCaptchaStore.ConsumeStatus.MATCHED || consumed.state() == null) {
+            throw invalid();
+        }
+
+        long now = clock.millis();
+        LoginCaptchaStore.ChallengeState challenge = consumed.state();
+        if (challenge.expireAtMs() <= now
+            || now - challenge.issuedAtMs() < LoginCaptchaProtocol.MIN_DURATION_MS
+            || !validTrajectory(request.trajectory())) {
+            throw invalid();
+        }
+
+        String proof = randomToken(PROOF_BYTES);
+        long expireAtMs = expireAt(now, properties.getProofTtlSeconds());
+        try {
+            // 键只使用 proof 摘要；proof 明文仅返回给当前调用方。
+            store.saveProof(sha256(proof), new LoginCaptchaStore.ProofState(fingerprint, expireAtMs),
+                properties.getProofTtlSeconds());
+        } catch (Exception e) {
+            log.error("login captcha proof persistence failed, code={}",
+                "LOGIN-CAPTCHA-PROOF-PERSIST-FAIL", e);
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
+        return new LoginCaptchaProofResponse(proof, properties.getProofTtlSeconds());
+    }
+
+    /** 在进入用户查询、BCrypt 或 LDAP Bind 前消费 proof。 */
+    public void consumeProof(String proof, String clientIp, String userAgent) {
+        if (!validToken(proof, PROOF_BYTES)) {
+            throw invalid();
+        }
+        requireRateLimit(PROOF_CONSUME_RATE_KEY_PREFIX, normalize(clientIp, MAX_IP_LENGTH),
+            properties.getMaxProofConsumePerWindow());
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ProofState> consumed;
+        try {
+            consumed = store.consumeProof(sha256(proof.trim()), fingerprint(clientIp, userAgent));
+        } catch (Exception e) {
+            log.error("login captcha proof consume failed, code={}",
+                "LOGIN-CAPTCHA-PROOF-CONSUME-FAIL", e);
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
+        if (consumed.status() != LoginCaptchaStore.ConsumeStatus.MATCHED
+            || consumed.state() == null
+            || consumed.state().expireAtMs() <= clock.millis()) {
+            throw invalid();
+        }
+    }
+
+    private boolean validTrajectory(List<SliderTrackPoint> points) {
+        if (points == null || points.size() < LoginCaptchaProtocol.MIN_POINTS
+            || points.size() > LoginCaptchaProtocol.MAX_POINTS) {
+            return false;
+        }
+        SliderTrackPoint first = points.get(0);
+        SliderTrackPoint last = points.get(points.size() - 1);
+        if (first == null || last == null
+            || first.x() > LoginCaptchaProtocol.START_X_MAX
+            || first.t() < 0 || first.t() > LoginCaptchaProtocol.MAX_INITIAL_TIME_MS
+            || last.x() < LoginCaptchaProtocol.END_X_MIN
+            || last.t() < LoginCaptchaProtocol.MIN_DURATION_MS
+            || last.t() > LoginCaptchaProtocol.MAX_DURATION_MS) {
+            return false;
+        }
+
+        Set<Integer> distinctX = new HashSet<>();
+        int intermediatePoints = 0;
+        long previousTime = -1;
+        for (int index = 0; index < points.size(); index++) {
+            SliderTrackPoint point = points.get(index);
+            if (point == null || point.x() < LoginCaptchaProtocol.TRACK_MIN_X
+                || point.x() > LoginCaptchaProtocol.TRACK_MAX_X
+                || point.y() < LoginCaptchaProtocol.TRACK_MIN_Y
+                || point.y() > LoginCaptchaProtocol.TRACK_MAX_Y
+                || point.t() < 0 || point.t() > LoginCaptchaProtocol.MAX_DURATION_MS
+                || point.t() <= previousTime) {
+                return false;
+            }
+            previousTime = point.t();
+            distinctX.add(point.x());
+            if (index > 0 && index < points.size() - 1
+                && point.x() > LoginCaptchaProtocol.START_X_MAX
+                && point.x() < LoginCaptchaProtocol.END_X_MIN) {
+                intermediatePoints++;
+            }
+        }
+        return distinctX.size() >= LoginCaptchaProtocol.MIN_DISTINCT_X
+            && intermediatePoints >= LoginCaptchaProtocol.MIN_INTERMEDIATE_POINTS;
+    }
+
+    private String fingerprint(String clientIp, String userAgent) {
+        String normalizedIp = normalize(clientIp, MAX_IP_LENGTH);
+        String normalizedUserAgent = normalize(userAgent, properties.getMaxUserAgentLength());
+        return sha256(normalizedIp + '\0' + normalizedUserAgent);
+    }
+
+    private void requireRateLimit(String keyPrefix, String normalizedIp, int limit) {
+        boolean allowed = counter.tryAcquireSliding(
+            keyPrefix + sha256(normalizedIp), limit, properties.getRateLimitWindowSeconds());
+        if (!allowed) {
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_TOO_FREQUENT);
+        }
+    }
+
+    /** 归一化空白并截断，避免同一 UA 因多余空格漂移，也限制进入摘要函数的输入规模。 */
+    private String normalize(String raw, int maxLength) {
+        if (raw == null || raw.isBlank()) {
+            return UNKNOWN_CLIENT;
+        }
+        StringBuilder normalized = new StringBuilder(Math.min(raw.length(), maxLength));
+        boolean previousWhitespace = false;
+        for (int i = 0; i < raw.length() && normalized.length() < maxLength; i++) {
+            char current = raw.charAt(i);
+            if (Character.isWhitespace(current)) {
+                if (normalized.length() > 0 && !previousWhitespace) {
+                    normalized.append(' ');
+                }
+                previousWhitespace = true;
+            } else {
+                normalized.append(current);
+                previousWhitespace = false;
+            }
+        }
+        int length = normalized.length();
+        if (length > 0 && normalized.charAt(length - 1) == ' ') {
+            normalized.deleteCharAt(length - 1);
+        }
+        return normalized.isEmpty() ? UNKNOWN_CLIENT : normalized.toString();
+    }
+
+    private String randomToken(int bytes) {
+        byte[] value = new byte[bytes];
+        random.nextBytes(value);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value);
+    }
+
+    private boolean validToken(String token, int bytes) {
+        if (token == null) {
+            return false;
+        }
+        String trimmed = token.trim();
+        int expectedLength = (bytes * 8 + 5) / 6;
+        if (trimmed.length() != expectedLength) {
+            return false;
+        }
+        for (int i = 0; i < trimmed.length(); i++) {
+            char current = trimmed.charAt(i);
+            boolean alphaNumeric = current >= 'a' && current <= 'z'
+                || current >= 'A' && current <= 'Z'
+                || current >= '0' && current <= '9';
+            if (!alphaNumeric && current != '-' && current != '_') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String sha256(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes(StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private long expireAt(long now, int ttlSeconds) {
+        if (ttlSeconds <= 0) {
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
+        try {
+            return Math.addExact(now, Math.multiplyExact((long) ttlSeconds, 1000L));
+        } catch (ArithmeticException e) {
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
+    }
+
+    private BizException invalid() {
+        return new BizException(ResultCode.LOGIN_CAPTCHA_INVALID);
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaStore.java
@@ -1,0 +1,49 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+/**
+ * 登录滑块 challenge/proof 的一次性存储。
+ *
+ * <p>实现必须保证：指纹匹配时读取与删除是同一个原子操作；指纹不匹配时不删除，
+ * 避免第三方仅凭 challengeId 或 proof 摘要让真实用户的凭据失效。分布式实现的任何
+ * 读写异常必须向上抛，由服务层 fail-closed；请求期不得切换到另一份存储。</p>
+ * @author owlzhangfq@gmail.com
+ */
+public interface LoginCaptchaStore {
+
+    void saveChallenge(String challengeId, ChallengeState state, int ttlSeconds);
+
+    ConsumeResult<ChallengeState> consumeChallenge(String challengeId, String fingerprint);
+
+    /** @param proofHash proof 明文的 SHA-256 十六进制摘要，存储层不得接收 proof 明文。 */
+    void saveProof(String proofHash, ProofState state, int ttlSeconds);
+
+    /** @param proofHash proof 明文的 SHA-256 十六进制摘要。 */
+    ConsumeResult<ProofState> consumeProof(String proofHash, String fingerprint);
+
+    record ChallengeState(String fingerprint, long issuedAtMs, long expireAtMs) {
+    }
+
+    record ProofState(String fingerprint, long expireAtMs) {
+    }
+
+    enum ConsumeStatus {
+        MATCHED,
+        NOT_FOUND,
+        FINGERPRINT_MISMATCH
+    }
+
+    record ConsumeResult<T>(ConsumeStatus status, T state) {
+
+        public static <T> ConsumeResult<T> matched(T state) {
+            return new ConsumeResult<>(ConsumeStatus.MATCHED, state);
+        }
+
+        public static <T> ConsumeResult<T> notFound() {
+            return new ConsumeResult<>(ConsumeStatus.NOT_FOUND, null);
+        }
+
+        public static <T> ConsumeResult<T> fingerprintMismatch() {
+            return new ConsumeResult<>(ConsumeStatus.FINGERPRINT_MISMATCH, null);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStore.java
@@ -1,0 +1,135 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBucket;
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * 登录滑块的 Redis 存储。
+ *
+ * <p>匹配消费用 Lua 在 Redis 内完成“读取指纹、匹配、删除”：匹配时原子消费，
+ * 不匹配时保留原值。实例一旦在启动阶段选用 Redis，所有读写异常都必须向上抛；
+ * 请求期不能退进程内存储，否则响应状态不确定时可能让已消费的 challenge/proof 复活。</p>
+ * @author owlzhangfq@gmail.com
+ */
+@Slf4j
+public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
+
+    private static final String KEY_PREFIX = "cw:admin:login-captcha:";
+    private static final String CHALLENGE_KEY_PREFIX = KEY_PREFIX + "challenge:";
+    private static final String PROOF_KEY_PREFIX = KEY_PREFIX + "proof:";
+    private static final String FINGERPRINT_MISMATCH = "__FINGERPRINT_MISMATCH__";
+
+    private static final String CONSUME_IF_FINGERPRINT_MATCHES_SCRIPT =
+        "local value = redis.call('GET', KEYS[1]) "
+            + "if not value then return nil end "
+            + "local prefix = ARGV[1] .. ':' "
+            + "if string.sub(value, 1, string.len(prefix)) ~= prefix then "
+            + "  return '__FINGERPRINT_MISMATCH__' "
+            + "end "
+            + "redis.call('DEL', KEYS[1]) "
+            + "return value";
+
+    private final RedissonClient redisson;
+
+    public RedissonLoginCaptchaStore(RedissonClient redisson) {
+        this.redisson = redisson;
+    }
+
+    @Override
+    public void saveChallenge(String challengeId, ChallengeState state, int ttlSeconds) {
+        bucket(CHALLENGE_KEY_PREFIX + challengeId).set(
+            encode(state), Duration.ofSeconds(ttlSeconds));
+    }
+
+    @Override
+    public ConsumeResult<ChallengeState> consumeChallenge(String challengeId, String fingerprint) {
+        String encoded = consume(CHALLENGE_KEY_PREFIX + challengeId, fingerprint);
+        if (encoded == null) {
+            return ConsumeResult.notFound();
+        }
+        if (FINGERPRINT_MISMATCH.equals(encoded)) {
+            return ConsumeResult.fingerprintMismatch();
+        }
+        ChallengeState state = decodeChallenge(encoded);
+        if (state == null) {
+            log.error("login captcha challenge state is malformed, code={}",
+                "LOGIN-CAPTCHA-CHALLENGE-STATE-INVALID");
+            throw new IllegalStateException("login captcha challenge state is malformed");
+        }
+        return ConsumeResult.matched(state);
+    }
+
+    @Override
+    public void saveProof(String proofHash, ProofState state, int ttlSeconds) {
+        bucket(PROOF_KEY_PREFIX + proofHash).set(
+            encode(state), Duration.ofSeconds(ttlSeconds));
+    }
+
+    @Override
+    public ConsumeResult<ProofState> consumeProof(String proofHash, String fingerprint) {
+        String encoded = consume(PROOF_KEY_PREFIX + proofHash, fingerprint);
+        if (encoded == null) {
+            return ConsumeResult.notFound();
+        }
+        if (FINGERPRINT_MISMATCH.equals(encoded)) {
+            return ConsumeResult.fingerprintMismatch();
+        }
+        ProofState state = decodeProof(encoded);
+        if (state == null) {
+            log.error("login captcha proof state is malformed, code={}",
+                "LOGIN-CAPTCHA-PROOF-STATE-INVALID");
+            throw new IllegalStateException("login captcha proof state is malformed");
+        }
+        return ConsumeResult.matched(state);
+    }
+
+    private String consume(String key, String fingerprint) {
+        return redisson.getScript(StringCodec.INSTANCE).eval(
+            RScript.Mode.READ_WRITE,
+            CONSUME_IF_FINGERPRINT_MATCHES_SCRIPT,
+            RScript.ReturnType.VALUE,
+            List.of(key), fingerprint);
+    }
+
+    private RBucket<String> bucket(String key) {
+        return redisson.getBucket(key, StringCodec.INSTANCE);
+    }
+
+    private String encode(ChallengeState state) {
+        return state.fingerprint() + ":" + state.issuedAtMs() + ":" + state.expireAtMs();
+    }
+
+    private String encode(ProofState state) {
+        return state.fingerprint() + ":" + state.expireAtMs();
+    }
+
+    private ChallengeState decodeChallenge(String value) {
+        String[] parts = value.split(":", -1);
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            return new ChallengeState(parts[0], Long.parseLong(parts[1]), Long.parseLong(parts[2]));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private ProofState decodeProof(String value) {
+        String[] parts = value.split(":", -1);
+        if (parts.length != 2) {
+            return null;
+        }
+        try {
+            return new ProofState(parts[0], Long.parseLong(parts[1]));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationGuardProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RegistrationGuardProperties.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
+import java.util.List;
+
 /**
  * 自助注册与登录的防滥用参数。
  *
@@ -43,12 +45,17 @@ public class RegistrationGuardProperties {
     /**
      * 是否信任反向代理写入的 {@code X-Forwarded-For}。
      *
-     * <p>默认信任：对外实例必然部署在网关/Nginx 之后，不信任的话所有请求的来源地址
-     * 都是同一个反代 IP，限流会把全体用户按一个桶算。<b>运维侧的前提是反代必须
-     * 覆写而不是追加该请求头</b>，否则客户端可以自己伪造首段绕开 IP 限流。
-     * 直连暴露的部署要把它设为 false。</p>
+     * <p>默认不信任，避免直连暴露或错误代理配置时客户端伪造来源地址绕开限流。
+     * 显式开启后仍只有 {@link #trustedProxyCidrs} 命中的直接连接方可以写入转发链，
+     * 服务端会从右向左剥离可信代理，而不是直接采信客户端可控的最左段。</p>
      */
-    private boolean trustForwardedHeader = true;
+    private boolean trustForwardedHeader = false;
+
+    /**
+     * 允许写入转发头的直接代理网段。开启转发头信任时至少配置一项，支持 IPv4/IPv6 CIDR。
+     * 空列表代表任何连接方都不可信。
+     */
+    private List<String> trustedProxyCidrs = List.of();
 
     /** 按来源 IP 的注册频率上限。 */
     @Getter

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/service/AuthService.java
@@ -8,9 +8,8 @@ import com.richard.fyoung.customeradmin.auth.dto.ChangePasswordRequest;
 import com.richard.fyoung.customeradmin.auth.dto.LoginRequest;
 import com.richard.fyoung.customeradmin.auth.dto.LoginResponse;
 import com.richard.fyoung.customeradmin.auth.dto.SsoLoginRequest;
-import com.richard.fyoung.customeradmin.auth.guard.ClientIpResolver;
 import com.richard.fyoung.customeradmin.auth.guard.LoginAttemptGuard;
-import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.system.log.entity.SysOperationLog;
@@ -52,6 +51,8 @@ import java.util.Objects;
 @Service
 public class AuthService {
 
+    private static final int MAX_LOGIN_USERNAME_LENGTH = 64;
+
     private static final Logger log = LoggerFactory.getLogger(AuthService.class);
 
     /** 种子数据里 admin 账号的初始密码哈希——当前密码仍等于此值即视为"从未改过密"，强制改密。 */
@@ -70,7 +71,7 @@ public class AuthService {
     private final TenantService tenantService;
     private final SessionRevocationService sessionRevocationService;
     private final LoginAttemptGuard loginAttemptGuard;
-    private final RegistrationGuardProperties registrationProperties;
+    private final LoginCaptchaService loginCaptchaService;
 
     /** “记住我”勾选后登录态有效期（秒），默认 7 天；不勾选时沿用 sa-token.timeout（2 小时）全局配置。 */
     @Value("${admin.remember-me-timeout-seconds:604800}")
@@ -82,7 +83,7 @@ public class AuthService {
                        SysUserRoleMapper userRoleMapper, TenantService tenantService,
                        SessionRevocationService sessionRevocationService,
                        LoginAttemptGuard loginAttemptGuard,
-                       RegistrationGuardProperties registrationProperties) {
+                       LoginCaptchaService loginCaptchaService) {
         this.userMapper = userMapper;
         this.passwordEncoder = passwordEncoder;
         this.operationLogMapper = operationLogMapper;
@@ -93,14 +94,16 @@ public class AuthService {
         this.tenantService = tenantService;
         this.sessionRevocationService = sessionRevocationService;
         this.loginAttemptGuard = loginAttemptGuard;
-        this.registrationProperties = registrationProperties;
+        this.loginCaptchaService = loginCaptchaService;
     }
 
-    public LoginResponse login(LoginRequest request) {
-        String clientIp = resolveClientIp();
+    public LoginResponse login(LoginRequest request, String clientIp, String userAgent) {
+        // proof 必须先于查库与 BCrypt 消费；只在 Controller 校验会给未来新增入口留下绕过路径。
+        loginCaptchaService.consumeProof(request.captchaProof(), clientIp, userAgent);
+        String lockScopeIp = lockScopeIp(clientIp);
         // 锁定判定要在查库与密码比对之前：被锁期间不该再消耗一次 BCrypt 计算，
         // 那正是爆破想要的——每次尝试都让服务端做一次昂贵的哈希
-        loginAttemptGuard.checkNotLocked(request.username(), lockScopeIp(clientIp));
+        loginAttemptGuard.checkNotLocked(request.username(), lockScopeIp);
 
         // 跨租户查：此刻还不知道这个用户名属于哪个租户，租户上下文正是登录要产出的结果。
         // sys_user.username 全局唯一（见 docs/多租户架构设计.md §2.3），故按用户名足以唯一定位。
@@ -113,14 +116,14 @@ public class AuthService {
 
         recordLoginLog(loginLogTenant(user), request.username(), user == null ? null : user.getId(), success,
             success ? null : "用户名或密码错误，或账号已禁用",
-            success ? "登录" : "登录失败", "AuthController#login");
+            success ? "登录" : "登录失败", "AuthController#login", clientIp);
 
         if (!success) {
             // 账号不存在与密码错误记同一个计数：区分两者会让失败计数本身变成账号存在性探针
-            loginAttemptGuard.recordFailure(request.username(), lockScopeIp(clientIp));
+            loginAttemptGuard.recordFailure(request.username(), lockScopeIp);
             throw new BizException(ResultCode.LOGIN_FAILED);
         }
-        loginAttemptGuard.recordSuccess(request.username(), lockScopeIp(clientIp));
+        loginAttemptGuard.recordSuccess(request.username(), lockScopeIp);
 
         doLogin(user, request.rememberMe());
 
@@ -139,37 +142,46 @@ public class AuthService {
      * 首次登录自动在 {@code sys_user} 创建本地影子账号（{@code login_type=LDAP}）并按配置默认角色，
      * 后继开始复用同一行、不重复创建。</p>
      */
-    public LoginResponse ssoLogin(SsoLoginRequest request) {
+    public LoginResponse ssoLogin(SsoLoginRequest request, String clientIp, String userAgent) {
         if (!ldapProperties.isEnabled()) {
             throw new BizException(ResultCode.SSO_NOT_ENABLED);
         }
         String username = normalizeLdapUsername(request.username());
+        // OA 功能关闭不消耗 proof；启用后必须在任何外部 LDAP 请求之前消费。
+        loginCaptchaService.consumeProof(request.captchaProof(), clientIp, userAgent);
+        String lockScopeIp = lockScopeIp(clientIp);
+        loginAttemptGuard.checkNotLocked(username, lockScopeIp);
 
         LdapBindResult bindResult = ldapAuthService.bind(username, request.password());
         if (bindResult == LdapBindResult.SERVICE_UNAVAILABLE) {
             recordLoginLog(TenantContext.DEFAULT, username, null, false, "OA域服务不可用",
-                "OA登录失败", "AuthController#ssoLogin");
+                "OA登录失败", "AuthController#ssoLogin", clientIp);
+            // 域控不可用不是凭据失败，不累计登录锁定计数。
             throw new BizException(ResultCode.SSO_SERVICE_UNAVAILABLE);
         }
         if (bindResult == LdapBindResult.INVALID_CREDENTIALS) {
             recordLoginLog(TenantContext.DEFAULT, username, null, false, "OA账号或密码错误",
-                "OA登录失败", "AuthController#ssoLogin");
+                "OA登录失败", "AuthController#ssoLogin", clientIp);
+            loginAttemptGuard.recordFailure(username, lockScopeIp);
             throw new BizException(ResultCode.SSO_LOGIN_FAILED);
         }
 
         SysUser user = findOrCreateLdapUser(username);
         if (user.getStatus() == null || user.getStatus() != 1) {
             recordLoginLog(loginLogTenant(user), username, user.getId(), false, "账号已禁用",
-                "OA登录失败", "AuthController#ssoLogin");
+                "OA登录失败", "AuthController#ssoLogin", clientIp);
+            loginAttemptGuard.recordFailure(username, lockScopeIp);
             throw new BizException(ResultCode.SSO_LOGIN_FAILED, "账号已被禁用，请联系管理员");
         }
 
-        recordLoginLog(loginLogTenant(user), username, user.getId(), true, null, "OA登录", "AuthController#ssoLogin");
+        loginAttemptGuard.recordSuccess(username, lockScopeIp);
+        recordLoginLog(loginLogTenant(user), username, user.getId(), true, null,
+            "OA登录", "AuthController#ssoLogin", clientIp);
 
         doLogin(user, request.rememberMe());
 
         user.setLastLoginTime(LocalDateTime.now());
-        user.setLastLoginIp(resolveClientIp());
+        user.setLastLoginIp(clientIp);
         userMapper.updateById(user);
 
         // LDAP 账号密码由企业域控统一管理，不走本地初始密码强制改密逻辑
@@ -235,7 +247,7 @@ public class AuthService {
      * 租户管理员就看不到自己用户的登录记录了。用户名不存在时归默认租户，作为系统级安全事件留痕。</p>
      */
     private void recordLoginLog(String tenantId, String username, Long userId, boolean success, String errorMsg,
-                                 String operation, String method) {
+                                 String operation, String method, String clientIp) {
         try {
             SysOperationLog entity = new SysOperationLog();
             entity.setUserId(userId);
@@ -245,7 +257,7 @@ public class AuthService {
             entity.setTarget("sys_user");
             entity.setResult(success ? SysOperationLog.RESULT_SUCCESS : SysOperationLog.RESULT_FAILURE);
             entity.setErrorMsg(errorMsg);
-            entity.setIp(resolveClientIp());
+            entity.setIp(clientIp);
             entity.initializeAudit(SysOperationLog.AUDIT_COMPLETED, LocalDateTime.now());
             TenantContext.runWith(tenantId, () -> operationLogMapper.insert(entity));
         } catch (Exception e) {
@@ -262,7 +274,11 @@ public class AuthService {
     private String normalizeLdapUsername(String rawUsername) {
         String trimmed = rawUsername.trim();
         int at = trimmed.indexOf('@');
-        return at > 0 ? trimmed.substring(0, at) : trimmed;
+        String username = at >= 0 ? trimmed.substring(0, at) : trimmed;
+        if (username.isBlank() || username.length() > MAX_LOGIN_USERNAME_LENGTH) {
+            throw new BizException(ResultCode.PARAM_INVALID, "OA账号格式不正确");
+        }
+        return username;
     }
 
     /**
@@ -389,16 +405,6 @@ public class AuthService {
         UserApprovalStatus approvalStatus = UserApprovalStatus.parse(user.getApprovalStatus());
         return new LoginResponse(StpUtil.getTokenValue(), user.getNickname(), forceChangePassword,
             approvalStatus.name(), user.getApprovalRemark());
-    }
-
-    /**
-     * 来源 IP：解析规则与注册限流共用 {@link ClientIpResolver} 一处实现。
-     *
-     * <p>此前这里另写了一份 X-Forwarded-For 解析，与限流那份是同一个概念的两个真相来源——
-     * 一边改了信任策略而另一边没跟，就会出现"限流按真实 IP、登录日志按反代 IP"的错配。</p>
-     */
-    private String resolveClientIp() {
-        return ClientIpResolver.fromCurrentRequest(registrationProperties.isTrustForwardedHeader());
     }
 
     /** 锁定计数用的 IP：拿不到来源地址时退化为固定桶，宁可锁得偏严也不放行。 */

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/log/SensitiveDataMasker.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/log/SensitiveDataMasker.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class SensitiveDataMasker {
 
     private static final List<String> SENSITIVE_KEYWORDS =
-        List.of("apikey", "password", "secret", "token");
+        List.of("apikey", "password", "proof", "secret", "token");
 
     private static final String MASK = "******";
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -40,6 +40,7 @@ public enum ResultCode {
     PASSWORD_TOO_WEAK(30011, "密码强度不足，请至少包含字母与数字且不少于 8 位"),
     EMAIL_CODE_INVALID(30012, "邮箱验证码错误"),
     EMAIL_CODE_REISSUE_REQUIRED(30013, "邮箱验证码已失效，请重新获取"),
+    LOGIN_CAPTCHA_INVALID(30014, "拖动验证码无效或已过期，请重新验证"),
 
     // 4xxxx 外部依赖类
     MODEL_TEST_TIMEOUT(40001, "模型连通性测试超时"),
@@ -115,6 +116,8 @@ public enum ResultCode {
     // 前端据此提示"稍后再试"，而不是把它混进注册频率里让人以为是自己点太快
     EMAIL_CODE_TOO_FREQUENT(40052, "验证码获取过于频繁，请稍后再试"),
     EMAIL_CODE_SEND_FAILED(40053, "验证码发送失败，请稍后重试"),
+    LOGIN_CAPTCHA_TOO_FREQUENT(40054, "拖动验证请求过于频繁，请稍后再试"),
+    LOGIN_CAPTCHA_UNAVAILABLE(40055, "拖动验证码服务暂不可用，请稍后重试"),
 
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/SaTokenConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/SaTokenConfig.java
@@ -22,6 +22,8 @@ public class SaTokenConfig implements WebMvcConfigurer {
             .addPathPatterns("/api/**")
             .excludePathPatterns(
                 "/api/auth/login",
+                "/api/auth/login-captcha/challenge",
+                "/api/auth/login-captcha/verify",
                 "/api/auth/register",
                 // 注册页在未登录状态下就要取验证码图片与"本实例开不开放注册"，
                 // 两者都不含敏感信息，防滥用由 RegistrationGuard 的 IP 限流负责

--- a/customer-admin-server/src/main/resources/application.yml
+++ b/customer-admin-server/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 server:
   port: 8082   # 与 customer-work-app-server(8080)、customer-channel(8081) 分开
+  # 禁止容器在 Controller 之前按自带规则重写 remoteAddr；匿名接口统一由
+  # ClientIpResolver 按显式 trusted-proxy-cidrs 解析，避免两套信任链相互绕过。
+  forward-headers-strategy: none
 
 spring:
   application:
@@ -131,9 +134,10 @@ admin:
       # 否则整条注册链路在"获取验证码"那一步就走不下去。
       # 开启时图形验证码改在「发码」那一步校验，注册那一步不再要——手里的邮箱验证码已经是更强的证据。
       enabled: ${ADMIN_REGISTRATION_EMAIL_VERIFICATION:false}
-    # 反代必须“覆写”而不是“追加”X-Forwarded-For，否则客户端可伪造首段绕开 IP 限流；
-    # 直连暴露的部署要设为 false
-    trust-forwarded-header: ${ADMIN_REGISTRATION_TRUST_XFF:true}
+    # 默认不采信客户端可控的转发头。开启时必须同时配置直接连接方的可信代理 CIDR；
+    # 服务端从右向左剥离可信代理链，直连、异常头和伪造的最左段都不会被采信
+    trust-forwarded-header: ${ADMIN_REGISTRATION_TRUST_XFF:false}
+    trusted-proxy-cidrs: ${ADMIN_REGISTRATION_TRUSTED_PROXY_CIDRS:}
     login-lock:
       # 对外部署强制启用，此处只对内网实例生效
       enabled: ${ADMIN_LOGIN_LOCK_ENABLED:false}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/AdminProdProfileConfigTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/AdminProdProfileConfigTest.java
@@ -37,6 +37,11 @@ class AdminProdProfileConfigTest {
             property(sources, "admin.customer-work-db.database"));
         assertEquals("${MYSQL_USERNAME:root}", property(sources, "admin.customer-work-db.username"));
         assertEquals("${MYSQL_PASSWORD:root}", property(sources, "admin.customer-work-db.password"));
+        assertEquals("${ADMIN_REGISTRATION_TRUST_XFF:false}", property(sources,
+            "admin.registration.trust-forwarded-header"));
+        assertEquals("${ADMIN_REGISTRATION_TRUSTED_PROXY_CIDRS:}", property(sources,
+            "admin.registration.trusted-proxy-cidrs"));
+        assertEquals("none", property(sources, "server.forward-headers-strategy"));
     }
 
     @Test

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerLoginCaptchaTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerLoginCaptchaTest.java
@@ -1,0 +1,270 @@
+package com.richard.fyoung.customeradmin.auth.controller;
+
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaChallengeResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaProofResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginResponse;
+import com.richard.fyoung.customeradmin.auth.guard.ClientIpResolver;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
+import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuard;
+import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
+import com.richard.fyoung.customeradmin.auth.service.AuthService;
+import com.richard.fyoung.customeradmin.common.exception.GlobalExceptionHandler;
+import com.richard.fyoung.customeradmin.config.SaTokenConfig;
+import com.richard.fyoung.customeradmin.system.user.service.UserRegistrationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 登录滑块匿名接口、请求契约及同一来源上下文传递。 */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = AuthControllerLoginCaptchaTest.WebMvcTestConfig.class)
+class AuthControllerLoginCaptchaTest {
+
+    private static final String CLIENT_IP = "203.0.113.7";
+    private static final String USER_AGENT = "Mozilla/5.0 Contract";
+
+    @Autowired
+    private WebApplicationContext applicationContext;
+
+    @Autowired
+    private LoginCaptchaService loginCaptchaService;
+
+    @Autowired
+    private AuthService authService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        reset(loginCaptchaService, authService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
+    }
+
+    @Test
+    void challenge_shouldBeAnonymousAndExposeStableContract() throws Exception {
+        when(loginCaptchaService.issueChallenge(CLIENT_IP, USER_AGENT))
+            .thenReturn(new LoginCaptchaChallengeResponse("challenge-id", 120));
+
+        mockMvc.perform(post("/api/auth/login-captcha/challenge")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("X-Forwarded-For", CLIENT_IP + ", 10.0.0.1")
+                .header("User-Agent", USER_AGENT))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.data.challengeId").value("challenge-id"))
+            .andExpect(jsonPath("$.data.ttlSeconds").value(120));
+
+        verify(loginCaptchaService).issueChallenge(CLIENT_IP, USER_AGENT);
+    }
+
+    @Test
+    void challenge_shouldKeepSameSourceForChangingForgedHeadersFromUntrustedPeer() throws Exception {
+        String directPeer = "192.0.2.44";
+        when(loginCaptchaService.issueChallenge(directPeer, USER_AGENT))
+            .thenReturn(new LoginCaptchaChallengeResponse("challenge-id", 120));
+
+        for (String forgedIp : java.util.List.of(CLIENT_IP, "198.51.100.99")) {
+            mockMvc.perform(post("/api/auth/login-captcha/challenge")
+                    .with(request -> {
+                        request.setRemoteAddr(directPeer);
+                        return request;
+                    })
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header("X-Forwarded-For", forgedIp)
+                    .header("User-Agent", USER_AGENT))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0));
+        }
+
+        verify(loginCaptchaService, times(2)).issueChallenge(directPeer, USER_AGENT);
+    }
+
+    @Test
+    void verify_shouldBeAnonymousAndPassNormalizedTrajectoryContract() throws Exception {
+        when(loginCaptchaService.verify(any(), eq(CLIENT_IP), eq(USER_AGENT)))
+            .thenReturn(new LoginCaptchaProofResponse("opaque-proof", 120));
+
+        mockMvc.perform(post("/api/auth/login-captcha/verify")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Forwarded-For", CLIENT_IP)
+                .header("User-Agent", USER_AGENT)
+                .content("""
+                    {"challengeId":"challenge-id","trajectory":[
+                      {"x":0,"y":0,"t":0},{"x":120,"y":1,"t":60},
+                      {"x":320,"y":-1,"t":120},{"x":560,"y":2,"t":190},
+                      {"x":800,"y":0,"t":260},{"x":1000,"y":1,"t":340}
+                    ]}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(0))
+            .andExpect(jsonPath("$.data.proof").value("opaque-proof"))
+            .andExpect(jsonPath("$.data.ttlSeconds").value(120));
+
+        verify(loginCaptchaService).verify(any(), eq(CLIENT_IP), eq(USER_AGENT));
+    }
+
+    @Test
+    void verify_outOfRangePoint_shouldFailBeforeService() throws Exception {
+        mockMvc.perform(post("/api/auth/login-captcha/verify")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("User-Agent", USER_AGENT)
+                .content("""
+                    {"challengeId":"challenge-id","trajectory":[
+                      {"x":0,"y":0,"t":0},{"x":120,"y":1,"t":60},
+                      {"x":320,"y":-1,"t":120},{"x":560,"y":2,"t":190},
+                      {"x":800,"y":0,"t":260},{"x":1001,"y":1,"t":340}
+                    ]}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(30001))
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("trajectory[5].x")));
+
+        verify(loginCaptchaService, never()).verify(any(), any(), any());
+    }
+
+    @Test
+    void localAndSsoLogin_shouldRequireProofAndReuseRequestContext() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"richard\",\"password\":\"password\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(30001))
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("captchaProof")));
+        verify(authService, never()).login(any(), any(), any());
+
+        when(authService.login(any(), eq(CLIENT_IP), eq(USER_AGENT)))
+            .thenReturn(new LoginResponse("token", "Richard", false, "APPROVED", null));
+        mockMvc.perform(post("/api/auth/login")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Forwarded-For", CLIENT_IP)
+                .header("User-Agent", USER_AGENT)
+                .content("""
+                    {"username":"richard","password":"password",
+                     "rememberMe":false,"captchaProof":"proof"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(0));
+        verify(authService).login(any(), eq(CLIENT_IP), eq(USER_AGENT));
+
+        when(authService.ssoLogin(any(), eq(CLIENT_IP), eq(USER_AGENT)))
+            .thenReturn(new LoginResponse("token", "Richard", false, "APPROVED", null));
+        mockMvc.perform(post("/api/auth/sso-login")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Forwarded-For", CLIENT_IP)
+                .header("User-Agent", USER_AGENT)
+                .content("""
+                    {"username":"richard","password":"password",
+                     "rememberMe":false,"captchaProof":"proof"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(0));
+        verify(authService).ssoLogin(any(), eq(CLIENT_IP), eq(USER_AGENT));
+    }
+
+    @ParameterizedTest
+    @MethodSource("oversizedLoginPayloads")
+    void loginCredentialsBeyondContract_shouldFailBeforeService(String path, String payload) throws Exception {
+        mockMvc.perform(post(path)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(30001));
+
+        verify(authService, never()).login(any(), any(), any());
+        verify(authService, never()).ssoLogin(any(), any(), any());
+    }
+
+    private static Stream<Arguments> oversizedLoginPayloads() {
+        return Stream.of(
+            Arguments.of("/api/auth/login", loginPayload("u".repeat(65), "password")),
+            Arguments.of("/api/auth/login", loginPayload("richard", "p".repeat(65))),
+            Arguments.of("/api/auth/login", loginPayload("richard", "password", "p".repeat(257))),
+            Arguments.of("/api/auth/sso-login", loginPayload("u".repeat(257), "password")),
+            Arguments.of("/api/auth/sso-login", loginPayload("richard", "p".repeat(257))),
+            Arguments.of("/api/auth/sso-login", loginPayload("richard", "password", "p".repeat(257))));
+    }
+
+    private static String loginPayload(String username, String password) {
+        return loginPayload(username, password, "proof");
+    }
+
+    private static String loginPayload(String username, String password, String captchaProof) {
+        return "{\"username\":\"" + username + "\",\"password\":\"" + password
+            + "\",\"rememberMe\":false,\"captchaProof\":\"" + captchaProof + "\"}";
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableWebMvc
+    @Import({AuthController.class, SaTokenConfig.class, GlobalExceptionHandler.class})
+    static class WebMvcTestConfig {
+
+        @Bean
+        AuthService authService() {
+            return mock(AuthService.class);
+        }
+
+        @Bean
+        UserRegistrationService userRegistrationService() {
+            return mock(UserRegistrationService.class);
+        }
+
+        @Bean
+        RegistrationGuard registrationGuard() {
+            return mock(RegistrationGuard.class);
+        }
+
+        @Bean
+        RegistrationGuardProperties registrationGuardProperties() {
+            RegistrationGuardProperties properties = new RegistrationGuardProperties();
+            properties.setTrustForwardedHeader(true);
+            properties.setTrustedProxyCidrs(java.util.List.of("127.0.0.1/32", "10.0.0.0/8"));
+            return properties;
+        }
+
+        @Bean
+        ClientIpResolver clientIpResolver(RegistrationGuardProperties properties) {
+            return new ClientIpResolver(properties);
+        }
+
+        @Bean
+        LoginCaptchaService loginCaptchaService() {
+            return mock(LoginCaptchaService.class);
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerRegisterOptionsTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerRegisterOptionsTest.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customeradmin.auth.controller;
 
+import com.richard.fyoung.customeradmin.auth.guard.ClientIpResolver;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
 import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuard;
 import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
 import com.richard.fyoung.customeradmin.auth.service.AuthService;
@@ -82,6 +84,16 @@ class AuthControllerRegisterOptionsTest {
         @Bean
         RegistrationGuardProperties registrationGuardProperties() {
             return new RegistrationGuardProperties();
+        }
+
+        @Bean
+        ClientIpResolver clientIpResolver(RegistrationGuardProperties properties) {
+            return new ClientIpResolver(properties);
+        }
+
+        @Bean
+        LoginCaptchaService loginCaptchaService() {
+            return mock(LoginCaptchaService.class);
         }
     }
 }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfigLoginCaptchaTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfigLoginCaptchaTest.java
@@ -1,0 +1,135 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** 登录滑块存储只允许在启动选型时二选一。 */
+class AuthGuardConfigLoginCaptchaTest {
+
+    private final AuthGuardConfig config = new AuthGuardConfig();
+    private final LoginCaptchaProperties properties = new LoginCaptchaProperties();
+    private final ApplicationContextRunner clientIpContextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(ClientIpTestConfig.class);
+
+    @Test
+    void loginCaptchaStore_shouldUsePureInMemoryWhenRedissonBeanIsAbsent() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<RedissonClient> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+
+        LoginCaptchaStore store = config.loginCaptchaStore(provider, properties);
+
+        assertInstanceOf(InMemoryLoginCaptchaStore.class, store);
+    }
+
+    @Test
+    void loginCaptchaStore_shouldApplyConfiguredInMemoryCapacity() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<RedissonClient> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        properties.setMaxInMemoryEntries(1);
+        LoginCaptchaStore store = config.loginCaptchaStore(provider, properties);
+        long expireAtMs = System.currentTimeMillis() + 60_000L;
+
+        store.saveProof("proof-1", new LoginCaptchaStore.ProofState("fingerprint", expireAtMs), 60);
+
+        assertThrows(IllegalStateException.class, () -> store.saveProof(
+            "proof-2", new LoginCaptchaStore.ProofState("fingerprint", expireAtMs), 60));
+    }
+
+    @Test
+    void loginCaptchaStore_shouldUseRedisOnlyWhenRedissonBeanIsPresent() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<RedissonClient> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(mock(RedissonClient.class));
+
+        LoginCaptchaStore store = config.loginCaptchaStore(provider, properties);
+
+        assertInstanceOf(RedissonLoginCaptchaStore.class, store);
+    }
+
+    @Test
+    void clientIpResolver_shouldRequireContainerForwardHeadersToRemainDisabled() {
+        RegistrationGuardProperties registration = new RegistrationGuardProperties();
+        ServerProperties safeServer = new ServerProperties();
+        safeServer.setForwardHeadersStrategy(ServerProperties.ForwardHeadersStrategy.NONE);
+        assertNotNull(config.clientIpResolver(registration, safeServer));
+
+        for (ServerProperties.ForwardHeadersStrategy unsafe : java.util.List.of(
+            ServerProperties.ForwardHeadersStrategy.FRAMEWORK,
+            ServerProperties.ForwardHeadersStrategy.NATIVE)) {
+            ServerProperties unsafeServer = new ServerProperties();
+            unsafeServer.setForwardHeadersStrategy(unsafe);
+            assertThrows(IllegalStateException.class,
+                () -> config.clientIpResolver(registration, unsafeServer));
+        }
+
+        ServerProperties remoteIpHeaderServer = serverPropertiesWithoutForwardHeaders();
+        remoteIpHeaderServer.getTomcat().getRemoteip().setRemoteIpHeader("X-Forwarded-For");
+        assertThrows(IllegalStateException.class,
+            () -> config.clientIpResolver(registration, remoteIpHeaderServer));
+
+        ServerProperties protocolHeaderServer = serverPropertiesWithoutForwardHeaders();
+        protocolHeaderServer.getTomcat().getRemoteip().setProtocolHeader("X-Forwarded-Proto");
+        assertThrows(IllegalStateException.class,
+            () -> config.clientIpResolver(registration, protocolHeaderServer));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "server.forward-headers-strategy=framework",
+        "server.forward-headers-strategy=native",
+        "server.tomcat.remoteip.remote-ip-header=X-Forwarded-For",
+        "server.tomcat.remoteip.protocol-header=X-Forwarded-Proto"
+    })
+    void clientIpResolver_shouldFailStartupForUnsafeBoundContainerSetting(String propertyValue) {
+        clientIpContextRunner.withPropertyValues(propertyValue).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure())
+                .hasRootCauseMessage(
+                    "container forward-header handling must remain disabled; ClientIpResolver is the only trust boundary");
+        });
+    }
+
+    @Test
+    void clientIpResolver_shouldStartWhenBoundContainerHandlingIsDisabled() {
+        clientIpContextRunner
+            .withPropertyValues("server.forward-headers-strategy=none")
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).hasSingleBean(ClientIpResolver.class);
+            });
+    }
+
+    private ServerProperties serverPropertiesWithoutForwardHeaders() {
+        ServerProperties serverProperties = new ServerProperties();
+        serverProperties.setForwardHeadersStrategy(ServerProperties.ForwardHeadersStrategy.NONE);
+        return serverProperties;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties({RegistrationGuardProperties.class, ServerProperties.class})
+    static class ClientIpTestConfig {
+
+        @Bean
+        ClientIpResolver clientIpResolver(RegistrationGuardProperties registration,
+                                          ServerProperties serverProperties) {
+            return new AuthGuardConfig().clientIpResolver(registration, serverProperties);
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/ClientIpResolverTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/ClientIpResolverTest.java
@@ -2,61 +2,190 @@ package com.richard.fyoung.customeradmin.auth.guard;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * 来源 IP 解析。
- *
- * <p>限流与登录锁定都按这个值分桶，解析错了要么全体共用一个桶（限得过严），
- * 要么每个伪造请求头各占一个桶（等于没限）。</p>
- */
+/** 来源 IP 解析必须先证明直接连接方可信，再解析代理链。 */
 class ClientIpResolverTest {
 
     @Test
-    void resolve_shouldTakeLeftmostForwardedAddressWhenTrusted() {
-        HttpServletRequest request = request("203.0.113.5, 70.41.3.18, 150.172.238.178", null, "10.0.0.1");
-
-        assertEquals("203.0.113.5", ClientIpResolver.resolve(request, true));
+    void registrationProperties_shouldDistrustForwardedHeadersByDefault() {
+        assertFalse(new RegistrationGuardProperties().isTrustForwardedHeader());
     }
 
     @Test
-    void resolve_shouldIgnoreForwardedHeaderWhenNotTrusted() {
-        HttpServletRequest request = request("203.0.113.5", "198.51.100.7", "10.0.0.1");
+    void resolve_shouldIgnoreForgedHeadersFromUntrustedImmediatePeer() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+        HttpServletRequest request = request("203.0.113.5", "198.51.100.7", "192.0.2.44");
 
-        assertEquals("10.0.0.1", ClientIpResolver.resolve(request, false));
+        assertEquals("192.0.2.44", resolver.resolve(request));
     }
 
     @Test
-    void resolve_shouldFallBackToRealIpThenRemoteAddress() {
+    void resolve_shouldUseSingleForwardedClientFromTrustedProxy() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+
+        assertEquals("203.0.113.5",
+            resolver.resolve(request("203.0.113.5", null, "10.0.0.7")));
         assertEquals("198.51.100.7",
-            ClientIpResolver.resolve(request(null, "198.51.100.7", "10.0.0.1"), true));
-        assertEquals("10.0.0.1",
-            ClientIpResolver.resolve(request(null, null, "10.0.0.1"), true));
+            resolver.resolve(request(null, "198.51.100.7", "10.0.0.7")));
     }
 
-    /** 代理链路里 unknown 是常见占位值，当成拿不到处理而不是当成一个 IP。 */
     @Test
-    void resolve_shouldTreatUnknownPlaceholderAsMissing() {
-        assertEquals("10.0.0.1",
-            ClientIpResolver.resolve(request("unknown", null, "10.0.0.1"), true));
-        assertEquals("10.0.0.1",
-            ClientIpResolver.resolve(request("  ", "UNKNOWN", "10.0.0.1"), true));
+    void resolve_shouldIgnoreSpoofedLeftmostAddressInAppendMode() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+
+        assertEquals("198.51.100.9",
+            resolver.resolve(request("203.0.113.99, 198.51.100.9", null, "10.0.0.7")));
     }
 
-    /** 全都取不到时返回固定串：限流退化为"全体共用一个桶"，而不是放行。 */
     @Test
-    void resolve_shouldReturnStableFallbackInsteadOfNull() {
-        assertEquals("unknown", ClientIpResolver.resolve(request(null, null, null), true));
-        assertEquals("unknown", ClientIpResolver.resolve(null, true));
+    void resolve_shouldCombineRepeatedForwardedHeadersBeforeStrippingTrustedChain() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+
+        assertEquals("198.51.100.9", resolver.resolve(request(
+            List.of("203.0.113.99", "198.51.100.9"), List.of(), "10.0.0.7")));
+    }
+
+    @Test
+    void resolve_shouldStripMultipleTrustedProxiesFromRight() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8", "fd00::/8");
+
+        assertEquals("198.51.100.9", resolver.resolve(request(
+            "203.0.113.99, 198.51.100.9, fd00::12", null, "10.0.0.7")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "unknown",
+        "client.example.com",
+        "198.51.100.9:8080",
+        "198.51.100.9,,10.0.0.8",
+        "999.51.100.9"
+    })
+    void resolve_shouldFallBackToRemoteAddressWhenForwardedChainIsMalformed(String forwardedFor) {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+
+        assertEquals("10.0.0.7", resolver.resolve(request(forwardedFor, null, "10.0.0.7")));
+    }
+
+    @Test
+    void resolve_shouldRejectOversizedAndExcessiveForwardedChains() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+        String tooManyHops = IntStream.range(0, 17)
+            .mapToObj(index -> "198.51.100." + index)
+            .collect(Collectors.joining(","));
+
+        assertEquals("10.0.0.7",
+            resolver.resolve(request("1".repeat(2_049), null, "10.0.0.7")));
+        assertEquals("10.0.0.7",
+            resolver.resolve(request(tooManyHops, null, "10.0.0.7")));
+        assertEquals("10.0.0.7", resolver.resolve(request(
+            List.of(" ".repeat(1_020) + "198.51.100.8", " ".repeat(1_020) + "198.51.100.9"),
+            List.of(), "10.0.0.7")));
+        assertEquals("10.0.0.7", resolver.resolve(request(
+            List.of(
+                IntStream.range(0, 8).mapToObj(index -> "198.51.100." + index)
+                    .collect(Collectors.joining(",")),
+                IntStream.range(8, 17).mapToObj(index -> "198.51.100." + index)
+                    .collect(Collectors.joining(","))),
+            List.of(), "10.0.0.7")));
+    }
+
+    @Test
+    void resolve_shouldRejectRepeatedRealIpHeaders() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+
+        assertEquals("10.0.0.7", resolver.resolve(request(
+            List.of(), List.of("198.51.100.8", "198.51.100.9"), "10.0.0.7")));
+    }
+
+    @Test
+    void resolve_shouldFallBackWhenEntireForwardedChainIsTrusted() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/8");
+
+        assertEquals("10.0.0.7",
+            resolver.resolve(request("10.1.1.1, 10.2.2.2", null, "10.0.0.7")));
+        assertEquals("10.0.0.7",
+            resolver.resolve(request(null, "10.3.3.3", "10.0.0.7")));
+    }
+
+    @Test
+    void resolve_shouldCanonicalizeIpv6AndIpv4MappedAddresses() {
+        ClientIpResolver ipv6Resolver = resolver(true, "2001:db8:1::/48");
+        assertEquals("2001:db8:2:0:0:0:0:9", ipv6Resolver.resolve(
+            request("2001:0db8:0002:0000:0000:0000:0000:0009", null, "2001:db8:1::7")));
+
+        ClientIpResolver mappedResolver = resolver(true, "10.0.0.0/8");
+        assertEquals("198.51.100.9", mappedResolver.resolve(
+            request("198.51.100.9", null, "::ffff:10.0.0.7")));
+    }
+
+    @Test
+    void resolve_shouldHonorCidrBoundary() {
+        ClientIpResolver resolver = resolver(true, "10.0.0.0/25");
+
+        assertEquals("203.0.113.5",
+            resolver.resolve(request("203.0.113.5", null, "10.0.0.127")));
+        assertEquals("10.0.0.128",
+            resolver.resolve(request("203.0.113.5", null, "10.0.0.128")));
+
+        ClientIpResolver ipv6Resolver = resolver(true, "2001:db8::/65");
+        assertEquals("198.51.100.9", ipv6Resolver.resolve(
+            request("198.51.100.9", null, "2001:db8:0:0:7fff::1")));
+        assertEquals("2001:db8:0:0:8000:0:0:1", ipv6Resolver.resolve(
+            request("198.51.100.9", null, "2001:db8:0:0:8000::1")));
+    }
+
+    @Test
+    void constructor_shouldFailFastForUnsafeOrInvalidProxyConfiguration() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClientIpResolver(true, List.of()));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClientIpResolver(true, List.of("10.0.0.0/33")));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClientIpResolver(true, List.of("0.0.0.0/0")));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClientIpResolver(true, List.of("::/0")));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClientIpResolver(false, List.of("proxy.example.com/24")));
+    }
+
+    @Test
+    void resolve_shouldReturnStableUnknownBucketForMissingOrInvalidRemoteAddress() {
+        ClientIpResolver resolver = new ClientIpResolver(false, List.of());
+
+        assertEquals("unknown", resolver.resolve(null));
+        assertEquals("unknown", resolver.resolve(request("203.0.113.5", null, null)));
+        assertEquals("unknown", resolver.resolve(request("203.0.113.5", null, "localhost")));
+    }
+
+    private ClientIpResolver resolver(boolean trustForwardedHeader, String... cidrs) {
+        return new ClientIpResolver(trustForwardedHeader, List.of(cidrs));
     }
 
     private HttpServletRequest request(String forwardedFor, String realIp, String remoteAddr) {
+        return request(forwardedFor == null ? List.of() : List.of(forwardedFor),
+            realIp == null ? List.of() : List.of(realIp), remoteAddr);
+    }
+
+    private HttpServletRequest request(List<String> forwardedFor, List<String> realIp, String remoteAddr) {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getHeader("X-Forwarded-For")).thenReturn(forwardedFor);
-        when(request.getHeader("X-Real-IP")).thenReturn(realIp);
+        when(request.getHeaders("X-Forwarded-For"))
+            .thenReturn(Collections.enumeration(forwardedFor));
+        when(request.getHeaders("X-Real-IP"))
+            .thenReturn(Collections.enumeration(realIp));
         when(request.getRemoteAddr()).thenReturn(remoteAddr);
         return request;
     }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStoreTest.java
@@ -1,0 +1,205 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** 进程内登录滑块凭据存储的过期、容量与一次性消费语义。 */
+class InMemoryLoginCaptchaStoreTest {
+
+    private static final String FINGERPRINT = "fingerprint";
+
+    @Test
+    void consumeChallenge_shouldTreatAbsoluteExpiryAsNotFound() {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(2, clock);
+        store.saveChallenge("expired", challenge(FINGERPRINT, 999L), 120);
+
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState> result =
+            store.consumeChallenge("expired", FINGERPRINT);
+
+        assertEquals(LoginCaptchaStore.ConsumeStatus.NOT_FOUND, result.status());
+    }
+
+    @Test
+    void consumeProof_shouldTreatAbsoluteExpiryAsNotFound() {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(2, clock);
+        store.saveProof("proof", proof(FINGERPRINT, 999L), 120);
+
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ProofState> result =
+            store.consumeProof("proof", FINGERPRINT);
+
+        assertEquals(LoginCaptchaStore.ConsumeStatus.NOT_FOUND, result.status());
+    }
+
+    @Test
+    void consumeChallenge_shouldAtomicallyAllowOnlyOneConcurrentConsumer() throws Exception {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(2, clock);
+        store.saveChallenge("challenge", challenge(FINGERPRINT, 2_000L), 120);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState>>> results = List.of(
+                executor.submit(consumeAfterBarrier(store, ready, start)),
+                executor.submit(consumeAfterBarrier(store, ready, start)));
+            ready.await();
+            start.countDown();
+
+            long matched = 0;
+            long missing = 0;
+            for (Future<LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState>> result : results) {
+                if (result.get().status() == LoginCaptchaStore.ConsumeStatus.MATCHED) {
+                    matched++;
+                } else if (result.get().status() == LoginCaptchaStore.ConsumeStatus.NOT_FOUND) {
+                    missing++;
+                }
+            }
+            assertEquals(1, matched);
+            assertEquals(1, missing);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void save_shouldFailFastWhenCapacityIsExceededButAllowOverwrite() {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(1, clock);
+        store.saveProof("existing", proof(FINGERPRINT, 2_000L), 120);
+
+        assertDoesNotThrow(() -> store.saveProof("existing", proof("new-fingerprint", 2_000L), 120));
+        assertThrows(IllegalStateException.class,
+            () -> store.saveProof("new", proof(FINGERPRINT, 2_000L), 120));
+    }
+
+    @Test
+    void save_shouldPurgeExpiredEntriesBeforeCheckingCapacity() {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(1, clock);
+        store.saveChallenge("expired", challenge(FINGERPRINT, 1_000L), 120);
+
+        assertDoesNotThrow(() -> store.saveChallenge("fresh", challenge(FINGERPRINT, 2_000L), 120));
+    }
+
+    @Test
+    void saveProof_shouldKeepHardCapacityLimit_underConcurrentDistinctKeys() throws Exception {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(1, clock);
+
+        assertConcurrentCapacityLimit(key ->
+            store.saveProof(key, proof(FINGERPRINT, 2_000L), 120));
+    }
+
+    @Test
+    void saveChallenge_shouldKeepHardCapacityLimit_underConcurrentDistinctKeys() throws Exception {
+        MutableClock clock = new MutableClock(1_000L);
+        InMemoryLoginCaptchaStore store = new InMemoryLoginCaptchaStore(1, clock);
+
+        assertConcurrentCapacityLimit(key ->
+            store.saveChallenge(key, challenge(FINGERPRINT, 2_000L), 120));
+    }
+
+    private void assertConcurrentCapacityLimit(StoreWriter writer) throws Exception {
+        int concurrency = 24;
+        ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+        CountDownLatch ready = new CountDownLatch(concurrency);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Boolean>> results = new java.util.ArrayList<>();
+            for (int index = 0; index < concurrency; index++) {
+                String key = "credential-" + index;
+                results.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    try {
+                        writer.save(key);
+                        return true;
+                    } catch (IllegalStateException e) {
+                        return false;
+                    }
+                }));
+            }
+            assertTrue(ready.await(5, TimeUnit.SECONDS), "并发写入线程未及时就绪");
+            start.countDown();
+
+            long saved = 0;
+            for (Future<Boolean> result : results) {
+                if (result.get(5, TimeUnit.SECONDS)) {
+                    saved++;
+                }
+            }
+            assertEquals(1, saved, "不同 key 并发写入也不能突破硬容量上限");
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "并发写入线程未正常退出");
+        }
+    }
+
+    @FunctionalInterface
+    private interface StoreWriter {
+        void save(String key);
+    }
+
+    private Callable<LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState>> consumeAfterBarrier(
+        InMemoryLoginCaptchaStore store, CountDownLatch ready, CountDownLatch start) {
+        return () -> {
+            ready.countDown();
+            start.await();
+            return store.consumeChallenge("challenge", FINGERPRINT);
+        };
+    }
+
+    private LoginCaptchaStore.ChallengeState challenge(String fingerprint, long expireAtMs) {
+        return new LoginCaptchaStore.ChallengeState(fingerprint, 0L, expireAtMs);
+    }
+
+    private LoginCaptchaStore.ProofState proof(String fingerprint, long expireAtMs) {
+        return new LoginCaptchaStore.ProofState(fingerprint, expireAtMs);
+    }
+
+    private static final class MutableClock extends Clock {
+        private final long millis;
+
+        private MutableClock(long millis) {
+            this.millis = millis;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis);
+        }
+
+        @Override
+        public long millis() {
+            return millis;
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaPropertiesTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaPropertiesTest.java
@@ -1,0 +1,52 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.validation.BindValidationException;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 登录滑块运维配置必须在启动期失败，而不是把错误推迟到请求期。 */
+class LoginCaptchaPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(TestConfig.class);
+
+    @Test
+    void defaults_shouldBindSuccessfully() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(LoginCaptchaProperties.class);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "challenge-ttl-seconds",
+        "proof-ttl-seconds",
+        "max-issue-per-window",
+        "max-verify-per-window",
+        "max-proof-consume-per-window",
+        "rate-limit-window-seconds",
+        "max-in-memory-entries",
+        "max-user-agent-length"
+    })
+    void everyNonPositiveOperationalValue_shouldFailStartupValidation(String propertyName) {
+        contextRunner
+            .withPropertyValues("admin.login-captcha." + propertyName + "=0")
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(BindValidationException.class);
+            });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(LoginCaptchaProperties.class)
+    static class TestConfig {
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaServiceTest.java
@@ -1,0 +1,476 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaChallengeResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaProofResponse;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaProtocol;
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaVerifyRequest;
+import com.richard.fyoung.customeradmin.auth.dto.SliderTrackPoint;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customerwork.infra.counter.WindowCounter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** 登录滑块从 challenge 到 proof 的安全边界。 */
+class LoginCaptchaServiceTest {
+
+    private static final String IP = "203.0.113.31";
+    private static final String USER_AGENT = "Mozilla/5.0 customer-admin-test";
+
+    private MutableClock clock;
+    private LoginCaptchaProperties properties;
+    private WindowCounter counter;
+    private LoginCaptchaService service;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(10_000L);
+        properties = new LoginCaptchaProperties();
+        counter = mock(WindowCounter.class);
+        when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(true);
+        service = new LoginCaptchaService(new InMemoryLoginCaptchaStore(100, clock), properties,
+            counter, clock, new SecureRandom());
+    }
+
+    @Test
+    void verify_shouldIssueProofForValidTrajectory() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        LoginCaptchaProofResponse proof = service.verify(request(challenge, validTrajectory()), IP, USER_AGENT);
+
+        assertNotNull(proof.proof());
+        assertFalse(proof.proof().isBlank());
+        assertEquals(properties.getProofTtlSeconds(), proof.ttlSeconds());
+        assertDoesNotThrow(() -> service.consumeProof(proof.proof(), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldIssue32ByteBase64UrlProofAndStoreOnlyItsSha256() throws Exception {
+        InMemoryLoginCaptchaStore store = spy(new InMemoryLoginCaptchaStore(100, clock));
+        LoginCaptchaService localService = new LoginCaptchaService(
+            store, properties, counter, clock, new SecureRandom());
+        LoginCaptchaChallengeResponse challenge = localService.issueChallenge(IP, USER_AGENT);
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        LoginCaptchaProofResponse proof = localService.verify(
+            request(challenge, validTrajectory()), IP, USER_AGENT);
+
+        assertEquals(32, Base64.getUrlDecoder().decode(proof.proof()).length);
+        org.mockito.ArgumentCaptor<String> proofKey = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(store).saveProof(proofKey.capture(), any(), eq(properties.getProofTtlSeconds()));
+        String expectedHash = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+            .digest(proof.proof().getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        assertEquals(expectedHash, proofKey.getValue());
+        assertNotEquals(proof.proof(), proofKey.getValue());
+    }
+
+    @Test
+    void fingerprint_shouldNormalizeWhitespaceAndIgnoreUserAgentBeyondConfiguredLimit() {
+        properties.setMaxUserAgentLength(12);
+        LoginCaptchaChallengeResponse challenge = service.issueChallenge(IP, " Agent/1.0   suffix-a");
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        assertNotNull(service.verify(request(challenge, validTrajectory()), IP, "Agent/1.0 suffix-b"));
+    }
+
+    @Test
+    void verify_shouldRejectTooFastAndConsumeChallenge() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS - 1);
+
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldRejectTooFewPointsAndConsumeChallenge() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory().subList(0, 5)), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldRejectTeleportTrackAndConsumeChallenge() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        List<SliderTrackPoint> teleport = List.of(
+            point(0, 0), point(0, 80), point(0, 160), point(0, 240), point(0, 320), point(1000, 400));
+
+        assertInvalid(() -> service.verify(request(challenge, teleport), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldRejectTrackThatDoesNotReachEndAndConsumeChallenge() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        List<SliderTrackPoint> incomplete = new ArrayList<>(validTrajectory());
+        incomplete.set(incomplete.size() - 1, point(LoginCaptchaProtocol.END_X_MIN - 1, 400));
+
+        assertInvalid(() -> service.verify(request(challenge, incomplete), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldRejectNonIncreasingTimeAndConsumeChallenge() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        List<SliderTrackPoint> nonIncreasing = new ArrayList<>(validTrajectory());
+        nonIncreasing.set(3, point(520, 120));
+
+        assertInvalid(() -> service.verify(request(challenge, nonIncreasing), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldRejectTrackWithInsufficientIntermediatePoints() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        List<SliderTrackPoint> sparse = List.of(
+            point(0, 0), point(10, 80), point(200, 160), point(500, 240), point(800, 320),
+            point(1000, 400));
+
+        assertInvalid(() -> service.verify(request(challenge, sparse), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("independentInvalidTrajectoryCases")
+    void verify_shouldRejectEveryIndependentTrajectoryBoundaryAndConsumeChallenge(
+        String caseName, List<SliderTrackPoint> trajectory) {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        assertInvalid(() -> service.verify(request(challenge, trajectory), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldKeepChallengeWhenIpDoesNotMatch() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), "198.51.100.42", USER_AGENT));
+
+        assertNotNull(service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldKeepChallengeWhenUserAgentDoesNotMatch() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, "other-agent"));
+
+        assertNotNull(service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void consumeProof_shouldBeOneTimeAndKeepProofOnFingerprintMismatch() {
+        LoginCaptchaProofResponse proof = verifiedProof();
+
+        assertInvalid(() -> service.consumeProof(proof.proof(), "198.51.100.42", USER_AGENT));
+        assertDoesNotThrow(() -> service.consumeProof(proof.proof(), IP, USER_AGENT));
+        assertInvalid(() -> service.consumeProof(proof.proof(), IP, USER_AGENT));
+    }
+
+    @Test
+    void consumeProof_shouldRejectExpiredProof() {
+        properties.setProofTtlSeconds(1);
+        LoginCaptchaProofResponse proof = verifiedProof();
+        clock.advance(1_001L);
+
+        assertInvalid(() -> service.consumeProof(proof.proof(), IP, USER_AGENT));
+    }
+
+    @Test
+    void issueChallenge_shouldMapStoreSaveFailureToUnavailable() {
+        LoginCaptchaStore failingStore = mock(LoginCaptchaStore.class);
+        doThrow(new IllegalStateException("redis timeout")).when(failingStore)
+            .saveChallenge(anyString(), any(), anyInt());
+
+        assertUnavailable(() -> serviceWith(failingStore).issueChallenge(IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldMapChallengeConsumeFailureToUnavailable() {
+        LoginCaptchaStore failingStore = mock(LoginCaptchaStore.class);
+        LoginCaptchaService failingService = serviceWith(failingStore);
+        LoginCaptchaChallengeResponse challenge = failingService.issueChallenge(IP, USER_AGENT);
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        when(failingStore.consumeChallenge(eq(challenge.challengeId()), anyString()))
+            .thenThrow(new IllegalStateException("redis timeout"));
+
+        assertUnavailable(() -> failingService.verify(
+            request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldMapProofSaveFailureToUnavailable() {
+        LoginCaptchaStore failingStore = mock(LoginCaptchaStore.class);
+        LoginCaptchaService failingService = serviceWith(failingStore);
+        long issuedAt = clock.millis();
+        LoginCaptchaChallengeResponse challenge = failingService.issueChallenge(IP, USER_AGENT);
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        when(failingStore.consumeChallenge(eq(challenge.challengeId()), anyString()))
+            .thenReturn(LoginCaptchaStore.ConsumeResult.matched(
+                new LoginCaptchaStore.ChallengeState("fingerprint", issuedAt, clock.millis() + 10_000L)));
+        doThrow(new IllegalStateException("redis timeout")).when(failingStore)
+            .saveProof(anyString(), any(), anyInt());
+
+        assertUnavailable(() -> failingService.verify(
+            request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void consumeProof_shouldMapStoreFailureToUnavailable() {
+        LoginCaptchaStore failingStore = mock(LoginCaptchaStore.class);
+        LoginCaptchaService failingService = serviceWith(failingStore);
+        String proof = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[32]);
+        when(failingStore.consumeProof(anyString(), anyString()))
+            .thenThrow(new IllegalStateException("redis timeout"));
+
+        assertUnavailable(() -> failingService.consumeProof(proof, IP, USER_AGENT));
+    }
+
+    @Test
+    void issueChallenge_shouldEnforcePerIpRateLimit() {
+        properties.setMaxIssuePerWindow(2);
+        when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(true, true, false);
+
+        assertNotNull(issue());
+        assertNotNull(issue());
+        BizException error = assertThrows(BizException.class, () -> issue());
+
+        assertEquals(ResultCode.LOGIN_CAPTCHA_TOO_FREQUENT, error.getResultCode());
+        verify(counter, times(3)).tryAcquireSliding(anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    void issueChallenge_shouldUseNormalizedPerIpRateKeyAndConfiguredWindow() throws Exception {
+        service.issueChallenge("  " + IP + "  ", USER_AGENT);
+        service.issueChallenge(IP, USER_AGENT);
+        service.issueChallenge("198.51.100.42", USER_AGENT);
+
+        org.mockito.ArgumentCaptor<String> keys = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(counter, times(3)).tryAcquireSliding(keys.capture(),
+            eq(properties.getMaxIssuePerWindow()), eq(properties.getRateLimitWindowSeconds()));
+        List<String> captured = keys.getAllValues();
+        assertEquals(captured.get(0), captured.get(1), "同一 IP 归一化后应共享限流键");
+        assertNotEquals(captured.get(1), captured.get(2), "不同 IP 不能共享限流键");
+        assertEquals("admin:login-captcha:issue:" + sha256(IP), captured.get(0));
+    }
+
+    @Test
+    void issueChallenge_shouldNotPersistWhenRateLimitRejects() {
+        LoginCaptchaStore store = mock(LoginCaptchaStore.class);
+        when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(false);
+
+        BizException error = assertThrows(BizException.class,
+            () -> serviceWith(store).issueChallenge(IP, USER_AGENT));
+
+        assertEquals(ResultCode.LOGIN_CAPTCHA_TOO_FREQUENT, error.getResultCode());
+        verify(store, never()).saveChallenge(anyString(), any(), anyInt());
+    }
+
+    @Test
+    void verify_shouldRejectRateLimitBeforeAccessingStore() throws Exception {
+        LoginCaptchaStore store = mock(LoginCaptchaStore.class);
+        properties.setMaxVerifyPerWindow(7);
+        when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(false);
+        LoginCaptchaVerifyRequest request = new LoginCaptchaVerifyRequest(
+            Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[16]), validTrajectory());
+
+        BizException error = assertThrows(BizException.class,
+            () -> serviceWith(store).verify(request, IP, USER_AGENT));
+
+        assertEquals(ResultCode.LOGIN_CAPTCHA_TOO_FREQUENT, error.getResultCode());
+        verify(store, never()).consumeChallenge(anyString(), anyString());
+        verify(counter).tryAcquireSliding(
+            eq("admin:login-captcha:verify:" + sha256(IP)),
+            eq(7), eq(properties.getRateLimitWindowSeconds()));
+    }
+
+    @Test
+    void consumeProof_shouldRejectRateLimitBeforeAccessingStore() throws Exception {
+        LoginCaptchaStore store = mock(LoginCaptchaStore.class);
+        properties.setMaxProofConsumePerWindow(11);
+        when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(false);
+        String proof = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[32]);
+
+        BizException error = assertThrows(BizException.class,
+            () -> serviceWith(store).consumeProof(proof, IP, USER_AGENT));
+
+        assertEquals(ResultCode.LOGIN_CAPTCHA_TOO_FREQUENT, error.getResultCode());
+        verify(store, never()).consumeProof(anyString(), anyString());
+        verify(counter).tryAcquireSliding(
+            eq("admin:login-captcha:consume:" + sha256(IP)),
+            eq(11), eq(properties.getRateLimitWindowSeconds()));
+    }
+
+    private LoginCaptchaChallengeResponse issue() {
+        return service.issueChallenge(IP, USER_AGENT);
+    }
+
+    private LoginCaptchaService serviceWith(LoginCaptchaStore store) {
+        return new LoginCaptchaService(store, properties, counter, clock, new SecureRandom());
+    }
+
+    private LoginCaptchaProofResponse verifiedProof() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        return service.verify(request(challenge, validTrajectory()), IP, USER_AGENT);
+    }
+
+    private LoginCaptchaVerifyRequest request(LoginCaptchaChallengeResponse challenge,
+                                              List<SliderTrackPoint> trajectory) {
+        return new LoginCaptchaVerifyRequest(challenge.challengeId(), trajectory);
+    }
+
+    private List<SliderTrackPoint> validTrajectory() {
+        return List.of(point(0, 0), point(120, 50), point(300, 120),
+            point(520, 210), point(760, 320), point(1000, 400));
+    }
+
+    private SliderTrackPoint point(int x, long timeMs) {
+        return new SliderTrackPoint(x, 0, timeMs);
+    }
+
+    private static Stream<Arguments> independentInvalidTrajectoryCases() {
+        List<SliderTrackPoint> startTooFar = mutableValidTrajectory();
+        startTooFar.set(0, trackPoint(21, 0, 0));
+
+        List<SliderTrackPoint> initialPointTooLate = mutableValidTrajectory();
+        initialPointTooLate.set(0, trackPoint(0, 0, 101));
+        initialPointTooLate.set(1, trackPoint(120, 0, 150));
+
+        List<SliderTrackPoint> durationTooShort = mutableValidTrajectory();
+        durationTooShort.set(1, trackPoint(120, 0, 40));
+        durationTooShort.set(2, trackPoint(300, 0, 90));
+        durationTooShort.set(3, trackPoint(520, 0, 150));
+        durationTooShort.set(4, trackPoint(760, 0, 220));
+        durationTooShort.set(5, trackPoint(1000, 0, 299));
+
+        List<SliderTrackPoint> durationTooLong = mutableValidTrajectory();
+        durationTooLong.set(5, trackPoint(1000, 0, 8_001));
+
+        List<SliderTrackPoint> tooManyPoints = IntStream.rangeClosed(0, 80)
+            .mapToObj(index -> trackPoint(index * 1_000 / 80, 0, index * 10L))
+            .toList();
+
+        List<SliderTrackPoint> yTooLarge = mutableValidTrajectory();
+        yTooLarge.set(3, trackPoint(520, 1_001, 210));
+
+        List<SliderTrackPoint> nullIntermediate = new ArrayList<>(
+            Arrays.asList(trackPoint(0, 0, 0), trackPoint(120, 0, 50), null,
+                trackPoint(520, 0, 210), trackPoint(760, 0, 320), trackPoint(1000, 0, 400)));
+
+        return Stream.of(
+            Arguments.of("起点超过 20", startTooFar),
+            Arguments.of("首点晚于 100ms", initialPointTooLate),
+            Arguments.of("轨迹短于 300ms", durationTooShort),
+            Arguments.of("轨迹长于 8000ms", durationTooLong),
+            Arguments.of("轨迹超过 80 点", tooManyPoints),
+            Arguments.of("Y 偏移超过 1000", yTooLarge),
+            Arguments.of("中间采样点为空", nullIntermediate));
+    }
+
+    private static List<SliderTrackPoint> mutableValidTrajectory() {
+        return new ArrayList<>(List.of(trackPoint(0, 0, 0), trackPoint(120, 0, 50),
+            trackPoint(300, 0, 120), trackPoint(520, 0, 210), trackPoint(760, 0, 320),
+            trackPoint(1000, 0, 400)));
+    }
+
+    private static SliderTrackPoint trackPoint(int x, int y, long timeMs) {
+        return new SliderTrackPoint(x, y, timeMs);
+    }
+
+    private String sha256(String value) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+            .digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+    }
+
+    private void assertInvalid(ThrowingRunnable action) {
+        BizException error = assertThrows(BizException.class, action::run);
+        assertEquals(ResultCode.LOGIN_CAPTCHA_INVALID, error.getResultCode());
+    }
+
+    private void assertUnavailable(ThrowingRunnable action) {
+        BizException error = assertThrows(BizException.class, action::run);
+        assertEquals(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE, error.getResultCode());
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run();
+    }
+
+    private static final class MutableClock extends Clock {
+        private long currentMillis;
+
+        private MutableClock(long currentMillis) {
+            this.currentMillis = currentMillis;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(currentMillis);
+        }
+
+        @Override
+        public long millis() {
+            return currentMillis;
+        }
+
+        private void advance(long millis) {
+            currentMillis += millis;
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreIntegrationTest.java
@@ -1,0 +1,246 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.redisson.Redisson;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Redis 登录滑块存储的真服务门禁，覆盖 Lua 原子消费、TTL、并发重放与故障关闭。
+ *
+ * <p>真实 Redis 用例在服务不可达或鉴权不匹配时按仓库惯例跳过；故障关闭用例使用本进程
+ * black-hole 端口独立执行，不依赖外部 Redis 的可用状态。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class RedissonLoginCaptchaStoreIntegrationTest {
+
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 6379;
+    private static final int PROBE_TIMEOUT_MILLIS = 800;
+    private static final String KEY_PREFIX = "cw:admin:login-captcha:";
+    private static final String FINGERPRINT = "fingerprint";
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class LiveRedis {
+
+        private RedissonClient redisson;
+        private RedissonLoginCaptchaStore store;
+
+        @BeforeAll
+        void setUp() {
+            String host = envOrDefault("ADMIN_REDIS_HOST", DEFAULT_HOST);
+            int port = Integer.parseInt(envOrDefault("ADMIN_REDIS_PORT", String.valueOf(DEFAULT_PORT)));
+            assumeTrue(reachable(host, port),
+                "Redis 不可达（" + host + ":" + port + "），跳过真实 Redis 用例");
+            try {
+                redisson = createClient(host, port, false);
+                String probeKey = KEY_PREFIX + "probe:" + UUID.randomUUID();
+                redisson.getBucket(probeKey, StringCodec.INSTANCE).set("1", Duration.ofSeconds(5));
+                redisson.getBucket(probeKey, StringCodec.INSTANCE).delete();
+                store = new RedissonLoginCaptchaStore(redisson);
+            } catch (Exception e) {
+                shutdown(redisson);
+                assumeTrue(false, "Redis 鉴权或连接配置不可用，跳过真实 Redis 用例");
+            }
+        }
+
+        @AfterAll
+        void tearDown() {
+            shutdown(redisson);
+        }
+
+        @Test
+        void credential_shouldKeepOnFingerprintMismatch_thenConsumeOnce_andExpireBothTtls()
+            throws InterruptedException {
+            String mismatchId = UUID.randomUUID().toString();
+            String expiringId = UUID.randomUUID().toString();
+            String expiringProofHash = UUID.randomUUID().toString();
+            RBucket<String> mismatchBucket = bucket("challenge:", mismatchId);
+            RBucket<String> challengeBucket = bucket("challenge:", expiringId);
+            RBucket<String> proofBucket = bucket("proof:", expiringProofHash);
+            long now = System.currentTimeMillis();
+            try {
+                store.saveChallenge(mismatchId,
+                    new LoginCaptchaStore.ChallengeState(FINGERPRINT, now, now + 10_000), 10);
+
+                assertEquals(LoginCaptchaStore.ConsumeStatus.FINGERPRINT_MISMATCH,
+                    store.consumeChallenge(mismatchId, "other-fingerprint").status());
+                assertTrue(mismatchBucket.isExists(), "错误指纹不能烧掉真实用户的 challenge");
+                assertEquals(LoginCaptchaStore.ConsumeStatus.MATCHED,
+                    store.consumeChallenge(mismatchId, FINGERPRINT).status());
+                assertEquals(LoginCaptchaStore.ConsumeStatus.NOT_FOUND,
+                    store.consumeChallenge(mismatchId, FINGERPRINT).status());
+
+                store.saveChallenge(expiringId,
+                    new LoginCaptchaStore.ChallengeState(FINGERPRINT, now, now + 2_000), 2);
+                store.saveProof(expiringProofHash,
+                    new LoginCaptchaStore.ProofState(FINGERPRINT, now + 2_000), 2);
+                assertRedisTtl(challengeBucket, "challenge");
+                assertRedisTtl(proofBucket, "proof");
+
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+                while ((challengeBucket.isExists() || proofBucket.isExists())
+                    && System.nanoTime() < deadline) {
+                    Thread.sleep(25);
+                }
+                assertFalse(challengeBucket.isExists(), "challenge 应由 Redis TTL 自动清理");
+                assertFalse(proofBucket.isExists(), "proof 应由 Redis TTL 自动清理");
+                assertEquals(LoginCaptchaStore.ConsumeStatus.NOT_FOUND,
+                    store.consumeChallenge(expiringId, FINGERPRINT).status());
+                assertEquals(LoginCaptchaStore.ConsumeStatus.NOT_FOUND,
+                    store.consumeProof(expiringProofHash, FINGERPRINT).status());
+            } finally {
+                mismatchBucket.delete();
+                challengeBucket.delete();
+                proofBucket.delete();
+            }
+        }
+
+        @Test
+        void proof_shouldAllowExactlyOneMatchedConsumer_underConcurrentReplay() throws Exception {
+            String proofHash = UUID.randomUUID().toString();
+            RBucket<String> proofBucket = bucket("proof:", proofHash);
+            store.saveProof(proofHash,
+                new LoginCaptchaStore.ProofState(FINGERPRINT, System.currentTimeMillis() + 10_000), 10);
+
+            int concurrency = 16;
+            ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+            CountDownLatch ready = new CountDownLatch(concurrency);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<LoginCaptchaStore.ConsumeStatus>> futures = new ArrayList<>();
+            try {
+                for (int i = 0; i < concurrency; i++) {
+                    futures.add(executor.submit(() -> {
+                        ready.countDown();
+                        start.await();
+                        return store.consumeProof(proofHash, FINGERPRINT).status();
+                    }));
+                }
+
+                assertTrue(ready.await(5, TimeUnit.SECONDS), "并发消费线程未能及时就绪");
+                start.countDown();
+
+                long matched = 0;
+                long notFound = 0;
+                for (Future<LoginCaptchaStore.ConsumeStatus> future : futures) {
+                    LoginCaptchaStore.ConsumeStatus status = future.get(10, TimeUnit.SECONDS);
+                    if (status == LoginCaptchaStore.ConsumeStatus.MATCHED) {
+                        matched++;
+                    }
+                    if (status == LoginCaptchaStore.ConsumeStatus.NOT_FOUND) {
+                        notFound++;
+                    }
+                }
+                assertEquals(1, matched, "同一 proof 只能有一个并发请求消费成功");
+                assertEquals(concurrency - 1L, notFound, "其余并发重放必须全部失败");
+            } finally {
+                start.countDown();
+                executor.shutdownNow();
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "并发测试线程未正常退出");
+                proofBucket.delete();
+            }
+        }
+
+        private RBucket<String> bucket(String type, String id) {
+            return redisson.getBucket(KEY_PREFIX + type + id, StringCodec.INSTANCE);
+        }
+
+        private void assertRedisTtl(RBucket<String> bucket, String type) {
+            long ttlMillis = bucket.remainTimeToLive();
+            assertTrue(ttlMillis > 0 && ttlMillis <= 2_000,
+                type + " TTL 应真实落到 Redis，实际 " + ttlMillis + "ms");
+        }
+    }
+
+    @Test
+    void write_shouldPropagateRealCommandTimeout_withoutExternalRedis() throws Exception {
+        try (ServerSocket blackHole = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            Config config = new Config();
+            config.setLazyInitialization(true);
+            config.useSingleServer()
+                .setAddress("redis://127.0.0.1:" + blackHole.getLocalPort())
+                .setConnectTimeout(300)
+                .setTimeout(300)
+                .setRetryAttempts(0)
+                .setConnectionMinimumIdleSize(1)
+                .setConnectionPoolSize(1);
+            RedissonClient unavailable = Redisson.create(config);
+            try {
+                RedissonLoginCaptchaStore unavailableStore = new RedissonLoginCaptchaStore(unavailable);
+                assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+                    assertThrows(RuntimeException.class, () -> unavailableStore.saveProof(
+                        UUID.randomUUID().toString(),
+                        new LoginCaptchaStore.ProofState(
+                            FINGERPRINT, System.currentTimeMillis() + 10_000),
+                        10)));
+            } finally {
+                shutdown(unavailable);
+            }
+        }
+    }
+
+    private RedissonClient createClient(String host, int port, boolean lazyInitialization) {
+        String addressHost = "localhost".equalsIgnoreCase(host) ? "127.0.0.1" : host;
+        Config config = new Config();
+        config.setLazyInitialization(lazyInitialization);
+        SingleServerConfig server = config.useSingleServer()
+            .setAddress("redis://" + addressHost + ":" + port)
+            .setConnectionMinimumIdleSize(1)
+            .setConnectionPoolSize(4);
+        String password = System.getenv("ADMIN_REDIS_PASSWORD");
+        if (password != null && !password.isBlank()) {
+            server.setPassword(password);
+        }
+        return Redisson.create(config);
+    }
+
+    private void shutdown(RedissonClient client) {
+        if (client != null && !client.isShutdown()) {
+            client.shutdown();
+        }
+    }
+
+    private String envOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private boolean reachable(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), PROBE_TIMEOUT_MILLIS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreTest.java
@@ -1,0 +1,133 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Redis 登录滑块存储的原子消费与请求期 fail-closed 边界。 */
+class RedissonLoginCaptchaStoreTest {
+
+    private static final String FINGERPRINT = "fingerprint";
+
+    private RedissonClient redisson;
+    private RScript script;
+    private RedissonLoginCaptchaStore store;
+
+    @BeforeEach
+    void setUp() {
+        redisson = mock(RedissonClient.class);
+        script = mock(RScript.class);
+        store = new RedissonLoginCaptchaStore(redisson);
+    }
+
+    @Test
+    void consumeChallenge_shouldUseAtomicLuaScriptForMatchingFingerprint() {
+        when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq(FINGERPRINT)))
+            .thenReturn(FINGERPRINT + ":100:200");
+
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState> result =
+            store.consumeChallenge("challenge-id", FINGERPRINT);
+
+        assertEquals(LoginCaptchaStore.ConsumeStatus.MATCHED, result.status());
+        assertEquals(new LoginCaptchaStore.ChallengeState(FINGERPRINT, 100L, 200L), result.state());
+        ArgumentCaptor<String> lua = ArgumentCaptor.forClass(String.class);
+        verify(script).eval(eq(RScript.Mode.READ_WRITE), lua.capture(), eq(RScript.ReturnType.VALUE),
+            eq(List.of("cw:admin:login-captcha:challenge:challenge-id")), eq(FINGERPRINT));
+        assertTrue(lua.getValue().contains("redis.call('DEL', KEYS[1])"));
+        assertTrue(lua.getValue().contains("return '__FINGERPRINT_MISMATCH__'"));
+    }
+
+    @Test
+    void consumeProof_shouldKeepCredentialWhenFingerprintDoesNotMatch() {
+        when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq("wrong-fingerprint")))
+            .thenReturn("__FINGERPRINT_MISMATCH__");
+
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ProofState> result =
+            store.consumeProof("proof-hash", "wrong-fingerprint");
+
+        assertEquals(LoginCaptchaStore.ConsumeStatus.FINGERPRINT_MISMATCH, result.status());
+        verify(redisson, never()).getBucket(anyString(), any());
+    }
+
+    @Test
+    void consumeProof_shouldPropagateWhenRedisThrows() {
+        when(redisson.getScript(StringCodec.INSTANCE)).thenThrow(new IllegalStateException("redis unavailable"));
+
+        assertThrows(IllegalStateException.class,
+            () -> store.consumeProof("proof-hash", FINGERPRINT));
+    }
+
+    @Test
+    void consumeProof_shouldReturnNotFoundWhenRedisReturnsNull() {
+        when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq(FINGERPRINT))).thenReturn(null);
+
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ProofState> result =
+            store.consumeProof("proof-hash", FINGERPRINT);
+
+        assertEquals(LoginCaptchaStore.ConsumeStatus.NOT_FOUND, result.status());
+    }
+
+    @Test
+    void saveChallenge_shouldPropagateAmbiguousRedisFailure() {
+        @SuppressWarnings("unchecked")
+        RBucket<String> bucket = mock(RBucket.class);
+        when(redisson.<String>getBucket(
+            "cw:admin:login-captcha:challenge:challenge-id", StringCodec.INSTANCE))
+            .thenReturn(bucket);
+        doThrow(new IllegalStateException("redis timeout"))
+            .when(bucket).set(anyString(), eq(Duration.ofSeconds(60)));
+
+        assertThrows(IllegalStateException.class, () -> store.saveChallenge(
+            "challenge-id", new LoginCaptchaStore.ChallengeState(FINGERPRINT, 100L, 200L), 60));
+    }
+
+    @Test
+    void saveProof_shouldPropagateAmbiguousRedisFailure() {
+        @SuppressWarnings("unchecked")
+        RBucket<String> bucket = mock(RBucket.class);
+        when(redisson.<String>getBucket(
+            "cw:admin:login-captcha:proof:proof-hash", StringCodec.INSTANCE))
+            .thenReturn(bucket);
+        doThrow(new IllegalStateException("redis timeout"))
+            .when(bucket).set(anyString(), eq(Duration.ofSeconds(60)));
+
+        assertThrows(IllegalStateException.class, () -> store.saveProof(
+            "proof-hash", new LoginCaptchaStore.ProofState(FINGERPRINT, 200L), 60));
+    }
+
+    @Test
+    void consumeChallenge_shouldPropagateMalformedPersistedState() {
+        when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq(FINGERPRINT)))
+            .thenReturn(FINGERPRINT + ":malformed");
+
+        assertThrows(IllegalStateException.class,
+            () -> store.consumeChallenge("challenge-id", FINGERPRINT));
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/service/AuthServiceAccessEpochTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/service/AuthServiceAccessEpochTest.java
@@ -3,7 +3,7 @@ package com.richard.fyoung.customeradmin.auth.service;
 import cn.dev33.satoken.session.SaSession;
 import cn.dev33.satoken.stp.StpUtil;
 import com.richard.fyoung.customeradmin.auth.guard.LoginAttemptGuard;
-import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
 import com.richard.fyoung.customeradmin.auth.config.AdminLdapProperties;
 import com.richard.fyoung.customeradmin.auth.dto.ChangePasswordRequest;
 import com.richard.fyoung.customeradmin.system.log.mapper.OperationLogMapper;
@@ -92,7 +92,7 @@ class AuthServiceAccessEpochTest {
             mock(SysUserRoleMapper.class),
             tenantService,
             revocationService,
-            mock(LoginAttemptGuard.class), new RegistrationGuardProperties());
+            mock(LoginAttemptGuard.class), mock(LoginCaptchaService.class));
     }
 
     private SysUser user() {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/service/AuthServiceLdapRolePolicyTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/service/AuthServiceLdapRolePolicyTest.java
@@ -1,7 +1,7 @@
 package com.richard.fyoung.customeradmin.auth.service;
 
 import com.richard.fyoung.customeradmin.auth.guard.LoginAttemptGuard;
-import com.richard.fyoung.customeradmin.auth.guard.RegistrationGuardProperties;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
 import com.richard.fyoung.customeradmin.auth.config.AdminLdapProperties;
 import com.richard.fyoung.customeradmin.common.exception.BizException;
 import com.richard.fyoung.customeradmin.common.result.ResultCode;
@@ -54,7 +54,7 @@ class AuthServiceLdapRolePolicyTest {
             mock(SysUserMapper.class), mock(PasswordEncoder.class), mock(OperationLogMapper.class),
             mock(LdapAuthService.class), properties, roleMapper, userRoleMapper, mock(TenantService.class),
             mock(SessionRevocationService.class),
-            mock(LoginAttemptGuard.class), new RegistrationGuardProperties());
+            mock(LoginAttemptGuard.class), mock(LoginCaptchaService.class));
 
         BizException exception = assertThrows(BizException.class,
             () -> ReflectionTestUtils.invokeMethod(service, "resolveAssignableDefaultRoles"));
@@ -73,7 +73,7 @@ class AuthServiceLdapRolePolicyTest {
             mock(SysUserMapper.class), mock(PasswordEncoder.class), mock(OperationLogMapper.class),
             mock(LdapAuthService.class), properties, roleMapper, mock(SysUserRoleMapper.class),
             mock(TenantService.class), mock(SessionRevocationService.class),
-            mock(LoginAttemptGuard.class), new RegistrationGuardProperties());
+            mock(LoginAttemptGuard.class), mock(LoginCaptchaService.class));
 
         BizException exception = assertThrows(BizException.class,
             () -> ReflectionTestUtils.invokeMethod(service, "resolveAssignableDefaultRoles"));
@@ -94,7 +94,7 @@ class AuthServiceLdapRolePolicyTest {
             mock(SysUserMapper.class), mock(PasswordEncoder.class), mock(OperationLogMapper.class),
             mock(LdapAuthService.class), properties, roleMapper, mock(SysUserRoleMapper.class),
             mock(TenantService.class), mock(SessionRevocationService.class),
-            mock(LoginAttemptGuard.class), new RegistrationGuardProperties());
+            mock(LoginAttemptGuard.class), mock(LoginCaptchaService.class));
 
         BizException exception = assertThrows(BizException.class,
             () -> ReflectionTestUtils.invokeMethod(service, "resolveAssignableDefaultRoles"));
@@ -160,7 +160,7 @@ class AuthServiceLdapRolePolicyTest {
             userRoleMapper,
             mock(TenantService.class),
             mock(SessionRevocationService.class),
-            mock(LoginAttemptGuard.class), new RegistrationGuardProperties());
+            mock(LoginAttemptGuard.class), mock(LoginCaptchaService.class));
     }
 
     private SysUser localUser() {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/service/AuthServiceLoginCaptchaTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/service/AuthServiceLoginCaptchaTest.java
@@ -1,0 +1,182 @@
+package com.richard.fyoung.customeradmin.auth.service;
+
+import com.richard.fyoung.customeradmin.auth.config.AdminLdapProperties;
+import com.richard.fyoung.customeradmin.auth.dto.LoginRequest;
+import com.richard.fyoung.customeradmin.auth.dto.SsoLoginRequest;
+import com.richard.fyoung.customeradmin.auth.guard.LoginAttemptGuard;
+import com.richard.fyoung.customeradmin.auth.guard.LoginCaptchaService;
+import com.richard.fyoung.customeradmin.common.exception.BizException;
+import com.richard.fyoung.customeradmin.common.result.ResultCode;
+import com.richard.fyoung.customeradmin.system.log.entity.SysOperationLog;
+import com.richard.fyoung.customeradmin.system.log.mapper.OperationLogMapper;
+import com.richard.fyoung.customeradmin.system.role.mapper.SysRoleMapper;
+import com.richard.fyoung.customeradmin.system.user.entity.SysUser;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserMapper;
+import com.richard.fyoung.customeradmin.system.user.mapper.SysUserRoleMapper;
+import com.richard.fyoung.customeradmin.tenant.service.TenantService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/** 登录 proof 的消费顺序与 OA 失败计数边界。 */
+class AuthServiceLoginCaptchaTest {
+
+    private static final String CLIENT_IP = "203.0.113.9";
+    private static final String USER_AGENT = "Mozilla/5.0 Test";
+
+    @Test
+    void localLogin_invalidProof_shouldStopBeforeLockDatabaseAndBcrypt() {
+        Dependencies dependencies = new Dependencies(false);
+        doThrow(new BizException(ResultCode.LOGIN_CAPTCHA_INVALID))
+            .when(dependencies.loginCaptchaService).consumeProof("bad-proof", CLIENT_IP, USER_AGENT);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.login(
+            new LoginRequest("richard", "password", false, "bad-proof"), CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.LOGIN_CAPTCHA_INVALID, exception.getResultCode());
+        verifyNoInteractions(dependencies.loginAttemptGuard, dependencies.userMapper,
+            dependencies.passwordEncoder, dependencies.ldapAuthService);
+    }
+
+    @Test
+    void localLogin_wrongPassword_shouldConsumeProofBeforeLockDatabaseAndBcrypt() {
+        Dependencies dependencies = new Dependencies(false);
+        SysUser user = activeUser("richard");
+        user.setPassword("hash");
+        when(dependencies.userMapper.selectOne(any())).thenReturn(user);
+        when(dependencies.passwordEncoder.matches("wrong", "hash")).thenReturn(false);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.login(
+            new LoginRequest("richard", "wrong", false, "proof"), CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.LOGIN_FAILED, exception.getResultCode());
+        InOrder ordered = inOrder(dependencies.loginCaptchaService, dependencies.loginAttemptGuard,
+            dependencies.userMapper, dependencies.passwordEncoder);
+        ordered.verify(dependencies.loginCaptchaService).consumeProof("proof", CLIENT_IP, USER_AGENT);
+        ordered.verify(dependencies.loginAttemptGuard).checkNotLocked("richard", CLIENT_IP);
+        ordered.verify(dependencies.userMapper).selectOne(any());
+        ordered.verify(dependencies.passwordEncoder).matches("wrong", "hash");
+        verify(dependencies.loginAttemptGuard).recordFailure("richard", CLIENT_IP);
+
+        ArgumentCaptor<SysOperationLog> logCaptor = ArgumentCaptor.forClass(SysOperationLog.class);
+        verify(dependencies.operationLogMapper).insert(logCaptor.capture());
+        assertEquals(CLIENT_IP, logCaptor.getValue().getIp());
+    }
+
+    @Test
+    void ssoLogin_disabled_shouldNotConsumeProofOrCallLdap() {
+        Dependencies dependencies = new Dependencies(false);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.ssoLogin(
+            new SsoLoginRequest("richard", "password", false, "proof"), CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.SSO_NOT_ENABLED, exception.getResultCode());
+        verifyNoInteractions(dependencies.loginCaptchaService, dependencies.loginAttemptGuard,
+            dependencies.ldapAuthService);
+    }
+
+    @Test
+    void ssoLogin_invalidProof_shouldStopBeforeAttemptLockAndLdapBind() {
+        Dependencies dependencies = new Dependencies(true);
+        doThrow(new BizException(ResultCode.LOGIN_CAPTCHA_INVALID))
+            .when(dependencies.loginCaptchaService).consumeProof("bad-proof", CLIENT_IP, USER_AGENT);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.ssoLogin(
+            new SsoLoginRequest("richard@example.com", "password", false, "bad-proof"),
+            CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.LOGIN_CAPTCHA_INVALID, exception.getResultCode());
+        verifyNoInteractions(dependencies.loginAttemptGuard, dependencies.ldapAuthService);
+    }
+
+    @Test
+    void ssoLogin_oversizedNormalizedUsername_shouldStopBeforeProofAndLdap() {
+        Dependencies dependencies = new Dependencies(true);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.ssoLogin(
+            new SsoLoginRequest("u".repeat(65) + "@example.com", "password", false, "proof"),
+            CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.PARAM_INVALID, exception.getResultCode());
+        verifyNoInteractions(dependencies.loginCaptchaService, dependencies.loginAttemptGuard,
+            dependencies.ldapAuthService);
+    }
+
+    @Test
+    void ssoLogin_serviceUnavailable_shouldConsumeBeforeBindWithoutCredentialFailure() {
+        Dependencies dependencies = new Dependencies(true);
+        when(dependencies.ldapAuthService.bind("richard", "password"))
+            .thenReturn(LdapBindResult.SERVICE_UNAVAILABLE);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.ssoLogin(
+            new SsoLoginRequest("richard@example.com", "password", false, "proof"),
+            CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.SSO_SERVICE_UNAVAILABLE, exception.getResultCode());
+        InOrder ordered = inOrder(dependencies.loginCaptchaService, dependencies.loginAttemptGuard,
+            dependencies.ldapAuthService);
+        ordered.verify(dependencies.loginCaptchaService).consumeProof("proof", CLIENT_IP, USER_AGENT);
+        ordered.verify(dependencies.loginAttemptGuard).checkNotLocked("richard", CLIENT_IP);
+        ordered.verify(dependencies.ldapAuthService).bind("richard", "password");
+        verify(dependencies.loginAttemptGuard, never()).recordFailure(any(), any());
+        verify(dependencies.loginAttemptGuard, never()).recordSuccess(any(), any());
+    }
+
+    @Test
+    void ssoLogin_invalidCredentials_shouldRecordFailureAfterBind() {
+        Dependencies dependencies = new Dependencies(true);
+        when(dependencies.ldapAuthService.bind("richard", "wrong"))
+            .thenReturn(LdapBindResult.INVALID_CREDENTIALS);
+
+        BizException exception = assertThrows(BizException.class, () -> dependencies.service.ssoLogin(
+            new SsoLoginRequest("richard", "wrong", false, "proof"), CLIENT_IP, USER_AGENT));
+
+        assertEquals(ResultCode.SSO_LOGIN_FAILED, exception.getResultCode());
+        InOrder ordered = inOrder(dependencies.loginCaptchaService, dependencies.loginAttemptGuard,
+            dependencies.ldapAuthService);
+        ordered.verify(dependencies.loginCaptchaService).consumeProof("proof", CLIENT_IP, USER_AGENT);
+        ordered.verify(dependencies.loginAttemptGuard).checkNotLocked("richard", CLIENT_IP);
+        ordered.verify(dependencies.ldapAuthService).bind("richard", "wrong");
+        ordered.verify(dependencies.loginAttemptGuard).recordFailure("richard", CLIENT_IP);
+    }
+
+    private static SysUser activeUser(String username) {
+        SysUser user = new SysUser();
+        user.setId(9L);
+        user.setUsername(username);
+        user.setStatus(1);
+        user.setTenantId("default");
+        return user;
+    }
+
+    private static final class Dependencies {
+        private final SysUserMapper userMapper = mock(SysUserMapper.class);
+        private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+        private final OperationLogMapper operationLogMapper = mock(OperationLogMapper.class);
+        private final LdapAuthService ldapAuthService = mock(LdapAuthService.class);
+        private final LoginAttemptGuard loginAttemptGuard = mock(LoginAttemptGuard.class);
+        private final LoginCaptchaService loginCaptchaService = mock(LoginCaptchaService.class);
+        private final AuthService service;
+
+        private Dependencies(boolean ldapEnabled) {
+            AdminLdapProperties ldapProperties = new AdminLdapProperties();
+            ldapProperties.setEnabled(ldapEnabled);
+            service = new AuthService(userMapper, passwordEncoder, operationLogMapper, ldapAuthService,
+                ldapProperties, mock(SysRoleMapper.class), mock(SysUserRoleMapper.class),
+                mock(TenantService.class), mock(SessionRevocationService.class),
+                loginAttemptGuard, loginCaptchaService);
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/log/SensitiveDataMaskerTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/common/log/SensitiveDataMaskerTest.java
@@ -21,6 +21,7 @@ class SensitiveDataMaskerTest {
         Map<String, Object> params = Map.of(
             "username", "admin",
             "password", "admin123",
+            "captchaProof", "one-time-login-proof",
             "apiKey", "sk-real-secret-key",
             "modelName", "gpt-4o");
 
@@ -30,7 +31,9 @@ class SensitiveDataMaskerTest {
         assertTrue(json.contains("\"modelName\":\"gpt-4o\""));
         assertFalse(json.contains("admin123"), "password 字段值不应出现在输出中");
         assertFalse(json.contains("sk-real-secret-key"), "apiKey 字段值不应出现在输出中");
+        assertFalse(json.contains("one-time-login-proof"), "proof 字段值不应出现在输出中");
         assertTrue(json.contains("\"password\":\"******\""));
+        assertTrue(json.contains("\"captchaProof\":\"******\""));
         assertTrue(json.contains("\"apiKey\":\"******\""));
     }
 

--- a/customer-admin-web/src/api/auth.ts
+++ b/customer-admin-web/src/api/auth.ts
@@ -3,6 +3,9 @@ import type {
   CaptchaChallenge,
   ChangePasswordRequest,
   EmailCodeRequest,
+  LoginCaptchaChallenge,
+  LoginCaptchaProof,
+  LoginCaptchaVerifyRequest,
   LoginRequest,
   LoginResponse,
   RegisterOptionsVO,
@@ -28,6 +31,25 @@ export function fetchCaptcha() {
 /** 向注册邮箱发送验证码，返回有效期（秒）。 */
 export function sendRegisterEmailCode(data: EmailCodeRequest) {
   return request<number>({ url: '/auth/email-code', method: 'post', data })
+}
+
+/** 签发与当前来源 IP、浏览器绑定的登录拖动挑战。 */
+export function fetchLoginCaptchaChallenge() {
+  return request<LoginCaptchaChallenge>({
+    url: '/auth/login-captcha/challenge',
+    method: 'post',
+    suppressErrorMessage: true,
+  })
+}
+
+/** 提交归一化拖动轨迹，换取短期、一次性的登录 proof。 */
+export function verifyLoginCaptcha(data: LoginCaptchaVerifyRequest) {
+  return request<LoginCaptchaProof>({
+    url: '/auth/login-captcha/verify',
+    method: 'post',
+    data,
+    suppressErrorMessage: true,
+  })
 }
 
 export function login(data: LoginRequest) {

--- a/customer-admin-web/src/api/request.ts
+++ b/customer-admin-web/src/api/request.ts
@@ -3,6 +3,11 @@ import router from '@/router'
 import { useAuthStore } from '@/store/auth'
 import type { Result } from '@/types/api'
 
+/** 需要在组件内就地呈现错误的请求，可关闭全局顶部消息。 */
+export interface AppRequestConfig extends AxiosRequestConfig {
+  suppressErrorMessage?: boolean
+}
+
 // ResultCode 分段（与后端 common/result/ResultCode.java 保持一致）
 const CODE_UNAUTHORIZED = 10001
 const CODE_FORCE_CHANGE_PASSWORD = 20002
@@ -25,7 +30,7 @@ http.interceptors.request.use((config) => {
 
 // 拦截器把 AxiosResponse<Result<T>> 拆箱为 T 直接返回，与 axios 自身的类型声明（要求返回
 // AxiosResponse）不一致，是该封装模式的既有取舍，用 any 顶掉这一层类型摩擦。
-http.interceptors.response.use(((response: { data: Result<unknown> | Blob; config: AxiosRequestConfig }) => {
+http.interceptors.response.use(((response: { data: Result<unknown> | Blob; config: AppRequestConfig }) => {
   // 二进制下载（responseType: 'blob'，如 SQL 查询导出 xlsx）响应体不是 Result 包装，
   // 原样透传整个 response，交给下面的 download() 解析 Content-Disposition 后再落盘，
   // 不复用下面的 Result 拆箱逻辑（body.code 在 Blob 上访问不到，会被误判成请求失败）。
@@ -52,20 +57,40 @@ http.interceptors.response.use(((response: { data: Result<unknown> | Blob; confi
     router.push('/change-password')
     return Promise.reject(body)
   }
-  ElMessage.error(body.message || '请求失败')
+  if (!response.config.suppressErrorMessage) {
+    ElMessage.error(body.message || '请求失败')
+  }
   return Promise.reject(body)
 }) as never, (error) => {
   // 非 2xx 的响应体同样是 Result 包装（如额度用尽返回 429 + code 40043），优先显示后端文案：
   // 只读 error.message 的话用户看到的是 "Request failed with status code 429"，
   // 而真正该看的"最近 60 分钟内已达 N 次上限"就被吞掉了
   const body = error.response?.data as Result<unknown> | undefined
-  ElMessage.error(body?.message || error.message || '网络异常')
+  const config = error.config as AppRequestConfig | undefined
+  if (!config?.suppressErrorMessage) {
+    ElMessage.error(body?.message || error.message || '网络异常')
+  }
   return Promise.reject(error)
 })
 
 /** 统一走 Result<T> 拦截解包，业务代码直接拿到 data。 */
-export function request<T>(config: AxiosRequestConfig): Promise<T> {
+export function request<T>(config: AppRequestConfig): Promise<T> {
   return http.request(config) as unknown as Promise<T>
+}
+
+/** 就地错误展示优先取标准 Result 文案，再回退 Axios/业务异常的顶层 message。 */
+export function getRequestErrorMessage(error: unknown, fallback: string): string {
+  if (!error || typeof error !== 'object') {
+    return fallback
+  }
+  const responseMessage = (error as {
+    response?: { data?: { message?: unknown } }
+  }).response?.data?.message
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage.trim()
+  }
+  const message = (error as { message?: unknown }).message
+  return typeof message === 'string' && message.trim() ? message.trim() : fallback
 }
 
 /** 从 Content-Disposition 头解析文件名，兼容 filename="x.xlsx" 与 RFC 5987 filename*=UTF-8''x.xlsx 两种形式。 */

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -44,6 +44,8 @@ export interface LoginRequest {
   password: string
   /** 记住我：勾选后登录态有效期延长（见后端 admin.remember-me-timeout-seconds），默认 7 天免登录。 */
   rememberMe?: boolean
+  /** 登录拖动验证通过后由服务端签发的一次性凭据。 */
+  captchaProof: string
 }
 
 // OA 域账号（LDAP/AD）单点登录请求，字段与本地登录保持一致。
@@ -51,6 +53,31 @@ export interface SsoLoginRequest {
   username: string
   password: string
   rememberMe?: boolean
+  captchaProof: string
+}
+
+/** 登录拖动验证挑战。挑战与当前来源 IP、浏览器 UA 绑定。 */
+export interface LoginCaptchaChallenge {
+  challengeId: string
+  ttlSeconds: number
+}
+
+/** 拖动轨迹点：横纵坐标归一到千分比，t 为按下后的相对毫秒数。 */
+export interface LoginCaptchaTrackPoint {
+  x: number
+  y: number
+  t: number
+}
+
+export interface LoginCaptchaVerifyRequest {
+  challengeId: string
+  trajectory: LoginCaptchaTrackPoint[]
+}
+
+/** 轨迹核验成功后签发的短期一次性登录凭据。 */
+export interface LoginCaptchaProof {
+  proof: string
+  ttlSeconds: number
 }
 
 export interface LoginResponse {

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -11,6 +11,7 @@ import { useThemeStore } from '@/store/theme'
 import type { LoginResponse, RegisterOptionsVO } from '@/types/api'
 import { chooseButtonTextColor } from '@/utils/themeContrast'
 import LoginBrandStage from './LoginBrandStage.vue'
+import LoginSliderCaptcha from './LoginSliderCaptcha.vue'
 import RegisterPanel from './RegisterPanel.vue'
 import {
   createLoginSubmission,
@@ -34,7 +35,9 @@ const ssoModePresentation = getLoginModePresentation('sso')
 const primaryTextColor = computed(() => chooseButtonTextColor(themeStore.primaryColor))
 
 const formRef = ref<FormInstance>()
+const loginCaptchaRef = ref<InstanceType<typeof LoginSliderCaptcha>>()
 const submitting = ref(false)
+const captchaProof = ref('')
 const form = reactive({ username: '', password: '', rememberMe: false })
 const rules: FormRules = {
   username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
@@ -83,6 +86,8 @@ async function switchMode(mode: LoginMode) {
   }
   loginMode.value = mode
   form.password = ''
+  captchaProof.value = ''
+  void loginCaptchaRef.value?.reset()
   loadRememberedUsername(mode)
   formRef.value?.clearValidate()
   await resetAuthScroll()
@@ -106,6 +111,7 @@ async function openRegister() {
   if (submitting.value || !canRegister.value) {
     return
   }
+  captchaProof.value = ''
   authPanel.value = 'register'
   await resetAuthScroll()
 }
@@ -114,6 +120,7 @@ async function backToLogin(username?: string) {
   authPanel.value = 'login'
   loginMode.value = 'local'
   form.password = ''
+  captchaProof.value = ''
   if (username) {
     form.username = username
     form.rememberMe = false
@@ -154,8 +161,14 @@ async function handleSubmit() {
     if (!valid) {
       return
     }
+    if (!captchaProof.value) {
+      loginCaptchaRef.value?.requireVerification()
+      return
+    }
     // 请求发出后，界面仍可能因脚本触发变化；后续处理必须绑定本次提交身份。
-    const submission = createLoginSubmission(loginMode.value, form)
+    const submission = createLoginSubmission(loginMode.value, form, captchaProof.value)
+    // proof 在服务端按一次性凭据消费；请求一旦发出，当前页面就不再复用它。
+    captchaProof.value = ''
     let result: LoginResponse
     try {
       result = submission.mode === 'local'
@@ -163,6 +176,7 @@ async function handleSubmit() {
         : await ssoLogin(submission.credentials)
     } catch {
       // 请求层已展示业务或网络错误，组件只负责恢复可提交状态。
+      await loginCaptchaRef.value?.reset()
       return
     }
     const rememberKey = REMEMBER_KEY_PREFIX + submission.mode
@@ -284,6 +298,14 @@ onMounted(() => {
                 :disabled="submitting"
               />
             </el-form-item>
+
+            <LoginSliderCaptcha
+              ref="loginCaptchaRef"
+              :disabled="submitting"
+              :primary-text-color="primaryTextColor"
+              @verified="captchaProof = $event"
+              @invalidated="captchaProof = ''"
+            />
 
             <div class="remember-row">
               <el-checkbox v-model="form.rememberMe" :disabled="submitting">保持登录</el-checkbox>
@@ -536,19 +558,71 @@ onMounted(() => {
 
 @media (min-width: 900px) and (max-height: 720px) {
   .auth-toolbar {
-    min-height: 52px;
+    min-height: 44px;
   }
 
   .auth-content {
-    padding-block: 16px 18px;
+    padding-block: 8px 10px;
   }
 
   .login-heading {
-    margin-bottom: 18px;
+    margin-bottom: 12px;
+  }
+
+  .eyebrow {
+    margin-bottom: 4px;
+    font-size: 11px;
+  }
+
+  .login-heading h1 {
+    font-size: 28px;
+  }
+
+  .login-heading > p:last-child {
+    margin-top: 4px;
+    font-size: 13px;
+    line-height: 1.4;
   }
 
   .mode-switch {
-    margin-bottom: 18px;
+    margin-bottom: 12px;
+    padding: 3px;
+  }
+
+  .mode-switch button {
+    min-height: 32px;
+  }
+
+  .field-label {
+    margin-bottom: 4px;
+  }
+
+  .login-form :deep(.el-form-item) {
+    margin-bottom: 10px;
+  }
+
+  .login-form :deep(.el-input__wrapper) {
+    min-height: 40px;
+  }
+
+  .login-form :deep(.login-captcha) {
+    margin-bottom: 10px;
+  }
+
+  .login-form :deep(.keyboard-hint) {
+    display: none;
+  }
+
+  .remember-row {
+    margin-bottom: 10px;
+  }
+
+  .mode-note {
+    margin-top: 8px;
+  }
+
+  .register-entry {
+    margin-top: 10px;
   }
 }
 

--- a/customer-admin-web/src/views/login/LoginBrandStage.vue
+++ b/customer-admin-web/src/views/login/LoginBrandStage.vue
@@ -8,19 +8,19 @@ const props = defineProps<{
 const carouselRef = ref<{ setActiveItem: (index: number) => void }>()
 const activeImageIndex = ref(0)
 const manuallyPaused = ref(false)
-const pointerPaused = ref(false)
-const focusPaused = ref(false)
 const prefersReducedMotion = ref(false)
+const pageVisible = ref(true)
 let reducedMotionQuery: MediaQueryList | undefined
+
+const CAROUSEL_INTERVAL_MS = 3000
 
 const displayImages = computed(() => props.images.map((image) => image.trim()).filter(Boolean))
 const hasMultipleImages = computed(() => displayImages.value.length > 1)
 const shouldAutoplay = computed(() => (
   hasMultipleImages.value
   && !manuallyPaused.value
-  && !pointerPaused.value
-  && !focusPaused.value
   && !prefersReducedMotion.value
+  && pageVisible.value
 ))
 
 function syncReducedMotion(event: MediaQueryListEvent | MediaQueryList) {
@@ -29,7 +29,6 @@ function syncReducedMotion(event: MediaQueryListEvent | MediaQueryList) {
 
 function selectImage(index: number) {
   activeImageIndex.value = index
-  manuallyPaused.value = true
   carouselRef.value?.setActiveItem(index)
 }
 
@@ -39,14 +38,21 @@ function toggleAutoplay() {
   }
 }
 
+function syncPageVisibility() {
+  pageVisible.value = document.visibilityState === 'visible'
+}
+
 onMounted(() => {
   reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
   syncReducedMotion(reducedMotionQuery)
   reducedMotionQuery.addEventListener('change', syncReducedMotion)
+  syncPageVisibility()
+  document.addEventListener('visibilitychange', syncPageVisibility)
 })
 
 onBeforeUnmount(() => {
   reducedMotionQuery?.removeEventListener('change', syncReducedMotion)
+  document.removeEventListener('visibilitychange', syncPageVisibility)
 })
 </script>
 
@@ -54,10 +60,6 @@ onBeforeUnmount(() => {
   <section
     class="brand-stage"
     aria-labelledby="brand-stage-title"
-    @mouseenter="pointerPaused = true"
-    @mouseleave="pointerPaused = false"
-    @focusin="focusPaused = true"
-    @focusout="focusPaused = false"
   >
     <div class="brand-media" aria-hidden="true">
       <el-carousel
@@ -65,7 +67,7 @@ onBeforeUnmount(() => {
         ref="carouselRef"
         height="100%"
         :autoplay="shouldAutoplay"
-        :interval="8000"
+        :interval="CAROUSEL_INTERVAL_MS"
         :pause-on-hover="false"
         arrow="never"
         indicator-position="none"

--- a/customer-admin-web/src/views/login/LoginSliderCaptcha.vue
+++ b/customer-admin-web/src/views/login/LoginSliderCaptcha.vue
@@ -1,0 +1,688 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { fetchLoginCaptchaChallenge, verifyLoginCaptcha } from '@/api/auth'
+import { getRequestErrorMessage } from '@/api/request'
+import type { LoginCaptchaChallenge, LoginCaptchaTrackPoint } from '@/types/api'
+
+type CaptchaState = 'loading' | 'ready' | 'dragging' | 'verifying' | 'verified' | 'failed'
+
+const props = withDefaults(defineProps<{
+  disabled?: boolean
+  primaryTextColor?: string
+}>(), {
+  disabled: false,
+  primaryTextColor: '#ffffff',
+})
+
+const emit = defineEmits<{
+  verified: [proof: string]
+  invalidated: []
+}>()
+
+const TRACK_MAX = 1000
+const TRACK_COMPLETE = 980
+const CLIENT_MAX_POINTS = 80
+const HANDLE_OUTER_WIDTH = 46
+const MIN_KEYBOARD_TRAJECTORY_MS = 320
+
+const trackRef = ref<HTMLElement>()
+const handleRef = ref<HTMLElement>()
+const state = ref<CaptchaState>('loading')
+const challenge = ref<LoginCaptchaChallenge>()
+const progress = ref(0)
+const handleOffsetPx = ref(0)
+const errorMessage = ref('')
+
+let activePointerId: number | undefined
+let dragStartX = 0
+let dragStartY = 0
+let dragStartAt = 0
+let maxTravelPx = 0
+let trajectory: LoginCaptchaTrackPoint[] = []
+let requestGeneration = 0
+let disposed = false
+let challengeLoadPromise: Promise<void> | undefined
+let preserveFailureIntent = false
+let expiryTimer: ReturnType<typeof setTimeout> | undefined
+let keyboardSubmitTimer: ReturnType<typeof setTimeout> | undefined
+let resizeObserver: ResizeObserver | undefined
+
+const interactionDisabled = computed(() => (
+  props.disabled
+  || !challenge.value
+  || state.value === 'loading'
+  || state.value === 'verifying'
+  || state.value === 'verified'
+))
+
+const statusText = computed(() => {
+  switch (state.value) {
+    case 'loading':
+      return '正在准备安全验证…'
+    case 'dragging':
+      return '继续拖动，到达轨道终点'
+    case 'verifying':
+      return '正在校验拖动轨迹…'
+    case 'verified':
+      return '验证通过'
+    case 'failed':
+      return errorMessage.value || '验证未通过，请重新拖动'
+    default:
+      return '按住滑块，拖动完成验证'
+  }
+})
+
+const trackStyle = computed(() => ({
+  '--captcha-handle-offset': `${handleOffsetPx.value}px`,
+  '--captcha-fill-width': state.value === 'verified' ? '100%' : `${handleOffsetPx.value + 44}px`,
+  '--captcha-thumb-text': props.primaryTextColor,
+}))
+
+function clearExpiryTimer() {
+  if (expiryTimer) {
+    clearTimeout(expiryTimer)
+    expiryTimer = undefined
+  }
+}
+
+function clearKeyboardSubmitTimer() {
+  if (keyboardSubmitTimer) {
+    clearTimeout(keyboardSubmitTimer)
+    keyboardSubmitTimer = undefined
+  }
+}
+
+function scheduleExpiry(ttlSeconds: number, generation: number) {
+  clearExpiryTimer()
+  expiryTimer = setTimeout(() => {
+    if (!disposed && generation === requestGeneration) {
+      void reset()
+    }
+  }, Math.max(1, ttlSeconds) * 1000)
+}
+
+function measureTrack() {
+  if (!trackRef.value) {
+    maxTravelPx = 0
+    return
+  }
+  maxTravelPx = Math.max(0, trackRef.value.clientWidth - HANDLE_OUTER_WIDTH)
+  handleOffsetPx.value = maxTravelPx * progress.value / TRACK_MAX
+}
+
+function updateProgress(value: number) {
+  progress.value = Math.min(TRACK_MAX, Math.max(0, Math.round(value)))
+  handleOffsetPx.value = maxTravelPx * progress.value / TRACK_MAX
+}
+
+function invalidateProof() {
+  emit('invalidated')
+}
+
+async function performChallengeLoad() {
+  const generation = ++requestGeneration
+  clearExpiryTimer()
+  clearKeyboardSubmitTimer()
+  challenge.value = undefined
+  trajectory = []
+  activePointerId = undefined
+  updateProgress(0)
+  invalidateProof()
+  try {
+    const nextChallenge = await fetchLoginCaptchaChallenge()
+    if (disposed || generation !== requestGeneration) {
+      return
+    }
+    challenge.value = nextChallenge
+    state.value = preserveFailureIntent ? 'failed' : 'ready'
+    scheduleExpiry(nextChallenge.ttlSeconds, generation)
+  } catch (error) {
+    if (disposed || generation !== requestGeneration) {
+      return
+    }
+    state.value = 'failed'
+    errorMessage.value = getRequestErrorMessage(error, '验证服务暂不可用，点击滑块重试')
+  }
+}
+
+function loadChallenge(preserveFailure = false): Promise<void> {
+  // 网络请求保持 single-flight，展示状态以最后一次用户操作为准。
+  preserveFailureIntent = preserveFailure
+  if (!preserveFailure) {
+    state.value = 'loading'
+    errorMessage.value = ''
+  }
+  if (challengeLoadPromise) {
+    return challengeLoadPromise
+  }
+  const pending = performChallengeLoad()
+  challengeLoadPromise = pending
+  void pending.finally(() => {
+    if (challengeLoadPromise === pending) {
+      challengeLoadPromise = undefined
+    }
+  })
+  return pending
+}
+
+async function reset() {
+  await loadChallenge(false)
+}
+
+function requireVerification() {
+  if (state.value === 'loading' || state.value === 'verifying') {
+    return
+  }
+  state.value = 'failed'
+  errorMessage.value = challenge.value ? '请先完成拖动验证' : '验证服务暂不可用，点击滑块重试'
+  updateProgress(0)
+  void nextTick(() => handleRef.value?.focus())
+}
+
+function normalizedPoint(clientX: number, clientY: number, elapsed: number): LoginCaptchaTrackPoint {
+  const x = maxTravelPx <= 0 ? 0 : Math.round((clientX - dragStartX) / maxTravelPx * TRACK_MAX)
+  const trackHeight = Math.max(trackRef.value?.clientHeight ?? 1, 1)
+  const y = Math.round((clientY - dragStartY) / trackHeight * TRACK_MAX)
+  return {
+    x: Math.min(TRACK_MAX, Math.max(0, x)),
+    y: Math.min(TRACK_MAX, Math.max(-TRACK_MAX, y)),
+    t: Math.max(0, Math.round(elapsed)),
+  }
+}
+
+function appendPoint(point: LoginCaptchaTrackPoint, force = false) {
+  const previous = trajectory.at(-1)
+  if (previous && point.t <= previous.t) {
+    point = { ...point, t: previous.t + 1 }
+  }
+  if (!force && previous && previous.x === point.x && previous.y === point.y) {
+    return
+  }
+  if (trajectory.length >= CLIENT_MAX_POINTS) {
+    trajectory[CLIENT_MAX_POINTS - 1] = point
+    return
+  }
+  trajectory.push(point)
+}
+
+function beginDrag(clientX: number, clientY: number) {
+  measureTrack()
+  if (maxTravelPx <= 0) {
+    return false
+  }
+  state.value = 'dragging'
+  errorMessage.value = ''
+  dragStartX = clientX
+  dragStartY = clientY
+  dragStartAt = performance.now()
+  trajectory = [{ x: 0, y: 0, t: 0 }]
+  updateProgress(0)
+  return true
+}
+
+function handlePointerDown(event: PointerEvent) {
+  if (props.disabled || event.button !== 0) {
+    return
+  }
+  if (!challenge.value) {
+    void reset()
+    return
+  }
+  if (interactionDisabled.value || !beginDrag(event.clientX, event.clientY)) {
+    return
+  }
+  activePointerId = event.pointerId
+  handleRef.value?.setPointerCapture(event.pointerId)
+  handleRef.value?.focus()
+  event.preventDefault()
+}
+
+function handlePointerMove(event: PointerEvent) {
+  if (state.value !== 'dragging' || activePointerId !== event.pointerId) {
+    return
+  }
+  const point = normalizedPoint(event.clientX, event.clientY, performance.now() - dragStartAt)
+  updateProgress(point.x)
+  appendPoint(point)
+  event.preventDefault()
+}
+
+function releasePointer(pointerId: number) {
+  if (handleRef.value?.hasPointerCapture(pointerId)) {
+    handleRef.value.releasePointerCapture(pointerId)
+  }
+  activePointerId = undefined
+}
+
+async function submitTrajectory() {
+  const currentChallenge = challenge.value
+  if (!currentChallenge) {
+    await reset()
+    return
+  }
+  const generation = ++requestGeneration
+  state.value = 'verifying'
+  challenge.value = undefined
+  clearExpiryTimer()
+  try {
+    const result = await verifyLoginCaptcha({
+      challengeId: currentChallenge.challengeId,
+      trajectory: trajectory.map((point) => ({ ...point })),
+    })
+    if (disposed || generation !== requestGeneration) {
+      return
+    }
+    state.value = 'verified'
+    updateProgress(TRACK_MAX)
+    emit('verified', result.proof)
+    scheduleExpiry(result.ttlSeconds, generation)
+  } catch (error) {
+    if (disposed || generation !== requestGeneration) {
+      return
+    }
+    state.value = 'failed'
+    errorMessage.value = getRequestErrorMessage(error, '验证未通过，请重新拖动')
+    updateProgress(0)
+    await loadChallenge(true)
+  }
+}
+
+function finishDrag(event: PointerEvent) {
+  if (state.value !== 'dragging' || activePointerId !== event.pointerId) {
+    return
+  }
+  const point = normalizedPoint(event.clientX, event.clientY, performance.now() - dragStartAt)
+  appendPoint(point, true)
+  updateProgress(point.x)
+  releasePointer(event.pointerId)
+  if (progress.value < TRACK_COMPLETE) {
+    state.value = 'failed'
+    errorMessage.value = '请拖动到轨道终点'
+    trajectory = []
+    updateProgress(0)
+    return
+  }
+  // 到达终点时把最后一点统一为 1000，避免不同轨道像素宽度影响服务端判断。
+  const last = trajectory.at(-1)
+  if (last && last.x !== TRACK_MAX) {
+    trajectory[trajectory.length - 1] = { ...last, x: TRACK_MAX }
+  }
+  void submitTrajectory()
+}
+
+function handlePointerCancel(event: PointerEvent) {
+  if (activePointerId !== event.pointerId) {
+    return
+  }
+  releasePointer(event.pointerId)
+  state.value = 'failed'
+  errorMessage.value = '拖动已取消，请重新验证'
+  trajectory = []
+  updateProgress(0)
+}
+
+function appendKeyboardPoint(nextProgress: number) {
+  const elapsed = performance.now() - dragStartAt
+  appendPoint({ x: nextProgress, y: 0, t: Math.round(elapsed) }, true)
+  updateProgress(nextProgress)
+}
+
+function scheduleKeyboardSubmit() {
+  const challengeId = challenge.value?.challengeId
+  if (!challengeId) {
+    return
+  }
+  const generation = requestGeneration
+  const elapsed = performance.now() - dragStartAt
+  state.value = 'verifying'
+  clearKeyboardSubmitTimer()
+  keyboardSubmitTimer = setTimeout(() => {
+    keyboardSubmitTimer = undefined
+    if (disposed || generation !== requestGeneration || challenge.value?.challengeId !== challengeId) {
+      return
+    }
+    appendPoint({
+      x: TRACK_MAX,
+      y: 0,
+      t: Math.max(MIN_KEYBOARD_TRAJECTORY_MS, Math.round(performance.now() - dragStartAt)),
+    }, true)
+    void submitTrajectory()
+  }, Math.max(0, MIN_KEYBOARD_TRAJECTORY_MS - elapsed))
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (props.disabled || state.value === 'loading' || state.value === 'verifying' || state.value === 'verified') {
+    return
+  }
+  if (!challenge.value) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      void reset()
+    }
+    return
+  }
+  if (event.key === 'Home') {
+    event.preventDefault()
+    state.value = 'ready'
+    trajectory = []
+    updateProgress(0)
+    return
+  }
+  if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+    return
+  }
+  event.preventDefault()
+  if (state.value !== 'dragging' && !beginDrag(0, 0)) {
+    return
+  }
+  const direction = event.key === 'ArrowRight' ? 1 : -1
+  appendKeyboardPoint(Math.min(TRACK_MAX, Math.max(0, progress.value + direction * 100)))
+  if (progress.value === TRACK_MAX) {
+    scheduleKeyboardSubmit()
+  }
+}
+
+onMounted(() => {
+  resizeObserver = new ResizeObserver(measureTrack)
+  if (trackRef.value) {
+    resizeObserver.observe(trackRef.value)
+  }
+  void reset()
+})
+
+onBeforeUnmount(() => {
+  disposed = true
+  requestGeneration += 1
+  clearExpiryTimer()
+  clearKeyboardSubmitTimer()
+  resizeObserver?.disconnect()
+})
+
+defineExpose({ reset, requireVerification })
+</script>
+
+<template>
+  <div class="login-captcha">
+    <div class="captcha-label">
+      <span>安全验证</span>
+      <small>GUARD · 安全拖动确认</small>
+    </div>
+    <div
+      ref="trackRef"
+      class="captcha-track"
+      :class="`is-${state}`"
+      :style="trackStyle"
+      data-login-captcha
+    >
+      <span class="captcha-fill" aria-hidden="true" />
+      <span class="captcha-copy" :class="{ 'is-error': state === 'failed' }" aria-live="polite">
+        {{ statusText }}
+      </span>
+      <span class="captcha-route" aria-hidden="true"><i /><i /><i /><i /><i /></span>
+      <span class="captcha-shield" aria-hidden="true">
+        <svg viewBox="0 0 24 24">
+          <path d="M12 3.4 19 6v5.1c0 4.4-2.8 8-7 9.5-4.2-1.5-7-5.1-7-9.5V6l7-2.6Z" />
+          <path d="m9 12 2 2 4-4" />
+        </svg>
+      </span>
+      <span
+        ref="handleRef"
+        class="captcha-handle"
+        role="slider"
+        tabindex="0"
+        aria-label="拖动验证码"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        :aria-valuenow="Math.round(progress / 10)"
+        :aria-valuetext="statusText"
+        :aria-disabled="interactionDisabled"
+        @pointerdown="handlePointerDown"
+        @pointermove="handlePointerMove"
+        @pointerup="finishDrag"
+        @pointercancel="handlePointerCancel"
+        @keydown="handleKeydown"
+      >
+        <svg v-if="state === 'verified'" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="m5 12.5 4.2 4.2L19 7" />
+        </svg>
+        <svg v-else-if="state === 'failed' && !challenge" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18.3 8.2A7.6 7.6 0 1 0 19.5 14" />
+          <path d="M18.3 4.5v3.7h-3.7" />
+        </svg>
+        <svg v-else viewBox="0 0 24 24" aria-hidden="true">
+          <path d="m6 7 5 5-5 5" />
+          <path d="m11 7 5 5-5 5" />
+        </svg>
+      </span>
+    </div>
+    <p class="keyboard-hint">可拖动滑块，或聚焦后使用左右方向键完成验证</p>
+  </div>
+</template>
+
+<style scoped>
+.login-captcha {
+  margin-bottom: 18px;
+}
+
+.captcha-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 7px;
+  color: var(--el-text-color-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.captcha-label small {
+  color: var(--el-color-primary-dark-2);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+}
+
+.captcha-track {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 48px;
+  overflow: hidden;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: linear-gradient(180deg, var(--el-fill-color-blank), var(--el-fill-color-extra-light));
+  box-shadow: inset 0 1px 2px rgba(25, 18, 52, 0.03);
+  user-select: none;
+}
+
+.captcha-track.is-failed {
+  border-color: var(--el-color-danger-light-5);
+  background: var(--el-color-danger-light-9);
+}
+
+.captcha-track.is-verified {
+  border-color: var(--el-color-success-light-5);
+  background: var(--el-color-success-light-9);
+}
+
+.captcha-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--captcha-fill-width);
+  background: linear-gradient(90deg, var(--el-color-primary-light-8), transparent);
+  transition: width 100ms ease-out;
+}
+
+.is-verified .captcha-fill {
+  background: var(--el-color-success-light-8);
+}
+
+.is-failed .captcha-fill {
+  background: var(--el-color-danger-light-8);
+}
+
+.captcha-copy {
+  position: absolute;
+  inset: 0 48px 0 50px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.is-dragging .captcha-copy,
+.is-verifying .captcha-copy {
+  color: var(--el-color-primary-dark-2);
+}
+
+.is-verified .captcha-copy {
+  color: var(--el-color-success-dark-2, #168d78);
+  font-weight: 650;
+}
+
+.captcha-copy.is-error {
+  color: var(--el-color-danger-dark-2, #bd4f5a);
+}
+
+.captcha-route {
+  position: absolute;
+  right: 70px;
+  bottom: 6px;
+  left: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.captcha-route::before {
+  position: absolute;
+  right: 2px;
+  left: 2px;
+  height: 1px;
+  background: linear-gradient(90deg, var(--el-color-primary-light-5), var(--el-color-primary-light-9));
+  content: '';
+}
+
+.captcha-route i {
+  position: relative;
+  z-index: 1;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--el-color-primary-light-5);
+}
+
+.is-verified .captcha-route i {
+  background: var(--el-color-success-light-3);
+}
+
+.is-failed .captcha-route i {
+  background: var(--el-color-danger-light-5);
+}
+
+.captcha-shield {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 18px;
+  height: 18px;
+  color: var(--el-text-color-placeholder);
+}
+
+.captcha-shield svg,
+.captcha-handle svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.captcha-handle {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  display: grid;
+  width: 42px;
+  height: 42px;
+  box-sizing: border-box;
+  place-items: center;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--el-color-primary), var(--el-color-primary-dark-2));
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--el-color-primary) 28%, transparent);
+  color: var(--captcha-thumb-text);
+  cursor: grab;
+  outline: none;
+  touch-action: none;
+  transform: translate3d(var(--captcha-handle-offset), 0, 0);
+  transition: transform 100ms ease-out, background-color 160ms ease-out, box-shadow 160ms ease-out;
+}
+
+.captcha-handle:focus-visible {
+  box-shadow: 0 0 0 3px var(--el-color-primary-light-7),
+    0 5px 14px color-mix(in srgb, var(--el-color-primary) 28%, transparent);
+}
+
+.is-dragging .captcha-handle {
+  cursor: grabbing;
+  transition: none;
+}
+
+.is-loading .captcha-handle,
+.is-verifying .captcha-handle {
+  cursor: wait;
+  opacity: 0.78;
+}
+
+.is-verified .captcha-handle {
+  background: linear-gradient(135deg, var(--el-color-success), var(--el-color-success-dark-2, #168d78));
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--el-color-success) 24%, transparent);
+  cursor: default;
+}
+
+.is-failed .captcha-handle {
+  background: linear-gradient(135deg, var(--el-color-danger-light-3), var(--el-color-danger));
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--el-color-danger) 20%, transparent);
+  transition: background-color 160ms ease-out, box-shadow 160ms ease-out;
+}
+
+.captcha-handle svg {
+  width: 21px;
+  height: 21px;
+}
+
+.keyboard-hint {
+  margin: 5px 2px 0;
+  color: var(--el-text-color-placeholder);
+  font-size: 10px;
+  line-height: 1.4;
+  text-align: right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .captcha-fill,
+  .captcha-handle {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .captcha-label small {
+    letter-spacing: 0.06em;
+  }
+
+  .captcha-copy {
+    font-size: 12px;
+  }
+
+  .keyboard-hint {
+    display: none;
+  }
+}
+</style>

--- a/customer-admin-web/src/views/login/loginPageModel.test.ts
+++ b/customer-admin-web/src/views/login/loginPageModel.test.ts
@@ -55,19 +55,25 @@ describe('getLoginModePresentation', () => {
 })
 
 describe('createLoginSubmission', () => {
-  it('冻结登录模式与凭据快照，且请求凭据不混入 mode', () => {
+  it.each(['local', 'sso'] as const)('%s 模式冻结登录凭据与一次性 proof，且不携带原始轨迹', (mode) => {
     const form = { username: 'richard', password: 'Secret123', rememberMe: true }
 
-    const submission = createLoginSubmission('local', form)
+    const submission = createLoginSubmission(mode, form, 'proof-once')
     form.username = 'changed'
     form.password = 'Changed456'
     form.rememberMe = false
 
     expect(submission).toEqual({
-      mode: 'local',
-      credentials: { username: 'richard', password: 'Secret123', rememberMe: true },
+      mode,
+      credentials: {
+        username: 'richard',
+        password: 'Secret123',
+        rememberMe: true,
+        captchaProof: 'proof-once',
+      },
     })
     expect(submission.credentials).not.toHaveProperty('mode')
+    expect(submission.credentials).not.toHaveProperty('trajectory')
     expect(Object.isFrozen(submission)).toBe(true)
     expect(Object.isFrozen(submission.credentials)).toBe(true)
   })

--- a/customer-admin-web/src/views/login/loginPageModel.ts
+++ b/customer-admin-web/src/views/login/loginPageModel.ts
@@ -43,9 +43,13 @@ export interface LoginFormData {
   rememberMe: boolean
 }
 
+export interface LoginSubmissionCredentials extends LoginFormData {
+  captchaProof: string
+}
+
 export interface LoginSubmission {
   readonly mode: LoginMode
-  readonly credentials: Readonly<LoginFormData>
+  readonly credentials: Readonly<LoginSubmissionCredentials>
 }
 
 /**
@@ -54,11 +58,13 @@ export interface LoginSubmission {
 export function createLoginSubmission(
   mode: LoginMode,
   form: Readonly<LoginFormData>,
+  captchaProof: string,
 ): Readonly<LoginSubmission> {
   const credentials = Object.freeze({
     username: form.username,
     password: form.password,
     rememberMe: form.rememberMe,
+    captchaProof,
   })
   return Object.freeze({ mode, credentials })
 }

--- a/customer-admin-web/tests/e2e/login.e2e.ts
+++ b/customer-admin-web/tests/e2e/login.e2e.ts
@@ -5,6 +5,8 @@ import { LOGIN_E2E_ORIGIN } from './loginTestEnvironment'
 const LOGIN_PATH = '/login?redirect=/home'
 const LOGIN_IMAGES_API = `${LOGIN_E2E_ORIGIN}/api/login-images/list`
 const REGISTER_OPTIONS_API = `${LOGIN_E2E_ORIGIN}/api/auth/register-options`
+const LOGIN_CAPTCHA_CHALLENGE_API = `${LOGIN_E2E_ORIGIN}/api/auth/login-captcha/challenge`
+const LOGIN_CAPTCHA_VERIFY_API = `${LOGIN_E2E_ORIGIN}/api/auth/login-captcha/verify`
 const CAPTCHA_API = `${LOGIN_E2E_ORIGIN}/api/auth/captcha`
 const EMAIL_CODE_API = `${LOGIN_E2E_ORIGIN}/api/auth/email-code`
 const REGISTER_API = `${LOGIN_E2E_ORIGIN}/api/auth/register`
@@ -36,17 +38,71 @@ interface PendingLoginRequest {
   release: () => void
 }
 
+interface LoginBootstrapOverrides {
+  images?: string[]
+  challengeResponse?: (attempt: number) => unknown | Promise<unknown>
+  verifyResponse?: (attempt: number, payload: Record<string, unknown>) => unknown
+}
+
+interface LoginCaptchaHarness {
+  challengeRequestCount: number
+  verificationPayloads: Record<string, unknown>[]
+}
+
 function successResult<T>(data: T) {
   return { code: 0, message: 'success', data }
 }
 
-async function mockLoginBootstrap(page: Page, options: RegisterOptionsVO = REGISTER_OPTIONS) {
+async function mockLoginCaptcha(
+  page: Page,
+  overrides: LoginBootstrapOverrides = {},
+): Promise<LoginCaptchaHarness> {
+  const harness: LoginCaptchaHarness = {
+    challengeRequestCount: 0,
+    verificationPayloads: [],
+  }
+  await page.route(LOGIN_CAPTCHA_CHALLENGE_API, async (route) => {
+    harness.challengeRequestCount += 1
+    const response = await overrides.challengeResponse?.(harness.challengeRequestCount)
+      ?? successResult({
+        challengeId: `login-challenge-${harness.challengeRequestCount}`,
+        ttlSeconds: 120,
+      })
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response),
+    })
+  })
+  await page.route(LOGIN_CAPTCHA_VERIFY_API, async (route) => {
+    const payload = route.request().postDataJSON() as Record<string, unknown>
+    harness.verificationPayloads.push(payload)
+    const attempt = harness.verificationPayloads.length
+    const response = overrides.verifyResponse?.(attempt, payload) ?? successResult({
+      proof: `login-proof-${attempt}`,
+      ttlSeconds: 120,
+    })
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response),
+    })
+  })
+  return harness
+}
+
+async function mockLoginBootstrap(
+  page: Page,
+  options: RegisterOptionsVO = REGISTER_OPTIONS,
+  overrides: LoginBootstrapOverrides = {},
+): Promise<LoginCaptchaHarness> {
+  const captchaHarness = await mockLoginCaptcha(page, overrides)
   // 只拦截浏览器真正访问的后端 URL；不能使用 **/api/**，否则会误伤 Vite 的 /src/api/*.ts。
   await page.route(LOGIN_IMAGES_API, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(successResult([])),
+      body: JSON.stringify(successResult(overrides.images ?? [])),
     })
   })
   await page.route(REGISTER_OPTIONS_API, async (route) => {
@@ -56,6 +112,7 @@ async function mockLoginBootstrap(page: Page, options: RegisterOptionsVO = REGIS
       body: JSON.stringify(successResult(options)),
     })
   })
+  return captchaHarness
 }
 
 async function mockAuthenticatedBootstrap(page: Page, onRequest?: (url: string) => void) {
@@ -151,11 +208,54 @@ async function suppressExpectedLoginRejection(page: Page) {
   }, TEST_BUSINESS_REJECTION_CODE)
 }
 
-async function openLogin(page: Page) {
-  await mockLoginBootstrap(page)
+async function openLogin(
+  page: Page,
+  overrides: LoginBootstrapOverrides = {},
+): Promise<LoginCaptchaHarness> {
+  const captchaHarness = await mockLoginBootstrap(page, REGISTER_OPTIONS, overrides)
   await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
   await expect(page.getByRole('button', { name: '创建账号' })).toBeVisible()
+  await expect(page.getByRole('slider', { name: '拖动验证码' }))
+    .toHaveAttribute('aria-valuetext', '按住滑块，拖动完成验证')
+  return captchaHarness
+}
+
+async function dragLoginCaptcha(page: Page) {
+  const track = page.locator('[data-login-captcha]')
+  const handle = page.getByRole('slider', { name: '拖动验证码' })
+  await expect(handle).toHaveAttribute('aria-disabled', 'false')
+  await expect.poll(async () => {
+    const [trackBox, handleBox] = await Promise.all([track.boundingBox(), handle.boundingBox()])
+    return trackBox && handleBox ? Math.abs(handleBox.x - trackBox.x - 2) : Number.POSITIVE_INFINITY
+  }).toBeLessThanOrEqual(2)
+  const [trackBox, handleBox] = await Promise.all([track.boundingBox(), handle.boundingBox()])
+  expect(trackBox).not.toBeNull()
+  expect(handleBox).not.toBeNull()
+  if (!trackBox || !handleBox) {
+    return
+  }
+
+  const startX = handleBox.x + handleBox.width / 2
+  const startY = handleBox.y + handleBox.height / 2
+  const endX = trackBox.x + trackBox.width - handleBox.width / 2
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+  for (let step = 1; step <= 10; step += 1) {
+    const ratio = step / 10
+    await page.mouse.move(
+      startX + (endX - startX) * ratio,
+      startY + (step % 2 === 0 ? 1 : -1),
+    )
+    await page.waitForTimeout(35)
+  }
+  await page.mouse.up()
+}
+
+async function completeLoginCaptcha(page: Page) {
+  await dragLoginCaptcha(page)
+  await expect(page.getByRole('slider', { name: '拖动验证码' }))
+    .toHaveAttribute('aria-valuetext', '验证通过')
 }
 
 async function documentScrollTop(page: Page) {
@@ -280,12 +380,27 @@ test.describe('桌面登录布局', () => {
     await page.getByRole('checkbox', { name: '保持登录' })
       .evaluate((element: HTMLInputElement) => element.click())
     await expect(page.getByRole('checkbox', { name: '保持登录' })).toBeChecked()
+
+    const loginBeforeCaptcha = page.waitForRequest(LOCAL_LOGIN_API, { timeout: 500 })
+      .then(() => true)
+      .catch(() => false)
+    await page.getByRole('button', { name: '进入运营台' }).click()
+    expect(await loginBeforeCaptcha).toBe(false)
+    await expect(page.getByText('请先完成拖动验证', { exact: true })).toBeVisible()
+
+    await completeLoginCaptcha(page)
     await page.getByRole('button', { name: '进入运营台' }).click()
 
     const localRequest = await localCapture.requestCaptured
     try {
       expect(localRequest.url).toBe(LOCAL_LOGIN_API)
-      expect(localRequest.body).toMatchObject({ username: 'local.richard', rememberMe: true })
+      expect(localRequest.body).toEqual({
+        username: 'local.richard',
+        password: 'Local1234',
+        rememberMe: true,
+        captchaProof: 'login-proof-1',
+      })
+      expect(localRequest.body).not.toHaveProperty('trajectory')
       await expect(localTab).toBeDisabled()
       await expect(ssoTab).toBeDisabled()
     } finally {
@@ -293,18 +408,27 @@ test.describe('桌面登录布局', () => {
     }
     await expect(localTab).toBeEnabled()
     await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}${LOGIN_PATH}`)
+    await expect(page.locator('#login-username')).toHaveValue('local.richard')
+    await expect(page.locator('#login-password')).toHaveValue('Local1234')
 
     await ssoTab.click()
     const ssoCapture = await captureRejectedLogin(page, SSO_LOGIN_API)
     await page.locator('#login-username').fill('oa.richard')
     await page.locator('#login-password').fill('Sso12345')
     await expect(page.getByRole('checkbox', { name: '保持登录' })).not.toBeChecked()
+    await completeLoginCaptcha(page)
     await page.getByRole('button', { name: '使用 OA 账号登录' }).click()
 
     const ssoRequest = await ssoCapture.requestCaptured
     try {
       expect(ssoRequest.url).toBe(SSO_LOGIN_API)
-      expect(ssoRequest.body).toMatchObject({ username: 'oa.richard', rememberMe: false })
+      expect(ssoRequest.body).toEqual({
+        username: 'oa.richard',
+        password: 'Sso12345',
+        rememberMe: false,
+        captchaProof: 'login-proof-2',
+      })
+      expect(ssoRequest.body).not.toHaveProperty('trajectory')
       await expect(localTab).toBeDisabled()
       await expect(ssoTab).toBeDisabled()
     } finally {
@@ -312,6 +436,162 @@ test.describe('桌面登录布局', () => {
     }
     await expect(ssoTab).toBeEnabled()
     await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}${LOGIN_PATH}`)
+  })
+
+  test('轨迹校验失败就地恢复，不清空账号密码，也不弹全局消息', async ({ page }) => {
+    const captchaHarness = await openLogin(page, {
+      verifyResponse: (attempt) => (
+        attempt === 1
+          ? { code: 30014, message: '拖动轨迹无效，请重试', data: null }
+          : successResult({ proof: 'recovered-login-proof', ttlSeconds: 120 })
+      ),
+    })
+    await page.locator('#login-username').fill('local.richard')
+    await page.locator('#login-password').fill('Local1234')
+
+    await dragLoginCaptcha(page)
+
+    await expect(page.getByText('拖动轨迹无效，请重试', { exact: true })).toBeVisible()
+    await expect(page.locator('#login-username')).toHaveValue('local.richard')
+    await expect(page.locator('#login-password')).toHaveValue('Local1234')
+    await expect(page.locator('.el-message')).toHaveCount(0)
+    await expect.poll(() => captchaHarness.challengeRequestCount).toBe(2)
+    const slider = page.getByRole('slider', { name: '拖动验证码' })
+    await expect(slider).toHaveAttribute('aria-valuetext', '拖动轨迹无效，请重试')
+    await expect(slider).toHaveAttribute('aria-disabled', 'false')
+
+    await page.waitForTimeout(50)
+    await completeLoginCaptcha(page)
+
+    expect(captchaHarness.verificationPayloads).toHaveLength(2)
+    expect(captchaHarness.verificationPayloads[0]).toMatchObject({
+      challengeId: 'login-challenge-1',
+    })
+    expect(captchaHarness.verificationPayloads[1]).toMatchObject({
+      challengeId: 'login-challenge-2',
+    })
+    for (const payload of captchaHarness.verificationPayloads) {
+      const trajectory = payload.trajectory as Array<{ x: number; y: number; t: number }>
+      expect(trajectory.length).toBeGreaterThanOrEqual(6)
+      expect(trajectory.at(0)).toEqual({ x: 0, y: 0, t: 0 })
+      expect(trajectory.at(-1)?.x).toBe(1000)
+    }
+  })
+
+  test('慢网重取 challenge 时复用同一请求，重复点击和 Enter 不消耗签发额度', async ({ page }) => {
+    let releaseSecondChallenge!: () => void
+    const secondChallengeReleased = new Promise<void>((resolve) => {
+      releaseSecondChallenge = resolve
+    })
+    const captchaHarness = await openLogin(page, {
+      challengeResponse: async (attempt) => {
+        if (attempt === 2) {
+          await secondChallengeReleased
+        }
+        return successResult({ challengeId: `login-challenge-${attempt}`, ttlSeconds: 120 })
+      },
+      verifyResponse: (attempt) => (
+        attempt === 1
+          ? { code: 30014, message: '拖动轨迹无效，请重试', data: null }
+          : successResult({ proof: 'recovered-login-proof', ttlSeconds: 120 })
+      ),
+    })
+
+    try {
+      await dragLoginCaptcha(page)
+      await expect(page.getByText('拖动轨迹无效，请重试', { exact: true })).toBeVisible()
+      await expect.poll(() => captchaHarness.challengeRequestCount).toBe(2)
+
+      const slider = page.getByRole('slider', { name: '拖动验证码' })
+      await slider.focus()
+      await page.keyboard.press('Enter')
+      await expect(slider).toHaveAttribute('aria-valuetext', '正在准备安全验证…')
+      for (let attempt = 0; attempt < 4; attempt += 1) {
+        await slider.click({ force: true })
+      }
+      await page.keyboard.press('Enter')
+      await page.waitForTimeout(100)
+
+      expect(captchaHarness.challengeRequestCount).toBe(2)
+      await expect(slider).toHaveAttribute('aria-valuetext', '正在准备安全验证…')
+      await expect(page.getByText('拖动轨迹无效，请重试', { exact: true })).toHaveCount(0)
+    } finally {
+      releaseSecondChallenge()
+    }
+
+    const slider = page.getByRole('slider', { name: '拖动验证码' })
+    await expect(slider).toHaveAttribute('aria-valuetext', '按住滑块，拖动完成验证')
+    await expect(slider).toHaveAttribute('aria-disabled', 'false')
+    await expect(page.getByText('拖动轨迹无效，请重试', { exact: true })).toHaveCount(0)
+    expect(captchaHarness.challengeRequestCount).toBe(2)
+  })
+
+  test('键盘可完成验证，并满足服务端最短轨迹时长契约', async ({ page }) => {
+    const captchaHarness = await openLogin(page)
+    const slider = page.getByRole('slider', { name: '拖动验证码' })
+    await slider.focus()
+
+    for (let step = 0; step < 10; step += 1) {
+      await page.keyboard.press('ArrowRight')
+    }
+
+    await expect(slider).toHaveAttribute('aria-valuetext', '验证通过')
+    expect(captchaHarness.verificationPayloads).toHaveLength(1)
+    const trajectory = captchaHarness.verificationPayloads[0].trajectory as Array<{ t: number }>
+    expect(trajectory.at(-1)?.t).toBeGreaterThanOrEqual(300)
+  })
+})
+
+test.describe('品牌背景轮播', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('严格按 3 秒轮播，悬停、聚焦和圆点选择都不会永久停止', async ({ page }) => {
+    await openLogin(page, { images: ['/A1.jpg', '/A2.jpg', '/A3.jpg'] })
+
+    const firstDot = page.getByRole('button', { name: '查看第 1 张品牌背景图' })
+    const secondDot = page.getByRole('button', { name: '查看第 2 张品牌背景图' })
+    const thirdDot = page.getByRole('button', { name: '查看第 3 张品牌背景图' })
+    const pauseButton = page.getByRole('button', { name: '暂停轮播' })
+    const currentImage = () => page.locator('.carousel-dots button[aria-current="true"]')
+      .getAttribute('aria-label')
+    await expect(firstDot).toHaveAttribute('aria-current', 'true')
+
+    // 先暂停再恢复，以恢复点击作为新的计时起点，钉住 3000ms 而不是宽松的“最终会切换”。
+    await pauseButton.click()
+    await page.getByRole('button', { name: '继续轮播' }).click()
+    await page.waitForTimeout(2_700)
+    await expect(firstDot).toHaveAttribute('aria-current', 'true')
+    await expect(secondDot).toHaveAttribute('aria-current', 'true', { timeout: 900 })
+
+    await page.locator('.brand-stage').hover()
+    await pauseButton.focus()
+    await expect(thirdDot).toHaveAttribute('aria-current', 'true', { timeout: 3_600 })
+
+    await firstDot.click()
+    await expect(firstDot).toHaveAttribute('aria-current', 'true')
+    await expect(secondDot).toHaveAttribute('aria-current', 'true', { timeout: 3_600 })
+
+    await pauseButton.click()
+    await expect(page.getByRole('button', { name: '继续轮播' })).toHaveAttribute('aria-pressed', 'true')
+    const pausedImage = await currentImage()
+    await page.waitForTimeout(3_500)
+    expect(await currentImage()).toBe(pausedImage)
+
+    await page.getByRole('button', { name: '继续轮播' }).click()
+    await page.waitForTimeout(2_700)
+    expect(await currentImage()).toBe(pausedImage)
+    await expect.poll(currentImage, { timeout: 900 }).not.toBe(pausedImage)
+  })
+
+  test('系统要求减少动态效果时保持静止并禁用自动轮播开关', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await openLogin(page, { images: ['/A1.jpg', '/A2.jpg'] })
+
+    const firstDot = page.getByRole('button', { name: '查看第 1 张品牌背景图' })
+    await expect(firstDot).toHaveAttribute('aria-current', 'true')
+    await expect(page.getByRole('button', { name: '自动切换已关闭' })).toBeDisabled()
+    await page.waitForTimeout(3_500)
+    await expect(firstDot).toHaveAttribute('aria-current', 'true')
   })
 })
 
@@ -337,6 +617,7 @@ test.describe('登录成功状态机', () => {
     await page.locator('#login-password').fill('Local1234')
     await page.getByRole('checkbox', { name: '保持登录' })
       .evaluate((element: HTMLInputElement) => element.click())
+    await completeLoginCaptcha(page)
     await page.getByRole('button', { name: '进入运营台' }).click()
 
     await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}/home`)
@@ -344,6 +625,7 @@ test.describe('登录成功状态机', () => {
       username: 'local.richard',
       password: 'Local1234',
       rememberMe: true,
+      captchaProof: 'login-proof-1',
     })
     expect(bootstrapRequests).toEqual([
       PERMISSIONS_API,
@@ -386,6 +668,7 @@ test.describe('登录成功状态机', () => {
 
     await page.locator('#login-username').fill('first.login')
     await page.locator('#login-password').fill('Local1234')
+    await completeLoginCaptcha(page)
     await page.getByRole('button', { name: '进入运营台' }).click()
 
     await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}/change-password`)
@@ -801,6 +1084,7 @@ test.describe('注册入口能力', () => {
   test.use({ viewport: { width: 1280, height: 720 } })
 
   test('注册选项业务失败时 fail-closed，仍保留本地登录能力', async ({ page }) => {
+    await mockLoginCaptcha(page)
     await page.route(LOGIN_IMAGES_API, async (route) => {
       await route.fulfill({
         status: 200,

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -978,7 +978,12 @@ AppKey 扩展为模型资产/部署分离、SecretRef
 流式对话 SSE + VibeCoding SSE + 降级版产物清单。前端:登录/强制改密页 + 动态路由(按菜单树运行时
 `router.addRoute`)+ 菜单版本号轮询兜底刷新 + `v-permission` 按钮级权限指令 + 系统管理三页 + AI 配置四页
 + 智能体工作区(聊天 + VibeCoding 双 Tab)；`/aiconfig/model` 以抽屉集中展示部署、凭据元数据、健康、认证与影响。
-这里描述的是源码与接口事实，不代表已经完成登录浏览器的端到端验证。
+登录页已有真实 Chrome 端到端回归，覆盖本地/OA 分流、拖动与键盘验证码、一次性 proof、失败复位、
+紧凑/移动视口，以及品牌背景图每 3 秒轮播、显式暂停和减少动态效果偏好。
+为保证匿名接口的来源 IP 边界只有一处，`server.forward-headers-strategy` 固定为 `none`，
+最终绑定为其它值时启动失败；
+同样禁止配置 `server.tomcat.remoteip.remote-ip-header` / `protocol-header`。转发头只能由
+按显式代理 CIDR 工作的 `ClientIpResolver` 解析。
 
 ```bash
 # 后端：端口 8082；dev profile 自动跑 Flyway 迁移建出 customer_admin 库全部表 + 种子数据（admin/admin）
@@ -992,7 +997,9 @@ cd customer-admin-web && npm ci && npm run dev
 
 | 入口 | 能力 |
 |---|---|
-| `POST /api/auth/login` | 登录（`admin/admin` 首次登录返回 `forceChangePassword=true`；响应含注册审核状态与说明） |
+| `POST /api/auth/login-captcha/challenge` | 匿名签发登录拖动 challenge；按来源 IP 限流，并与 IP、User-Agent 指纹绑定 |
+| `POST /api/auth/login-captcha/verify` | 原子消费 challenge 并校验归一化轨迹，成功后签发短期、一次性的 `captchaProof` |
+| `POST /api/auth/login` / `POST /api/auth/sso-login` | 本地/OA 登录；都必须携带 `captchaProof`，且 proof 在查用户、BCrypt 或 LDAP Bind 前原子消费。`admin/admin` 首次本地登录返回 `forceChangePassword=true` |
 | `POST /api/auth/register` | 登录页公开自助注册；仅创建 `default` 租户的 `PENDING` 本地账号，不自动授予角色或菜单 |
 | `POST /api/auth/change-password` / `POST /api/auth/logout` | 改密 / 登出 |
 | `GET /api/system/user/approval-options?tenantId=...` | 注册审核租户与角色选项；普通审核人仅当前租户，控制面审核人可选择任一可用租户，权限点 `user:edit` |
@@ -2227,7 +2234,8 @@ Redis 配额旧计数与 MinIO 历史工作区由过渡兼容逻辑承接，完�
 | `subject-quota` | enabled(false), store-mode(memory), refresh-interval-ms(60000), default-user-level(free), anonymous-level(anonymous), api-key-level(api-key), level-cache-ttl-ms(60000), level-cache-max-size(10000), paths([/api/customer/chat, /intent, /consult, /agui, /api/customer/user/]), builtin-levels{free,anonymous,api-key}（见 §6.32；按调用者限流，与 §6.29 的按租户限费并存） |
 | `admin.subject-quota`（非 `customer-work.*` 前缀，属 admin 自身配置）| enabled(true，`application.yml` 显式开启), default-level(admin-default), lazy-refresh-ms(60000), level-cache-ttl-ms(60000), path-patterns([/api/workspace/*/chat/stream, /api/workspace/*/chat/plan/confirm, /api/workspace/*/vibecoding/**, /api/aiconfig/agent-task/**, /api/eval/run, /api/aiconfig/knowledge-base/*/test-connectivity])（见 §6.32.1；后台登录用户的 AI 用量额度。对外开放实例须把 default-level 换成 `public-trial`，`AdminProductionReadinessValidator` 会强制校验） |
 | `admin.public-deployment`（admin 自身配置）| enabled(false)：对外开放实例总开关。打开后内部运维工具（SQL 客户端/账号本/开发者工具箱）菜单与接口一并下架、自助注册强制验证码与邮箱、审核不允许并入 `default` 租户。详见《部署手册》§8.1 |
-| `admin.registration`（admin 自身配置）| self-service-enabled(true), captcha-enabled(false), email-required(false), trust-forwarded-header(true), rate-limit{max-attempts(5), window-seconds(3600)}, captcha{length(4), ttl-seconds(180), width(120), height(40), max-issue-per-window(30)}, login-lock{enabled(false), max-failures(5), window-seconds(900)}, email-verification{enabled(false), code-length(6), ttl-seconds(600), max-attempts(5), resend-cooldown-seconds(60), max-send-per-email-per-day(10), max-send-per-ip-per-window(10)}。**captcha-enabled / email-required / login-lock.enabled / email-verification.enabled 在对外开放实例上被强制为 true，配 false 不生效**。开启邮箱验证后图形码改在「发码」那一步校验，注册那一步只认邮箱验证码 |
+| `admin.registration`（admin 自身配置）| self-service-enabled(true), captcha-enabled(false), email-required(false), trust-forwarded-header(false), trusted-proxy-cidrs([]), rate-limit{max-attempts(5), window-seconds(3600)}, captcha{length(4), ttl-seconds(180), width(120), height(40), max-issue-per-window(30)}, login-lock{enabled(false), max-failures(5), window-seconds(900)}, email-verification{enabled(false), code-length(6), ttl-seconds(600), max-attempts(5), resend-cooldown-seconds(60), max-send-per-email-per-day(10), max-send-per-ip-per-window(10)}。**captcha-enabled / email-required / login-lock.enabled / email-verification.enabled 在对外开放实例上被强制为 true，配 false 不生效**。转发头默认不信任；开启时可信代理 CIDR 不能为空，且仅从命中网段的直接连接方接收 XFF，再从右向左剥离可信代理链。开启邮箱验证后图形码改在「发码」那一步校验，注册那一步只认邮箱验证码 |
+| `admin.login-captcha`（admin 自身配置）| challenge-ttl-seconds(120), proof-ttl-seconds(120), max-issue-per-window(30), max-verify-per-window(120), max-proof-consume-per-window(120), rate-limit-window-seconds(3600), max-in-memory-entries(10000), max-user-agent-length(512)。所有配置必须为正数；独立于注册图形验证码且无关闭开关。签发、轨迹校验与 proof 消费分别按可信来源 IP 限流，三者共用限流窗口时长；轨迹点数、坐标和时长是固定接口协议，不开放运行期调参；challenge/proof 都绑定 IP+UA 并只允许成功消费一次 |
 | `admin.notification.mail`（admin 自身配置）| enabled(false), host, port(587), username, password, from, from-name(客服智能体平台), start-tls-enabled(true), ssl-enabled(false), timeout-ms(5000), platform-name, login-url：注册审核结果邮件通知。开放注册时为必填项 |
 | `eval`（B6）| store-mode(memory), baseline-enabled(false), baseline-cron(0 0 3 * * ?), judge-timeout-seconds(60)，见 §6.31 |
 | `badcase`（B6）| store-mode(memory), auto-collect(true)，见 §6.31 |

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -530,12 +530,38 @@ ADMIN_PUBLIC_DEPLOYMENT_ENABLED=true
 |---|---|---|
 | `ADMIN_PUBLIC_DEPLOYMENT_ENABLED` | `false` | 对外开放总开关 |
 | `ADMIN_REGISTRATION_SELF_SERVICE` | `true` | 关闭后只能由管理员预建账号 |
-| `ADMIN_REGISTRATION_TRUST_XFF` | `true` | 是否采信 `X-Forwarded-For`。**前提是反代必须覆写而非追加该请求头**,否则客户端可伪造首段绕开 IP 限流;直连暴露的部署设为 `false` |
+| `ADMIN_REGISTRATION_TRUST_XFF` | `false` | 是否启用可信代理链解析。单独开启但未配置可信代理 CIDR 会启动失败，不存在“信任所有来源”的退化路径 |
+| `ADMIN_REGISTRATION_TRUSTED_PROXY_CIDRS` | 空 | 直接连接到服务端的可信代理网段，逗号分隔，如 `10.0.0.0/8,fd00::/8`，禁止用 `/0` 退化为信任全网。服务端仅在 `remoteAddr` 命中时读取转发头，并从 XFF 右向左剥离可信代理；异常、超长、跳数过多或全可信链均回退直连地址 |
+| `ADMIN_LOGIN_CAPTCHA_CHALLENGE_TTL_SECONDS` / `ADMIN_LOGIN_CAPTCHA_PROOF_TTL_SECONDS` | `120` / `120` | 登录拖动 challenge 与一次性 proof 的有效期；不建议放大，过期后前端会自动重新签发 |
+| `ADMIN_LOGIN_CAPTCHA_MAX_ISSUE_PER_WINDOW` / `ADMIN_LOGIN_CAPTCHA_RATE_LIMIT_WINDOW_SECONDS` | `30` / `3600` | 单个来源 IP 的 challenge 签发上限与三条限流链路共用窗口；与注册图形码分桶 |
+| `ADMIN_LOGIN_CAPTCHA_MAX_VERIFY_PER_WINDOW` / `ADMIN_LOGIN_CAPTCHA_MAX_PROOF_CONSUME_PER_WINDOW` | `120` / `120` | 同一窗口内单个可信来源 IP 的轨迹校验与 proof 消费上限；在访问 challenge/proof 存储前判定，拦截随机 token 对 Redis 的放大请求 |
 | `ADMIN_REGISTRATION_EMAIL_VERIFICATION` | `false` | 注册必须先收邮箱验证码。对外部署强制为 true |
 | `ADMIN_MAIL_ENABLED` / `ADMIN_MAIL_HOST` / `ADMIN_MAIL_USERNAME` / `ADMIN_MAIL_PASSWORD` / `ADMIN_MAIL_FROM` | 关闭 | SMTP 连接参数,注册验证码与审核结果通知共用。**开放注册时必填**——验证码发不出去注册就走不下去,而审核结果只发站内信的话,被拒绝的人永远看不到 |
 | `ADMIN_MAIL_LOGIN_URL` | 空 | 写进邮件正文的登录地址 |
 
+`application.yml` 固定 `server.forward-headers-strategy=none`，不允许 Tomcat `RemoteIpValve` 或
+`ForwardedHeaderFilter` 在业务代码之前改写 `remoteAddr`；最终绑定值被环境变量或启动参数改成
+`native` / `framework` 时应用会直接启动失败。反向代理部署只配置上表两个
+`ADMIN_REGISTRATION_*` 参数；不要在容器、Java 启动参数或额外 Filter 中再启一套转发头解析。
+`SERVER_TOMCAT_REMOTEIP_REMOTE_IP_HEADER` 与 `SERVER_TOMCAT_REMOTEIP_PROTOCOL_HEADER` 同样必须保持未配置，
+任一有值都会在启动期被拒绝。
+
 限流与锁定参数(`admin.registration.rate-limit.*`、`admin.registration.captcha.max-issue-per-window`、`admin.registration.login-lock.*`)默认值在 Java 里:IP 注册 5 次/小时、验证码签发 30 张/小时、登录连续失败 5 次锁 15 分钟。**验证码签发单独计数**——它比注册宽松得多(真人看不清会点着换几张),共用一个桶会让刷新几次图就把注册额度用光;而完全不限的话,这个免登接口本身就是一条廉价的画图消耗路径。它们按"账号+来源 IP"的组合锁定而非只锁账号——只锁账号的话,任何人拿一个已知用户名连打几次就能把真实用户挡在门外。
+
+#### 登录拖动验证码
+
+本地登录与 OA 登录共用同一条准入链：`challenge → 轨迹核验 → 一次性 proof → 登录原子消费`。
+登录请求只携带 proof，不携带客户端的“已验证”布尔值或原始轨迹；proof 在用户查询、BCrypt 和 LDAP Bind
+之前消费，密码错误、域控不可用或账号禁用都不会返还。challenge 与 proof 同时绑定来源 IP 和归一化
+User-Agent，因而不能直接搬到另一浏览器或网络环境重放。
+
+后台没有 Redisson Bean 时使用有容量上限的进程内存储，适合单实例开发；一旦启动时选中 Redis，
+保存或消费响应不确定都 **fail-closed**，运行期不会再切到内存副本。这样会牺牲 Redis 瞬时故障期间的登录
+可用性，但避免“Redis 已成功写入/删除、客户端却收到超时”时同一 challenge 或 proof 在两处复活。
+
+这是一道基础准入而不是风险引擎：静态轨迹没有服务端秘密，脚本仍能构造满足时长与采样约束的数据。
+当前实现用于阻断省略验证、一次性凭据重放、跨来源搬运和低成本批量请求；面向高风险公网对抗时，
+应替换成带随机目标的拼图或接入第三方风控，不能把本滑块宣传成完整的反机器人方案。
 
 #### 成本闸门
 


### PR DESCRIPTION
## 背景

登录入口需要在本地密码校验和 OA/LDAP Bind 之前增加一次可消费的拖动确认，同时修复登录页品牌背景不会持续轮播的问题。

## 变更

- 新增 `challenge -> 轨迹校验 -> 一次性 proof -> 登录消费` 链路，本地登录与 OA 登录共用同一准入契约。
- 新增鼠标/触摸拖动和键盘操作的登录验证组件；失败就地复位，不清空账号密码，慢网下合并重复签发请求。
- 品牌背景固定每 3 秒切换；悬停、聚焦和手动选图不再导致永久停播，仍尊重减少动态效果和页面不可见状态。
- challenge/proof 绑定可信来源 IP + User-Agent，Redis/内存存储均原子消费；签发、校验、proof 消费独立限流，存储故障 fail-closed。
- 只在直接连接方命中显式可信代理 CIDR 时处理完整 XFF 链；禁止 `/0`，并在启动期拒绝 Spring/Tomcat 额外转发头预处理。

## 部署注意

- 如需采信反向代理头，同时配置 `ADMIN_REGISTRATION_TRUST_XFF=true` 和非空的 `ADMIN_REGISTRATION_TRUSTED_PROXY_CIDRS`。
- `server.forward-headers-strategy` 必须保持 `none`，Tomcat `remote-ip-header` / `protocol-header` 必须留空，否则启动失败。
- 无 Redis 时仅适合单实例；多实例生产环境需保证 Redis 可用。

## 验证

- JDK 17 六模块 `clean test`：3579 tests，0 failures，0 errors，6 skipped，`BUILD SUCCESS`。
- 前端单测：10 files / 105 tests 通过。
- 前端生产构建通过。
- Chrome E2E：18/18 通过，包含拖动/键盘验证、一次性 proof、慢网 single-flight、严格 3 秒轮播和移动端布局。
- 敏感凭据扫描与 `git diff --check` 通过。

## 能力边界

当前滑块是一次性准入 proof、最短操作时长和限流的组合，用于拦截直接绕过与低成本自动化，不等同于高强度真人识别。公网面对 botnet 或大规模 IPv6 轮换时，仍需网关/WAF 总量防护。
