### PR TITLE
feat(admin-web): 支持 VibeCoding 产物栏拖拽调宽

### DIFF
--- a/customer-admin-web/src/composables/useVibeCodingPanelResize.ts
+++ b/customer-admin-web/src/composables/useVibeCodingPanelResize.ts
@@ -1,0 +1,242 @@
+import { computed, onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue'
+import {
+  DEFAULT_ARTIFACTS_PANEL_WIDTH,
+  clampPreferredArtifactsPanelWidth,
+  parseStoredArtifactsPanelWidth,
+  resolveVibeCodingPanelResize,
+} from '@/utils/vibeCodingPanelResize'
+
+const ARTIFACTS_PANEL_WIDTH_STORAGE_KEY = 'customer-admin-vibecoding-artifacts-width'
+const KEYBOARD_RESIZE_STEP = 16
+const KEYBOARD_RESIZE_LARGE_STEP = 48
+const RESIZING_BODY_CLASS = 'is-vibecoding-panel-resizing'
+
+interface UseVibeCodingPanelResizeOptions {
+  panelRef: Ref<HTMLElement | undefined>
+  historyCollapsed: Ref<boolean>
+}
+
+/**
+ * 管理 VibeCoding 对话区与产物区之间的分隔线。
+ * preferredWidth 保存用户偏好，effectiveWidth 只负责当前容器下的临时夹紧，避免窄屏覆盖宽屏偏好。
+ */
+export function useVibeCodingPanelResize({ panelRef, historyCollapsed }: UseVibeCodingPanelResizeOptions) {
+  const containerWidth = ref(0)
+  const preferredWidth = ref(DEFAULT_ARTIFACTS_PANEL_WIDTH)
+  const isResizing = ref(false)
+  let resizeObserver: ResizeObserver | undefined
+  let activePointerId: number | undefined
+  let activeHandle: HTMLElement | undefined
+  let dragStartX = 0
+  let dragStartWidth = DEFAULT_ARTIFACTS_PANEL_WIDTH
+  let dragStartPreferredWidth = DEFAULT_ARTIFACTS_PANEL_WIDTH
+  let dragChanged = false
+
+  const layout = computed(() => resolveVibeCodingPanelResize({
+    containerWidth: containerWidth.value,
+    preferredWidth: preferredWidth.value,
+    historyCollapsed: historyCollapsed.value,
+  }))
+  const resizeEnabled = computed(() => layout.value.resizeEnabled)
+  const effectiveWidth = computed(() => layout.value.effectiveWidth)
+  const panelStyle = computed(() => ({
+    '--vibe-artifacts-column-width': `${effectiveWidth.value}px`,
+  }))
+  const ariaValueText = computed(() => `产物文件区宽度 ${effectiveWidth.value} 像素`)
+
+  function measureContainer() {
+    containerWidth.value = panelRef.value?.clientWidth ?? 0
+  }
+
+  function readPreferredWidth() {
+    try {
+      preferredWidth.value = parseStoredArtifactsPanelWidth(window.localStorage.getItem(ARTIFACTS_PANEL_WIDTH_STORAGE_KEY))
+    } catch {
+      preferredWidth.value = DEFAULT_ARTIFACTS_PANEL_WIDTH
+    }
+  }
+
+  function persistPreferredWidth() {
+    try {
+      window.localStorage.setItem(ARTIFACTS_PANEL_WIDTH_STORAGE_KEY, String(preferredWidth.value))
+    } catch {
+      // 布局偏好写入失败不影响 VibeCoding 主链路，保持本次页面内的有效宽度即可。
+    }
+  }
+
+  function setPreferredWidth(width: number, persist: boolean) {
+    preferredWidth.value = clampPreferredArtifactsPanelWidth(width)
+    if (persist) {
+      persistPreferredWidth()
+    }
+  }
+
+  /** 用户主动拖动/按键时按当前布局边界写入；单纯容器变窄不会走这里，因此不会覆盖宽屏偏好。 */
+  function setEffectiveWidth(width: number, persist: boolean): boolean {
+    const nextWidth = Math.min(
+      layout.value.maxWidth,
+      Math.max(layout.value.minWidth, clampPreferredArtifactsPanelWidth(width)),
+    )
+    if (nextWidth === effectiveWidth.value) {
+      return false
+    }
+    preferredWidth.value = nextWidth
+    if (persist) {
+      persistPreferredWidth()
+    }
+    return true
+  }
+
+  function applyDrag(clientX: number): boolean {
+    return setEffectiveWidth(dragStartWidth - (clientX - dragStartX), false)
+  }
+
+  function cleanupResize(pointerId?: number) {
+    const capturedPointerId = activePointerId
+    const handle = activeHandle
+    activePointerId = undefined
+    activeHandle = undefined
+    isResizing.value = false
+    document.body.classList.remove(RESIZING_BODY_CLASS)
+    if (
+      capturedPointerId !== undefined
+      && pointerId !== capturedPointerId
+      && handle?.hasPointerCapture(capturedPointerId)
+    ) {
+      handle.releasePointerCapture(capturedPointerId)
+    }
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (!resizeEnabled.value || !event.isPrimary || event.button !== 0 || activePointerId !== undefined) {
+      return
+    }
+    activePointerId = event.pointerId
+    activeHandle = event.currentTarget as HTMLElement
+    dragStartX = event.clientX
+    dragStartWidth = effectiveWidth.value
+    dragStartPreferredWidth = preferredWidth.value
+    dragChanged = false
+    activeHandle.setPointerCapture(event.pointerId)
+    activeHandle.focus()
+    isResizing.value = true
+    document.body.classList.add(RESIZING_BODY_CLASS)
+    event.preventDefault()
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (activePointerId !== event.pointerId) {
+      return
+    }
+    dragChanged = applyDrag(event.clientX) || dragChanged
+    event.preventDefault()
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (activePointerId !== event.pointerId) {
+      return
+    }
+    dragChanged = applyDrag(event.clientX) || dragChanged
+    if (activeHandle?.hasPointerCapture(event.pointerId)) {
+      activeHandle.releasePointerCapture(event.pointerId)
+    }
+    cleanupResize(event.pointerId)
+    if (dragChanged) {
+      persistPreferredWidth()
+    }
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (activePointerId !== event.pointerId) {
+      return
+    }
+    preferredWidth.value = dragStartPreferredWidth
+    if (activeHandle?.hasPointerCapture(event.pointerId)) {
+      activeHandle.releasePointerCapture(event.pointerId)
+    }
+    cleanupResize(event.pointerId)
+  }
+
+  function handleLostPointerCapture(event: PointerEvent) {
+    if (activePointerId !== event.pointerId) {
+      return
+    }
+    cleanupResize(event.pointerId)
+    persistPreferredWidth()
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!resizeEnabled.value) {
+      return
+    }
+    const step = event.shiftKey ? KEYBOARD_RESIZE_LARGE_STEP : KEYBOARD_RESIZE_STEP
+    let nextWidth: number | undefined
+    switch (event.key) {
+      case 'ArrowLeft':
+        nextWidth = effectiveWidth.value + step
+        break
+      case 'ArrowRight':
+        nextWidth = effectiveWidth.value - step
+        break
+      case 'Home':
+        nextWidth = layout.value.minWidth
+        break
+      case 'End':
+        nextWidth = layout.value.maxWidth
+        break
+      case 'Enter':
+        event.preventDefault()
+        resetWidth()
+        return
+      default:
+        return
+    }
+    if (nextWidth === undefined) {
+      return
+    }
+    event.preventDefault()
+    setEffectiveWidth(nextWidth, true)
+  }
+
+  function resetWidth() {
+    setPreferredWidth(DEFAULT_ARTIFACTS_PANEL_WIDTH, true)
+  }
+
+  onMounted(() => {
+    readPreferredWidth()
+    measureContainer()
+    resizeObserver = new ResizeObserver(measureContainer)
+    if (panelRef.value) {
+      resizeObserver.observe(panelRef.value)
+    }
+  })
+
+  watch(resizeEnabled, (enabled) => {
+    if (!enabled && activePointerId !== undefined) {
+      // 布局在拖动中切为堆叠态等价于取消本次手势，不能留下未持久化的半成品偏好。
+      preferredWidth.value = dragStartPreferredWidth
+      cleanupResize()
+    }
+  })
+
+  onBeforeUnmount(() => {
+    resizeObserver?.disconnect()
+    cleanupResize()
+  })
+
+  return {
+    ariaValueText,
+    effectiveWidth,
+    handleKeydown,
+    handleLostPointerCapture,
+    handlePointerCancel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    isResizing,
+    layout,
+    panelStyle,
+    resetWidth,
+    resizeEnabled,
+  }
+}

--- a/customer-admin-web/src/utils/vibeCodingPanelResize.test.ts
+++ b/customer-admin-web/src/utils/vibeCodingPanelResize.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPACT_LAYOUT_MAX_WIDTH,
+  DEFAULT_ARTIFACTS_PANEL_WIDTH,
+  MAX_ARTIFACTS_PANEL_WIDTH,
+  MIN_ARTIFACTS_PANEL_WIDTH,
+  STACKED_LAYOUT_MAX_WIDTH,
+  clampPreferredArtifactsPanelWidth,
+  parseStoredArtifactsPanelWidth,
+  resolveVibeCodingLayoutMode,
+  resolveVibeCodingPanelResize,
+} from './vibeCodingPanelResize'
+
+describe('resolveVibeCodingLayoutMode', () => {
+  it('按 700 与 1040 两个边界选择布局', () => {
+    expect(resolveVibeCodingLayoutMode(STACKED_LAYOUT_MAX_WIDTH)).toBe('stacked')
+    expect(resolveVibeCodingLayoutMode(STACKED_LAYOUT_MAX_WIDTH + 1)).toBe('compact')
+    expect(resolveVibeCodingLayoutMode(COMPACT_LAYOUT_MAX_WIDTH)).toBe('compact')
+    expect(resolveVibeCodingLayoutMode(COMPACT_LAYOUT_MAX_WIDTH + 1)).toBe('wide')
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])('非法容器宽度 %s 安全回落到 stacked', (width) => {
+    expect(resolveVibeCodingLayoutMode(width)).toBe('stacked')
+  })
+})
+
+describe('resolveVibeCodingPanelResize', () => {
+  it('wide 展开历史时为对话与历史保留横向空间', () => {
+    expect(resolveVibeCodingPanelResize({
+      containerWidth: 1200,
+      preferredWidth: 500,
+      historyCollapsed: false,
+    })).toEqual({
+      mode: 'wide',
+      resizeEnabled: true,
+      minWidth: 220,
+      maxWidth: 380,
+      effectiveWidth: 380,
+    })
+  })
+
+  it('wide 收起历史时释放 300px 给产物列', () => {
+    expect(resolveVibeCodingPanelResize({
+      containerWidth: 1200,
+      preferredWidth: 500,
+      historyCollapsed: true,
+    })).toEqual({
+      mode: 'wide',
+      resizeEnabled: true,
+      minWidth: 220,
+      maxWidth: 520,
+      effectiveWidth: 500,
+    })
+  })
+
+  it('compact 的历史位于下方，不占横向空间', () => {
+    expect(resolveVibeCodingPanelResize({
+      containerWidth: 800,
+      preferredWidth: 420,
+      historyCollapsed: false,
+    })).toEqual({
+      mode: 'compact',
+      resizeEnabled: true,
+      minWidth: 220,
+      maxWidth: 320,
+      effectiveWidth: 320,
+    })
+  })
+
+  it('可拖布局刚跨过断点时仍守住产物列 220px 下限', () => {
+    const compact = resolveVibeCodingPanelResize({
+      containerWidth: 701,
+      preferredWidth: 500,
+      historyCollapsed: false,
+    })
+    const wide = resolveVibeCodingPanelResize({
+      containerWidth: 1041,
+      preferredWidth: 500,
+      historyCollapsed: false,
+    })
+
+    expect(compact.maxWidth).toBe(221)
+    expect(compact.effectiveWidth).toBe(221)
+    expect(wide.maxWidth).toBe(221)
+    expect(wide.effectiveWidth).toBe(221)
+  })
+
+  it('stacked 禁止拖动并保留用户偏好', () => {
+    expect(resolveVibeCodingPanelResize({
+      containerWidth: 700,
+      preferredWidth: 420,
+      historyCollapsed: false,
+    })).toEqual({
+      mode: 'stacked',
+      resizeEnabled: false,
+      minWidth: 220,
+      maxWidth: 520,
+      effectiveWidth: 420,
+    })
+  })
+
+  it('窄屏临时 clamp 不会改变后续放大时使用的 preferred', () => {
+    const preferredWidth = 500
+    const compact = resolveVibeCodingPanelResize({
+      containerWidth: 800,
+      preferredWidth,
+      historyCollapsed: false,
+    })
+    const wide = resolveVibeCodingPanelResize({
+      containerWidth: 1400,
+      preferredWidth,
+      historyCollapsed: false,
+    })
+
+    expect(compact.effectiveWidth).toBe(320)
+    expect(wide.effectiveWidth).toBe(preferredWidth)
+  })
+
+  it.each([
+    [Number.NaN, DEFAULT_ARTIFACTS_PANEL_WIDTH],
+    [Number.POSITIVE_INFINITY, DEFAULT_ARTIFACTS_PANEL_WIDTH],
+    [-1, MIN_ARTIFACTS_PANEL_WIDTH],
+    [999, MAX_ARTIFACTS_PANEL_WIDTH],
+  ])('非法或越界 preferred %s 不产生 NaN', (preferredWidth, expected) => {
+    const result = resolveVibeCodingPanelResize({
+      containerWidth: 1400,
+      preferredWidth,
+      historyCollapsed: false,
+    })
+
+    expect(result.effectiveWidth).toBe(expected)
+    expect(Number.isNaN(result.effectiveWidth)).toBe(false)
+    expect(Number.isNaN(result.maxWidth)).toBe(false)
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])('非法 container %s 不产生 NaN', (containerWidth) => {
+    const result = resolveVibeCodingPanelResize({
+      containerWidth,
+      preferredWidth: 400,
+      historyCollapsed: false,
+    })
+
+    expect(result.mode).toBe('stacked')
+    expect(result.resizeEnabled).toBe(false)
+    expect(Number.isNaN(result.effectiveWidth)).toBe(false)
+    expect(Number.isNaN(result.maxWidth)).toBe(false)
+  })
+})
+
+describe('clampPreferredArtifactsPanelWidth', () => {
+  it('只将拖动值限制在 220..520', () => {
+    expect(clampPreferredArtifactsPanelWidth(100)).toBe(MIN_ARTIFACTS_PANEL_WIDTH)
+    expect(clampPreferredArtifactsPanelWidth(360)).toBe(360)
+    expect(clampPreferredArtifactsPanelWidth(800)).toBe(MAX_ARTIFACTS_PANEL_WIDTH)
+  })
+})
+
+describe('parseStoredArtifactsPanelWidth', () => {
+  it.each([null, undefined, '', '   ', 'NaN', 'Infinity', '-Infinity', '219', '521', '260px']) (
+    '损坏或越界存储值 %s 回落默认宽度',
+    (raw) => {
+      expect(parseStoredArtifactsPanelWidth(raw)).toBe(DEFAULT_ARTIFACTS_PANEL_WIDTH)
+    },
+  )
+
+  it('接受范围端点、普通数值与小数', () => {
+    expect(parseStoredArtifactsPanelWidth('220')).toBe(220)
+    expect(parseStoredArtifactsPanelWidth(' 360 ')).toBe(360)
+    expect(parseStoredArtifactsPanelWidth('420.5')).toBe(420.5)
+    expect(parseStoredArtifactsPanelWidth('520')).toBe(520)
+  })
+})

--- a/customer-admin-web/src/utils/vibeCodingPanelResize.ts
+++ b/customer-admin-web/src/utils/vibeCodingPanelResize.ts
@@ -1,0 +1,102 @@
+export const DEFAULT_ARTIFACTS_PANEL_WIDTH = 260
+export const MIN_ARTIFACTS_PANEL_WIDTH = 220
+export const MAX_ARTIFACTS_PANEL_WIDTH = 520
+
+export const STACKED_LAYOUT_MAX_WIDTH = 700
+export const COMPACT_LAYOUT_MAX_WIDTH = 1040
+
+export const WIDE_CONVERSATION_MIN_WIDTH = 520
+export const COMPACT_CONVERSATION_MIN_WIDTH = 480
+export const EXPANDED_HISTORY_RESERVED_WIDTH = 300
+export const COLLAPSED_HISTORY_RESERVED_WIDTH = 0
+
+export type VibeCodingLayoutMode = 'wide' | 'compact' | 'stacked'
+
+export interface VibeCodingPanelResizeInput {
+  containerWidth: number
+  preferredWidth: number
+  historyCollapsed: boolean
+}
+
+export interface VibeCodingPanelResizeResult {
+  mode: VibeCodingLayoutMode
+  resizeEnabled: boolean
+  minWidth: number
+  maxWidth: number
+  effectiveWidth: number
+}
+
+/**
+ * 将拖动产生的宽度归一到用户可保存的偏好范围。
+ * 非有限数不代表有效拖动结果，回落默认值，避免 NaN 进入样式或持久化。
+ */
+export function clampPreferredArtifactsPanelWidth(width: number): number {
+  if (!Number.isFinite(width)) return DEFAULT_ARTIFACTS_PANEL_WIDTH
+  return Math.min(MAX_ARTIFACTS_PANEL_WIDTH, Math.max(MIN_ARTIFACTS_PANEL_WIDTH, width))
+}
+
+/** localStorage 只接受完整、有限且位于偏好范围内的数值。损坏数据统一回落默认值。 */
+export function parseStoredArtifactsPanelWidth(raw: string | null | undefined): number {
+  if (raw == null || raw.trim() === '') return DEFAULT_ARTIFACTS_PANEL_WIDTH
+
+  const width = Number(raw)
+  if (!Number.isFinite(width)
+    || width < MIN_ARTIFACTS_PANEL_WIDTH
+    || width > MAX_ARTIFACTS_PANEL_WIDTH) {
+    return DEFAULT_ARTIFACTS_PANEL_WIDTH
+  }
+  return width
+}
+
+export function resolveVibeCodingLayoutMode(containerWidth: number): VibeCodingLayoutMode {
+  const safeContainerWidth = normalizeContainerWidth(containerWidth)
+  if (safeContainerWidth <= STACKED_LAYOUT_MAX_WIDTH) return 'stacked'
+  if (safeContainerWidth <= COMPACT_LAYOUT_MAX_WIDTH) return 'compact'
+  return 'wide'
+}
+
+/**
+ * 同时给出当前布局和产物列的临时有效宽度。
+ * preferredWidth 不会被窄容器的 maxWidth 覆盖；容器恢复后用同一偏好重新计算即可复原。
+ */
+export function resolveVibeCodingPanelResize(
+  input: VibeCodingPanelResizeInput,
+): VibeCodingPanelResizeResult {
+  const containerWidth = normalizeContainerWidth(input.containerWidth)
+  const preferredWidth = clampPreferredArtifactsPanelWidth(input.preferredWidth)
+  const mode = resolveVibeCodingLayoutMode(containerWidth)
+
+  if (mode === 'stacked') {
+    return {
+      mode,
+      resizeEnabled: false,
+      minWidth: MIN_ARTIFACTS_PANEL_WIDTH,
+      maxWidth: MAX_ARTIFACTS_PANEL_WIDTH,
+      effectiveWidth: preferredWidth,
+    }
+  }
+
+  const conversationMinWidth = mode === 'wide'
+    ? WIDE_CONVERSATION_MIN_WIDTH
+    : COMPACT_CONVERSATION_MIN_WIDTH
+  const historyReservedWidth = mode === 'wide' && !input.historyCollapsed
+    ? EXPANDED_HISTORY_RESERVED_WIDTH
+    : COLLAPSED_HISTORY_RESERVED_WIDTH
+  const availableWidth = containerWidth - conversationMinWidth - historyReservedWidth
+  const maxWidth = Math.min(
+    MAX_ARTIFACTS_PANEL_WIDTH,
+    Math.max(MIN_ARTIFACTS_PANEL_WIDTH, availableWidth),
+  )
+
+  return {
+    mode,
+    resizeEnabled: true,
+    minWidth: MIN_ARTIFACTS_PANEL_WIDTH,
+    maxWidth,
+    effectiveWidth: Math.min(preferredWidth, maxWidth),
+  }
+}
+
+function normalizeContainerWidth(containerWidth: number): number {
+  return Number.isFinite(containerWidth) && containerWidth > 0 ? containerWidth : 0
+}

--- a/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
+++ b/customer-admin-web/src/views/workspace/VibeCodingPanel.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, onUnmounted, ref, useId, watch } from 'vue'
 import { createScrollFollower } from '@/utils/scrollFollower'
 import { shouldRestoreMostRecentSession } from '@/utils/conversationRestore'
 import { ATTACHMENT_ACCEPT, useChatAttachments } from '@/composables/useChatAttachments'
+import { useVibeCodingPanelResize } from '@/composables/useVibeCodingPanelResize'
 import {
   confirmVibeCodingPlan,
   generateCommitMessage,
@@ -73,6 +74,24 @@ const historyLoading = ref(false)
 const scrollRef = ref<HTMLElement>()
 const historySidebar = ref<InstanceType<typeof ChatHistorySidebar>>()
 const historyCollapsed = ref(false)
+const panelRef = ref<HTMLElement>()
+const chatColumnId = useId()
+const artifactsColumnId = useId()
+const {
+  ariaValueText: artifactsResizeAriaValueText,
+  effectiveWidth: effectiveArtifactsWidth,
+  handleKeydown: handleArtifactsResizeKeydown,
+  handleLostPointerCapture: handleArtifactsResizeLostPointerCapture,
+  handlePointerCancel: handleArtifactsResizePointerCancel,
+  handlePointerDown: handleArtifactsResizePointerDown,
+  handlePointerMove: handleArtifactsResizePointerMove,
+  handlePointerUp: handleArtifactsResizePointerUp,
+  isResizing: isArtifactsResizing,
+  layout: artifactsResizeLayout,
+  panelStyle,
+  resetWidth: resetArtifactsWidth,
+  resizeEnabled: artifactsResizeEnabled,
+} = useVibeCodingPanelResize({ panelRef, historyCollapsed })
 const themeStore = useThemeStore()
 const toolsDrawer = ref<InstanceType<typeof VibeCodingToolsDrawer>>()
 
@@ -572,9 +591,17 @@ defineExpose({ newSession })
 </script>
 
 <template>
-  <div class="vibecoding-panel workspace-conversation" :class="{ 'is-history-collapsed': historyCollapsed }">
+  <div
+    ref="panelRef"
+    class="vibecoding-panel workspace-conversation"
+    :class="{
+      'is-history-collapsed': historyCollapsed,
+      'is-resizing': isArtifactsResizing,
+    }"
+    :style="panelStyle"
+  >
     <!-- 左列：对话区 -->
-    <div class="chat-column">
+    <div :id="chatColumnId" class="chat-column">
       <div
         ref="scrollRef"
         class="messages"
@@ -727,7 +754,31 @@ defineExpose({ newSession })
     </div>
 
     <!-- 中列：产物文件树 -->
-    <div class="artifacts-column">
+    <div :id="artifactsColumnId" class="artifacts-column">
+      <button
+        v-if="artifactsResizeEnabled"
+        type="button"
+        class="artifacts-resizer"
+        role="separator"
+        aria-label="调整对话区与产物文件区宽度"
+        aria-orientation="vertical"
+        :aria-controls="`${chatColumnId} ${artifactsColumnId}`"
+        :aria-valuemin="artifactsResizeLayout.minWidth"
+        :aria-valuemax="artifactsResizeLayout.maxWidth"
+        :aria-valuenow="effectiveArtifactsWidth"
+        :aria-valuetext="artifactsResizeAriaValueText"
+        title="拖动调整产物文件区宽度；双击恢复默认宽度"
+        @pointerdown="handleArtifactsResizePointerDown"
+        @pointermove="handleArtifactsResizePointerMove"
+        @pointerup="handleArtifactsResizePointerUp"
+        @pointercancel="handleArtifactsResizePointerCancel"
+        @lostpointercapture="handleArtifactsResizeLostPointerCapture"
+        @keydown="handleArtifactsResizeKeydown"
+        @dblclick="resetArtifactsWidth"
+      >
+        <span class="artifacts-resizer-grip" aria-hidden="true"><i /><i /></span>
+        <span class="artifacts-resizer-value" aria-hidden="true">{{ effectiveArtifactsWidth }} px</span>
+      </button>
       <div class="artifacts-header">
         <span>
           产物文件
@@ -972,15 +1023,21 @@ defineExpose({ newSession })
 .vibecoding-panel {
   --conversation-messages-padding: 28px 28px 36px;
   --conversation-composer-padding: 10px 20px 14px;
-  grid-template-columns: minmax(520px, 1fr) minmax(220px, 260px) 300px;
+  --vibe-artifacts-column-width: 260px;
+  grid-template-columns: minmax(520px, 1fr) minmax(220px, var(--vibe-artifacts-column-width)) 300px;
 }
 
 .vibecoding-panel.is-history-collapsed {
-  grid-template-columns: minmax(520px, 1fr) minmax(220px, 280px) 0;
+  grid-template-columns: minmax(520px, 1fr) minmax(220px, var(--vibe-artifacts-column-width)) 0;
+}
+
+.vibecoding-panel.is-resizing {
+  transition: none;
 }
 
 /* 产物文件树列 */
 .artifacts-column {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -989,6 +1046,108 @@ defineExpose({ newSession })
   padding: 15px 14px 12px 16px;
   background: color-mix(in srgb, var(--el-fill-color-lighter) 42%, var(--el-bg-color));
   border-left: 1px solid var(--el-border-color-lighter);
+}
+
+.artifacts-resizer {
+  position: absolute;
+  z-index: 4;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 12px;
+  padding: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.artifacts-resizer::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 2px;
+  background: transparent;
+  transition: background-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.artifacts-resizer-grip {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: 8px;
+  height: 42px;
+  border: 1px solid color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 36%, var(--el-border-color));
+  border-radius: 999px;
+  background: var(--el-bg-color);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--el-text-color-primary) 12%, transparent);
+  opacity: 0;
+  transform: translateY(-50%) scale(0.9);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.artifacts-resizer-grip i {
+  display: block;
+  width: 1px;
+  height: 16px;
+  background: var(--theme-primary, var(--el-color-primary));
+}
+
+.artifacts-resizer-value {
+  position: absolute;
+  top: 50%;
+  left: 16px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  color: #fff;
+  background: rgba(24, 31, 42, 0.92);
+  box-shadow: 0 4px 12px rgba(24, 31, 42, 0.16);
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%) translateX(4px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.artifacts-resizer:hover::before,
+.artifacts-resizer:focus-visible::before,
+.vibecoding-panel.is-resizing .artifacts-resizer::before {
+  background: var(--theme-primary, var(--el-color-primary));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 14%, transparent);
+}
+
+.artifacts-resizer:hover .artifacts-resizer-grip,
+.artifacts-resizer:focus-visible .artifacts-resizer-grip,
+.vibecoding-panel.is-resizing .artifacts-resizer-grip {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+
+.artifacts-resizer:focus-visible .artifacts-resizer-grip {
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 18%, transparent),
+    0 4px 12px color-mix(in srgb, var(--el-text-color-primary) 12%, transparent);
+}
+
+.artifacts-resizer:focus-visible .artifacts-resizer-value,
+.vibecoding-panel.is-resizing .artifacts-resizer-value {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+:global(body.is-vibecoding-panel-resizing),
+:global(body.is-vibecoding-panel-resizing *) {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 
 .artifacts-header {
@@ -1221,13 +1380,21 @@ defineExpose({ newSession })
 
 .tree-node {
   display: flex;
+  flex: 1;
   align-items: center;
+  width: 100%;
+  min-width: 0;
   font-size: 13px;
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
+}
+
+.tree-node > span {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 160px;
 }
 
 .tree-node:hover {
@@ -1313,13 +1480,13 @@ defineExpose({ newSession })
   .vibecoding-panel {
     --conversation-messages-padding: 28px 20px 36px;
     --conversation-composer-padding: 10px 14px 14px;
-    grid-template-columns: minmax(480px, 1fr) minmax(220px, 280px);
+    grid-template-columns: minmax(480px, 1fr) minmax(220px, var(--vibe-artifacts-column-width));
     grid-template-rows: minmax(480px, 1fr) 210px;
     overflow-y: auto;
   }
 
   .vibecoding-panel.is-history-collapsed {
-    grid-template-columns: minmax(480px, 1fr) minmax(220px, 280px);
+    grid-template-columns: minmax(480px, 1fr) minmax(220px, var(--vibe-artifacts-column-width));
     grid-template-rows: minmax(0, 1fr) 0;
   }
 
@@ -1341,6 +1508,10 @@ defineExpose({ newSession })
     padding: 14px 16px;
     border-top: 1px solid var(--el-border-color-lighter);
     border-left: 0;
+  }
+
+  .artifacts-resizer {
+    display: none;
   }
 
   .history-column {

--- a/customer-admin-web/tests/e2e/workspace-resize.e2e.ts
+++ b/customer-admin-web/tests/e2e/workspace-resize.e2e.ts
@@ -373,18 +373,18 @@ test.describe('VibeCoding 产物栏宽度', () => {
     expect(await separator.evaluate((element, activePointerId) => (
       element.hasPointerCapture(activePointerId)
     ), pointerId)).toBe(true)
-    await separator.evaluate((element, activePointerId) => new Promise<void>((resolve, reject) => {
-      const timeoutId = window.setTimeout(() => reject(new Error('lostpointercapture was not dispatched')), 1000)
+    await separator.evaluate((element, activePointerId) => {
       element.addEventListener('lostpointercapture', (event) => {
-        window.clearTimeout(timeoutId)
-        if (event.pointerId !== activePointerId) {
-          reject(new Error(`Unexpected pointer id: ${event.pointerId}`))
-          return
-        }
-        resolve()
+        element.setAttribute('data-e2e-lost-pointer-id', String(event.pointerId))
+        element.setAttribute('data-e2e-lost-pointer-trusted', String(event.isTrusted))
       }, { once: true })
       element.releasePointerCapture(activePointerId)
-    }), pointerId)
+    }, pointerId)
+    // releasePointerCapture 只更新待处理捕获目标；下一次真实指针事件才会派发 lostpointercapture。
+    await page.mouse.move(0, 0)
+    await expect(separator).toHaveAttribute('data-e2e-lost-pointer-id', String(pointerId))
+    await expect(separator).toHaveAttribute('data-e2e-lost-pointer-trusted', 'true')
+    await expect(separator).toHaveAttribute('aria-valuenow', '308')
     await expect(page.locator('body')).not.toHaveClass(/is-vibecoding-panel-resizing/)
     await page.mouse.up()
 

--- a/customer-admin-web/tests/e2e/workspace-resize.e2e.ts
+++ b/customer-admin-web/tests/e2e/workspace-resize.e2e.ts
@@ -1,0 +1,427 @@
+import { expect, test, type Page } from '@playwright/test'
+import { LOGIN_E2E_ORIGIN } from './loginTestEnvironment'
+
+const WORKSPACE_PATH = '/workspace/java-assistant?mode=vibecoding'
+const API_PATTERN = `${LOGIN_E2E_ORIGIN}/api/**`
+const ARTIFACTS_WIDTH_STORAGE_KEY = 'customer-admin-vibecoding-artifacts-width'
+const LONG_FILE_NAME = 'CustomerOrderReconciliationApplicationServiceWithLongDescriptiveName.java'
+const LONG_FILE_PATH = `src/main/java/com/example/customer/${LONG_FILE_NAME}`
+
+interface WorkspaceFixtures {
+  unknownRequests: string[]
+}
+
+interface PanelMetrics {
+  panelWidth: number
+  chatWidth: number
+  artifactsWidth: number
+  historyWidth: number
+  historyLeft: number
+  chatTop: number
+  historyTop: number
+  longFileLabelWidth: number
+  longFileLabelScrollWidth: number
+}
+
+function successResult<T>(data: T) {
+  return { code: 0, message: 'success', data, timestamp: Date.now() }
+}
+
+async function installWorkspaceFixtures(page: Page): Promise<WorkspaceFixtures> {
+  const fixtures: WorkspaceFixtures = { unknownRequests: [] }
+
+  await page.addInitScript(() => {
+    localStorage.setItem('admin-token', 'workspace-resize-e2e-token')
+    localStorage.setItem('admin-nickname', 'Resize E2E')
+    localStorage.setItem('admin-username', 'workspace-resize-e2e')
+    localStorage.setItem('admin-force-change-password', 'false')
+    localStorage.setItem('admin-approval-status', 'APPROVED')
+  })
+
+  await page.route(API_PATTERN, async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const path = url.pathname.replace(/^\/api/, '')
+    const fulfill = (data: unknown) => route.fulfill({
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: JSON.stringify(successResult(data)),
+    })
+
+    if (path === '/auth/permissions') return fulfill([])
+    if (path === '/menu/version') return fulfill(1)
+    if (path === '/menu/routes') {
+      return fulfill([
+        {
+          id: 1,
+          name: '首页',
+          path: '/home',
+          icon: 'House',
+          iconType: 'library',
+          permCode: null,
+          sort: 1,
+          agentCode: null,
+          capabilities: null,
+          dynamic: false,
+          children: [],
+        },
+        {
+          id: 10,
+          name: '智能体工作区',
+          path: '/workspace',
+          icon: 'Cpu',
+          iconType: 'library',
+          permCode: null,
+          sort: 2,
+          agentCode: null,
+          capabilities: null,
+          dynamic: false,
+          children: [
+            {
+              id: 11,
+              name: '编程语言智能体',
+              path: '/workspace/java-assistant',
+              icon: 'Monitor',
+              iconType: 'library',
+              permCode: null,
+              sort: 1,
+              agentCode: 'java-assistant',
+              capabilities: ['vibecoding'],
+              dynamic: true,
+              children: [],
+            },
+          ],
+        },
+      ])
+    }
+    if (path === '/tenant/current-view') {
+      return fulfill({
+        userTenantId: 'default',
+        effectiveTenantId: 'default',
+        crossTenantAuthority: false,
+      })
+    }
+    if (path === '/message/unread-count') return fulfill(0)
+    if (path === '/workspace/java-assistant/chat/sessions') {
+      return fulfill({
+        pageNum: 1,
+        pageSize: 20,
+        total: 1,
+        list: [
+          {
+            sessionId: 'resize-history-session',
+            preview: 'VibeCoding 分栏回归',
+            lastMessageTime: '2026-08-30 09:30:00.000',
+            messageCount: 2,
+          },
+        ],
+      })
+    }
+    if (path === '/workspace/java-assistant/chat/sessions/resize-history-session/messages') {
+      return fulfill([
+        {
+          id: 'resize-message-1',
+          role: 'user',
+          text: '[VibeCoding指引-local] 请检查分栏拖动。',
+          timestamp: '2026-08-30 09:29:59',
+          attachments: [],
+        },
+        {
+          id: 'resize-message-2',
+          role: 'assistant',
+          text: '分栏回归 fixture 已加载。',
+          timestamp: '2026-08-30 09:30:00',
+          attachments: [],
+        },
+      ])
+    }
+    if (path === '/workspace/java-assistant/vibecoding/sandbox-mode') {
+      return fulfill({ mode: 'local' })
+    }
+    if (path === '/workspace/java-assistant/vibecoding/files') {
+      return fulfill([
+        {
+          name: LONG_FILE_NAME,
+          relativePath: LONG_FILE_PATH,
+          directory: false,
+          children: [],
+        },
+      ])
+    }
+
+    fixtures.unknownRequests.push(`${request.method()} ${path}`)
+    return fulfill([])
+  })
+
+  return fixtures
+}
+
+async function openVibeCodingWorkspace(page: Page) {
+  await page.goto(WORKSPACE_PATH, { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('.workspace-view')).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'VibeCoding' })).toHaveAttribute('aria-selected', 'true')
+  await expect(page.locator('.vibecoding-panel')).toBeVisible()
+  await expect(page.locator(`.tree-node > span[title="${LONG_FILE_PATH}"]`)).toBeVisible()
+}
+
+async function panelMetrics(page: Page): Promise<PanelMetrics> {
+  return page.locator('.vibecoding-panel').evaluate((panel, longFilePath) => {
+    const rect = (selector: string) => {
+      const element = panel.querySelector<HTMLElement>(selector)
+      if (!element) throw new Error(`Missing E2E element: ${selector}`)
+      return element.getBoundingClientRect()
+    }
+    const panelRect = panel.getBoundingClientRect()
+    const chatRect = rect('.chat-column')
+    const artifactsRect = rect('.artifacts-column')
+    const historyRect = rect('.history-column')
+    const longFileLabel = panel.querySelector<HTMLElement>(`.tree-node > span[title="${longFilePath}"]`)
+    if (!longFileLabel) throw new Error('Missing long workspace filename')
+    return {
+      panelWidth: panelRect.width,
+      chatWidth: chatRect.width,
+      artifactsWidth: artifactsRect.width,
+      historyWidth: historyRect.width,
+      historyLeft: historyRect.left,
+      chatTop: chatRect.top,
+      historyTop: historyRect.top,
+      longFileLabelWidth: longFileLabel.clientWidth,
+      longFileLabelScrollWidth: longFileLabel.scrollWidth,
+    }
+  }, LONG_FILE_PATH)
+}
+
+async function dragSeparator(page: Page, deltaX: number) {
+  await startSeparatorDrag(page, deltaX)
+  await page.mouse.up()
+}
+
+async function startSeparatorDrag(page: Page, deltaX: number): Promise<number> {
+  const separator = page.getByRole('separator', { name: '调整对话区与产物文件区宽度' })
+  await separator.evaluate((element) => {
+    element.addEventListener('pointerdown', (event) => {
+      element.setAttribute('data-e2e-pointer-id', String(event.pointerId))
+    }, { once: true })
+  })
+  const box = await separator.boundingBox()
+  expect(box).not.toBeNull()
+  if (!box) throw new Error('Missing resize separator bounding box')
+
+  const startX = box.x + box.width / 2
+  const startY = box.y + box.height / 2
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+  await page.mouse.move(startX + deltaX, startY, { steps: 8 })
+
+  const rawPointerId = await separator.getAttribute('data-e2e-pointer-id')
+  expect(rawPointerId).not.toBeNull()
+  if (!rawPointerId) throw new Error('Missing pointer id after separator pointerdown')
+  const pointerId = Number(rawPointerId)
+  expect(Number.isInteger(pointerId)).toBe(true)
+  return pointerId
+}
+
+function expectHistoryUnchanged(before: PanelMetrics, after: PanelMetrics) {
+  expect(Math.abs(after.historyWidth - before.historyWidth)).toBeLessThanOrEqual(1)
+  expect(Math.abs(after.historyLeft - before.historyLeft)).toBeLessThanOrEqual(1)
+}
+
+test.describe('VibeCoding 产物栏宽度', () => {
+  test.use({ viewport: { width: 1600, height: 1000 } })
+
+  test('鼠标、键盘、刷新与响应式切换都保留同一宽度偏好', async ({ page }, testInfo) => {
+    const fixtures = await installWorkspaceFixtures(page)
+    await openVibeCodingWorkspace(page)
+
+    const separator = page.getByRole('separator', { name: '调整对话区与产物文件区宽度' })
+    await expect(separator).toBeVisible()
+    await expect(separator).toHaveAttribute('aria-orientation', 'vertical')
+    await expect(separator).toHaveAttribute('aria-valuemin', '220')
+    await expect(separator).toHaveAttribute('aria-valuenow', '260')
+    await expect(separator).toHaveAttribute('aria-valuetext', '产物文件区宽度 260 像素')
+    expect(Number(await separator.getAttribute('aria-valuemax'))).toBeGreaterThan(260)
+
+    const controlledIds = (await separator.getAttribute('aria-controls'))?.split(/\s+/) ?? []
+    expect(controlledIds).toHaveLength(2)
+    for (const id of controlledIds) {
+      await expect(page.locator(`#${id}`)).toHaveCount(1)
+    }
+
+    const initial = await panelMetrics(page)
+    await dragSeparator(page, -120)
+    const draggedLeft = await panelMetrics(page)
+    expect(draggedLeft.artifactsWidth).toBeGreaterThan(initial.artifactsWidth + 90)
+    expect(draggedLeft.chatWidth).toBeLessThan(initial.chatWidth - 90)
+    expectHistoryUnchanged(initial, draggedLeft)
+    expect(draggedLeft.longFileLabelWidth).toBeGreaterThan(initial.longFileLabelWidth + 80)
+    expect(draggedLeft.longFileLabelScrollWidth).toBeGreaterThan(draggedLeft.longFileLabelWidth)
+
+    await dragSeparator(page, 80)
+    const draggedRight = await panelMetrics(page)
+    expect(draggedRight.artifactsWidth).toBeLessThan(draggedLeft.artifactsWidth - 55)
+    expect(draggedRight.chatWidth).toBeGreaterThan(draggedLeft.chatWidth + 55)
+    expectHistoryUnchanged(draggedLeft, draggedRight)
+
+    await separator.focus()
+    const preferredWidth = Number(await separator.getAttribute('aria-valuenow'))
+    await page.keyboard.press('ArrowLeft')
+    await expect(separator).toHaveAttribute('aria-valuenow', String(preferredWidth + 16))
+    await page.keyboard.press('ArrowRight')
+    await expect(separator).toHaveAttribute('aria-valuenow', String(preferredWidth))
+    expect(await page.evaluate((key) => localStorage.getItem(key), ARTIFACTS_WIDTH_STORAGE_KEY))
+      .toBe(String(preferredWidth))
+
+    const beforeReload = await panelMetrics(page)
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('tab', { name: 'VibeCoding' })).toHaveAttribute('aria-selected', 'true')
+    await expect(page.locator(`.tree-node > span[title="${LONG_FILE_PATH}"]`)).toBeVisible()
+    await expect(separator).toHaveAttribute('aria-valuenow', String(preferredWidth))
+    await expect.poll(async () => (
+      Math.abs((await panelMetrics(page)).artifactsWidth - beforeReload.artifactsWidth)
+    )).toBeLessThanOrEqual(1)
+
+    await dragSeparator(page, -100)
+    const compactPreferredWidth = preferredWidth + 100
+    await expect(separator).toHaveAttribute('aria-valuenow', String(compactPreferredWidth))
+    await page.setViewportSize({ width: 1100, height: 1000 })
+    await expect.poll(async () => {
+      const width = (await panelMetrics(page)).panelWidth
+      return width > 700 && width <= 1040
+    }).toBe(true)
+    await expect(separator).toBeVisible()
+    await expect.poll(async () => Number(await separator.getAttribute('aria-valuenow'))
+      - Number(await separator.getAttribute('aria-valuemax'))).toBe(0)
+    const compactMetrics = await panelMetrics(page)
+    expect(compactMetrics.historyTop - compactMetrics.chatTop).toBeGreaterThan(400)
+    expect(await page.evaluate((key) => localStorage.getItem(key), ARTIFACTS_WIDTH_STORAGE_KEY))
+      .toBe(String(compactPreferredWidth))
+
+    await page.setViewportSize({ width: 1600, height: 1000 })
+    await expect(separator).toHaveAttribute('aria-valuenow', String(compactPreferredWidth))
+    await expect.poll(async () => Math.abs(
+      (await panelMetrics(page)).artifactsWidth - compactPreferredWidth,
+    )).toBeLessThanOrEqual(1)
+    await dragSeparator(page, 100)
+    await expect(separator).toHaveAttribute('aria-valuenow', String(preferredWidth))
+
+    await page.setViewportSize({ width: 760, height: 1000 })
+    await expect.poll(async () => (await panelMetrics(page)).panelWidth).toBeLessThanOrEqual(700)
+    await expect(separator).toHaveCount(0)
+    expect(await page.evaluate((key) => localStorage.getItem(key), ARTIFACTS_WIDTH_STORAGE_KEY))
+      .toBe(String(preferredWidth))
+
+    await page.setViewportSize({ width: 1600, height: 1000 })
+    await expect(separator).toBeVisible()
+    await expect(separator).toHaveAttribute('aria-valuenow', String(preferredWidth))
+
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    await expect(separator).toBeVisible()
+    await separator.focus()
+    await page.keyboard.press('Home')
+    await expect.poll(async () => Number(await separator.getAttribute('aria-valuenow'))
+      - Number(await separator.getAttribute('aria-valuemin'))).toBe(0)
+    await page.keyboard.press('End')
+    await expect.poll(async () => Number(await separator.getAttribute('aria-valuenow'))
+      - Number(await separator.getAttribute('aria-valuemax'))).toBe(0)
+    await page.keyboard.press('Enter')
+    await expect(separator).toHaveAttribute('aria-valuenow', '260')
+    expect(fixtures.unknownRequests).toEqual([])
+    await page.screenshot({ path: testInfo.outputPath('workspace-resize.png'), fullPage: true })
+  })
+
+  test('pointercancel 恢复拖动前偏好并释放全局拖动状态', async ({ page }) => {
+    const fixtures = await installWorkspaceFixtures(page)
+    await openVibeCodingWorkspace(page)
+    const separator = page.getByRole('separator', { name: '调整对话区与产物文件区宽度' })
+
+    await separator.focus()
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press('ArrowRight')
+    await expect.poll(async () => Math.abs((await panelMetrics(page)).artifactsWidth - 260))
+      .toBeLessThanOrEqual(1)
+
+    const pointerId = await startSeparatorDrag(page, -64)
+    await expect(separator).toHaveAttribute('aria-valuenow', '324')
+    await expect(page.locator('body')).toHaveClass(/is-vibecoding-panel-resizing/)
+    await separator.evaluate((element) => {
+      element.addEventListener('lostpointercapture', () => {
+        element.setAttribute('data-e2e-cancel-capture-released', 'true')
+      }, { once: true })
+    })
+    await separator.dispatchEvent('pointercancel', {
+      pointerId,
+      pointerType: 'mouse',
+      isPrimary: true,
+      bubbles: true,
+    })
+    await page.mouse.up()
+
+    await expect(separator).toHaveAttribute('data-e2e-cancel-capture-released', 'true')
+    await expect(separator).toHaveAttribute('aria-valuenow', '260')
+    await expect(page.locator('body')).not.toHaveClass(/is-vibecoding-panel-resizing/)
+    expect(await page.evaluate((key) => localStorage.getItem(key), ARTIFACTS_WIDTH_STORAGE_KEY)).toBe('260')
+    expect(fixtures.unknownRequests).toEqual([])
+  })
+
+  test('lostpointercapture 保留并持久化最后有效宽度', async ({ page }) => {
+    const fixtures = await installWorkspaceFixtures(page)
+    await openVibeCodingWorkspace(page)
+    const separator = page.getByRole('separator', { name: '调整对话区与产物文件区宽度' })
+
+    const pointerId = await startSeparatorDrag(page, -48)
+    await expect(separator).toHaveAttribute('aria-valuenow', '308')
+    expect(await separator.evaluate((element, activePointerId) => (
+      element.hasPointerCapture(activePointerId)
+    ), pointerId)).toBe(true)
+    await separator.evaluate((element, activePointerId) => new Promise<void>((resolve, reject) => {
+      const timeoutId = window.setTimeout(() => reject(new Error('lostpointercapture was not dispatched')), 1000)
+      element.addEventListener('lostpointercapture', (event) => {
+        window.clearTimeout(timeoutId)
+        if (event.pointerId !== activePointerId) {
+          reject(new Error(`Unexpected pointer id: ${event.pointerId}`))
+          return
+        }
+        resolve()
+      }, { once: true })
+      element.releasePointerCapture(activePointerId)
+    }), pointerId)
+    await expect(page.locator('body')).not.toHaveClass(/is-vibecoding-panel-resizing/)
+    await page.mouse.up()
+
+    await expect.poll(() => separator.evaluate((element, activePointerId) => (
+      element.hasPointerCapture(activePointerId)
+    ), pointerId)).toBe(false)
+    expect(await page.evaluate((key) => localStorage.getItem(key), ARTIFACTS_WIDTH_STORAGE_KEY)).toBe('308')
+    expect(fixtures.unknownRequests).toEqual([])
+  })
+
+  test('拖动中切入 stacked 会取消手势并可在回到宽屏后继续拖动', async ({ page }) => {
+    const fixtures = await installWorkspaceFixtures(page)
+    await openVibeCodingWorkspace(page)
+    const separator = page.getByRole('separator', { name: '调整对话区与产物文件区宽度' })
+
+    await separator.focus()
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press('ArrowRight')
+    await expect.poll(async () => Math.abs((await panelMetrics(page)).artifactsWidth - 260))
+      .toBeLessThanOrEqual(1)
+    await startSeparatorDrag(page, -48)
+    await expect(page.locator('body')).toHaveClass(/is-vibecoding-panel-resizing/)
+
+    await page.setViewportSize({ width: 760, height: 1000 })
+    await expect.poll(async () => (await panelMetrics(page)).panelWidth).toBeLessThanOrEqual(700)
+    await expect(separator).toHaveCount(0)
+    await expect(page.locator('body')).not.toHaveClass(/is-vibecoding-panel-resizing/)
+    await page.mouse.up()
+    expect(await page.evaluate((key) => localStorage.getItem(key), ARTIFACTS_WIDTH_STORAGE_KEY)).toBe('260')
+
+    await page.setViewportSize({ width: 1600, height: 1000 })
+    await expect(separator).toBeVisible()
+    await expect(separator).toHaveAttribute('aria-valuenow', '260')
+    await expect.poll(async () => Math.abs((await panelMetrics(page)).artifactsWidth - 260))
+      .toBeLessThanOrEqual(1)
+    await dragSeparator(page, -32)
+    await expect(separator).toHaveAttribute('aria-valuenow', '292')
+    expect(fixtures.unknownRequests).toEqual([])
+  })
+})


### PR DESCRIPTION
## 改动说明

- 在 VibeCoding 对话区与产物文件区之间增加可拖动分隔线，历史会话栏宽度保持不变。
- 产物栏支持 220–520px 动态边界，并为对话区和历史栏保留最小可用空间。
- 宽度偏好写入本地存储；compact/stacked 响应式切换只做临时夹紧，回到宽屏后恢复用户偏好。
- 支持方向键、Home、End、Enter 和双击复位，并补齐 separator ARIA 语义。
- 文件树名称随产物栏宽度自适应，拖动异常结束时正确释放 Pointer Capture 和全局拖动态。

## 验证

- `npm test`：134 个 Vitest 单测、22 个 Playwright E2E 全部通过。
- `npm run build`：`vue-tsc -b` 与 Vite 生产构建通过。
- 分栏 E2E 稳定性复跑：`--repeat-each=3`，12/12 通过。
- JDK 17 全仓 Maven：3579 tests，0 failures，0 errors，6 skipped，6 个模块均 `SUCCESS`。
- 质量审查、安全审计、测试覆盖审查均无阻塞项。

浏览器验收使用固定假凭据和精确 `/api/**` mock，未请求真实后端，也未触发外部模型调用。
