### PR TITLE
feat(admin-web): 统一后台 UI 设计系统

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/slo/controller/SloController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/slo/controller/SloController.java
@@ -5,6 +5,7 @@ import cn.dev33.satoken.stp.StpUtil;
 import com.richard.fyoung.customeradmin.common.log.OperationLog;
 import com.richard.fyoung.customeradmin.common.result.Result;
 import com.richard.fyoung.customeradmin.slo.dto.SloAlertEventVO;
+import com.richard.fyoung.customeradmin.slo.dto.SloAlertSummaryVO;
 import com.richard.fyoung.customeradmin.slo.dto.SloAlertVO;
 import com.richard.fyoung.customeradmin.slo.dto.SloEvaluationVO;
 import com.richard.fyoung.customeradmin.slo.dto.SloPolicySaveRequest;
@@ -65,6 +66,12 @@ public class SloController {
     public Result<List<SloAlertVO>> alerts(@RequestParam(required = false) String status,
                                            @RequestParam(required = false) Integer limit) {
         return Result.success(alertService.list(status, limit));
+    }
+
+    @SaCheckPermission("slo:view")
+    @GetMapping("/alerts/summary")
+    public Result<SloAlertSummaryVO> alertSummary() {
+        return Result.success(alertService.summary());
     }
 
     @SaCheckPermission("slo:view")

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/slo/dto/SloAlertSummaryVO.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/slo/dto/SloAlertSummaryVO.java
@@ -1,0 +1,5 @@
+package com.richard.fyoung.customeradmin.slo.dto;
+
+/** 当前租户活跃 SLO 告警汇总，不受明细分页窗口影响。 */
+public record SloAlertSummaryVO(long openCount, long acknowledgedCount) {
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/slo/service/SloAlertService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/slo/service/SloAlertService.java
@@ -6,6 +6,7 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.slo.domain.SloAlertEventType;
 import com.richard.fyoung.customeradmin.slo.domain.SloAlertStatus;
 import com.richard.fyoung.customeradmin.slo.dto.SloAlertEventVO;
+import com.richard.fyoung.customeradmin.slo.dto.SloAlertSummaryVO;
 import com.richard.fyoung.customeradmin.slo.dto.SloAlertVO;
 import com.richard.fyoung.customeradmin.slo.dto.SloWindowEvaluation;
 import com.richard.fyoung.customeradmin.slo.entity.SloAlert;
@@ -102,6 +103,20 @@ public class SloAlertService {
                 alerts.stream().map(SloAlert::getPolicyId).distinct().toList())
             .stream().collect(Collectors.toMap(SloPolicy::getId, Function.identity()));
         return alerts.stream().map(alert -> toVO(alert, policies.get(alert.getPolicyId()))).toList();
+    }
+
+    /** 顶部指标必须直接聚合事实表，不能从最多 200 条的明细窗口反推。 */
+    public SloAlertSummaryVO summary() {
+        String tenantId = SloPolicyService.requireTenant();
+        return new SloAlertSummaryVO(
+            countByStatus(tenantId, SloAlertStatus.OPEN),
+            countByStatus(tenantId, SloAlertStatus.ACKED));
+    }
+
+    private long countByStatus(String tenantId, SloAlertStatus status) {
+        return alertMapper.selectCount(new QueryWrapper<SloAlert>()
+            .eq("tenant_id", tenantId)
+            .eq("status", status.name()));
     }
 
     public List<SloAlertEventVO> events(Long alertId) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/slo/service/SloAlertServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/slo/service/SloAlertServiceTest.java
@@ -18,15 +18,18 @@ import org.mockito.MockedStatic;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -148,6 +151,34 @@ class SloAlertServiceTest {
             assertThrows(BizException.class, () -> service.acknowledge(101L, 9L));
         }
         verify(eventMapper, never()).insert(any(SloAlertEvent.class));
+    }
+
+    @Test
+    void summary_shouldCountAllActiveAlertsByTenantAndStatus() {
+        when(alertMapper.selectCount(any())).thenReturn(203L, 17L);
+
+        try (MockedStatic<TenantSession> session = mockStatic(TenantSession.class)) {
+            session.when(TenantSession::effectiveTenant).thenReturn("tenant-a");
+            var summary = service.summary();
+
+            assertEquals(203L, summary.openCount());
+            assertEquals(17L, summary.acknowledgedCount());
+        }
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<com.baomidou.mybatisplus.core.conditions.query.QueryWrapper<SloAlert>> captor =
+            ArgumentCaptor.forClass(com.baomidou.mybatisplus.core.conditions.query.QueryWrapper.class);
+        verify(alertMapper, times(2)).selectCount(captor.capture());
+        captor.getAllValues().forEach(wrapper -> {
+            String sql = wrapper.getExpression().getNormal().getSqlSegment();
+            assertTrue(sql.contains("tenant_id ="));
+            assertTrue(sql.contains("status ="));
+            assertTrue(wrapper.getParamNameValuePairs().containsValue("tenant-a"));
+        });
+        assertTrue(captor.getAllValues().get(0).getParamNameValuePairs()
+            .containsValue(SloAlertStatus.OPEN.name()));
+        assertTrue(captor.getAllValues().get(1).getParamNameValuePairs()
+            .containsValue(SloAlertStatus.ACKED.name()));
     }
 
     private SloPolicy policy() {

--- a/customer-admin-web/playwright.config.ts
+++ b/customer-admin-web/playwright.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
     headless: true,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
+    // 网络夹具依赖 BrowserContext 路由；禁用 Service Worker，避免其在路由之前截获请求。
+    serviceWorkers: 'block',
   },
   projects: [
     {

--- a/customer-admin-web/src/App.vue
+++ b/customer-admin-web/src/App.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
+import { onBeforeUnmount } from 'vue'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
 import { useThemeStore } from '@/store/theme'
 
 const themeStore = useThemeStore()
 // 在首个路由组件渲染前应用已保存的明暗模式，避免全局壳先以亮色闪现再切暗色。
 themeStore.apply()
+onBeforeUnmount(() => themeStore.disposeSystemThemeListener())
 </script>
 
 <template>
-  <router-view />
+  <el-config-provider :locale="zhCn">
+    <router-view />
+  </el-config-provider>
 </template>

--- a/customer-admin-web/src/api/slo.ts
+++ b/customer-admin-web/src/api/slo.ts
@@ -80,6 +80,11 @@ export interface SloAlertEvent {
   occurredAt: string
 }
 
+export interface SloAlertSummary {
+  openCount: number
+  acknowledgedCount: number
+}
+
 export function listSloPolicies() {
   return request<SloPolicy[]>({ url: '/slo/policies', method: 'get' })
 }
@@ -94,6 +99,10 @@ export function evaluateSloPolicy(id: number) {
 
 export function listSloAlerts(status?: SloAlertStatus) {
   return request<SloAlert[]>({ url: '/slo/alerts', method: 'get', params: { status, limit: 200 } })
+}
+
+export function getSloAlertSummary() {
+  return request<SloAlertSummary>({ url: '/slo/alerts/summary', method: 'get' })
 }
 
 export function acknowledgeSloAlert(id: number) {

--- a/customer-admin-web/src/components/CrudLoadState.vue
+++ b/customer-admin-web/src/components/CrudLoadState.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+defineProps<{
+  error: unknown
+  hasStaleData: boolean
+  loading: boolean
+}>()
+
+defineEmits<{
+  retry: []
+}>()
+</script>
+
+<template>
+  <el-alert
+    v-if="error"
+    class="crud-load-state"
+    type="error"
+    :closable="false"
+    show-icon
+    :title="hasStaleData ? '数据更新失败，已保留上次结果' : '数据加载失败'"
+    role="status"
+    aria-live="polite"
+  >
+    <div class="crud-load-state__content">
+      <span>{{ hasStaleData ? '当前内容可能已过期，请重试获取最新数据。' : '没有把错误伪装成空数据，请检查连接后重试。' }}</span>
+      <el-button type="primary" plain :loading="loading" @click="$emit('retry')">重新加载</el-button>
+    </div>
+  </el-alert>
+</template>
+
+<style scoped>
+.crud-load-state {
+  margin-bottom: 14px;
+  border: 1px solid color-mix(in srgb, var(--cw-danger) 36%, var(--cw-line));
+}
+
+.crud-load-state__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+}
+
+@media (max-width: 640px) {
+  .crud-load-state__content {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/customer-admin-web/src/components/TenantSwitcher.vue
+++ b/customer-admin-web/src/components/TenantSwitcher.vue
@@ -52,6 +52,7 @@ onMounted(load)
     size="default"
     :loading="switching"
     filterable
+    title="切换租户视角"
     aria-label="租户视角"
   >
     <template #prefix>
@@ -75,5 +76,54 @@ onMounted(load)
 .tenant-switcher {
   width: 220px;
   margin-right: 8px;
+}
+
+.tenant-switcher :deep(.el-select__wrapper) {
+  min-height: 34px;
+  border-radius: var(--cw-radius-md, 8px);
+  background: var(--cw-canvas, var(--el-fill-color-extra-light));
+  box-shadow: 0 0 0 1px var(--cw-line, var(--el-border-color-lighter)) inset;
+}
+
+.tenant-switcher:hover :deep(.el-select__wrapper) {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 45%, var(--cw-line, var(--el-border-color))) inset;
+}
+
+.tenant-switcher :deep(.el-select__prefix) {
+  color: var(--cw-cobalt, var(--el-color-primary));
+}
+
+@media (max-width: 760px) {
+  .tenant-switcher {
+    width: 36px;
+    margin-right: 0;
+  }
+
+  .tenant-switcher :deep(.el-select__wrapper) {
+    min-height: 34px;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .tenant-switcher:hover :deep(.el-select__wrapper) {
+    background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 8%, transparent);
+    box-shadow: none;
+  }
+
+  .tenant-switcher :deep(.el-select__selection),
+  .tenant-switcher :deep(.el-select__suffix) {
+    width: 0;
+    min-width: 0;
+    margin: 0;
+    overflow: hidden;
+    opacity: 0;
+  }
+
+  .tenant-switcher :deep(.el-select__prefix) {
+    margin: 0;
+    font-size: 16px;
+  }
 }
 </style>

--- a/customer-admin-web/src/components/ThemeToolbar.vue
+++ b/customer-admin-web/src/components/ThemeToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useThemeStore, PRESET_COLORS } from '@/store/theme'
 import { chooseButtonTextColor } from '@/utils/themeContrast'
 
@@ -11,9 +11,6 @@ const themeStore = useThemeStore()
 const showPicker = ref(false)
 const toolbarRef = ref<HTMLElement>()
 const themeButtonRef = ref<HTMLButtonElement>()
-
-/** 为实心主题色按钮选择满足普通文字对比度的黑/白文字。 */
-const primaryTextColor = computed(() => chooseButtonTextColor(themeStore.primaryColor))
 
 function togglePicker() {
   showPicker.value = !showPicker.value
@@ -91,7 +88,7 @@ onBeforeUnmount(() => {
             type="button"
             class="color-option"
             :class="{ active: themeStore.primaryColor === color }"
-            :style="{ backgroundColor: color }"
+            :style="{ backgroundColor: color, color: chooseButtonTextColor(color) }"
             :title="`使用主题色 ${color}`"
             :aria-label="`使用主题色 ${color}`"
             :aria-pressed="themeStore.primaryColor === color"
@@ -106,7 +103,6 @@ onBeforeUnmount(() => {
     <button
       type="button"
       class="new-session-btn"
-      :style="{ color: primaryTextColor }"
       @click="props.onNewSession"
     >
       <el-icon aria-hidden="true"><Plus /></el-icon>
@@ -196,7 +192,7 @@ onBeforeUnmount(() => {
 }
 
 .check-mark {
-  color: #fff;
+  color: currentColor;
   font-size: 13px;
   filter: drop-shadow(0 1px 2px rgb(0 0 0 / 45%));
 }
@@ -209,25 +205,26 @@ onBeforeUnmount(() => {
   min-width: 106px;
   height: 36px;
   padding: 0 14px;
-  background: var(--theme-primary, var(--el-color-primary));
-  border: 1px solid var(--theme-primary, var(--el-color-primary));
+  color: var(--cw-on-primary);
+  background: var(--theme-primary-solid, var(--el-color-primary));
+  border: 1px solid var(--theme-primary-solid, var(--el-color-primary));
   border-radius: 10px;
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
-  box-shadow: 0 4px 10px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 25%, transparent);
-  transition: filter 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--theme-primary-solid, var(--el-color-primary)) 25%, transparent);
+  transition: background-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
 }
 
 .new-session-btn:hover {
-  filter: brightness(0.96);
-  box-shadow: 0 6px 14px color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 32%, transparent);
+  background: var(--theme-primary-solid-hover, var(--theme-primary-solid));
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--theme-primary-solid, var(--el-color-primary)) 32%, transparent);
   transform: translateY(-1px);
 }
 
 .new-session-btn:active {
+  background: var(--theme-primary-solid-active, var(--theme-primary-solid));
   transform: translateY(0);
-  filter: brightness(0.96);
 }
 
 .theme-btn:focus-visible,

--- a/customer-admin-web/src/components/attachment/AttachmentPendingList.vue
+++ b/customer-admin-web/src/components/attachment/AttachmentPendingList.vue
@@ -133,7 +133,8 @@ const emit = defineEmits<{ remove: [localId: string] }>()
 }
 
 .pending-thumb-remove:hover {
-  background: var(--el-color-danger);
+  color: var(--cw-on-danger, #fff);
+  background: var(--cw-danger-solid, #c2414b);
 }
 
 .pending-thumb-remove .el-icon {

--- a/customer-admin-web/src/composables/useCrudPage.test.ts
+++ b/customer-admin-web/src/composables/useCrudPage.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCrudPage } from './useCrudPage'
+
+const feedback = vi.hoisted(() => ({
+  success: vi.fn(),
+  confirm: vi.fn(),
+}))
+
+vi.mock('element-plus/es', () => ({
+  ElMessage: { success: feedback.success },
+  ElMessageBox: { confirm: feedback.confirm },
+}))
+
+interface Row {
+  id: number
+  name: string
+}
+
+interface Query {
+  pageNum: number
+  pageSize: number
+  keyword: string
+}
+
+interface Form {
+  name: string
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  feedback.success.mockReset()
+  feedback.confirm.mockReset().mockResolvedValue(undefined)
+})
+
+describe('useCrudPage', () => {
+  it('搜索会回到第一页', async () => {
+    const page = vi.fn().mockResolvedValue({ list: [], total: 0 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      initQuery: () => ({ pageNum: 3, pageSize: 10, keyword: 'agent' }),
+      initForm: () => ({ name: '' }),
+    })
+
+    crud.handleSearch()
+    expect(crud.query.pageNum).toBe(1)
+    await vi.waitFor(() => expect(page).toHaveBeenCalledTimes(1))
+  })
+
+  it('加载失败保留旧数据并暴露页面级错误，成功重试后清除', async () => {
+    const failure = new Error('network unavailable')
+    const page = vi.fn()
+      .mockResolvedValueOnce({ list: [{ id: 1, name: 'cached' }], total: 1 })
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ list: [{ id: 2, name: 'fresh' }], total: 1 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+
+    await crud.loadList()
+    await crud.loadList()
+    expect(crud.list.value).toEqual([{ id: 1, name: 'cached' }])
+    expect(crud.loadError.value).toBe(failure)
+
+    await crud.loadList()
+    expect(crud.list.value).toEqual([{ id: 2, name: 'fresh' }])
+    expect(crud.loadError.value).toBeNull()
+  })
+
+  it('快速连续查询时只接收最后一次响应', async () => {
+    const slow = deferred<{ list: Row[]; total: number }>()
+    const fast = deferred<{ list: Row[]; total: number }>()
+    const page = vi.fn()
+      .mockImplementationOnce(() => slow.promise)
+      .mockImplementationOnce(() => fast.promise)
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+
+    const first = crud.loadList()
+    crud.query.keyword = 'latest'
+    const second = crud.loadList()
+    fast.resolve({ list: [{ id: 2, name: 'latest' }], total: 1 })
+    await second
+    expect(crud.list.value).toEqual([{ id: 2, name: 'latest' }])
+    expect(crud.loading.value).toBe(false)
+
+    slow.resolve({ list: [{ id: 1, name: 'stale' }], total: 1 })
+    await first
+    expect(crud.list.value).toEqual([{ id: 2, name: 'latest' }])
+  })
+
+  it('旧请求晚失败不会污染最新成功请求的数据和错误状态', async () => {
+    const stale = deferred<{ list: Row[]; total: number }>()
+    const latest = deferred<{ list: Row[]; total: number }>()
+    const page = vi.fn()
+      .mockImplementationOnce(() => stale.promise)
+      .mockImplementationOnce(() => latest.promise)
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+
+    const staleLoad = crud.loadList()
+    crud.query.keyword = 'latest'
+    const latestLoad = crud.loadList()
+    latest.resolve({ list: [{ id: 2, name: 'latest' }], total: 1 })
+    await latestLoad
+
+    stale.reject(new Error('stale request failed'))
+    await staleLoad
+
+    expect(crud.list.value).toEqual([{ id: 2, name: 'latest' }])
+    expect(crud.total.value).toBe(1)
+    expect(crud.loadError.value).toBeNull()
+    expect(crud.loading.value).toBe(false)
+  })
+
+  it('保存期间拒绝重复提交并暴露 loading 状态', async () => {
+    const createResult = deferred<unknown>()
+    const create = vi.fn(() => createResult.promise)
+    const page = vi.fn().mockResolvedValue({ list: [], total: 0 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      create,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+    crud.openCreate()
+    crud.form.name = 'Customer Agent'
+
+    const first = crud.handleSubmit()
+    const second = crud.handleSubmit()
+    expect(crud.submitting.value).toBe(true)
+    expect(create).toHaveBeenCalledTimes(1)
+
+    createResult.resolve(undefined)
+    await Promise.all([first, second])
+    expect(crud.submitting.value).toBe(false)
+    expect(crud.dialogVisible.value).toBe(false)
+    expect(page).toHaveBeenCalledTimes(1)
+  })
+
+  it('新建失败后恢复提交状态并保留弹窗与表单', async () => {
+    const failure = new Error('create failed')
+    const create = vi.fn().mockRejectedValue(failure)
+    const page = vi.fn().mockResolvedValue({ list: [], total: 0 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      create,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+    crud.openCreate()
+    crud.form.name = 'Customer Agent'
+
+    await expect(crud.handleSubmit()).rejects.toBe(failure)
+
+    expect(crud.submitting.value).toBe(false)
+    expect(crud.dialogVisible.value).toBe(true)
+    expect(crud.form.name).toBe('Customer Agent')
+    expect(page).not.toHaveBeenCalled()
+    expect(feedback.success).not.toHaveBeenCalled()
+  })
+
+  it('更新失败后恢复提交状态并保留编辑上下文', async () => {
+    const failure = new Error('update failed')
+    const update = vi.fn().mockRejectedValue(failure)
+    const page = vi.fn().mockResolvedValue({ list: [], total: 0 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      update,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+      toForm: (row) => ({ name: row.name }),
+    })
+    crud.openEdit({ id: 7, name: 'Existing Agent' })
+    crud.form.name = 'Edited Agent'
+
+    await expect(crud.handleSubmit()).rejects.toBe(failure)
+
+    expect(update).toHaveBeenCalledWith(7, crud.form)
+    expect(crud.submitting.value).toBe(false)
+    expect(crud.dialogVisible.value).toBe(true)
+    expect(crud.dialogMode.value).toBe('edit')
+    expect(crud.editingId.value).toBe(7)
+    expect(crud.form.name).toBe('Edited Agent')
+    expect(page).not.toHaveBeenCalled()
+    expect(feedback.success).not.toHaveBeenCalled()
+  })
+
+  it('取消删除后恢复行操作状态且不调用删除接口', async () => {
+    const confirmation = deferred<unknown>()
+    feedback.confirm.mockReturnValueOnce(confirmation.promise)
+    const remove = vi.fn()
+    const page = vi.fn().mockResolvedValue({ list: [], total: 0 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      remove,
+      initQuery: () => ({ pageNum: 1, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+
+    const deletion = crud.handleDelete({ id: 5, name: 'Protected Agent' })
+    expect(feedback.confirm).toHaveBeenCalledTimes(1)
+    expect(feedback.confirm.mock.results[0]?.value).toBe(confirmation.promise)
+    confirmation.reject('cancel')
+    await expect(deletion).resolves.toBeUndefined()
+
+    expect(crud.deletingId.value).toBeNull()
+    expect(remove).not.toHaveBeenCalled()
+    expect(page).not.toHaveBeenCalled()
+    expect(feedback.success).not.toHaveBeenCalled()
+  })
+
+  it('删除接口失败后恢复行操作状态且不刷新列表', async () => {
+    const failure = new Error('delete failed')
+    const remove = vi.fn().mockRejectedValue(failure)
+    const page = vi.fn().mockResolvedValue({ list: [], total: 0 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      remove,
+      initQuery: () => ({ pageNum: 2, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+
+    await expect(crud.handleDelete({ id: 6, name: 'Failing Agent' })).rejects.toBe(failure)
+
+    expect(remove).toHaveBeenCalledTimes(1)
+    expect(crud.deletingId.value).toBeNull()
+    expect(crud.query.pageNum).toBe(2)
+    expect(page).not.toHaveBeenCalled()
+    expect(feedback.success).not.toHaveBeenCalled()
+  })
+
+  it('删除当前页最后一条后回到合法页码，并拒绝重复删除', async () => {
+    const removeResult = deferred<unknown>()
+    const remove = vi.fn(() => removeResult.promise)
+    const page = vi.fn()
+      .mockResolvedValueOnce({ list: [{ id: 9, name: 'last' }], total: 11 })
+      .mockResolvedValueOnce({ list: [{ id: 8, name: 'previous' }], total: 10 })
+    const crud = useCrudPage<Row, Query, Form>({
+      page,
+      remove,
+      initQuery: () => ({ pageNum: 2, pageSize: 10, keyword: '' }),
+      initForm: () => ({ name: '' }),
+    })
+    await crud.loadList()
+
+    const first = crud.handleDelete(crud.list.value[0])
+    const second = crud.handleDelete(crud.list.value[0])
+    expect(crud.deletingId.value).toBe(9)
+    await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(1))
+
+    removeResult.resolve(undefined)
+    await Promise.all([first, second])
+    expect(crud.query.pageNum).toBe(1)
+    expect(crud.deletingId.value).toBeNull()
+    expect(page).toHaveBeenCalledTimes(2)
+  })
+})

--- a/customer-admin-web/src/composables/useCrudPage.ts
+++ b/customer-admin-web/src/composables/useCrudPage.ts
@@ -56,6 +56,9 @@ export interface CrudPageOptions<VO, Q extends PageQuery, F extends object> {
  */
 export function useCrudPage<VO, Q extends PageQuery, F extends object>(options: CrudPageOptions<VO, Q, F>) {
   const loading = ref(false)
+  const loadError = ref<unknown>(null)
+  const submitting = ref(false)
+  const deletingId = ref<number | null>(null)
   const list = ref([]) as Ref<VO[]>
   const total = ref(0)
   const query = reactive(options.initQuery()) as Q
@@ -64,23 +67,37 @@ export function useCrudPage<VO, Q extends PageQuery, F extends object>(options: 
   const dialogMode = ref<CrudDialogMode>('create')
   const editingId = ref<number | null>(null)
   const form = reactive(options.initForm()) as F
+  let loadRequestId = 0
 
   const rowId = options.rowId ?? ((row: VO) => (row as { id: number }).id)
 
   async function loadList() {
+    const requestId = ++loadRequestId
     loading.value = true
     try {
       const result = await options.page(query)
+      if (requestId !== loadRequestId) {
+        return
+      }
       list.value = result.list
       total.value = result.total
+      loadError.value = null
+    } catch (error) {
+      // request.ts 已负责全局错误提示；这里保留页面级状态，避免失败被伪装成“暂无数据”。
+      if (requestId === loadRequestId) {
+        loadError.value = error
+      }
     } finally {
-      loading.value = false
+      // 快速切换筛选条件时，旧请求结束不能提前关闭新请求的 loading。
+      if (requestId === loadRequestId) {
+        loading.value = false
+      }
     }
   }
 
   function handleSearch() {
     query.pageNum = 1
-    loadList()
+    return loadList()
   }
 
   function openCreate() {
@@ -98,43 +115,74 @@ export function useCrudPage<VO, Q extends PageQuery, F extends object>(options: 
   }
 
   async function handleSubmit() {
-    if (options.formRef) {
-      const valid = await options.formRef.value?.validate().catch(() => false)
-      if (!valid) {
-        return
-      }
-    }
-    if (options.beforeSubmit && !options.beforeSubmit(dialogMode.value, form)) {
+    if (submitting.value) {
       return
     }
-    if (dialogMode.value === 'create' && options.create) {
-      await options.create(form)
-      ElMessage.success(options.messages?.created ?? '新建成功')
-    } else if (dialogMode.value === 'edit' && options.update) {
-      if (!editingId.value) {
+    submitting.value = true
+    try {
+      if (options.formRef) {
+        const valid = await options.formRef.value?.validate().catch(() => false)
+        if (!valid) {
+          return
+        }
+      }
+      if (options.beforeSubmit && !options.beforeSubmit(dialogMode.value, form)) {
         return
       }
-      await options.update(editingId.value, form)
-      ElMessage.success(options.messages?.updated ?? '保存成功')
-    } else {
-      return
+      if (dialogMode.value === 'create' && options.create) {
+        await options.create(form)
+        ElMessage.success(options.messages?.created ?? '新建成功')
+      } else if (dialogMode.value === 'edit' && options.update) {
+        if (!editingId.value) {
+          return
+        }
+        await options.update(editingId.value, form)
+        ElMessage.success(options.messages?.updated ?? '保存成功')
+      } else {
+        return
+      }
+      dialogVisible.value = false
+      await loadList()
+    } finally {
+      submitting.value = false
     }
-    dialogVisible.value = false
-    await loadList()
   }
 
   async function handleDelete(row: VO) {
-    if (!options.remove) {
+    if (!options.remove || deletingId.value !== null) {
       return
     }
-    await ElMessageBox.confirm(options.deleteConfirm?.(row) ?? '确认删除该条记录？', '提示', { type: 'warning' })
-    await options.remove(row)
-    ElMessage.success(options.messages?.deleted ?? '删除成功')
-    await loadList()
+    const id = rowId(row)
+    deletingId.value = id
+    try {
+      try {
+        await ElMessageBox.confirm(options.deleteConfirm?.(row) ?? '确认删除该条记录？', '提示', { type: 'warning' })
+      } catch (error) {
+        // Element Plus 用 reject 表达用户主动取消；这是正常交互，不应冒泡成未处理异常。
+        const reason = error instanceof Error ? error.message : error
+        if (reason === 'cancel' || reason === 'close') {
+          return
+        }
+        throw error
+      }
+      await options.remove(row)
+      ElMessage.success(options.messages?.deleted ?? '删除成功')
+      // 删除当前页最后一条时先回到上一页，避免成功后展示一个不存在的空页。
+      const currentPage = query.pageNum ?? 1
+      if (list.value.length === 1 && currentPage > 1) {
+        query.pageNum = currentPage - 1
+      }
+      await loadList()
+    } finally {
+      deletingId.value = null
+    }
   }
 
   return {
     loading,
+    loadError,
+    submitting,
+    deletingId,
     list,
     total,
     query,

--- a/customer-admin-web/src/layouts/AppBreadcrumb.vue
+++ b/customer-admin-web/src/layouts/AppBreadcrumb.vue
@@ -32,9 +32,38 @@ const shouldShow = computed(() => crumbs.value.length > 2)
   min-height: 30px;
   display: flex;
   align-items: center;
-  padding: 0 18px;
-  border-bottom: 1px solid var(--el-border-color-lighter);
-  background: var(--el-bg-color);
+  padding: 0 16px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  background: var(--cw-paper, var(--el-bg-color));
   font-size: 12px;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+
+.app-breadcrumb::-webkit-scrollbar {
+  display: none;
+}
+
+.app-breadcrumb :deep(.el-breadcrumb__inner) {
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
+  font-weight: 500;
+}
+
+.app-breadcrumb :deep(.el-breadcrumb__item:last-child .el-breadcrumb__inner) {
+  color: var(--cw-cobalt, var(--el-color-primary));
+  font-weight: 650;
+}
+
+.app-breadcrumb :deep(.el-breadcrumb__separator) {
+  color: var(--cw-text-muted, var(--el-text-color-placeholder));
+  font-weight: 400;
+  opacity: 0.65;
+}
+
+@media (max-width: 760px) {
+  .app-breadcrumb {
+    padding: 0 10px;
+  }
 }
 </style>

--- a/customer-admin-web/src/layouts/AppHeader.vue
+++ b/customer-admin-web/src/layouts/AppHeader.vue
@@ -51,6 +51,8 @@ async function handleLogout() {
         text
         :icon="navigationToggleIcon"
         :aria-label="navigationToggleLabel"
+        aria-controls="lifecycle-navigation-shell"
+        :aria-expanded="compactViewport ? overlayOpen : !navigationCollapsed"
         @click="emit('navigationToggle', $event)"
       />
       <span class="header-separator" aria-hidden="true" />
@@ -97,10 +99,11 @@ async function handleLogout() {
   flex: 0 0 var(--cw-topbar-height);
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 16px 0 12px;
-  background: color-mix(in srgb, var(--el-bg-color) 96%, transparent);
-  border-bottom: 1px solid var(--el-border-color-lighter);
+  gap: 8px;
+  padding: 0 14px 0 10px;
+  border-bottom: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  background: color-mix(in srgb, var(--cw-paper, var(--el-bg-color)) 97%, transparent);
+  backdrop-filter: blur(12px);
 }
 
 .header-left,
@@ -111,46 +114,47 @@ async function handleLogout() {
 
 .header-left {
   flex: 0 1 auto;
-  min-width: 150px;
-  gap: 10px;
+  min-width: 154px;
+  gap: 8px;
 }
 
 .header-center {
   flex: 1;
-  min-width: 164px;
+  min-width: 180px;
   display: flex;
   justify-content: center;
-  padding: 0 8px;
+  padding: 0 6px;
 }
 
 .header-right {
+  min-width: 0;
   flex: 0 0 auto;
-  gap: 4px;
+  gap: 3px;
 }
 
 .header-right :deep(.tenant-switcher) {
-  width: 200px;
-  margin-right: 4px;
+  width: 188px;
+  margin-right: 3px;
 }
 
 .icon-button {
   width: 36px;
   height: 36px;
   padding: 0;
-  border-radius: 9px;
-  color: var(--el-text-color-regular);
-  font-size: 18px;
+  border-radius: var(--cw-radius-md, 8px);
+  color: var(--cw-text-muted, var(--el-text-color-regular));
+  font-size: 17px;
 }
 
 .icon-button:hover {
-  color: var(--el-color-primary);
-  background: var(--el-fill-color-light);
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 8%, transparent);
+  color: var(--cw-cobalt, var(--el-color-primary));
 }
 
 .header-separator {
   width: 1px;
-  height: 28px;
-  background: var(--el-border-color-lighter);
+  height: 24px;
+  background: var(--cw-line, var(--el-border-color-lighter));
 }
 
 .location-copy {
@@ -162,43 +166,46 @@ async function handleLogout() {
 }
 
 .location-product {
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-cobalt, var(--el-color-primary));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  font-weight: 750;
+  letter-spacing: 0.09em;
 }
 
 .location-copy strong {
+  color: var(--cw-text, var(--el-text-color-primary));
   font-size: 14px;
-  font-weight: 650;
+  font-weight: 680;
 }
 
 .user-menu-trigger {
-  height: 38px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 6px;
   padding: 0 6px 0 4px;
   border: 0;
-  border-radius: 9px;
+  border-radius: var(--cw-radius-md, 8px);
   background: transparent;
-  color: var(--el-text-color-regular);
+  color: var(--cw-text-muted, var(--el-text-color-regular));
   cursor: pointer;
 }
 
 .user-menu-trigger:hover {
-  background: var(--el-fill-color-light);
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 8%, transparent);
+  color: var(--cw-cobalt, var(--el-color-primary));
 }
 
 .user-avatar {
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 9px;
-  background: linear-gradient(145deg, var(--el-color-primary-light-7), var(--el-color-primary-light-9));
-  color: var(--el-color-primary-dark-2);
+  border-radius: var(--cw-radius-md, 8px);
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 11%, var(--cw-paper, var(--el-bg-color)));
+  color: var(--cw-cobalt, var(--el-color-primary));
   font-size: 12px;
   font-weight: 750;
 }
@@ -213,7 +220,7 @@ async function handleLogout() {
 
 @media (max-width: 1280px) {
   .header-right :deep(.tenant-switcher) {
-    width: 174px;
+    width: 168px;
   }
 
   .location-product {
@@ -233,12 +240,71 @@ async function handleLogout() {
 }
 
 @media (max-width: 900px) {
-  .location-copy {
+  .location-copy,
+  .header-separator {
     display: none;
   }
 
   .header-right :deep(.tenant-switcher) {
-    width: 150px;
+    width: 148px;
+  }
+}
+
+@media (max-width: 760px) {
+  .layout-header {
+    gap: 3px;
+    padding: 0 7px;
+  }
+
+  .header-left {
+    min-width: 36px;
+    flex: 0 0 36px;
+    gap: 0;
+  }
+
+  .header-center {
+    min-width: 36px;
+    flex: 0 0 36px;
+    padding: 0;
+  }
+
+  .header-right {
+    flex: 1 1 auto;
+    justify-content: flex-end;
+    gap: 1px;
+  }
+
+  .header-right :deep(.tenant-switcher) {
+    width: 36px;
+    margin-right: 0;
+  }
+
+  .icon-button,
+  .user-menu-trigger {
+    width: 34px;
+    height: 34px;
+  }
+
+  .user-menu-trigger {
+    justify-content: center;
+    padding: 0;
+  }
+
+  .user-name,
+  .user-menu-trigger > .el-icon {
+    display: none;
+  }
+}
+
+@media (max-width: 410px) {
+  .layout-header {
+    padding: 0 5px;
+  }
+
+  .header-left,
+  .header-center {
+    min-width: 34px;
+    flex-basis: 34px;
   }
 }
 </style>

--- a/customer-admin-web/src/layouts/GlobalCommandSearch.vue
+++ b/customer-admin-web/src/layouts/GlobalCommandSearch.vue
@@ -115,6 +115,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', handleGlobalShortcut
     ref="triggerButton"
     type="button"
     class="global-search-trigger"
+    title="搜索菜单、智能体或配置"
     aria-label="搜索菜单、智能体或配置"
     @click="openSearch"
   >
@@ -198,22 +199,24 @@ onBeforeUnmount(() => window.removeEventListener('keydown', handleGlobalShortcut
 .global-search-trigger {
   width: min(420px, 30vw);
   min-width: 220px;
-  height: 38px;
+  height: 36px;
   display: flex;
   align-items: center;
   gap: 9px;
   padding: 0 10px 0 12px;
-  border: 1px solid var(--el-border-color);
-  border-radius: 9px;
-  background: var(--el-fill-color-extra-light);
-  color: var(--el-text-color-secondary);
+  border: 1px solid var(--cw-line-strong, var(--el-border-color));
+  border-radius: var(--cw-radius-md, 8px);
+  background: var(--cw-canvas, var(--el-fill-color-extra-light));
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
   cursor: pointer;
   transition: border-color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
 }
 
 .global-search-trigger:hover {
-  border-color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 55%, var(--el-border-color));
-  background: var(--el-bg-color);
+  border-color: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 48%, var(--cw-line, var(--el-border-color)));
+  background: var(--cw-paper, var(--el-bg-color));
+  color: var(--cw-cobalt, var(--el-color-primary));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 7%, transparent);
 }
 
 .global-search-placeholder {
@@ -233,12 +236,12 @@ kbd {
   align-items: center;
   justify-content: center;
   padding: 0 5px;
-  border: 1px solid var(--el-border-color);
+  border: 1px solid var(--cw-line-strong, var(--el-border-color));
   border-radius: 5px;
-  background: var(--el-bg-color);
-  color: var(--el-text-color-secondary);
+  background: var(--cw-paper, var(--el-bg-color));
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
   font: 11px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  box-shadow: 0 1px 0 color-mix(in srgb, var(--el-border-color) 80%, transparent);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--cw-line-strong, var(--el-border-color)) 80%, transparent);
 }
 
 .sr-only {
@@ -255,9 +258,10 @@ kbd {
 
 :global(.navigation-command-dialog) {
   overflow: hidden;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 14px;
-  box-shadow: 0 24px 80px rgb(15 23 42 / 24%);
+  border: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  border-radius: var(--cw-radius-lg, 12px);
+  background: var(--cw-paper, var(--el-bg-color));
+  box-shadow: var(--cw-shadow-lg, 0 24px 80px rgb(15 23 42 / 24%));
 }
 
 :global(.navigation-command-dialog .el-dialog__header) {
@@ -275,7 +279,7 @@ kbd {
   align-items: center;
   gap: 10px;
   padding-bottom: 10px;
-  border-bottom: 1px solid var(--el-border-color-lighter);
+  border-bottom: 1px solid var(--cw-line, var(--el-border-color-lighter));
 }
 
 .command-search-box :deep(.el-input) {
@@ -294,7 +298,7 @@ kbd {
 
 .command-escape {
   padding-right: 4px;
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted, var(--el-text-color-placeholder));
   font-size: 11px;
   white-space: nowrap;
 }
@@ -314,15 +318,16 @@ kbd {
   gap: 11px;
   padding: 8px 10px;
   border: 0;
-  border-radius: 9px;
+  border-radius: var(--cw-radius-md, 8px);
   background: transparent;
-  color: var(--el-text-color-primary);
+  color: var(--cw-text, var(--el-text-color-primary));
   text-align: left;
   cursor: pointer;
 }
 
 .command-result.is-selected {
-  background: var(--el-color-primary-light-9);
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 10%, var(--cw-paper, var(--el-bg-color)));
+  color: var(--cw-cobalt, var(--el-color-primary));
 }
 
 .command-result-icon {
@@ -332,16 +337,16 @@ kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 9px;
-  background: var(--el-bg-color);
-  color: var(--el-text-color-secondary);
+  border: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  border-radius: var(--cw-radius-md, 8px);
+  background: var(--cw-paper, var(--el-bg-color));
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
 }
 
 .command-result-icon.is-agent {
-  border-color: color-mix(in srgb, var(--theme-primary, var(--el-color-primary)) 30%, transparent);
-  background: var(--el-color-primary-light-9);
-  color: var(--el-color-primary);
+  border-color: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 30%, transparent);
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 9%, var(--cw-paper, var(--el-bg-color)));
+  color: var(--cw-cobalt, var(--el-color-primary));
 }
 
 .command-result-copy {
@@ -362,7 +367,7 @@ kbd {
 
 .command-result-meta,
 .command-result-path {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
   font-size: 12px;
 }
 
@@ -376,7 +381,8 @@ kbd {
 
 .command-enter {
   flex: 0 0 auto;
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted, var(--el-text-color-placeholder));
+  opacity: 0.65;
 }
 
 .command-footer {
@@ -386,9 +392,9 @@ kbd {
   gap: 14px;
   margin: 0 -12px;
   padding: 0 14px;
-  border-top: 1px solid var(--el-border-color-lighter);
-  background: var(--el-fill-color-extra-light);
-  color: var(--el-text-color-secondary);
+  border-top: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  background: var(--cw-canvas, var(--el-fill-color-extra-light));
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
   font-size: 11px;
 }
 
@@ -412,9 +418,43 @@ kbd {
 }
 
 @media (max-width: 760px) {
+  .global-search-trigger {
+    width: 34px;
+    min-width: 34px;
+    height: 34px;
+    justify-content: center;
+    gap: 0;
+    padding: 0;
+    border-color: transparent;
+    background: transparent;
+    font-size: 17px;
+  }
+
+  .global-search-trigger:hover {
+    border-color: transparent;
+  }
+
+  .global-search-placeholder,
+  .global-search-trigger kbd,
   .command-result-path,
   .command-footer span:last-child {
     display: none;
+  }
+
+  :global(.navigation-command-dialog .el-dialog__body) {
+    padding-right: 8px;
+    padding-left: 8px;
+  }
+
+  .command-result {
+    gap: 8px;
+    padding-right: 7px;
+    padding-left: 7px;
+  }
+
+  .command-footer {
+    margin-right: -8px;
+    margin-left: -8px;
   }
 }
 

--- a/customer-admin-web/src/layouts/LifecycleNavigation.vue
+++ b/customer-admin-web/src/layouts/LifecycleNavigation.vue
@@ -19,20 +19,32 @@ const emit = defineEmits<{
 const route = useRoute()
 const router = useRouter()
 const menuStore = useMenuStore()
+const COMPACT_VIEWPORT_QUERY = '(max-width: 1023px)'
 const navigationSections = computed(() => buildNavigationSections(menuStore.tree))
 const selectedSectionKey = ref<NavigationSectionKey>('overview')
 const contextQuery = ref('')
-const compactViewport = ref(false)
+// 首帧就按真实视口计算，避免窄屏先渲染 272px 侧栏、挂载后再突然收起。
+const compactViewport = ref(
+  typeof window !== 'undefined'
+  && typeof window.matchMedia === 'function'
+  && window.matchMedia(COMPACT_VIEWPORT_QUERY).matches,
+)
 const overlayOpen = ref(false)
 const contextSearchInput = ref<InputInstance>()
+const navigationShell = ref<HTMLElement>()
 let compactViewportQuery: MediaQueryList | null = null
 let overlayTrigger: HTMLElement | null = null
 
 // SQL 通用查询页靠 defineKey 区分菜单，高亮必须保留 query；普通页面仍按 path 对齐。
 const activePath = computed(() => (route.path === '/sql/query' ? route.fullPath : route.path))
 const isNavigationCompact = computed(() => menuStore.collapsed || compactViewport.value)
+const isDesktopCollapsed = computed(() => menuStore.collapsed && !compactViewport.value)
 const asideWidth = computed(() => (
-  isNavigationCompact.value ? 'var(--cw-nav-rail-width)' : 'var(--cw-shell-expanded-width)'
+  compactViewport.value
+    ? '0px'
+    : isDesktopCollapsed.value
+      ? 'var(--cw-nav-rail-width)'
+      : 'var(--cw-shell-expanded-width)'
 ))
 const currentSection = computed(() => (
   navigationSections.value.find((section) => section.key === selectedSectionKey.value)
@@ -54,7 +66,11 @@ function focusContextSearch() {
 }
 
 function openOverlay(trigger: HTMLElement | null) {
-  overlayTrigger = trigger
+  // 移动端先由顶栏按钮打开完整抽屉，随后点击生命周期阶段时不能把焦点归还目标
+  // 覆盖成抽屉内部按钮；否则关闭抽屉后焦点会落到不可见元素。
+  if (!overlayOpen.value) {
+    overlayTrigger = trigger
+  }
   overlayOpen.value = true
   focusContextSearch()
 }
@@ -129,8 +145,26 @@ function handleEscape(event: KeyboardEvent) {
   }
 }
 
+function handleNavigationKeydown(event: KeyboardEvent) {
+  if (!compactViewport.value || !overlayOpen.value || event.key !== 'Tab') return
+  const focusable = Array.from(navigationShell.value?.querySelectorAll<HTMLElement>(
+    'button:not(:disabled), a[href], input:not(:disabled), [tabindex]:not([tabindex="-1"])',
+  ) ?? []).filter((element) => element.offsetParent !== null)
+  if (focusable.length === 0) return
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
 onMounted(() => {
-  compactViewportQuery = window.matchMedia('(max-width: 1023px)')
+  compactViewportQuery = window.matchMedia(COMPACT_VIEWPORT_QUERY)
   updateCompactViewport(compactViewportQuery)
   compactViewportQuery.addEventListener('change', updateCompactViewport)
   window.addEventListener('keydown', handleEscape)
@@ -148,87 +182,102 @@ defineExpose({ toggleFromHeader })
   <el-aside
     :width="asideWidth"
     class="layout-aside"
-    :class="{ 'is-compact': isNavigationCompact }"
+    :class="{
+      'is-compact': isNavigationCompact,
+      'is-desktop-collapsed': isDesktopCollapsed,
+      'is-mobile': compactViewport,
+      'is-mobile-open': compactViewport && overlayOpen,
+    }"
   >
-    <div class="primary-rail">
-      <button
-        class="rail-brand"
-        type="button"
-        title="返回首页"
-        aria-label="返回首页"
-        @click="router.push('/home')"
-      >
-        <span class="logo-mark">CW</span>
-      </button>
-
-      <nav class="rail-nav" aria-label="智能体生命周期导航">
-        <button
-          v-for="section in navigationSections"
-          :key="section.key"
-          type="button"
-          class="rail-item"
-          :class="{ 'is-active': selectedSectionKey === section.key }"
-          :title="section.label"
-          :aria-current="selectedSectionKey === section.key ? 'true' : undefined"
-          aria-controls="lifecycle-context-menu"
-          :aria-expanded="selectedSectionKey === section.key && (!isNavigationCompact || overlayOpen)"
-          @click="selectSection(section.key, $event)"
-        >
-          <el-icon class="rail-icon"><component :is="section.icon" /></el-icon>
-          <span class="rail-label">{{ section.label }}</span>
-        </button>
-      </nav>
-    </div>
-
-    <section
-      v-show="!isNavigationCompact || overlayOpen"
-      id="lifecycle-context-menu"
-      class="context-pane"
-      :class="{ 'is-overlay': isNavigationCompact }"
-      :aria-label="currentSection ? `${currentSection.title}菜单` : '上下文菜单'"
+    <div
+      id="lifecycle-navigation-shell"
+      ref="navigationShell"
+      class="navigation-shell"
+      :role="compactViewport && overlayOpen ? 'dialog' : undefined"
+      :aria-modal="compactViewport && overlayOpen ? 'true' : undefined"
+      :aria-label="compactViewport && overlayOpen ? '页面导航' : undefined"
+      @keydown="handleNavigationKeydown"
     >
-      <div v-if="currentSection" class="context-head">
-        <div class="context-eyebrow">CUSTOMER WORK</div>
-        <div class="context-title-row">
-          <strong>{{ currentSection.title }}</strong>
-          <span class="context-count">{{ currentSection.itemCount }}</span>
+      <div class="primary-rail">
+        <button
+          class="rail-brand"
+          type="button"
+          title="返回首页"
+          aria-label="返回首页"
+          @click="router.push('/home')"
+        >
+          <span class="logo-mark">CW</span>
+        </button>
+
+        <nav class="rail-nav" aria-label="智能体生命周期导航">
+          <button
+            v-for="section in navigationSections"
+            :key="section.key"
+            type="button"
+            class="rail-item"
+            :class="{ 'is-active': selectedSectionKey === section.key }"
+            :title="section.label"
+            :aria-current="selectedSectionKey === section.key ? 'true' : undefined"
+            aria-controls="lifecycle-context-menu"
+            :aria-expanded="selectedSectionKey === section.key && (!isNavigationCompact || overlayOpen)"
+            @click="selectSection(section.key, $event)"
+          >
+            <el-icon class="rail-icon"><component :is="section.icon" /></el-icon>
+            <span class="rail-label">{{ section.label }}</span>
+          </button>
+        </nav>
+      </div>
+
+      <section
+        v-show="!isNavigationCompact || overlayOpen"
+        id="lifecycle-context-menu"
+        class="context-pane"
+        :class="{ 'is-overlay': isDesktopCollapsed }"
+        :aria-label="currentSection ? `${currentSection.title}菜单` : '上下文菜单'"
+      >
+        <div v-if="currentSection" class="context-head">
+          <div class="context-eyebrow">CUSTOMER WORK</div>
+          <div class="context-title-row">
+            <strong>{{ currentSection.title }}</strong>
+            <span class="context-count">{{ currentSection.itemCount }}</span>
+          </div>
+          <el-button
+            v-if="isNavigationCompact"
+            class="context-close"
+            text
+            :icon="'Close'"
+            aria-label="关闭上下文菜单"
+            @click="closeOverlay()"
+          />
         </div>
-        <el-button
-          v-if="isNavigationCompact"
-          class="context-close"
-          text
-          :icon="'Close'"
-          aria-label="关闭上下文菜单"
-          @click="closeOverlay()"
-        />
-      </div>
 
-      <div v-if="currentSection" class="context-search-wrap">
-        <el-input
-          ref="contextSearchInput"
-          v-model="contextQuery"
-          class="context-search"
-          :placeholder="currentSection.searchPlaceholder"
-          clearable
-          :aria-label="currentSection.searchPlaceholder"
-        >
-          <template #prefix><el-icon><Search /></el-icon></template>
-        </el-input>
-      </div>
+        <div v-if="currentSection" class="context-search-wrap">
+          <el-input
+            ref="contextSearchInput"
+            v-model="contextQuery"
+            class="context-search"
+            :placeholder="currentSection.searchPlaceholder"
+            clearable
+            :aria-label="currentSection.searchPlaceholder"
+          >
+            <template #prefix><el-icon><Search /></el-icon></template>
+          </el-input>
+        </div>
 
-      <div class="context-scroll">
-        <el-menu
-          v-if="filteredContextNodes.length > 0"
-          class="context-menu"
-          :default-active="activePath"
-          router
-          unique-opened
-        >
-          <MenuTree :nodes="filteredContextNodes" />
-        </el-menu>
-        <el-empty v-else description="没有匹配的入口" :image-size="52" />
-      </div>
-    </section>
+        <div class="context-scroll">
+          <el-menu
+            v-if="filteredContextNodes.length > 0"
+            class="context-menu"
+            :default-active="activePath"
+            router
+            unique-opened
+          >
+            <MenuTree :nodes="filteredContextNodes" />
+          </el-menu>
+          <el-empty v-else description="没有匹配的入口" :image-size="52" />
+        </div>
+      </section>
+    </div>
   </el-aside>
 
   <button
@@ -242,16 +291,21 @@ defineExpose({ toggleFromHeader })
 
 <style scoped>
 .layout-aside {
-  --cw-rail-bg: var(--cw-brand-ink);
-  --cw-rail-hover: var(--cw-brand-ink-hover);
   height: 100%;
-  display: flex;
   position: relative;
   z-index: 1200;
+  flex: 0 0 auto;
   overflow: visible;
-  background: var(--cw-rail-bg);
-  border-right: 1px solid var(--el-border-color-lighter);
+  background: transparent;
   transition: width 180ms ease-out;
+}
+
+.navigation-shell {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  background: var(--cw-ink, var(--cw-brand-ink));
 }
 
 .primary-rail {
@@ -260,8 +314,8 @@ defineExpose({ toggleFromHeader })
   flex: 0 0 var(--cw-nav-rail-width);
   display: flex;
   flex-direction: column;
-  background: var(--cw-rail-bg);
-  color: #b7c5d8;
+  background: var(--cw-ink, var(--cw-brand-ink));
+  color: rgb(255 255 255 / 68%);
 }
 
 .rail-brand {
@@ -279,18 +333,19 @@ defineExpose({ toggleFromHeader })
 }
 
 .logo-mark {
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 10px;
-  background: linear-gradient(145deg, var(--cw-brand-logo-start), var(--cw-brand-logo-end));
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 9px;
+  background: linear-gradient(145deg, var(--cw-brand-logo-start), var(--cw-cobalt, var(--cw-brand-logo-end)));
   color: #fff;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.04em;
-  box-shadow: 0 7px 18px rgb(58 86 210 / 32%);
+  letter-spacing: 0.05em;
+  box-shadow: 0 7px 18px rgb(62 99 221 / 28%);
 }
 
 .rail-nav {
@@ -299,58 +354,67 @@ defineExpose({ toggleFromHeader })
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 14px 8px;
+  gap: 3px;
+  padding: 11px 8px;
   overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.rail-nav::-webkit-scrollbar {
+  display: none;
 }
 
 .rail-item {
-  width: 56px;
-  min-height: 55px;
+  width: 48px;
+  min-height: 48px;
   position: relative;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 7px 4px 6px;
-  border: 0;
-  border-radius: 10px;
+  gap: 3px;
+  padding: 5px 2px;
+  border: 1px solid transparent;
+  border-radius: 9px;
   background: transparent;
-  color: #91a1b7;
+  color: rgb(255 255 255 / 58%);
   cursor: pointer;
-  transition: background-color 160ms ease, color 160ms ease;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
 }
 
-.rail-item:hover {
-  background: var(--cw-rail-hover);
-  color: #e6edf7;
+.rail-item::before {
+  width: 3px;
+  height: 0;
+  position: absolute;
+  top: 50%;
+  left: -7px;
+  border-radius: 0 3px 3px 0;
+  background: var(--cw-amber);
+  content: '';
+  transform: translateY(-50%);
+  transition: height 180ms ease-out;
 }
 
+.rail-item:hover,
 .rail-item.is-active {
-  background: rgb(79 110 247 / 17%);
+  border-color: rgb(255 255 255 / 9%);
+  background: rgb(255 255 255 / 9%);
   color: #fff;
 }
 
-.rail-item.is-active::after {
-  content: '';
-  width: 3px;
-  height: 24px;
-  position: absolute;
-  right: -8px;
-  top: 50%;
-  border-radius: 3px 0 0 3px;
-  background: var(--cw-brand-signal);
-  transform: translateY(-50%);
+.rail-item.is-active::before {
+  height: 25px;
 }
 
 .rail-icon {
-  font-size: 19px;
+  font-size: 18px;
+  line-height: 1;
 }
 
 .rail-label {
-  font-size: 11px;
-  line-height: 16px;
+  font-size: 10px;
+  line-height: 14px;
   letter-spacing: 0.02em;
 }
 
@@ -361,18 +425,16 @@ defineExpose({ toggleFromHeader })
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: var(--el-bg-color);
-  color: var(--el-text-color-primary);
-  box-shadow: 1px 0 0 var(--el-border-color-lighter);
+  border-right: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  background: var(--cw-paper, var(--el-bg-color));
+  color: var(--cw-text, var(--el-text-color-primary));
 }
 
 .context-pane.is-overlay {
-  width: 220px;
-  min-width: 220px;
   position: absolute;
   inset: 0 auto 0 var(--cw-nav-rail-width);
   z-index: 2;
-  box-shadow: 14px 0 36px rgb(15 23 42 / 18%);
+  box-shadow: var(--cw-shadow-lg, 14px 0 36px rgb(15 23 42 / 18%));
 }
 
 .context-head {
@@ -381,16 +443,17 @@ defineExpose({ toggleFromHeader })
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 4px;
+  gap: 3px;
   padding: 0 14px;
-  border-bottom: 1px solid var(--el-border-color-lighter);
+  border-bottom: 1px solid var(--cw-line, var(--el-border-color-lighter));
 }
 
 .context-eyebrow {
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-cobalt, var(--el-color-primary));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
+  font-weight: 750;
+  letter-spacing: 0.13em;
 }
 
 .context-title-row {
@@ -405,8 +468,8 @@ defineExpose({ toggleFromHeader })
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
-  font-weight: 650;
+  font-size: 14px;
+  font-weight: 680;
 }
 
 .context-count {
@@ -417,25 +480,30 @@ defineExpose({ toggleFromHeader })
   justify-content: center;
   padding: 0 5px;
   border-radius: 9px;
-  background: var(--el-fill-color-light);
-  color: var(--el-text-color-secondary);
-  font-size: 10px;
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 9%, transparent);
+  color: var(--cw-cobalt, var(--el-color-primary));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 9px;
+  font-weight: 700;
 }
 
 .context-close {
+  width: 32px;
+  height: 32px;
   position: absolute;
-  top: 16px;
+  top: 12px;
   right: 8px;
+  padding: 0;
 }
 
 .context-search-wrap {
-  padding: 12px 10px 8px;
+  padding: 11px 10px 8px;
 }
 
 .context-search :deep(.el-input__wrapper) {
-  border-radius: 8px;
+  border-radius: var(--cw-radius-sm, 6px);
   background: var(--el-fill-color-extra-light);
-  box-shadow: 0 0 0 1px var(--el-border-color-lighter) inset;
+  box-shadow: 0 0 0 1px var(--cw-line, var(--el-border-color-lighter)) inset;
 }
 
 .context-search :deep(.el-input__inner) {
@@ -447,6 +515,8 @@ defineExpose({ toggleFromHeader })
   min-height: 0;
   overflow-y: auto;
   padding: 2px 8px 14px;
+  scrollbar-color: var(--cw-line, var(--el-border-color)) transparent;
+  scrollbar-width: thin;
 }
 
 .context-menu {
@@ -454,19 +524,19 @@ defineExpose({ toggleFromHeader })
   background: transparent;
   --el-menu-bg-color: transparent;
   --el-menu-hover-bg-color: var(--el-fill-color-light);
-  --el-menu-active-color: var(--el-text-color-primary);
+  --el-menu-active-color: var(--cw-cobalt, var(--el-color-primary));
   --el-menu-text-color: var(--el-text-color-regular);
 }
 
 .context-menu :deep(.el-menu-item),
 .context-menu :deep(.el-sub-menu__title) {
   min-width: 0;
-  height: 40px;
+  height: 38px;
   position: relative;
   margin: 2px 0;
-  border-radius: 8px;
-  line-height: 40px;
-  font-size: 13px;
+  border-radius: var(--cw-radius-sm, 6px);
+  line-height: 38px;
+  font-size: 12px;
 }
 
 .context-menu :deep(.el-menu-item .el-icon),
@@ -482,20 +552,24 @@ defineExpose({ toggleFromHeader })
 }
 
 .context-menu :deep(.el-menu-item.is-active) {
-  background: var(--el-color-primary-light-9);
-  color: var(--el-text-color-primary);
-  font-weight: 600;
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 10%, var(--cw-paper, var(--el-bg-color)));
+  color: var(--cw-cobalt, var(--el-color-primary));
+  font-weight: 650;
+}
+
+.context-menu :deep(.el-menu-item.is-active .el-icon) {
+  color: var(--cw-cobalt, var(--el-color-primary)) !important;
 }
 
 .context-menu :deep(.el-menu-item.is-active::before) {
-  content: '';
   width: 2px;
-  height: 22px;
+  height: 21px;
   position: absolute;
-  left: 0;
   top: 50%;
+  left: 0;
   border-radius: 0 2px 2px 0;
-  background: var(--theme-primary, var(--el-color-primary));
+  background: var(--cw-cobalt, var(--el-color-primary));
+  content: '';
   transform: translateY(-50%);
 }
 
@@ -505,13 +579,40 @@ defineExpose({ toggleFromHeader })
   z-index: 1180;
   padding: 0;
   border: 0;
-  background: rgb(15 23 42 / 18%);
+  background: rgb(5 13 30 / 52%);
   cursor: default;
+}
+
+.layout-aside.is-mobile .navigation-shell {
+  width: min(var(--cw-shell-expanded-width), calc(100vw - 24px));
+  position: fixed;
+  inset: 0 auto 0 0;
+  visibility: hidden;
+  overflow: hidden;
+  box-shadow: var(--cw-shadow-lg, 18px 0 48px rgb(5 13 30 / 26%));
+  pointer-events: none;
+  transform: translateX(-100%);
+  transition: visibility 180ms step-end, transform 180ms ease-out;
+}
+
+.layout-aside.is-mobile-open .navigation-shell {
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(0);
+  transition: transform 180ms ease-out;
+}
+
+.layout-aside.is-mobile .context-pane {
+  width: calc(100% - var(--cw-nav-rail-width));
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .layout-aside,
-  .rail-item {
+  .navigation-shell,
+  .rail-item,
+  .rail-item::before {
     transition: none;
   }
 }

--- a/customer-admin-web/src/layouts/MainLayout.vue
+++ b/customer-admin-web/src/layouts/MainLayout.vue
@@ -7,6 +7,8 @@ import LifecycleNavigation from './LifecycleNavigation.vue'
 import AppHeader from './AppHeader.vue'
 import TabsBar from './TabsBar.vue'
 import AppBreadcrumb from './AppBreadcrumb.vue'
+import PageContextHeader from './PageContextHeader.vue'
+import { resolvePageTemplate } from './pagePresentation'
 import FooterCopyright from '@/components/FooterCopyright.vue'
 
 interface LifecycleNavigationHandle {
@@ -26,6 +28,14 @@ const navigationState = reactive({
 
 // 工作区需要接管 el-main 的剩余高度来承载内部滚动；只按精确路由名收口，避免表格、表单页受影响。
 const isWorkspaceRoute = computed(() => route.name === 'Workspace')
+const pageTemplate = computed(() => resolvePageTemplate(route.path))
+const shouldShowPageContext = computed(() => ![
+  'Home',
+  'Workspace',
+  'WorkspaceEmpty',
+  'ChangePassword',
+  'NotFound',
+].includes(String(route.name ?? '')))
 
 // MainLayout 只负责壳层编排：路由变化落标签，导航归属与焦点生命周期由 LifecycleNavigation 自己维护。
 watch(() => route.fullPath, () => tabsStore.openTab(route), { immediate: true })
@@ -68,7 +78,9 @@ function focusMainContent() {
           'layout-main--home': route.name === 'Home',
           'layout-main--workspace': isWorkspaceRoute,
         }"
+        :data-page-template="pageTemplate"
       >
+        <PageContextHeader v-if="shouldShowPageContext" />
         <!-- 只精确缓存 WorkspaceView：不要给 component 增加 fullPath key，也不要因主导航切换卸载
              router-view；否则切页会中断进行中的 SSE，并丢失对话或 VibeCoding 状态。 -->
         <router-view v-slot="{ Component }">

--- a/customer-admin-web/src/layouts/PageContextHeader.vue
+++ b/customer-admin-web/src/layouts/PageContextHeader.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useMenuStore } from '@/store/menu'
+import { findMenuTrail } from './navigationModel'
+import { resolvePagePresentation } from './pagePresentation'
+
+const route = useRoute()
+const menuStore = useMenuStore()
+
+const presentation = computed(() => resolvePagePresentation(route.path))
+const menuTitle = computed(() => {
+  const trail = findMenuTrail(menuStore.tree, route.fullPath, route.path)
+  return trail?.at(-1)
+})
+const title = computed(() => (
+  menuTitle.value
+  ?? (route.meta.title as string | undefined)
+  ?? presentation.value.title
+))
+</script>
+
+<template>
+  <header class="cw-page-context" aria-labelledby="cw-page-title">
+    <div class="cw-page-context__copy">
+      <span class="cw-page-context__eyebrow">{{ presentation.eyebrow }}</span>
+      <h1 id="cw-page-title">{{ title }}</h1>
+      <p>{{ presentation.description }}</p>
+    </div>
+    <div class="cw-page-context__scope" title="数据由后端租户隔离与权限校验共同约束">
+      <span aria-hidden="true" />
+      当前租户与权限范围
+    </div>
+  </header>
+</template>

--- a/customer-admin-web/src/layouts/TabsBar.vue
+++ b/customer-admin-web/src/layouts/TabsBar.vue
@@ -198,18 +198,18 @@ onBeforeUnmount(() => {
   position: relative;
   flex: 0 0 var(--cw-tabs-height);
   overflow: hidden;
-  background: var(--el-bg-color);
-  border-bottom: 1px solid var(--el-border-color-lighter);
+  border-bottom: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  background: var(--cw-paper, var(--el-bg-color));
 }
 
 .tabs-bar {
   height: var(--cw-tabs-height);
-  padding: 5px 14px 0;
-  background: var(--el-bg-color);
+  padding: 3px 12px 0;
+  background: var(--cw-paper, var(--el-bg-color));
 }
 
 .tabs-bar :deep(.el-tabs__header) {
-  height: 35px;
+  height: 34px;
   margin: 0;
   border-bottom: 0;
 }
@@ -217,23 +217,23 @@ onBeforeUnmount(() => {
 .tabs-bar :deep(.el-tabs__nav-wrap),
 .tabs-bar :deep(.el-tabs__nav-scroll),
 .tabs-bar :deep(.el-tabs__nav) {
-  height: 35px;
+  height: 34px;
 }
 
 .tabs-bar :deep(.el-tabs__nav) {
   border: 0;
-  gap: 4px;
+  gap: 2px;
 }
 
 .tabs-bar :deep(.el-tabs__item) {
-  height: 31px;
+  height: 34px;
   position: relative;
-  padding: 0 12px;
+  padding: 0 11px;
   border: 1px solid transparent;
-  border-radius: 8px 8px 0 0;
+  border-radius: var(--cw-radius-sm, 6px) var(--cw-radius-sm, 6px) 0 0;
   background: transparent;
-  color: var(--el-text-color-secondary);
-  line-height: 31px;
+  color: var(--cw-text-muted, var(--el-text-color-secondary));
+  line-height: 34px;
   font-size: 12px;
   transition: background-color 140ms ease, color 140ms ease;
 }
@@ -243,25 +243,25 @@ onBeforeUnmount(() => {
 }
 
 .tabs-bar :deep(.el-tabs__item:hover) {
-  background: var(--el-fill-color-light);
-  color: var(--el-text-color-primary);
+  background: var(--cw-canvas, var(--el-fill-color-light));
+  color: var(--cw-text, var(--el-text-color-primary));
 }
 
 .tabs-bar :deep(.el-tabs__item.is-active) {
-  border-color: var(--el-border-color-lighter);
-  border-bottom-color: var(--el-bg-color);
-  background: var(--el-bg-color);
-  color: var(--el-text-color-primary);
-  font-weight: 600;
+  border-color: var(--cw-line, var(--el-border-color-lighter));
+  border-bottom-color: var(--cw-paper, var(--el-bg-color));
+  background: var(--cw-paper, var(--el-bg-color));
+  color: var(--cw-cobalt, var(--el-color-primary));
+  font-weight: 650;
 }
 
 .tabs-bar :deep(.el-tabs__item.is-active::before) {
   content: '';
   height: 2px;
   position: absolute;
-  inset: -1px 8px auto;
+  inset: -1px 7px auto;
   border-radius: 0 0 2px 2px;
-  background: var(--theme-primary, var(--el-color-primary));
+  background: var(--cw-cobalt, var(--el-color-primary));
 }
 
 .tabs-bar :deep(.el-tabs__item .is-icon-close) {
@@ -292,10 +292,10 @@ onBeforeUnmount(() => {
   flex-direction: column;
   gap: 2px;
   padding: 5px;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 9px;
-  background: var(--el-bg-color-overlay);
-  box-shadow: 0 12px 30px rgb(15 23 42 / 16%);
+  border: 1px solid var(--cw-line, var(--el-border-color-lighter));
+  border-radius: var(--cw-radius-md, 8px);
+  background: var(--cw-paper, var(--el-bg-color-overlay));
+  box-shadow: var(--cw-shadow-sm, 0 12px 30px rgb(15 23 42 / 16%));
 }
 
 .tab-context-menu button {
@@ -303,9 +303,9 @@ onBeforeUnmount(() => {
   height: 32px;
   padding: 0 10px;
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--cw-radius-sm, 6px);
   background: transparent;
-  color: var(--el-text-color-regular);
+  color: var(--cw-text-muted, var(--el-text-color-regular));
   text-align: left;
   font-size: 12px;
   cursor: pointer;
@@ -313,13 +313,33 @@ onBeforeUnmount(() => {
 
 .tab-context-menu button:hover:not(:disabled),
 .tab-context-menu button:focus-visible:not(:disabled) {
-  background: var(--el-fill-color-light);
-  color: var(--el-text-color-primary);
+  background: color-mix(in srgb, var(--cw-cobalt, var(--el-color-primary)) 9%, var(--cw-paper, var(--el-bg-color)));
+  color: var(--cw-cobalt, var(--el-color-primary));
 }
 
 .tab-context-menu button:disabled {
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted, var(--el-text-color-placeholder));
+  opacity: 0.55;
   cursor: not-allowed;
+}
+
+@media (max-width: 760px) {
+  .tabs-bar {
+    padding-right: 4px;
+    padding-left: 4px;
+  }
+
+  .tabs-bar :deep(.el-tabs__nav) {
+    gap: 1px;
+  }
+
+  .tabs-bar :deep(.el-tabs__item) {
+    padding: 0 9px;
+  }
+
+  .tab-label {
+    max-width: 116px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/customer-admin-web/src/layouts/pagePresentation.test.ts
+++ b/customer-admin-web/src/layouts/pagePresentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { staticRouteComponents } from '@/router/component-map'
+import {
+  PAGE_PRESENTATIONS,
+  PAGE_TEMPLATE_BY_PATH,
+  resolvePagePresentation,
+  resolvePageTemplate,
+} from './pagePresentation'
+
+describe('pagePresentation', () => {
+  it('覆盖全部静态业务路由，避免新页面回退成无语境标题', () => {
+    expect(Object.keys(staticRouteComponents).every((path) => PAGE_PRESENTATIONS[path])).toBe(true)
+    expect(Object.keys(PAGE_PRESENTATIONS).sort()).toEqual([
+      ...Object.keys(staticRouteComponents),
+      '/sql/query',
+    ].sort())
+  })
+
+  it('SQL 报表按 path 复用展示语境，不依赖 defineKey', () => {
+    expect(resolvePagePresentation('/sql/query')).toMatchObject({
+      eyebrow: 'DATA EXECUTION',
+      title: 'SQL 查询',
+    })
+  })
+
+  it('全部业务页面明确归入三类内容母版', () => {
+    expect(Object.keys(PAGE_TEMPLATE_BY_PATH).sort()).toEqual(Object.keys(PAGE_PRESENTATIONS).sort())
+    expect(Object.values(PAGE_TEMPLATE_BY_PATH).filter((item) => item === 'list')).toHaveLength(21)
+    expect(Object.values(PAGE_TEMPLATE_BY_PATH).filter((item) => item === 'dashboard')).toHaveLength(11)
+    expect(Object.values(PAGE_TEMPLATE_BY_PATH).filter((item) => item === 'console')).toHaveLength(10)
+    expect(resolvePageTemplate('/aiconfig/model')).toBe('console')
+    expect(resolvePageTemplate('/home')).toBeUndefined()
+  })
+
+  it('未知动态页面安全回退，不暴露内部路径', () => {
+    expect(resolvePagePresentation('/future/custom')).toEqual({
+      eyebrow: 'CUSTOMER WORK',
+      title: '工作页面',
+      description: '在当前租户和权限范围内完成这项工作。',
+    })
+  })
+})

--- a/customer-admin-web/src/layouts/pagePresentation.ts
+++ b/customer-admin-web/src/layouts/pagePresentation.ts
@@ -1,0 +1,121 @@
+export interface PagePresentation {
+  eyebrow: string
+  title: string
+  description: string
+}
+
+export type PageTemplate = 'list' | 'dashboard' | 'console'
+
+/**
+ * 路由级页面文案只回答“这里负责什么”，不重复按钮或表格字段。
+ * 动态菜单仍以服务端下发的名称为准；这里提供稳定的视觉语境与未知路由兜底。
+ */
+export const PAGE_PRESENTATIONS: Readonly<Record<string, PagePresentation>> = {
+  '/system/user': { eyebrow: 'IDENTITY & ACCESS', title: '用户管理', description: '管理平台身份、角色归属、账号状态与最近活动。' },
+  '/system/role': { eyebrow: 'IDENTITY & ACCESS', title: '角色管理', description: '审查角色权限边界、数据范围及其影响成员。' },
+  '/system/log': { eyebrow: 'AUDIT EVIDENCE', title: '操作日志', description: '按主体、动作、对象和结果还原真实操作轨迹。' },
+  '/system/ai-audit': { eyebrow: 'AUDIT EVIDENCE', title: 'AI 审计', description: '串联输入、模型、工具、输出与业务结果的完整证据。' },
+  '/system/agent-call-stats': { eyebrow: 'RUNTIME EVIDENCE', title: '调用统计', description: '在调用量、成功率、延迟与成本之间建立可行动关联。' },
+  '/system/menu': { eyebrow: 'SYSTEM STRUCTURE', title: '菜单管理', description: '维护平台信息架构、访问入口与菜单发布状态。' },
+  '/system/devtools': { eyebrow: 'MY WORKBENCH', title: '开发者工具箱', description: '在本地完成常用编码、签名、时间与文本处理任务。' },
+  '/system/login-image': { eyebrow: 'BRAND SETTINGS', title: '登录页图片', description: '管理登录场景视觉资产及桌面、移动端裁切效果。' },
+  '/system/dict': { eyebrow: 'SYSTEM CONTRACTS', title: '字典管理', description: '维护跨功能复用的稳定枚举、排序与启停状态。' },
+  '/system/tenant': { eyebrow: 'TENANT OPERATIONS', title: '租户管理', description: '管理租户生命周期、套餐、成员配额与到期风险。' },
+  '/system/billing': { eyebrow: 'COST GOVERNANCE', title: '计费中心', description: '连接预算、实际消耗、趋势预测与成本归属。' },
+  '/system/config-version': { eyebrow: 'CHANGE GOVERNANCE', title: '配置版本', description: '在比较差异和影响范围后发布或回滚配置。' },
+  '/system/slo': { eyebrow: 'RELIABILITY GOVERNANCE', title: 'SLO 管理', description: '用服务目标和错误预算驱动可靠性决策。' },
+  '/aiconfig/model': { eyebrow: 'MODEL ASSETS', title: '模型管理', description: '管理模型资产、路由策略、能力验证与生产认证。' },
+  '/aiconfig/mcp': { eyebrow: 'CAPABILITY ASSETS', title: 'MCP 管理', description: '登记、测试并治理智能体可调用的 MCP 服务。' },
+  '/aiconfig/skill': { eyebrow: 'CAPABILITY ASSETS', title: 'Skill 管理', description: '沉淀可复用技能包，并明确版本、依赖与可见范围。' },
+  '/aiconfig/agent': { eyebrow: 'AGENT ASSETS', title: '智能体管理', description: '从能力装配到发布状态，管理可运行的智能体资产。' },
+  '/aiconfig/system-tool': { eyebrow: 'CAPABILITY ASSETS', title: '系统工具', description: '管理平台内置工具的参数、安全边界与启用范围。' },
+  '/aiconfig/knowledge-base': { eyebrow: 'KNOWLEDGE ASSETS', title: '知识库', description: '管理知识来源、同步进度与召回健康度。' },
+  '/aiconfig/scheduled-task': { eyebrow: 'AUTOMATION', title: '定时任务', description: '管理任务计划、下次运行、最近结果和失败责任。' },
+  '/aiconfig/agent-task': { eyebrow: 'AGENT RUNS', title: '智能体任务', description: '用任务状态、耗时和执行证据定位运行异常。' },
+  '/aiconfig/channel-robot': { eyebrow: 'CHANNEL DELIVERY', title: '渠道机器人', description: '连接渠道身份、智能体版本与投放健康度。' },
+  '/project': { eyebrow: 'DELIVERY PROJECTS', title: '项目管理', description: '组织项目目标、环境、成员与最近交付进展。' },
+  '/sql/datasource': { eyebrow: 'DATA ASSETS', title: '数据源', description: '管理连接可用性、授权范围与最近探测结果。' },
+  '/sql/define': { eyebrow: 'DATA CONTRACTS', title: 'SQL 定义', description: '以参数契约、权限范围与验证样例管理可复用查询。' },
+  '/sql/query': { eyebrow: 'DATA EXECUTION', title: 'SQL 查询', description: '按已批准契约输入参数，并保留执行边界和结果证据。' },
+  '/ops/eval': { eyebrow: 'QUALITY OPERATIONS', title: '评测中心', description: '从总体质量下钻到数据集、评测维度与失败样本。' },
+  '/ops/badcase': { eyebrow: 'QUALITY OPERATIONS', title: 'Badcase 管理', description: '将失败样本变成有负责人、有结论、有回归结果的闭环。' },
+  '/ops/semantic-cache': { eyebrow: 'RUNTIME OPERATIONS', title: '语义缓存', description: '判断缓存是否真正降低成本，同时守住答案时效。' },
+  '/ops/prompt-version': { eyebrow: 'QUALITY OPERATIONS', title: 'Prompt 版本', description: '比较运行时快照、全文差异与变更证据。' },
+  '/ops/csat': { eyebrow: 'EXPERIENCE OPERATIONS', title: '满意度分析', description: '按时间窗口和评价明细定位满意度波动。' },
+  '/ops/knowledge-gap': { eyebrow: 'KNOWLEDGE OPERATIONS', title: '知识缺口', description: '把未命中问题聚类为知识补充与验证任务。' },
+  '/ops/dead-letter': { eyebrow: 'RUNTIME OPERATIONS', title: '死信处理', description: '呈现失败原因、影响范围、重试条件与处理记录。' },
+  '/ops/business-outcome': { eyebrow: 'OUTCOME OPERATIONS', title: '业务结果', description: '聚焦自动解决代理、转人工、满意度与成本证据。' },
+  '/ticket/user-ticket': { eyebrow: 'SERVICE OPERATIONS', title: '客服工单', description: '集中处理工单状态、服务问题与完整沟通轨迹。' },
+  '/ticket/user-order': { eyebrow: 'SERVICE OPERATIONS', title: '用户订单', description: '按用户、订单状态与服务节点定位履约问题。' },
+  '/contentguard/sensitive-word': { eyebrow: 'CONTENT GOVERNANCE', title: '敏感词库', description: '按风险级别、适用范围与版本管理内容规则。' },
+  '/contentguard/rate-limit': { eyebrow: 'RUNTIME GOVERNANCE', title: '限流规则', description: '明确保护主体、阈值窗口与触发后的处置动作。' },
+  '/contentguard/hit-log': { eyebrow: 'CONTENT GOVERNANCE', title: '命中看板', description: '识别风险趋势，并下钻到归并后的命中证据。' },
+  '/contentguard/subject-quota': { eyebrow: 'CAPACITY GOVERNANCE', title: '主体配额', description: '连接配额消耗、耗尽预测与容量调整责任。' },
+  '/workbench/site': { eyebrow: 'MY WORKBENCH', title: '内网工作台', description: '集中访问已授权站点，并保留最近工作上下文。' },
+  '/workbench/sql-console': { eyebrow: 'MY WORKBENCH', title: 'SQL 客户端', description: '以键盘友好的库表树、编辑器和结果区诊断数据。' },
+}
+
+/**
+ * 五类页面母版中的三类业务内容页。首页、工作区与认证页由各自组件接管布局，
+ * 因此不在这里重复登记。显式映射让新增路由必须先决定信息层级，避免悄悄退回卡片堆叠。
+ */
+export const PAGE_TEMPLATE_BY_PATH: Readonly<Record<string, PageTemplate>> = {
+  '/system/user': 'list',
+  '/system/role': 'list',
+  '/system/log': 'list',
+  '/system/ai-audit': 'list',
+  '/system/login-image': 'list',
+  '/system/tenant': 'list',
+  '/aiconfig/mcp': 'list',
+  '/aiconfig/skill': 'list',
+  '/aiconfig/agent': 'list',
+  '/aiconfig/system-tool': 'list',
+  '/aiconfig/knowledge-base': 'list',
+  '/aiconfig/scheduled-task': 'list',
+  '/aiconfig/agent-task': 'list',
+  '/aiconfig/channel-robot': 'list',
+  '/contentguard/sensitive-word': 'list',
+  '/contentguard/rate-limit': 'list',
+  '/ticket/user-ticket': 'list',
+  '/ticket/user-order': 'list',
+  '/project': 'list',
+  '/sql/datasource': 'list',
+  '/workbench/site': 'list',
+
+  '/system/agent-call-stats': 'dashboard',
+  '/system/slo': 'dashboard',
+  '/ops/eval': 'dashboard',
+  '/ops/badcase': 'dashboard',
+  '/ops/semantic-cache': 'dashboard',
+  '/ops/prompt-version': 'dashboard',
+  '/ops/csat': 'dashboard',
+  '/ops/knowledge-gap': 'dashboard',
+  '/ops/dead-letter': 'dashboard',
+  '/ops/business-outcome': 'dashboard',
+  '/contentguard/hit-log': 'dashboard',
+
+  '/system/menu': 'console',
+  '/system/devtools': 'console',
+  '/system/dict': 'console',
+  '/system/billing': 'console',
+  '/system/config-version': 'console',
+  '/aiconfig/model': 'console',
+  '/contentguard/subject-quota': 'console',
+  '/sql/define': 'console',
+  '/sql/query': 'console',
+  '/workbench/sql-console': 'console',
+}
+
+const DEFAULT_PRESENTATION: PagePresentation = {
+  eyebrow: 'CUSTOMER WORK',
+  title: '工作页面',
+  description: '在当前租户和权限范围内完成这项工作。',
+}
+
+export function resolvePagePresentation(path: string): PagePresentation {
+  return PAGE_PRESENTATIONS[path] ?? DEFAULT_PRESENTATION
+}
+
+export function resolvePageTemplate(path: string): PageTemplate | undefined {
+  return PAGE_TEMPLATE_BY_PATH[path]
+}

--- a/customer-admin-web/src/main.ts
+++ b/customer-admin-web/src/main.ts
@@ -9,6 +9,7 @@ import { installPermissionDirective } from './directives/permission'
 import { installElementPlusIcons } from './plugins/icons'
 import './style.css'
 import './theme.css'
+import './page-templates.css'
 
 const app = createApp(App)
 

--- a/customer-admin-web/src/page-templates.css
+++ b/customer-admin-web/src/page-templates.css
@@ -1,0 +1,311 @@
+/*
+ * 路由级页面母版。这里只描述信息层级与响应式几何，颜色、组件基线留在 theme.css。
+ * data-page-template 由 MainLayout 根据显式路由映射产生，避免靠 DOM 猜测页面类型。
+ */
+
+.cw-page-context {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  max-width: 1600px;
+  margin: 0 auto 18px;
+  padding: 4px 2px 0;
+}
+
+.cw-page-context__copy {
+  min-width: 0;
+}
+
+.cw-page-context__eyebrow {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--cw-cobalt);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  line-height: 1;
+}
+
+.cw-page-context h1 {
+  margin: 0;
+  color: var(--cw-text);
+  font-size: clamp(22px, 2vw, 29px);
+  font-weight: 760;
+  letter-spacing: -0.025em;
+  line-height: 1.18;
+}
+
+.cw-page-context p {
+  max-width: 760px;
+  margin: 7px 0 0;
+  color: var(--cw-text-muted);
+  line-height: 1.55;
+}
+
+.cw-page-context__scope {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 11px;
+  color: var(--cw-text-muted);
+  border: 1px solid var(--cw-line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cw-paper) 88%, transparent);
+  font-size: 12px;
+}
+
+.cw-page-context__scope span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--cw-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--cw-success) 15%, transparent);
+}
+
+.layout-main:not(.layout-main--home):not(.layout-main--workspace) {
+  padding: 22px 24px 28px;
+  overflow: auto;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--cw-line) 25%, transparent) 1px, transparent 1px) 0 0 / 32px 32px,
+    linear-gradient(color-mix(in srgb, var(--cw-line) 25%, transparent) 1px, transparent 1px) 0 0 / 32px 32px,
+    var(--cw-canvas);
+}
+
+.layout-main:not(.layout-main--home):not(.layout-main--workspace) > :not(.cw-page-context) {
+  width: 100%;
+  max-width: 1600px;
+  margin-inline: auto;
+}
+
+.layout-main[data-page-template] > :not(.cw-page-context) {
+  min-width: 0;
+}
+
+/* 标准列表：一个稳定工作面承载筛选、数据与分页，不再叠加重阴影卡片。 */
+.layout-main[data-page-template='list'] > .page,
+.layout-main[data-page-template='list'] > .login-image-page {
+  display: grid;
+  gap: 14px;
+}
+
+.layout-main[data-page-template='list'] > .page > .el-card,
+.layout-main[data-page-template='list'] > .login-image-page > .el-card {
+  box-shadow: var(--cw-shadow-xs);
+}
+
+/* 运营看板：指标连续带与证据区共享同一视觉节奏，页面仍保留自己的业务布局。 */
+.layout-main[data-page-template='dashboard'] :is(.stats, .summary-row, .stat-row, .metric-grid) {
+  gap: 12px;
+}
+
+.layout-main[data-page-template='dashboard'] :is(.stat, .stat-card, .metric) {
+  position: relative;
+  overflow: hidden;
+  border-color: var(--cw-line);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.layout-main[data-page-template='dashboard'] :is(.stat, .stat-card, .metric)::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--cw-cobalt);
+  content: '';
+}
+
+.layout-main[data-page-template='dashboard'] :is(.stat-value, .metric strong) {
+  color: var(--cw-text);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.025em;
+}
+
+.layout-main[data-page-template='dashboard'] :is(.stat-label, .metric span) {
+  color: var(--cw-text-muted);
+}
+
+/* 主从与控制台：允许内部双栏接管高度，但始终限制在内容视口内。 */
+.layout-main[data-page-template='console'] > :not(.cw-page-context) {
+  min-height: min(640px, calc(100vh - 250px));
+}
+
+.layout-main[data-page-template='console'] > :is(.page, .modelops-page, .devtoolbox-page) {
+  min-width: 0;
+}
+
+.layout-main[data-page-template='console'] :is(.devtoolbox-sidebar, .type-panel, .item-panel, .sidebar, .main) {
+  border-color: var(--cw-line);
+  background: var(--cw-paper);
+}
+
+.layout-main[data-page-template='console'] :is(.devtoolbox-item, .db-node, .table-node) {
+  transition: color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.layout-main[data-page-template='console'] :is(.devtoolbox-item.active, .db-node:hover, .table-node:hover) {
+  background: color-mix(in srgb, var(--cw-cobalt) 9%, var(--cw-paper));
+}
+
+.layout-main[data-page-template='console'] :is(.devtoolbox-item.active, .table-node:hover) {
+  color: var(--cw-cobalt);
+}
+
+.layout-main[data-page-template='console'] :is(.result-meta, .tip, .hint, .form-tip, .form-hint) {
+  color: var(--cw-text-muted);
+}
+
+.layout-main[data-page-template='console'] :is(.sql-input, .sql-textarea) textarea {
+  tab-size: 2;
+  color: var(--cw-text);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--cw-cobalt) 8%, transparent) 1px, transparent 1px) 0 0 / 28px 100%,
+    var(--cw-paper);
+  line-height: 1.65;
+}
+
+.layout-main[data-page-template='console'] .param-form {
+  padding: 14px 14px 2px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: color-mix(in srgb, var(--cw-paper) 94%, var(--cw-cobalt));
+}
+
+/* 兼容现有静态路由的 toolbar 命名；限制在路由内容，避免污染抽屉内部工具栏。 */
+.layout-main[data-page-template] > :not(.cw-page-context) .toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 12px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: color-mix(in srgb, var(--cw-paper) 94%, transparent);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.layout-main[data-page-template] > :not(.cw-page-context) .toolbar :is(.el-input, .el-select, .el-date-editor) {
+  max-width: 100%;
+}
+
+.layout-main[data-page-template] .el-table {
+  width: 100%;
+  max-width: 100%;
+}
+
+@media (max-width: 1023px) {
+  .layout-main:not(.layout-main--home):not(.layout-main--workspace) {
+    padding: 18px 16px 24px;
+  }
+
+  .cw-page-context {
+    align-items: flex-start;
+  }
+
+  .layout-main[data-page-template='console'] :is(.devtoolbox-page, .layout, .console-body) {
+    gap: 12px;
+  }
+}
+
+@media (max-width: 767px) {
+  .layout-main:not(.layout-main--home):not(.layout-main--workspace) {
+    padding: 16px 12px 20px;
+    background: var(--cw-canvas);
+  }
+
+  .cw-page-context {
+    display: block;
+    margin-bottom: 14px;
+  }
+
+  .cw-page-context p {
+    font-size: 13px;
+  }
+
+  .cw-page-context__scope {
+    margin-top: 12px;
+  }
+
+  .layout-main[data-page-template] > :not(.cw-page-context) .toolbar {
+    align-items: stretch;
+    padding: 10px;
+  }
+
+  .layout-main[data-page-template] > :not(.cw-page-context) .toolbar > * {
+    flex: 1 1 100%;
+    width: 100% !important;
+    margin-left: 0 !important;
+  }
+
+  .layout-main[data-page-template] > :not(.cw-page-context) .toolbar > .el-button + .el-button {
+    margin-left: 0;
+  }
+
+  .layout-main[data-page-template='dashboard'] :is(.stats, .summary-row, .stat-row, .metric-grid) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .layout-main[data-page-template='console'] > :not(.cw-page-context) {
+    min-height: 0;
+  }
+
+  .layout-main[data-page-template='console'] :is(.devtoolbox-page, .layout, .console-body) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    height: auto;
+    min-height: 0;
+  }
+
+  .layout-main[data-page-template='console'] :is(.devtoolbox-sidebar, .type-panel, .sidebar) {
+    box-sizing: border-box;
+    width: 100%;
+    height: auto;
+    max-height: 320px;
+    border-right: 0;
+    border-bottom: 1px solid var(--cw-line);
+  }
+
+  .layout-main[data-page-template='console'] :is(.devtoolbox-panel, .item-panel, .main) {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .layout-main[data-page-template='console'] .snapshot-pair {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .layout-main[data-page-template='console'] .diff-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .layout-main[data-page-template='console'] .diff-row {
+    min-width: 680px;
+  }
+
+  .layout-main[data-page-template='console'] .param-form {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    padding: 12px;
+  }
+
+  .layout-main[data-page-template='console'] .param-form .el-form-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    margin-right: 0;
+  }
+
+  .layout-main[data-page-template='console'] .param-form :is(.el-input, .el-select, .el-date-editor, .el-input-number) {
+    width: 100% !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .layout-main[data-page-template='dashboard'] :is(.stats, .summary-row, .stat-row, .metric-grid) {
+    grid-template-columns: 1fr;
+  }
+}

--- a/customer-admin-web/src/router/index.ts
+++ b/customer-admin-web/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/store/auth'
 import { useMenuStore } from '@/store/menu'
+import { useTabsStore } from '@/store/tabs'
 // WorkspaceView 特意同步导入（其余路由仍懒加载）：MainLayout 的 <keep-alive :include="['WorkspaceView']">
 // 按组件 name 字符串匹配，而懒加载 `() => import()` 交给 router-view 的是异步组件包装，KeepAlive 取不到
 // 里面真实组件的 name，include 匹配落空、缓存失效——对话/VibeCoding 面板切菜单再回来就被销毁重建、
@@ -86,8 +87,13 @@ router.beforeEach(async (to) => {
   }
   // 待审核/已拒绝账号即使手工输入已知地址，也只能停留在首页。真正的数据权限仍由后端
   // UserRoleResolver + 接口权限校验兜底；这里负责把前端可见范围收敛到“首页 + 品牌 Logo”。
-  if (!auth.isApproved && to.name !== 'Home') {
-    return { name: 'Home' }
+  if (!auth.isApproved) {
+    if (to.name !== 'Home') {
+      return { name: 'Home' }
+    }
+    // Home 只渲染本地准入状态；未审核账号不得继续落入菜单/权限 bootstrap，
+    // 否则即使数据接口受后端保护，也会泄露完整业务导航与功能结构。
+    return true
   }
 
   const menuStore = useMenuStore()
@@ -102,6 +108,7 @@ router.beforeEach(async (to) => {
       console.error('menu bootstrap failed, redirect to login', e)
       auth.clear()
       menuStore.reset()
+      useTabsStore().reset()
       return { name: 'Login', query: { redirect: to.fullPath } }
     }
     // 动态路由刚注册完，重新触发一次导航解析，命中新加入的路由记录。

--- a/customer-admin-web/src/store/menu.test.ts
+++ b/customer-admin-web/src/store/menu.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { MenuNode } from '@/types/api'
+
+const mocks = vi.hoisted(() => ({
+  addRoute: vi.fn(),
+  fetchMenuRoutes: vi.fn(),
+  fetchMenuVersion: vi.fn(),
+  loadPermissions: vi.fn(),
+}))
+
+vi.mock('@/router', () => ({
+  default: { addRoute: mocks.addRoute },
+}))
+
+vi.mock('@/api/menu', () => ({
+  fetchMenuRoutes: mocks.fetchMenuRoutes,
+  fetchMenuVersion: mocks.fetchMenuVersion,
+}))
+
+vi.mock('@/store/auth', () => ({
+  useAuthStore: () => ({ loadPermissions: mocks.loadPermissions }),
+}))
+
+import { useMenuStore } from './menu'
+
+function menuNode(id: number, path: string, children: MenuNode[] = []): MenuNode {
+  return {
+    id,
+    name: `菜单${id}`,
+    path,
+    icon: null,
+    iconType: null,
+    permCode: null,
+    sort: id,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children,
+  }
+}
+
+describe('menu store 动态路由生命周期', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('刷新时注销旧路由，并按名称和路径去重注册新投影', async () => {
+    const disposers: Array<ReturnType<typeof vi.fn>> = []
+    mocks.addRoute.mockImplementation(() => {
+      const dispose = vi.fn()
+      disposers.push(dispose)
+      return dispose
+    })
+    mocks.fetchMenuRoutes
+      .mockResolvedValueOnce([
+        menuNode(1, '/system/user'),
+        menuNode(2, '/system/user'),
+        menuNode(1, '/system/role'),
+      ])
+      .mockResolvedValueOnce([menuNode(3, '/system/role')])
+    mocks.fetchMenuVersion.mockResolvedValueOnce(1).mockResolvedValueOnce(2)
+
+    const store = useMenuStore()
+    await expect(store.refreshMenu()).resolves.toBe(true)
+
+    expect(mocks.addRoute).toHaveBeenCalledTimes(1)
+    expect(mocks.addRoute).toHaveBeenLastCalledWith('Layout', expect.objectContaining({
+      path: 'system/user',
+      name: 'menu-1',
+    }))
+
+    await expect(store.refreshMenu()).resolves.toBe(true)
+
+    expect(disposers[0]).toHaveBeenCalledOnce()
+    expect(mocks.addRoute).toHaveBeenCalledTimes(2)
+    expect(mocks.addRoute).toHaveBeenLastCalledWith('Layout', expect.objectContaining({
+      path: 'system/role',
+      name: 'menu-3',
+    }))
+
+    store.reset()
+    expect(disposers[1]).toHaveBeenCalledOnce()
+    expect(store.routeDisposers).toEqual([])
+  })
+
+  it('reset 后忽略晚到的旧请求，不能复活上一会话路由', async () => {
+    let resolveRoutes!: (nodes: MenuNode[]) => void
+    mocks.fetchMenuRoutes.mockReturnValue(new Promise<MenuNode[]>((resolve) => {
+      resolveRoutes = resolve
+    }))
+    mocks.fetchMenuVersion.mockResolvedValue(1)
+    mocks.addRoute.mockReturnValue(vi.fn())
+
+    const store = useMenuStore()
+    const refreshing = store.refreshMenu()
+    store.reset()
+    resolveRoutes([menuNode(1, '/system/user')])
+
+    await expect(refreshing).resolves.toBe(false)
+    expect(mocks.addRoute).not.toHaveBeenCalled()
+    expect(store.tree).toEqual([])
+    expect(store.routesRegistered).toBe(false)
+  })
+
+  it('本轮部分注册失败时回收已添加路由并保持 fail-closed', async () => {
+    const firstDisposer = vi.fn()
+    mocks.addRoute
+      .mockReturnValueOnce(firstDisposer)
+      .mockImplementationOnce(() => {
+        throw new Error('route registration failed')
+      })
+    mocks.fetchMenuRoutes.mockResolvedValue([
+      menuNode(1, '/system/user'),
+      menuNode(2, '/system/role'),
+    ])
+    mocks.fetchMenuVersion.mockResolvedValue(1)
+
+    const store = useMenuStore()
+    await expect(store.refreshMenu()).rejects.toThrow('route registration failed')
+
+    expect(firstDisposer).toHaveBeenCalledOnce()
+    expect(store.tree).toEqual([])
+    expect(store.version).toBe(-1)
+    expect(store.routesRegistered).toBe(false)
+    expect(store.routeDisposers).toEqual([])
+  })
+})

--- a/customer-admin-web/src/store/menu.ts
+++ b/customer-admin-web/src/store/menu.ts
@@ -11,6 +11,9 @@ interface MenuState {
   tree: MenuNode[]
   version: number
   routesRegistered: boolean
+  routeDisposers: Array<() => void>
+  routeGeneration: number
+  refreshRequestId: number
   pollTimer: ReturnType<typeof setInterval> | null
   collapsed: boolean
 }
@@ -20,6 +23,9 @@ export const useMenuStore = defineStore('menu', {
     tree: [],
     version: -1,
     routesRegistered: false,
+    routeDisposers: [],
+    routeGeneration: 0,
+    refreshRequestId: 0,
     pollTimer: null,
     collapsed: false,
   }),
@@ -27,43 +33,94 @@ export const useMenuStore = defineStore('menu', {
     /** 登录后首次进入：拉权限点 + 菜单树 + 注册动态路由 + 起版本号轮询。 */
     async bootstrap() {
       const auth = useAuthStore()
+      const generation = this.routeGeneration
       await auth.loadPermissions()
-      await this.refreshMenu()
+      if (generation !== this.routeGeneration) {
+        return
+      }
+      const refreshed = await this.refreshMenu()
+      if (!refreshed || generation !== this.routeGeneration) {
+        return
+      }
       this.routesRegistered = true
       this.startPolling()
     },
     /** 拉取最新菜单树并（重新）注册动态路由；智能体 CRUD/启停操作后主动调用，≤1s 内生效。 */
     async refreshMenu() {
-      this.tree = await fetchMenuRoutes()
-      this.registerRoutes(this.tree)
-      this.version = await fetchMenuVersion()
+      const generation = this.routeGeneration
+      const requestId = ++this.refreshRequestId
+      const [nextTree, nextVersion] = await Promise.all([fetchMenuRoutes(), fetchMenuVersion()])
+      // reset 或更新的 refresh 已发生时，晚到的旧请求不得把上一账号/旧版本路由重新注册回来。
+      if (generation !== this.routeGeneration || requestId !== this.refreshRequestId) {
+        return false
+      }
+
+      this.unregisterRoutes()
+      this.tree = nextTree
+      try {
+        this.registerRoutes(nextTree)
+        this.version = nextVersion
+        return true
+      } catch (error) {
+        // 路由投影必须整体成功；部分注册失败时回收本轮已注册项，避免留下不可见的权限入口。
+        this.unregisterRoutes()
+        this.tree = []
+        this.version = -1
+        this.routesRegistered = false
+        throw error
+      }
     },
     registerRoutes(nodes: MenuNode[]) {
-      for (const node of nodes) {
-        if (node.children && node.children.length > 0) {
-          this.registerRoutes(node.children)
-          continue
+      const seenNames = new Set<string>()
+      const seenPaths = new Set<string>()
+      const visit = (items: MenuNode[]) => {
+        for (const node of items) {
+          if (node.children && node.children.length > 0) {
+            visit(node.children)
+            continue
+          }
+          if (node.dynamic || !node.path) {
+            continue // 动态智能体节点复用 router/index.ts 里已注册的通配路由 workspace/:agentCode
+          }
+          const loader = staticRouteComponents[node.path]
+          if (!loader) {
+            continue
+          }
+          const routeName = `menu-${node.id}`
+          const routePath = node.path.replace(/^\//, '')
+          if (seenNames.has(routeName) || seenPaths.has(routePath)) {
+            continue
+          }
+          seenNames.add(routeName)
+          seenPaths.add(routePath)
+          const disposeRoute = router.addRoute('Layout', {
+            path: routePath,
+            name: routeName,
+            component: loader,
+            meta: { title: node.name },
+          })
+          this.routeDisposers.push(disposeRoute)
         }
-        if (node.dynamic || !node.path) {
-          continue // 动态智能体节点复用 router/index.ts 里已注册的通配路由 workspace/:agentCode
-        }
-        const loader = staticRouteComponents[node.path]
-        if (!loader) {
-          continue
-        }
-        router.addRoute('Layout', {
-          path: node.path.replace(/^\//, ''),
-          name: `menu-${node.id}`,
-          component: loader,
-          meta: { title: node.name },
-        })
       }
+      visit(nodes)
+    },
+    /** 仅注销本 store 动态注册的菜单路由，固定 Home/Workspace/SqlQuery 路由不在此生命周期内。 */
+    unregisterRoutes() {
+      for (let index = this.routeDisposers.length - 1; index >= 0; index -= 1) {
+        this.routeDisposers[index]()
+      }
+      this.routeDisposers = []
     },
     startPolling() {
       this.stopPolling()
       this.pollTimer = setInterval(async () => {
+        const generation = this.routeGeneration
         try {
           const latest = await fetchMenuVersion()
+          // stopPolling 无法取消已经发出的请求；会话 reset 后，旧轮询不能再触发一次 refresh。
+          if (generation !== this.routeGeneration || !this.routesRegistered) {
+            return
+          }
           if (latest !== this.version) {
             await this.refreshMenu()
           }
@@ -79,6 +136,10 @@ export const useMenuStore = defineStore('menu', {
       }
     },
     reset() {
+      // 先使所有在途 refresh 失效，再回收已注册路由，防止旧响应晚到后复活上一账号入口。
+      this.routeGeneration += 1
+      this.refreshRequestId += 1
+      this.unregisterRoutes()
       this.tree = []
       this.version = -1
       this.routesRegistered = false

--- a/customer-admin-web/src/store/theme.test.ts
+++ b/customer-admin-web/src/store/theme.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useThemeStore } from './theme'
+import { colorContrastRatio } from '@/utils/themeContrast'
+
+describe('theme store', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('auto 模式随系统主题变化，并立即刷新暗色语义变量', () => {
+    let systemDark = false
+    let changeListener: ((event: MediaQueryListEvent) => void) | undefined
+    const values = new Map<string, string>()
+    const classes = new Set<string>()
+    const storage = new Map<string, string>()
+    const mediaQuery = {
+      get matches() {
+        return systemDark
+      },
+      addEventListener: vi.fn((_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        changeListener = listener
+      }),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList
+    const root = {
+      classList: {
+        toggle: (name: string, enabled: boolean) => (enabled ? classes.add(name) : classes.delete(name)),
+      },
+      style: {
+        setProperty: (name: string, value: string) => values.set(name, value),
+      },
+    }
+    const localStorageStub = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    }
+
+    vi.stubGlobal('document', {
+      documentElement: root,
+      createElement: () => ({ textContent: '', disabled: false }),
+      head: { append: vi.fn() },
+    })
+    vi.stubGlobal('localStorage', localStorageStub)
+    vi.stubGlobal('window', { matchMedia: vi.fn(() => mediaQuery) })
+    setActivePinia(createPinia())
+
+    const theme = useThemeStore()
+    theme.setMode('auto')
+
+    expect(theme.isDark).toBe(false)
+    expect(classes.has('dark')).toBe(false)
+    expect(storage.get('customer-admin-theme-mode')).toBe('auto')
+
+    systemDark = true
+    changeListener?.({ matches: true } as MediaQueryListEvent)
+
+    expect(theme.systemDark).toBe(true)
+    expect(theme.isDark).toBe(true)
+    expect(classes.has('dark')).toBe(true)
+    expect(values.get('--theme-page-bg')).not.toBe('')
+    expect(colorContrastRatio(values.get('--el-color-primary') ?? '', '#101a2b')).toBeGreaterThanOrEqual(4.5)
+    expect(values.get('--cw-focus-ring')).toBe(values.get('--el-color-primary'))
+
+    theme.disposeSystemThemeListener()
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', changeListener)
+  })
+
+  it('重建 Pinia 后每个主题实例都监听系统变化', () => {
+    let systemDark = false
+    const listeners: Array<(event: MediaQueryListEvent) => void> = []
+    const mediaQuery = {
+      get matches() {
+        return systemDark
+      },
+      addEventListener: vi.fn((_type: string, listener: (event: MediaQueryListEvent) => void) => listeners.push(listener)),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList
+    const root = {
+      classList: { toggle: vi.fn() },
+      style: { setProperty: vi.fn() },
+    }
+    vi.stubGlobal('document', {
+      documentElement: root,
+      createElement: () => ({ textContent: '', disabled: false }),
+      head: { append: vi.fn() },
+    })
+    vi.stubGlobal('localStorage', { getItem: vi.fn(() => null), setItem: vi.fn() })
+    vi.stubGlobal('window', { matchMedia: vi.fn(() => mediaQuery) })
+
+    setActivePinia(createPinia())
+    const first = useThemeStore()
+    first.setMode('auto')
+    setActivePinia(createPinia())
+    const second = useThemeStore()
+    second.setMode('auto')
+
+    expect(listeners).toHaveLength(2)
+    systemDark = true
+    listeners.forEach((listener) => listener({ matches: true } as MediaQueryListEvent))
+    expect(first.systemDark).toBe(true)
+    expect(second.systemDark).toBe(true)
+
+    first.disposeSystemThemeListener()
+    second.disposeSystemThemeListener()
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledTimes(2)
+  })
+})

--- a/customer-admin-web/src/store/theme.ts
+++ b/customer-admin-web/src/store/theme.ts
@@ -1,12 +1,13 @@
 import { defineStore } from 'pinia'
 import { syncHljsTheme } from '@/utils/hljsTheme'
+import { createSolidColorPalette, ensureColorContrast } from '@/utils/themeContrast'
 
 const COLOR_STORAGE_KEY = 'customer-admin-theme-color'
 const MODE_STORAGE_KEY = 'customer-admin-theme-mode'
 
 /** 预设主题色盘。 */
 export const PRESET_COLORS = [
-  '#409eff', // 默认蓝
+  '#3e63dd', // 钴蓝
   '#14b8a6', // 青绿
   '#8b5cf6', // 紫色
   '#f59e0b', // 琥珀
@@ -21,6 +22,7 @@ export type ThemeMode = 'light' | 'dark' | 'auto'
 interface ThemeState {
   primaryColor: string
   mode: ThemeMode
+  systemDark: boolean
 }
 
 function getInitialColor(): string {
@@ -34,19 +36,29 @@ function getInitialMode(): ThemeMode {
   return saved === 'dark' || saved === 'auto' ? saved : 'light'
 }
 
-// auto 模式下监听系统明暗变化，只注册一次
-let systemListenerInstalled = false
+function getInitialSystemDark(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+interface SystemThemeRegistration {
+  mediaQuery: MediaQueryList
+  listener: (event: MediaQueryListEvent) => void
+}
+
+// 监听器按 Pinia store 实例隔离，避免测试、HMR 或微前端重挂载时仍更新已废弃的实例。
+const systemThemeRegistrations = new WeakMap<object, SystemThemeRegistration>()
 
 export const useThemeStore = defineStore('theme', {
   state: (): ThemeState => ({
     primaryColor: getInitialColor(),
     mode: getInitialMode(),
+    systemDark: getInitialSystemDark(),
   }),
   getters: {
     /** 当前是否处于暗色（mode=auto 时跟随系统）。 */
     isDark(state): boolean {
       if (state.mode === 'auto') {
-        return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+        return state.systemDark
       }
       return state.mode === 'dark'
     },
@@ -79,36 +91,62 @@ export const useThemeStore = defineStore('theme', {
      */
     apply() {
       if (typeof document === 'undefined') return
+      const systemTheme = typeof window !== 'undefined'
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : undefined
+      if (systemTheme) {
+        this.systemDark = systemTheme.matches
+      }
       const dark = this.isDark
       const root = document.documentElement
       root.classList.toggle('dark', dark)
 
+      // 品牌色可很明亮，但链接、Tabs 与焦点环是工作面上的前景色，必须先校准到 AA。
+      const surfaceColor = dark ? '#101a2b' : '#ffffff'
+      const solidPalette = createSolidColorPalette(this.primaryColor)
+      const accessiblePrimary = ensureColorContrast(solidPalette.base, surfaceColor)
+
       const towardBg = (hex: string, percent: number) => (dark ? this.darken(hex, percent) : this.lighten(hex, percent))
       const awayFromBg = (hex: string, percent: number) => (dark ? this.lighten(hex, percent) : this.darken(hex, percent))
 
-      root.style.setProperty('--theme-primary', this.primaryColor)
-      root.style.setProperty('--theme-primary-light', towardBg(this.primaryColor, 30))
-      root.style.setProperty('--theme-primary-lighter', towardBg(this.primaryColor, 45))
-      root.style.setProperty('--theme-page-bg', towardBg(this.primaryColor, dark ? 88 : 92))
+      root.style.setProperty('--theme-primary-source', solidPalette.base)
+      root.style.setProperty('--theme-primary', accessiblePrimary)
+      root.style.setProperty('--theme-primary-solid', solidPalette.base)
+      root.style.setProperty('--theme-primary-solid-hover', solidPalette.hover)
+      root.style.setProperty('--theme-primary-solid-active', solidPalette.active)
+      root.style.setProperty('--cw-on-primary', solidPalette.onColor)
+      root.style.setProperty('--cw-focus-ring', accessiblePrimary)
+      root.style.setProperty('--theme-primary-light', towardBg(accessiblePrimary, 30))
+      root.style.setProperty('--theme-primary-lighter', towardBg(accessiblePrimary, 45))
+      root.style.setProperty('--theme-page-bg', towardBg(solidPalette.base, dark ? 88 : 92))
       // 同步 Element Plus 主色变量，让按钮、tabs、link 等组件自动跟随主题
-      root.style.setProperty('--el-color-primary', this.primaryColor)
-      root.style.setProperty('--el-color-primary-light-3', towardBg(this.primaryColor, 10))
-      root.style.setProperty('--el-color-primary-light-5', towardBg(this.primaryColor, 25))
-      root.style.setProperty('--el-color-primary-light-7', towardBg(this.primaryColor, 40))
-      root.style.setProperty('--el-color-primary-light-8', towardBg(this.primaryColor, 50))
-      root.style.setProperty('--el-color-primary-light-9', towardBg(this.primaryColor, 58))
-      root.style.setProperty('--el-color-primary-dark-2', awayFromBg(this.primaryColor, 10))
+      root.style.setProperty('--el-color-primary', accessiblePrimary)
+      root.style.setProperty('--el-color-primary-light-3', towardBg(accessiblePrimary, 10))
+      root.style.setProperty('--el-color-primary-light-5', towardBg(accessiblePrimary, 25))
+      root.style.setProperty('--el-color-primary-light-7', towardBg(accessiblePrimary, 40))
+      root.style.setProperty('--el-color-primary-light-8', towardBg(accessiblePrimary, 50))
+      root.style.setProperty('--el-color-primary-light-9', towardBg(accessiblePrimary, 58))
+      root.style.setProperty('--el-color-primary-dark-2', awayFromBg(accessiblePrimary, 10))
 
       syncHljsTheme(dark)
 
-      if (!systemListenerInstalled && typeof window !== 'undefined') {
-        systemListenerInstalled = true
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if (systemTheme && !systemThemeRegistrations.has(this)) {
+        const listener = (event: MediaQueryListEvent) => {
+          this.systemDark = event.matches
           if (this.mode === 'auto') {
             this.apply()
           }
-        })
+        }
+        systemTheme.addEventListener('change', listener)
+        systemThemeRegistrations.set(this, { mediaQuery: systemTheme, listener })
       }
+    },
+    /** 释放当前挂载实例的系统主题监听器。 */
+    disposeSystemThemeListener() {
+      const registration = systemThemeRegistrations.get(this)
+      if (!registration) return
+      registration.mediaQuery.removeEventListener('change', registration.listener)
+      systemThemeRegistrations.delete(this)
     },
     /**
      * 简易颜色提亮：在 16 进制色上按百分比混入白色。

--- a/customer-admin-web/src/styles/workspace-conversation.css
+++ b/customer-admin-web/src/styles/workspace-conversation.css
@@ -195,13 +195,21 @@
 
 /* link“继续”靠透明背景显示主题文字，不能与实心主按钮共用背景覆盖。 */
 .workspace-conversation .input-bar .el-button--primary:not(.is-link) {
-  background-color: var(--theme-primary, var(--el-color-primary));
-  border-color: var(--theme-primary, var(--el-color-primary));
+  color: var(--cw-on-primary, #fff);
+  background-color: var(--theme-primary-solid, var(--el-color-primary));
+  border-color: var(--theme-primary-solid, var(--el-color-primary));
 }
 
 .workspace-conversation .input-bar .el-button--primary:not(.is-link):hover {
-  background-color: var(--theme-primary-light, #79bbff);
-  border-color: var(--theme-primary-light, #79bbff);
+  color: var(--cw-on-primary, #fff);
+  background-color: var(--theme-primary-solid-hover, var(--theme-primary-solid));
+  border-color: var(--theme-primary-solid-hover, var(--theme-primary-solid));
+}
+
+.workspace-conversation .input-bar .el-button--primary:not(.is-link):active {
+  color: var(--cw-on-primary, #fff);
+  background-color: var(--theme-primary-solid-active, var(--theme-primary-solid));
+  border-color: var(--theme-primary-solid-active, var(--theme-primary-solid));
 }
 
 .workspace-conversation .history-column {

--- a/customer-admin-web/src/theme.css
+++ b/customer-admin-web/src/theme.css
@@ -1,52 +1,562 @@
 /*
- * 全站视觉 token（方案阶段 B-1）。
- * 原则：只走运行时 CSS 变量覆盖，与 store/theme.ts 的换肤/明暗机制共存；
- * 所有视觉定制收敛在本文件，可整体回滚。禁止改用 SCSS 编译期定制（会干掉运行时换肤）。
+ * Customer Work 全站视觉语言。
+ * 设计锚点：深墨生命周期轨道、安静的数据工作面、清晰的 Agent 证据轨迹。
+ * 只使用运行时 CSS 变量，保留 store/theme.ts 的换肤与明暗能力。
  */
 
 :root {
-  --cw-nav-rail-width: 72px;
-  --cw-context-nav-width: 180px;
+  color-scheme: light;
+  --cw-nav-rail-width: 64px;
+  --cw-context-nav-width: 208px;
   --cw-shell-expanded-width: calc(var(--cw-nav-rail-width) + var(--cw-context-nav-width));
-  --cw-topbar-height: 64px;
-  --cw-tabs-height: 40px;
-  --cw-footer-height: 36px;
-  --cw-focus-ring: var(--theme-primary, var(--el-color-primary));
-  --cw-brand-ink: #0b1728;
-  --cw-brand-ink-hover: #15263c;
-  --cw-brand-logo-start: #5a78ff;
-  --cw-brand-logo-end: #3c5ee8;
-  --cw-brand-signal: #6f8aff;
-  /* 全局圆角从 4px 提到 6px，弹窗更圆润 */
-  --el-border-radius-base: 6px;
-  --el-dialog-border-radius: 10px;
-  /* 卡片投影：比 EP 默认更轻，减少大面积卡片的视觉噪音 */
-  --cw-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --cw-topbar-height: 56px;
+  --cw-tabs-height: 38px;
+  --cw-footer-height: 32px;
+
+  --cw-ink: #0b1630;
+  --cw-ink-elevated: #152441;
+  --cw-canvas: #f4f6fa;
+  --cw-paper: #ffffff;
+  --cw-cobalt: #3e63dd;
+  --cw-cobalt-solid: #3e63dd;
+  --cw-amber: #925500;
+  --cw-amber-solid: #d99217;
+  --cw-success: #16856a;
+  --cw-danger: #c2414b;
+  --cw-info: #677189;
+  --cw-success-solid: #16856a;
+  --cw-success-solid-hover: #147b62;
+  --cw-success-solid-active: #127159;
+  --cw-danger-solid: #c2414b;
+  --cw-danger-solid-hover: #b23c45;
+  --cw-danger-solid-active: #a63840;
+  --cw-info-solid: #5f6b82;
+  --cw-info-solid-hover: #576276;
+  --cw-info-solid-active: #515b6f;
+  --cw-warning-solid-hover: #e7a52c;
+  --cw-warning-solid-active: #bc7c0f;
+  --cw-on-success: #ffffff;
+  --cw-on-warning: #1e1608;
+  --cw-on-danger: #ffffff;
+  --cw-on-info: #ffffff;
+  --cw-text: #172033;
+  --cw-text-muted: #677189;
+  --cw-line: #dce1ea;
+  --cw-line-strong: #c9d0dc;
+  --cw-focus-ring: #3e63dd;
+  --theme-primary-solid: #3e63dd;
+  --theme-primary-solid-hover: #395bcb;
+  --theme-primary-solid-active: #3555be;
+  --cw-on-primary: #ffffff;
+
+  /* 兼容既有壳层变量。 */
+  --cw-brand-ink: var(--cw-ink);
+  --cw-brand-ink-hover: var(--cw-ink-elevated);
+  --cw-brand-logo-start: #6681ef;
+  --cw-brand-logo-end: var(--cw-cobalt-solid);
+  --cw-brand-signal: #8ba0ef;
+
+  --cw-shadow-xs: 0 1px 2px rgb(15 23 42 / 5%);
+  --cw-shadow-sm: 0 8px 24px rgb(15 23 42 / 7%);
+  --cw-shadow-lg: 0 24px 72px rgb(15 23 42 / 14%);
+  --cw-radius-sm: 6px;
+  --cw-radius-md: 10px;
+  --cw-radius-lg: 16px;
+
+  --el-bg-color-page: var(--cw-canvas);
+  --el-border-color: var(--cw-line);
+  --el-border-color-light: #e4e8ef;
+  --el-border-color-lighter: #edf0f5;
+  --el-fill-color-light: #f3f5f8;
+  --el-fill-color-lighter: #f7f8fa;
+  --el-fill-color-extra-light: #fafbfc;
+  --el-text-color-primary: var(--cw-text);
+  --el-text-color-regular: #465066;
+  --el-text-color-secondary: var(--cw-text-muted);
+  --el-color-success: var(--cw-success);
+  --el-color-warning: var(--cw-amber);
+  --el-color-danger: var(--cw-danger);
+  --el-color-info: var(--cw-info);
+  --el-border-radius-base: var(--cw-radius-sm);
+  --el-border-radius-small: 5px;
+  --el-dialog-border-radius: var(--cw-radius-md);
 }
 
 html.dark {
-  --cw-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.35);
+  color-scheme: dark;
+  --cw-canvas: #09111f;
+  --cw-paper: #101a2b;
+  /* 暗色工作面上的语义文字色需达到 WCAG AA；实心组件色由 *-solid 独立承载。 */
+  --cw-cobalt: #8ea6ff;
+  --cw-amber: #f3bb63;
+  --cw-success: #62d6b7;
+  --cw-danger: #ff929c;
+  --cw-info: #9da9bd;
+  --cw-focus-ring: #8ea6ff;
+  --cw-text: #edf2fb;
+  --cw-text-muted: #9da9bd;
+  --cw-line: #28354a;
+  --cw-line-strong: #3b4961;
+  --cw-shadow-xs: 0 1px 2px rgb(0 0 0 / 24%);
+  --cw-shadow-sm: 0 12px 32px rgb(0 0 0 / 24%);
+  --cw-shadow-lg: 0 30px 84px rgb(0 0 0 / 42%);
+
+  --el-bg-color: var(--cw-paper);
+  --el-bg-color-page: var(--cw-canvas);
+  --el-border-color: var(--cw-line);
+  --el-border-color-light: #233047;
+  --el-border-color-lighter: #1d293d;
+  --el-fill-color-light: #172338;
+  --el-fill-color-lighter: #142033;
+  --el-fill-color-extra-light: #111c2e;
+  --el-text-color-primary: var(--cw-text);
+  --el-text-color-regular: #cad3e3;
+  --el-text-color-secondary: var(--cw-text-muted);
+  /* 覆盖 Element Plus 暗色默认的亮实心色；语义前景与实心动作必须各自承担单一职责。 */
+  --el-color-success: var(--cw-success);
+  --el-color-warning: var(--cw-amber);
+  --el-color-danger: var(--cw-danger);
+  --el-color-info: var(--cw-info);
+}
+
+html,
+body,
+#app {
+  min-width: 320px;
+  height: 100%;
 }
 
 body {
-  background: var(--el-bg-color-page);
-  color: var(--el-text-color-primary);
+  margin: 0;
+  overflow: hidden;
+  background: var(--cw-canvas);
+  color: var(--cw-text);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* 卡片：轻投影 + 弱边框（body 前缀提高特异性，避免被按需加载的组件样式反超） */
 body .el-card {
-  --el-card-border-color: var(--el-border-color-lighter);
-  border-radius: 8px;
-  box-shadow: var(--cw-card-shadow);
+  --el-card-border-color: var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  box-shadow: var(--cw-shadow-xs);
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 
-/* 表格：表头带浅底色与页面主体区分，去掉表头文字的默认灰 */
+body .el-card.is-always-shadow,
+body .el-card.is-hover-shadow:hover {
+  border-color: var(--cw-line-strong);
+  box-shadow: var(--cw-shadow-sm);
+}
+
+body .el-card__header {
+  padding: 16px 18px;
+  border-bottom-color: var(--cw-line);
+  font-weight: 650;
+}
+
+body .el-card__body {
+  padding: 18px;
+}
+
 body .el-table {
-  --el-table-header-bg-color: var(--el-fill-color-light);
-  --el-table-header-text-color: var(--el-text-color-primary);
+  --el-table-border-color: var(--cw-line);
+  --el-table-header-bg-color: #eef1f6;
+  --el-table-header-text-color: #465066;
+  --el-table-row-hover-bg-color: color-mix(in srgb, var(--theme-primary, var(--cw-cobalt)) 7%, var(--cw-paper));
+  overflow: hidden;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
 }
 
-/* 弹窗标题与正文的间距收紧一点，视觉更聚拢 */
-body .el-dialog__header {
-  padding-bottom: 12px;
+html.dark body .el-table {
+  --el-table-header-bg-color: #172338;
+  --el-table-header-text-color: #b5c0d3;
+}
+
+body .el-table th.el-table__cell {
+  height: 42px;
+  padding: 8px 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+}
+
+body .el-table td.el-table__cell {
+  height: 46px;
+  padding: 7px 0;
+}
+
+body .el-table .cell {
+  line-height: 1.45;
+}
+
+body .el-button {
+  min-height: 32px;
+  border-radius: var(--cw-radius-sm);
+  font-weight: 600;
+  transition: color 160ms ease, background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+body .el-button:not(.is-disabled):active {
+  transform: translateY(1px);
+}
+
+body .el-button--primary:not(.is-link):not(.is-text):not(.is-plain):not(.is-dashed) {
+  --el-button-bg-color: var(--theme-primary-solid);
+  --el-button-border-color: var(--theme-primary-solid);
+  --el-button-hover-bg-color: var(--theme-primary-solid-hover);
+  --el-button-hover-border-color: var(--theme-primary-solid-hover);
+  --el-button-active-bg-color: var(--theme-primary-solid-active);
+  --el-button-active-border-color: var(--theme-primary-solid-active);
+  --el-button-text-color: var(--cw-on-primary, #ffffff);
+  --el-button-hover-text-color: var(--cw-on-primary, #ffffff);
+  --el-button-active-text-color: var(--cw-on-primary, #ffffff);
+  --el-button-outline-color: var(--cw-focus-ring);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--theme-primary-solid) 22%, transparent);
+}
+
+body .el-button--primary.is-link,
+body .el-button--primary.is-text,
+body .el-button--primary.is-dashed {
+  --el-button-text-color: var(--theme-primary);
+  --el-button-hover-text-color: var(--theme-primary);
+  --el-button-hover-link-text-color: var(--theme-primary);
+  --el-button-active-text-color: var(--theme-primary);
+  --el-button-active-color: var(--theme-primary);
+  --el-button-hover-bg-color: transparent;
+  --el-button-active-bg-color: transparent;
+  --el-button-hover-border-color: var(--theme-primary);
+  --el-button-active-border-color: var(--theme-primary);
+  --el-button-outline-color: var(--cw-focus-ring);
+}
+
+body .el-button.is-link:not(.is-disabled):hover {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+body :is(.el-button.is-text, .el-button.is-dashed):not(.is-disabled):hover {
+  background: color-mix(in srgb, currentColor 8%, var(--cw-paper));
+}
+
+body .el-button--primary.is-plain {
+  --el-button-text-color: var(--theme-primary);
+  --el-button-bg-color: var(--cw-paper);
+  --el-button-border-color: var(--theme-primary);
+  --el-button-hover-text-color: var(--cw-on-primary);
+  --el-button-hover-bg-color: var(--theme-primary-solid);
+  --el-button-hover-border-color: var(--theme-primary-solid);
+  --el-button-active-text-color: var(--cw-on-primary);
+  --el-button-active-bg-color: var(--theme-primary-solid-active);
+  --el-button-active-border-color: var(--theme-primary-solid-active);
+  --el-button-outline-color: var(--cw-focus-ring);
+}
+
+body .el-button--success {
+  --cw-semantic-foreground: var(--cw-success);
+  --cw-semantic-solid: var(--cw-success-solid);
+  --cw-semantic-solid-hover: var(--cw-success-solid-hover);
+  --cw-semantic-solid-active: var(--cw-success-solid-active);
+  --cw-on-semantic: var(--cw-on-success);
+}
+
+body .el-button--warning {
+  --cw-semantic-foreground: var(--cw-amber);
+  --cw-semantic-solid: var(--cw-amber-solid);
+  --cw-semantic-solid-hover: var(--cw-warning-solid-hover);
+  --cw-semantic-solid-active: var(--cw-warning-solid-active);
+  --cw-on-semantic: var(--cw-on-warning);
+}
+
+body .el-button--danger {
+  --cw-semantic-foreground: var(--cw-danger);
+  --cw-semantic-solid: var(--cw-danger-solid);
+  --cw-semantic-solid-hover: var(--cw-danger-solid-hover);
+  --cw-semantic-solid-active: var(--cw-danger-solid-active);
+  --cw-on-semantic: var(--cw-on-danger);
+}
+
+body :is(.el-button--success, .el-button--warning, .el-button--danger):not(.is-link):not(.is-text):not(.is-plain):not(.is-dashed) {
+  --el-button-bg-color: var(--cw-semantic-solid);
+  --el-button-border-color: var(--cw-semantic-solid);
+  --el-button-hover-bg-color: var(--cw-semantic-solid-hover);
+  --el-button-hover-border-color: var(--cw-semantic-solid-hover);
+  --el-button-active-bg-color: var(--cw-semantic-solid-active);
+  --el-button-active-border-color: var(--cw-semantic-solid-active);
+  --el-button-text-color: var(--cw-on-semantic);
+  --el-button-hover-text-color: var(--cw-on-semantic);
+  --el-button-active-text-color: var(--cw-on-semantic);
+  --el-button-outline-color: var(--cw-focus-ring);
+}
+
+body :is(.el-button--success, .el-button--warning, .el-button--danger):is(.is-link, .is-text, .is-dashed) {
+  --el-button-text-color: var(--cw-semantic-foreground);
+  --el-button-hover-text-color: var(--cw-semantic-foreground);
+  --el-button-hover-link-text-color: var(--cw-semantic-foreground);
+  --el-button-active-text-color: var(--cw-semantic-foreground);
+  --el-button-active-color: var(--cw-semantic-foreground);
+  --el-button-hover-bg-color: transparent;
+  --el-button-active-bg-color: transparent;
+  --el-button-hover-border-color: var(--cw-semantic-foreground);
+  --el-button-active-border-color: var(--cw-semantic-foreground);
+  --el-button-outline-color: var(--cw-focus-ring);
+}
+
+body :is(.el-button--success, .el-button--warning, .el-button--danger).is-plain {
+  --el-button-text-color: var(--cw-semantic-foreground);
+  --el-button-bg-color: var(--cw-paper);
+  --el-button-border-color: var(--cw-semantic-foreground);
+  --el-button-hover-text-color: var(--cw-on-semantic);
+  --el-button-hover-bg-color: var(--cw-semantic-solid);
+  --el-button-hover-border-color: var(--cw-semantic-solid);
+  --el-button-active-text-color: var(--cw-on-semantic);
+  --el-button-active-bg-color: var(--cw-semantic-solid-active);
+  --el-button-active-border-color: var(--cw-semantic-solid-active);
+  --el-button-outline-color: var(--cw-focus-ring);
+}
+
+body .el-tag.el-tag--primary {
+  --cw-tag-foreground: var(--theme-primary);
+  --cw-tag-solid: var(--theme-primary-solid);
+  --cw-tag-solid-hover: var(--theme-primary-solid-hover);
+  --cw-tag-on-color: var(--cw-on-primary);
+}
+
+body .el-tag.el-tag--success {
+  --cw-tag-foreground: var(--cw-success);
+  --cw-tag-solid: var(--cw-success-solid);
+  --cw-tag-solid-hover: var(--cw-success-solid-hover);
+  --cw-tag-on-color: var(--cw-on-success);
+}
+
+body .el-tag.el-tag--warning {
+  --cw-tag-foreground: var(--cw-amber);
+  --cw-tag-solid: var(--cw-amber-solid);
+  --cw-tag-solid-hover: var(--cw-warning-solid-hover);
+  --cw-tag-on-color: var(--cw-on-warning);
+}
+
+body :is(.el-tag.el-tag--danger, .el-tag.el-tag--error) {
+  --cw-tag-foreground: var(--cw-danger);
+  --cw-tag-solid: var(--cw-danger-solid);
+  --cw-tag-solid-hover: var(--cw-danger-solid-hover);
+  --cw-tag-on-color: var(--cw-on-danger);
+}
+
+body .el-tag.el-tag--info {
+  --cw-tag-foreground: var(--cw-info);
+  --cw-tag-solid: var(--cw-info-solid);
+  --cw-tag-solid-hover: var(--cw-info-solid-hover);
+  --cw-tag-on-color: var(--cw-on-info);
+}
+
+/*
+ * Element Plus 的 light tag 默认把语义前景叠在同色浅底上；品牌色可配置后，这个组合无法稳定达到 AA。
+ * light/plain 统一回到工作面上的可访问前景，dark 则显式消费实心色盘，关闭所有主题预设的对比度缺口。
+ */
+body .el-tag:is(.el-tag--primary, .el-tag--success, .el-tag--warning, .el-tag--danger, .el-tag--error, .el-tag--info):not(.el-tag--dark) {
+  --el-tag-text-color: var(--cw-tag-foreground);
+  --el-tag-bg-color: var(--cw-paper);
+  --el-tag-border-color: color-mix(in srgb, var(--cw-tag-foreground) 58%, var(--cw-paper));
+  --el-tag-hover-color: var(--cw-tag-solid-hover);
+}
+
+body .el-tag.el-tag--dark:is(.el-tag--primary, .el-tag--success, .el-tag--warning, .el-tag--danger, .el-tag--error, .el-tag--info) {
+  --el-tag-text-color: var(--cw-tag-on-color);
+  --el-tag-bg-color: var(--cw-tag-solid);
+  --el-tag-border-color: var(--cw-tag-solid);
+  --el-tag-hover-color: var(--cw-tag-solid-hover);
+}
+
+body .el-tag:is(.el-tag--primary, .el-tag--success, .el-tag--warning, .el-tag--danger, .el-tag--error, .el-tag--info) .el-tag__close:hover {
+  color: var(--cw-tag-on-color);
+}
+
+/* 选择控件的 checked 区域是实心背景，不能复用为正文校准后的 primary 前景色。 */
+body .el-radio-button {
+  --el-radio-button-checked-bg-color: var(--theme-primary-solid);
+  --el-radio-button-checked-border-color: var(--theme-primary-solid);
+  --el-radio-button-checked-text-color: var(--cw-on-primary);
+}
+
+body .el-checkbox {
+  --el-checkbox-checked-text-color: var(--theme-primary);
+  --el-checkbox-checked-input-border-color: var(--theme-primary-solid);
+  --el-checkbox-checked-bg-color: var(--theme-primary-solid);
+  --el-checkbox-checked-icon-color: var(--cw-on-primary);
+  --el-checkbox-input-border-color-hover: var(--cw-focus-ring);
+}
+
+body .el-radio__input.is-checked .el-radio__inner {
+  border-color: var(--theme-primary-solid);
+  background: var(--theme-primary-solid);
+}
+
+body .el-radio__input.is-checked .el-radio__inner::after {
+  background-color: var(--cw-on-primary);
+}
+
+body .el-radio__input.is-checked + .el-radio__label {
+  color: var(--theme-primary);
+}
+
+body .el-switch {
+  --el-switch-on-color: var(--theme-primary-solid);
+}
+
+body .el-switch.is-checked .el-switch__core .el-switch__action {
+  color: var(--theme-primary-solid);
+  background-color: var(--cw-on-primary);
+}
+
+body .el-switch.is-checked .el-switch__core .el-switch__inner-wrapper {
+  color: var(--cw-on-primary);
+}
+
+body .el-segmented {
+  --el-segmented-item-selected-color: var(--cw-on-primary);
+  --el-segmented-item-selected-bg-color: var(--theme-primary-solid);
+}
+
+body .el-pagination.is-background :is(.btn-prev, .btn-next, .el-pager li).is-active {
+  color: var(--cw-on-primary);
+  background-color: var(--theme-primary-solid);
+}
+
+body .el-date-table td.current:not(.disabled) .el-date-table-cell__text,
+body .el-date-table td.today.current .el-date-table-cell__text {
+  color: var(--cw-on-primary);
+  background-color: var(--theme-primary-solid);
+}
+
+body .el-button.cw-final-action {
+  --el-button-bg-color: var(--cw-amber-solid);
+  --el-button-border-color: var(--cw-amber-solid);
+  --el-button-hover-bg-color: var(--cw-warning-solid-hover);
+  --el-button-hover-border-color: var(--cw-warning-solid-hover);
+  --el-button-active-bg-color: var(--cw-warning-solid-active);
+  --el-button-active-border-color: var(--cw-warning-solid-active);
+  --el-button-text-color: var(--cw-on-warning);
+  --el-button-hover-text-color: var(--cw-on-warning);
+  --el-button-active-text-color: var(--cw-on-warning);
+  box-shadow: 0 4px 14px rgb(217 146 23 / 22%);
+}
+
+body .el-input__wrapper,
+body .el-select__wrapper,
+body .el-textarea__inner {
+  box-shadow: 0 0 0 1px var(--cw-line) inset;
+  transition: box-shadow 160ms ease, background-color 160ms ease;
+}
+
+body .el-input__wrapper.is-focus,
+body .el-select__wrapper.is-focused,
+body .el-textarea__inner:focus {
+  box-shadow: 0 0 0 1px var(--cw-focus-ring) inset, 0 0 0 3px color-mix(in srgb, var(--cw-focus-ring) 14%, transparent);
+}
+
+body .el-dialog,
+body .el-message-box {
+  max-width: calc(100vw - 32px);
+  overflow: hidden;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  box-shadow: var(--cw-shadow-lg);
+}
+
+body .el-dialog__header,
+body .el-drawer__header {
+  margin: 0;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--cw-line);
+  font-weight: 700;
+}
+
+body .el-dialog__body {
+  padding: 20px;
+}
+
+body .el-dialog__footer,
+body .el-drawer__footer {
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--cw-line);
+}
+
+body .el-drawer {
+  background: var(--cw-paper);
+}
+
+body .el-pagination {
+  justify-content: flex-end;
+  padding-top: 16px;
+}
+
+body .el-empty {
+  min-height: 240px;
+  padding: 36px 20px;
+}
+
+@media (max-width: 767px) {
+  body .el-dialog {
+    width: calc(100vw - 20px) !important;
+    max-width: none;
+    margin: 10px auto !important;
+  }
+
+  body .el-dialog__body {
+    max-height: calc(100vh - 144px);
+    overflow: auto;
+    padding: 16px;
+  }
+
+  /* Dialog 默认 teleport 到 body，页面 scoped 选择器无法命中；移动表单在全局统一改为纵向标签。 */
+  body .el-dialog .el-form-item {
+    display: block;
+  }
+
+  body .el-dialog .el-form-item__label {
+    width: 100% !important;
+    height: auto;
+    margin-bottom: 6px;
+    justify-content: flex-start;
+    line-height: 1.4;
+  }
+
+  body .el-dialog .el-form-item__content {
+    margin-left: 0 !important;
+    flex-wrap: wrap;
+  }
+
+  body .el-dialog .el-input-number {
+    max-width: 100%;
+  }
+
+  body .el-drawer.ltr,
+  body .el-drawer.rtl {
+    width: min(92vw, 560px) !important;
+  }
+
+  body .el-card__header,
+  body .el-card__body {
+    padding: 14px;
+  }
+
+  body .el-pagination {
+    justify-content: center;
+    overflow-x: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/customer-admin-web/src/utils/themeContrast.test.ts
+++ b/customer-admin-web/src/utils/themeContrast.test.ts
@@ -3,13 +3,22 @@ import { PRESET_COLORS } from '@/store/theme'
 import {
   chooseButtonTextColor,
   colorContrastRatio,
+  createSolidColorPalette,
   DARK_BUTTON_TEXT,
+  ensureColorContrast,
   LIGHT_BUTTON_TEXT,
 } from './themeContrast'
 
 describe('chooseButtonTextColor', () => {
   it('全部预设主题色都满足普通文字 WCAG AA 对比度', () => {
     for (const background of PRESET_COLORS) {
+      const foreground = chooseButtonTextColor(background)
+      expect(colorContrastRatio(background, foreground), background).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('最终动作的琥珀色阶都能选择满足 AA 的文字色', () => {
+    for (const background of ['#d99217', '#e7a52c', '#bc7c0f']) {
       const foreground = chooseButtonTextColor(background)
       expect(colorContrastRatio(background, foreground), background).toBeGreaterThanOrEqual(4.5)
     }
@@ -23,5 +32,36 @@ describe('chooseButtonTextColor', () => {
   it('非法颜色安全回退为白字', () => {
     expect(chooseButtonTextColor('var(--theme-primary)')).toBe(LIGHT_BUTTON_TEXT)
     expect(colorContrastRatio('#ffffff', 'invalid')).toBeNull()
+  })
+})
+
+describe('ensureColorContrast', () => {
+  it('全部预设色在亮暗工作面上都能作为普通文字与焦点环', () => {
+    for (const source of PRESET_COLORS) {
+      const lightForeground = ensureColorContrast(source, '#ffffff')
+      const darkForeground = ensureColorContrast(source, '#101a2b')
+      expect(colorContrastRatio(lightForeground, '#ffffff'), `${source} on light`).toBeGreaterThanOrEqual(4.5)
+      expect(colorContrastRatio(darkForeground, '#101a2b'), `${source} on dark`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('已满足阈值时保留原色，非法持久化值回退为钴蓝', () => {
+    expect(ensureColorContrast('#3e63dd', '#ffffff')).toBe('#3e63dd')
+    expect(ensureColorContrast('invalid', '#ffffff')).toBe('#3e63dd')
+  })
+})
+
+describe('createSolidColorPalette', () => {
+  it('全部预设色的默认、悬停与按下状态都满足实心按钮 AA 对比度', () => {
+    for (const source of PRESET_COLORS) {
+      const palette = createSolidColorPalette(source)
+      for (const background of [palette.base, palette.hover, palette.active]) {
+        expect(colorContrastRatio(background, palette.onColor), `${source} -> ${background}`).toBeGreaterThanOrEqual(4.5)
+      }
+    }
+  })
+
+  it('非法持久化颜色回退为完整安全色盘', () => {
+    expect(createSolidColorPalette('invalid')).toMatchObject({ base: '#3e63dd', onColor: LIGHT_BUTTON_TEXT })
   })
 })

--- a/customer-admin-web/src/utils/themeContrast.ts
+++ b/customer-admin-web/src/utils/themeContrast.ts
@@ -3,6 +3,13 @@ const HEX_COLOR_PATTERN = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i
 export const LIGHT_BUTTON_TEXT = '#ffffff'
 export const DARK_BUTTON_TEXT = '#000000'
 
+export interface SolidColorPalette {
+  base: string
+  hover: string
+  active: string
+  onColor: string
+}
+
 /**
  * 在主题色实心按钮上选择对比度更高的黑/白文字。
  * 黑白两端至少有一端满足 WCAG AA 的 4.5:1，避免中间亮度主题色出现临界不可读状态。
@@ -25,6 +32,70 @@ export function colorContrastRatio(first: string, second: string): number | null
     return null
   }
   return contrastFromLuminance(firstLuminance, secondLuminance)
+}
+
+/**
+ * 保留原色相，向黑或白中对比度更高的一端收敛，直到满足给定 WCAG 阈值。
+ * 用于把用户保存的品牌色转换为可安全承载正文链接和焦点环的前景色。
+ */
+export function ensureColorContrast(foreground: string, background: string, minimumRatio = 4.5): string {
+  const foregroundRgb = parseHexColor(foreground)
+  const backgroundLuminance = relativeLuminance(background)
+  if (!foregroundRgb || backgroundLuminance === null) {
+    return '#3e63dd'
+  }
+  if ((colorContrastRatio(foreground, background) ?? 0) >= minimumRatio) {
+    return foreground.toLowerCase()
+  }
+
+  const blackContrast = contrastFromLuminance(backgroundLuminance, 0)
+  const whiteContrast = contrastFromLuminance(backgroundLuminance, 1)
+  const target = blackContrast >= whiteContrast ? [0, 0, 0] : [255, 255, 255]
+  for (let step = 1; step <= 100; step += 1) {
+    const ratio = step / 100
+    const candidate = rgbToHex(foregroundRgb.map((channel, index) => (
+      Math.round(channel + (target[index] - channel) * ratio)
+    )))
+    if ((colorContrastRatio(candidate, background) ?? 0) >= minimumRatio) {
+      return candidate
+    }
+  }
+  return rgbToHex(target)
+}
+
+/** 实心交互色：hover/active 始终向文字的反方向移动，因此不会牺牲文字对比度。 */
+export function createSolidColorPalette(background: string): SolidColorPalette {
+  const base = parseHexColor(background) ? background.toLowerCase() : '#3e63dd'
+  const onColor = chooseButtonTextColor(base)
+  const target = onColor === DARK_BUTTON_TEXT ? [255, 255, 255] : [0, 0, 0]
+  return {
+    base,
+    hover: mixHexColor(base, target, 0.08),
+    active: mixHexColor(base, target, 0.14),
+    onColor,
+  }
+}
+
+function parseHexColor(color: string): [number, number, number] | null {
+  const matched = HEX_COLOR_PATTERN.exec(color)
+  if (!matched) return null
+  return [
+    Number.parseInt(matched[1], 16),
+    Number.parseInt(matched[2], 16),
+    Number.parseInt(matched[3], 16),
+  ]
+}
+
+function rgbToHex(channels: number[]): string {
+  return `#${channels.map((channel) => channel.toString(16).padStart(2, '0')).join('')}`
+}
+
+function mixHexColor(source: string, target: number[], ratio: number): string {
+  const sourceRgb = parseHexColor(source)
+  if (!sourceRgb) return '#3e63dd'
+  return rgbToHex(sourceRgb.map((channel, index) => (
+    Math.round(channel + (target[index] - channel) * ratio)
+  )))
 }
 
 function relativeLuminance(color: string): number | null {

--- a/customer-admin-web/src/views/Home.vue
+++ b/customer-admin-web/src/views/Home.vue
@@ -1,93 +1,142 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/store/auth'
+import { useMenuStore } from '@/store/menu'
+import { useTabsStore } from '@/store/tabs'
+import HomeAdmission from './home/components/HomeAdmission.vue'
+import HomeHero from './home/components/HomeHero.vue'
+import HomeWorkBoard from './home/components/HomeWorkBoard.vue'
+import {
+  buildHomeAdmissionPresentation,
+  buildHomeSnapshot,
+  type HomeEntry,
+} from './homePresentation'
 
 const auth = useAuthStore()
+const menuStore = useMenuStore()
+const tabsStore = useTabsStore()
+const router = useRouter()
 
-const homeMessage = computed(() => {
-  if (auth.approvalStatus === 'PENDING') {
-    return '账号正在等待管理员审核，审核并分配角色后即可查看菜单。'
-  }
-  if (auth.approvalStatus === 'REJECTED') {
-    return auth.approvalRemark
-      ? `账号审核未通过：${auth.approvalRemark}`
-      : '账号审核未通过，请联系管理员。'
-  }
-  if (auth.permissions.length === 0) {
-    return '账号尚未分配可用权限，请联系管理员。'
-  }
-  return '请从左侧菜单选择要管理的模块。'
+const snapshot = computed(() => buildHomeSnapshot({
+  approved: auth.isApproved,
+  menuTree: menuStore.tree,
+  tabs: tabsStore.tabs,
+}))
+
+const displayName = computed(() => auth.nickname || auth.username || '使用者')
+const accountName = computed(() => auth.username || '当前登录账号')
+
+const todayLabel = new Intl.DateTimeFormat('zh-CN', {
+  month: '2-digit',
+  day: '2-digit',
+  weekday: 'short',
+}).format(new Date())
+
+const greeting = computed(() => {
+  const hour = new Date().getHours()
+  if (hour < 6) return '夜深了'
+  if (hour < 12) return '早上好'
+  if (hour < 18) return '下午好'
+  return '晚上好'
 })
+
+const primaryEntry = computed<HomeEntry | undefined>(() => (
+  snapshot.value.quickEntries.find((entry) => entry.dynamic)
+  ?? snapshot.value.quickEntries[0]
+))
+
+const admissionPresentation = computed(() => buildHomeAdmissionPresentation(
+  auth.approvalStatus,
+  auth.approvalRemark,
+))
+
+function navigate(path: string) {
+  router.push(path)
+}
 </script>
 
 <template>
-  <div class="home-page">
-    <img src="/home-cover.jpg" alt="首页" class="home-cover" />
-    <p class="home-tip">
-      <strong>{{ auth.nickname }}</strong>，{{ homeMessage }}
-    </p>
-  </div>
+  <main v-if="auth.isApproved" class="home-page" aria-labelledby="home-title">
+    <div class="home-canvas">
+      <HomeHero
+        :display-name="displayName"
+        :today-label="todayLabel"
+        :greeting="greeting"
+        :routes-registered="menuStore.routesRegistered"
+        :snapshot="snapshot"
+        :primary-entry="primaryEntry"
+        @navigate="navigate"
+      />
+      <HomeWorkBoard :snapshot="snapshot" @navigate="navigate" />
+    </div>
+  </main>
+
+  <main v-else class="home-page home-page--admission" aria-labelledby="home-title">
+    <HomeAdmission
+      :display-name="displayName"
+      :username="accountName"
+      :presentation="admissionPresentation"
+    />
+  </main>
 </template>
 
 <style scoped>
 .home-page {
-  position: relative;
+  --home-ink: var(--cw-ink, #0b1630);
+  --home-ink-soft: var(--cw-ink-elevated, #152441);
+  --home-cobalt: var(--theme-primary, var(--cw-cobalt, #3e63dd));
+  --home-amber: var(--cw-amber, #d99217);
+  --home-signal: color-mix(in srgb, var(--home-amber) 72%, white);
+  --home-success: var(--cw-success, #16856a);
+  --home-on-ink: #f7fbff;
+  --home-on-ink-muted: color-mix(in srgb, white 60%, var(--home-ink));
+  --home-on-ink-soft: color-mix(in srgb, white 86%, var(--home-ink));
+  --home-on-ink-strong: color-mix(in srgb, white 94%, var(--home-ink));
+  --home-paper: var(--cw-paper, var(--el-bg-color, #ffffff));
+  --home-canvas: var(--cw-canvas, var(--el-bg-color-page, #f4f6fa));
+  --home-line: var(--cw-line, var(--el-border-color-lighter, #dce1ea));
+  --home-text: var(--cw-text, var(--el-text-color-primary, #172033));
+  --home-muted: var(--cw-text-muted, var(--el-text-color-secondary, #677189));
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  min-height: 0;
+  overflow: auto;
+  color: var(--home-text);
+  background:
+    linear-gradient(color-mix(in srgb, var(--home-line) 25%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--home-line) 25%, transparent) 1px, transparent 1px),
+    var(--home-canvas);
+  background-size: 32px 32px;
+  scrollbar-gutter: stable;
 }
 
-.home-cover {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
+.home-canvas {
+  width: min(100%, 1560px);
+  min-height: 100%;
+  margin: 0 auto;
+  padding: clamp(18px, 2.4vw, 36px);
+  box-sizing: border-box;
 }
 
-.home-tip {
-  position: absolute;
-  bottom: clamp(20px, 4vh, 48px);
-  left: 50%;
-  z-index: 1;
-  transform: translateX(-50%);
-  isolation: isolate;
-  margin: 0;
-  padding: 10px 18px;
-  width: max-content;
-  max-width: calc(100% - 32px);
-  border-radius: 999px;
-  font-size: clamp(15px, 1.1vw, 20px);
-  font-weight: 700;
-  letter-spacing: 1px;
-  overflow-wrap: anywhere;
-  text-align: center;
-  color: rgb(0 21 41 / 85%);
+.home-page--admission {
+  display: grid;
+  place-items: center;
 }
 
-.home-tip strong {
-  color: var(--el-color-primary);
+@media (max-width: 820px) {
+  .home-canvas {
+    padding: 16px;
+  }
 }
 
-.home-tip::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  border: 1px solid rgb(255 255 255 / 75%);
-  border-radius: inherit;
-  background: rgb(255 255 255 / 78%);
-  box-shadow: 0 6px 20px rgb(0 21 41 / 12%);
-  backdrop-filter: blur(10px);
-}
-
-@media (max-width: 768px) {
-  .home-cover {
-    object-position: 62% center;
+@media (max-width: 520px) {
+  .home-page {
+    scrollbar-gutter: auto;
   }
 
-  .home-tip {
-    bottom: 16px;
+  .home-canvas {
+    padding: 12px;
   }
 }
 </style>

--- a/customer-admin-web/src/views/NotFound.vue
+++ b/customer-admin-web/src/views/NotFound.vue
@@ -6,19 +6,92 @@ const router = useRouter()
 
 <template>
   <div class="not-found">
-    <el-result icon="warning" title="404" sub-title="页面不存在或您没有访问权限">
-      <template #extra>
-        <el-button type="primary" @click="router.push('/')">返回首页</el-button>
-      </template>
-    </el-result>
+    <section class="not-found-panel" aria-labelledby="not-found-title">
+      <span class="error-code">404 / ROUTE GAP</span>
+      <h1 id="not-found-title">这条工作路径没有可用页面</h1>
+      <p>链接可能已经失效，或当前账号不在该页面的权限范围内。返回首页可重新从已授权入口进入。</p>
+      <div class="route-trace" aria-hidden="true"><span></span><span></span><span></span><i></i></div>
+      <el-button class="cw-final-action" type="primary" @click="router.push('/')">返回工作首页</el-button>
+    </section>
   </div>
 </template>
 
 <style scoped>
 .not-found {
+  box-sizing: border-box;
   height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 24px;
+  background: var(--cw-canvas);
+}
+
+.not-found-panel {
+  width: min(560px, 100%);
+  padding: clamp(30px, 7vw, 58px);
+  text-align: center;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-lg);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-sm);
+}
+
+.error-code {
+  color: var(--cw-danger);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .14em;
+}
+
+.not-found-panel h1 {
+  margin: 10px 0;
+  color: var(--cw-text);
+  font-size: clamp(24px, 5vw, 34px);
+  letter-spacing: -.035em;
+}
+
+.not-found-panel p {
+  margin: 0;
+  color: var(--cw-text-muted);
+  line-height: 1.7;
+}
+
+.route-trace {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 28px auto;
+}
+
+.route-trace span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--cw-cobalt);
+}
+
+.route-trace i {
+  width: 68px;
+  height: 2px;
+  background: repeating-linear-gradient(90deg, var(--cw-danger) 0 7px, transparent 7px 12px);
+}
+
+@media (max-width: 480px) {
+  .not-found {
+    align-items: flex-start;
+    padding: 14px 12px;
+  }
+
+  .not-found-panel {
+    padding: 32px 20px;
+  }
+
+  .cw-final-action {
+    width: 100%;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/aiconfig/AgentManage.vue
+++ b/customer-admin-web/src/views/aiconfig/AgentManage.vue
@@ -335,11 +335,13 @@ onMounted(() => {
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'agent:add'" type="primary" @click="openCreate">新建智能体</el-button>
-        <el-button v-permission="'agent:view'" @click="channelBindingVisible = true">渠道绑定</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'agent:view'" @click="channelBindingVisible = true">渠道绑定</el-button>
+          <el-button v-permission="'agent:add'" class="cw-final-action" type="primary" @click="openCreate">新建智能体</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的智能体">
         <el-table-column label="图标" width="70">
           <template #default="{ row }">
             <el-icon v-if="row.icon" :size="18">
@@ -347,13 +349,13 @@ onMounted(() => {
             </el-icon>
           </template>
         </el-table-column>
-        <el-table-column prop="agentName" label="名称" />
+        <el-table-column prop="agentName" label="名称" class-name="primary-column" />
         <el-table-column prop="agentCode" label="编码" width="140" />
         <el-table-column prop="modelName" label="主模型" width="140" />
         <el-table-column label="备用模型" width="180">
           <template #default="{ row }">
             <el-tag v-for="n in row.backupModelNames" :key="n" type="info" style="margin-right: 4px">{{ n }}</el-tag>
-            <span v-if="!row.backupModelNames?.length" style="color: #909399">-</span>
+            <span v-if="!row.backupModelNames?.length" class="muted">-</span>
           </template>
         </el-table-column>
         <!-- 知识库名称由后端 AgentVO.knowledgeBaseNames 直接回填，前端不再二次查询 -->
@@ -362,7 +364,7 @@ onMounted(() => {
             <el-tooltip v-for="(k, index) in row.knowledgeBaseNames" :key="`${k}-${index}`" :content="`冻结版本 ID：${row.knowledgeBaseVersionIds?.[index] ?? '-'}`">
               <el-tag type="success" style="margin: 2px">{{ k }}</el-tag>
             </el-tooltip>
-            <span v-if="!row.knowledgeBaseNames?.length" style="color: #909399">-</span>
+            <span v-if="!row.knowledgeBaseNames?.length" class="muted">-</span>
           </template>
         </el-table-column>
         <el-table-column label="Skill" width="180">
@@ -370,7 +372,7 @@ onMounted(() => {
             <el-tooltip v-for="(skillId, index) in row.skillIds" :key="skillId" :content="`冻结版本 ID：${row.skillVersionIds?.[index] ?? '-'}`">
               <el-tag type="warning" style="margin: 2px">{{ skillName(skillId) }}</el-tag>
             </el-tooltip>
-            <span v-if="!row.skillIds?.length" style="color: #909399">-</span>
+            <span v-if="!row.skillIds?.length" class="muted">-</span>
           </template>
         </el-table-column>
         <el-table-column label="能力" width="260">
@@ -378,7 +380,7 @@ onMounted(() => {
             <el-tag v-for="c in row.capabilities" :key="c" style="margin: 2px">{{ capabilityLabel(c) }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '停用' }}</el-tag>
           </template>
@@ -408,7 +410,7 @@ onMounted(() => {
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -578,7 +580,7 @@ onMounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" :disabled="!canSubmit" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :disabled="!canSubmit" @click="handleSubmit">保存智能体</el-button>
       </template>
     </el-dialog>
 
@@ -614,8 +616,27 @@ onMounted(() => {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .connectivity-row {
@@ -628,7 +649,7 @@ onMounted(() => {
 .connectivity-hint {
   margin-top: 4px;
   font-size: 12px;
-  color: #f56c6c;
+  color: var(--el-color-danger);
 }
 
 .version-hint {
@@ -641,7 +662,11 @@ onMounted(() => {
 .memory-meta {
   margin-bottom: 8px;
   font-size: 12px;
-  color: #909399;
+  color: var(--el-text-color-secondary);
+}
+
+.muted {
+  color: var(--el-text-color-placeholder);
 }
 
 .memory-content {
@@ -654,6 +679,17 @@ onMounted(() => {
   white-space: pre-wrap;
   word-break: break-word;
   background: var(--el-fill-color-light);
-  border-radius: 4px;
+  border-radius: var(--cw-radius-sm);
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/aiconfig/AgentTaskManage.vue
+++ b/customer-admin-web/src/views/aiconfig/AgentTaskManage.vue
@@ -149,11 +149,11 @@ onBeforeUnmount(() => {
         <el-button @click="handleReset">重置</el-button>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="taskId" label="任务ID" width="180" show-overflow-tooltip />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的后台任务">
+        <el-table-column prop="taskId" label="任务ID" width="180" show-overflow-tooltip class-name="primary-column" />
         <el-table-column prop="subAgentId" label="子智能体" width="150" show-overflow-tooltip />
         <el-table-column prop="parentAgentCode" label="父智能体" width="150" show-overflow-tooltip />
-        <el-table-column label="状态" width="110">
+        <el-table-column label="状态" width="110" align="center">
           <template #default="{ row }: { row: AgentTaskVO }">
             <el-tag :type="statusTagType(row.status)">{{ row.status }}</el-tag>
           </template>
@@ -236,14 +236,20 @@ onBeforeUnmount(() => {
 
 .toolbar {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-bottom: 12px;
   flex-wrap: wrap;
 }
 
-.pagination {
-  margin-top: 12px;
-  justify-content: flex-end;
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .muted {

--- a/customer-admin-web/src/views/aiconfig/ChannelBindingDrawer.vue
+++ b/customer-admin-web/src/views/aiconfig/ChannelBindingDrawer.vue
@@ -234,7 +234,7 @@ async function handleGateOverride() {
 <template>
   <el-drawer v-model="visible" title="渠道绑定" size="980px">
     <div class="toolbar">
-      <el-button v-permission="'agent:edit'" type="primary" @click="openCreate">新建绑定</el-button>
+      <el-button v-permission="'agent:edit'" class="cw-final-action" type="primary" @click="openCreate">新建绑定</el-button>
     </div>
 
     <el-table v-loading="loading" :data="list" style="width: 100%">
@@ -309,7 +309,7 @@ async function handleGateOverride() {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleSubmit">保存绑定</el-button>
       </template>
     </el-dialog>
 

--- a/customer-admin-web/src/views/aiconfig/ChannelRobotManage.vue
+++ b/customer-admin-web/src/views/aiconfig/ChannelRobotManage.vue
@@ -193,7 +193,7 @@ onMounted(() => {
 
 <template>
   <div class="page">
-    <el-alert type="info" :closable="false" show-icon title="钉钉机器人接入指引" style="margin-bottom: 16px">
+    <el-alert type="info" :closable="false" show-icon title="钉钉机器人接入指引">
       <template #default>
         <div>1. 到钉钉开放平台创建「企业内部应用」。</div>
         <div>2. 为应用添加「机器人」能力。</div>
@@ -202,7 +202,7 @@ onMounted(() => {
       </template>
     </el-alert>
 
-    <el-alert type="warning" :closable="false" show-icon title="微信公众号接入指引" style="margin-bottom: 16px">
+    <el-alert type="warning" :closable="false" show-icon title="微信公众号接入指引">
       <template #default>
         <div>
           1. 申请
@@ -232,19 +232,21 @@ onMounted(() => {
           @keyup.enter="handleSearch"
         />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'channel-robot:add'" type="primary" @click="openCreate">新增机器人</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'channel-robot:add'" class="cw-final-action" type="primary" @click="openCreate">新增机器人</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column label="渠道类型" width="110">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的渠道机器人">
+        <el-table-column label="渠道类型" width="110" align="center">
           <template #default="{ row }: { row: ChannelRobotVO }">
             <el-tag :type="channelMetaOf(row.channelType).tagType">{{ channelMetaOf(row.channelType).label }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column prop="robotName" label="机器人名称" min-width="140" show-overflow-tooltip />
+        <el-table-column prop="robotName" label="机器人名称" min-width="140" show-overflow-tooltip class-name="primary-column" />
         <el-table-column prop="appKey" label="AppKey" min-width="160" show-overflow-tooltip />
         <el-table-column prop="robotCode" label="RobotCode" min-width="160" show-overflow-tooltip />
-        <el-table-column label="回调模式" width="100">
+        <el-table-column label="回调模式" width="100" align="center">
           <template #default="{ row }: { row: ChannelRobotVO }">
             <el-tag v-if="row.channelType === 'wechat'" :type="row.callbackMode === 'safe' ? 'success' : 'warning'" effect="plain">
               {{ row.callbackMode === 'safe' ? '安全' : '明文' }}
@@ -257,14 +259,14 @@ onMounted(() => {
             {{ agentNameOf(row.agentCode) }}
           </template>
         </el-table-column>
-        <el-table-column label="会话模式" width="100">
+        <el-table-column label="会话模式" width="100" align="center">
           <template #default="{ row }: { row: ChannelRobotVO }">
             <el-tag :type="row.sessionMode === 'per_message' ? 'warning' : 'success'" effect="plain">
               {{ row.sessionMode === 'per_message' ? '单次问答' : '持续会话' }}
             </el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }: { row: ChannelRobotVO }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '停用' }}</el-tag>
           </template>
@@ -284,7 +286,7 @@ onMounted(() => {
         v-model:page-size="query.size"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="handlePageChange"
       />
     </el-card>
@@ -301,7 +303,7 @@ onMounted(() => {
               :disabled="!c.selectable"
             >
               <span>{{ c.label }}</span>
-              <span v-if="!c.selectable" style="float: right; color: #c0c4cc; font-size: 12px">即将支持</span>
+              <span v-if="!c.selectable" style="float: right; color: var(--el-text-color-placeholder); font-size: 12px">即将支持</span>
             </el-option>
           </el-select>
         </el-form-item>
@@ -374,7 +376,7 @@ onMounted(() => {
               :disabled="agent.status !== 1"
             >
               <span>{{ agent.agentName }}</span>
-              <span v-if="agent.status !== 1" style="float: right; color: #c0c4cc; font-size: 12px">已停用</span>
+              <span v-if="agent.status !== 1" style="float: right; color: var(--el-text-color-placeholder); font-size: 12px">已停用</span>
             </el-option>
           </el-select>
         </el-form-item>
@@ -396,7 +398,7 @@ onMounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleSubmit">保存机器人</el-button>
       </template>
     </el-dialog>
   </div>
@@ -405,8 +407,26 @@ onMounted(() => {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .form-tip {
@@ -417,5 +437,16 @@ onMounted(() => {
   font-size: 12px;
   line-height: 1.5;
   margin-top: 4px;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/aiconfig/KnowledgeBaseManage.vue
+++ b/customer-admin-web/src/views/aiconfig/KnowledgeBaseManage.vue
@@ -10,19 +10,17 @@ import {
   updateKnowledgeBaseStatus,
 } from '@/api/knowledgeBase'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { KnowledgeBaseSaveRequest, KnowledgeBaseVO, PageQuery } from '@/types/api'
 import KnowledgeSourceDrawer from './components/KnowledgeSourceDrawer.vue'
 
 const testingId = ref<number | null>(null)
-// 保存会触发后端同步实测连通性（可达数秒），单独维护提交中状态给保存按钮加 loading，
-// 不进 useCrudPage（该动作是本页特有的耗时语义，composable 只收敛通用 CRUD 状态机）。
-const submitting = ref(false)
 const formRef = ref<FormInstance>()
 const knowledgeOpsVisible = ref(false)
 const knowledgeOpsRow = ref<KnowledgeBaseVO | null>(null)
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<KnowledgeBaseVO, PageQuery, KnowledgeBaseSaveRequest>({
@@ -72,15 +70,6 @@ function validateExtraHeadersJson(_rule: unknown, value: string, callback: (erro
   }
 }
 
-async function handleSubmitWithLoading() {
-  submitting.value = true
-  try {
-    await handleSubmit()
-  } finally {
-    submitting.value = false
-  }
-}
-
 async function handleTest(row: KnowledgeBaseVO) {
   testingId.value = row.id
   try {
@@ -114,15 +103,18 @@ onMounted(loadList)
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按知识库名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'knowledge-base:add'" type="primary" @click="openCreate">新建知识库</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'knowledge-base:add'" class="cw-final-action" type="primary" @click="openCreate">新建知识库</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="kbName" label="知识库名称" />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的知识库">
+        <el-table-column prop="kbName" label="知识库名称" class-name="primary-column" />
         <el-table-column prop="baseUrl" label="服务地址" show-overflow-tooltip />
         <el-table-column prop="appId" label="app_id" width="140" />
         <el-table-column label="appkey" width="140">
@@ -136,12 +128,12 @@ onMounted(loadList)
             </el-tooltip>
           </template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '停用' }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="连通性" width="140">
+        <el-table-column label="连通性" width="140" align="center">
           <template #default="{ row }">
             <el-tooltip :content="row.testTime ? `测试时间：${row.testTime}` : '尚未测试'" placement="top">
               <el-tag :type="testStatusMap[row.testStatus]?.type ?? 'info'">{{ testStatusMap[row.testStatus]?.label ?? '未测试' }}</el-tag>
@@ -157,7 +149,7 @@ onMounted(loadList)
             <el-button v-permission="'knowledge-base:edit'" link type="primary" @click="handleToggleStatus(row)">
               {{ row.status === 1 ? '停用' : '启用' }}
             </el-button>
-            <el-button v-permission="'knowledge-base:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'knowledge-base:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -167,7 +159,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -213,7 +205,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" :loading="submitting" @click="handleSubmitWithLoading">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存知识库</el-button>
       </template>
     </el-dialog>
 
@@ -228,8 +220,37 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 
 .score-hint {

--- a/customer-admin-web/src/views/aiconfig/McpManage.vue
+++ b/customer-admin-web/src/views/aiconfig/McpManage.vue
@@ -181,19 +181,21 @@ onMounted(loadList)
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'mcp:add'" type="primary" @click="openCreate">新建 MCP</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'mcp:add'" class="cw-final-action" type="primary" @click="openCreate">新建 MCP</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="mcpName" label="名称" />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的 MCP">
+        <el-table-column prop="mcpName" label="名称" class-name="primary-column" />
         <el-table-column prop="mcpType" label="类型" width="100" />
         <el-table-column prop="description" label="描述" show-overflow-tooltip />
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '禁用' }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="连通性" width="140">
+        <el-table-column label="连通性" width="140" align="center">
           <template #default="{ row }">
             <el-tag :type="testStatusMap[row.testStatus]?.type ?? 'info'">{{ testStatusMap[row.testStatus]?.label ?? '未测试' }}</el-tag>
           </template>
@@ -222,7 +224,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -270,7 +272,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleSubmit">保存 MCP</el-button>
       </template>
     </el-dialog>
 
@@ -281,8 +283,37 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 
 .config-hint {

--- a/customer-admin-web/src/views/aiconfig/ModelManage.vue
+++ b/customer-admin-web/src/views/aiconfig/ModelManage.vue
@@ -11,6 +11,7 @@ import {
   updateModel,
 } from '@/api/model'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import { useAuthStore } from '@/store/auth'
 import type { ModelAssetOption, ModelSaveRequest, ModelVO, PageQuery } from '@/types/api'
 import ModelExperimentPanel from './components/ModelExperimentPanel.vue'
@@ -18,6 +19,8 @@ import ModelGovernanceDrawer from './components/ModelGovernanceDrawer.vue'
 import ModelRoutingPanel from './components/ModelRoutingPanel.vue'
 
 const testingId = ref<number | null>(null)
+const preflightingSave = ref(false)
+const deletingId = ref<number | null>(null)
 const formRef = ref<FormInstance>()
 const assets = ref<ModelAssetOption[]>([])
 const assetMode = ref<'existing' | 'new'>('new')
@@ -27,7 +30,7 @@ const governanceModelId = ref<number | null>(null)
 const auth = useAuthStore()
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, list, total, query,
   dialogVisible, dialogMode, editingId, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit: submitCrud,
 } = useCrudPage<ModelVO, PageQuery, ModelSaveRequest>({
@@ -112,6 +115,7 @@ const healthyCount = computed(() => list.value.filter((row) => row.health?.healt
 const unknownCount = computed(() => list.value.filter((row) => !row.health || row.health.healthStatus === 'UNKNOWN').length)
 const credentialRiskCount = computed(() => list.value.filter((row) =>
   row.credential && row.credential.status !== 'ACTIVE').length)
+const savePending = computed(() => preflightingSave.value || submitting.value)
 
 interface ProviderPreset {
   value: string
@@ -166,25 +170,34 @@ function openEditModel(row: ModelVO) {
 }
 
 async function handleSubmitModel() {
-  if (dialogMode.value === 'edit'
-    && editingId.value
-    && editingRow.value?.status === 1
-    && form.status === 0) {
-    const impact = await getModelImpact(editingId.value, 'DISABLE')
-    if (!impact.allowed) {
-      ElMessage.error(`禁用被阻断：仍有 ${impact.blockerCount} 个生效引用`)
-      openGovernance(editingRow.value)
-      return
+  if (savePending.value) return
+  preflightingSave.value = true
+  try {
+    if (dialogMode.value === 'edit'
+      && editingId.value
+      && editingRow.value?.status === 1
+      && form.status === 0) {
+      const impact = await getModelImpact(editingId.value, 'DISABLE')
+      if (!impact.allowed) {
+        ElMessage.error(`禁用被阻断：仍有 ${impact.blockerCount} 个生效引用`)
+        openGovernance(editingRow.value)
+        return
+      }
     }
+    if (assetMode.value === 'new') {
+      form.assetId = null
+    }
+    await submitCrud()
+    if (!dialogVisible.value) {
+      await loadAssets()
+    }
+  } finally {
+    preflightingSave.value = false
   }
-  if (assetMode.value === 'new') {
-    form.assetId = null
-  }
-  await submitCrud()
-  await loadAssets()
 }
 
 async function handleTest(row: ModelVO) {
+  if (testingId.value !== null) return
   testingId.value = row.id
   try {
     const result = await runModelHealthCheck(row.id)
@@ -200,20 +213,30 @@ async function handleTest(row: ModelVO) {
 }
 
 async function handleDelete(row: ModelVO) {
-  const impact = await getModelImpact(row.id, 'DELETE')
-  if (!impact.allowed) {
-    ElMessage.error(`删除被阻断：仍有 ${impact.blockerCount} 个生效引用`)
-    openGovernance(row)
-    return
+  if (deletingId.value !== null) return
+  deletingId.value = row.id
+  try {
+    const impact = await getModelImpact(row.id, 'DELETE')
+    if (!impact.allowed) {
+      ElMessage.error(`删除被阻断：仍有 ${impact.blockerCount} 个生效引用`)
+      openGovernance(row)
+      return
+    }
+    await ElMessageBox.confirm(
+      `预检已通过。确认删除部署「${row.modelName}」？资产和凭据审计记录将保留。`,
+      '删除模型部署',
+      { type: 'warning' },
+    )
+    await deleteModel(row.id)
+    ElMessage.success('删除成功')
+    const currentPage = query.pageNum ?? 1
+    if (list.value.length === 1 && currentPage > 1) {
+      query.pageNum = currentPage - 1
+    }
+    await loadList()
+  } finally {
+    deletingId.value = null
   }
-  await ElMessageBox.confirm(
-    `预检已通过。确认删除部署「${row.modelName}」？资产和凭据审计记录将保留。`,
-    '删除模型部署',
-    { type: 'warning' },
-  )
-  await deleteModel(row.id)
-  ElMessage.success('删除成功')
-  await loadList()
 }
 
 function openGovernance(row: ModelVO) {
@@ -245,13 +268,14 @@ onMounted(async () => {
 
 <template>
   <div class="modelops-page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <section class="page-hero">
       <div>
         <p class="eyebrow">ENTERPRISE MODEL CONTROL PLANE</p>
-        <h1>模型治理工作台</h1>
+        <h2>模型治理工作台</h2>
         <p>把模型能力资产、运行部署、SecretRef 和健康证据放在同一条可审计链路中。</p>
       </div>
-      <el-button v-permission="'model:add'" type="primary" size="large" @click="openCreateModel">新建部署</el-button>
+      <el-button v-permission="'model:add'" class="cw-final-action" type="primary" size="large" @click="openCreateModel">新建部署</el-button>
     </section>
 
     <section class="summary-strip">
@@ -312,9 +336,16 @@ onMounted(async () => {
         <el-table-column label="操作" width="286" fixed="right">
           <template #default="{ row }">
             <el-button link type="primary" @click="openGovernance(row)">治理详情</el-button>
-            <el-button v-permission="'model:health-test'" link type="primary" :loading="testingId === row.id" @click="handleTest(row)">健康探测</el-button>
+            <el-button
+              v-permission="'model:health-test'"
+              link
+              type="primary"
+              :loading="testingId === row.id"
+              :disabled="testingId !== null && testingId !== row.id"
+              @click="handleTest(row)"
+            >健康探测</el-button>
             <el-button v-permission="'model:edit'" link type="primary" @click="openEditModel(row)">编辑</el-button>
-            <el-button v-permission="'model:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'model:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -413,7 +444,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmitModel">保存部署</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="savePending" @click="handleSubmitModel">保存部署</el-button>
       </template>
     </el-dialog>
 
@@ -422,30 +453,30 @@ onMounted(async () => {
 </template>
 
 <style scoped>
-.modelops-page { --ink: #172033; --muted: #64748b; --line: #dfe5ed; --accent: #2457d6; min-height: 100%; background: #f3f6fa; }
+.modelops-page { --ink: var(--cw-text); --muted: var(--cw-text-muted); --line: var(--cw-line); --accent: var(--cw-cobalt); min-height: 100%; background: var(--cw-canvas); }
 .page-hero { display: flex; align-items: flex-end; justify-content: space-between; gap: 28px; padding: 30px 34px 28px; color: white; border-radius: 16px 16px 0 0; background: linear-gradient(120deg, rgb(10 22 43 / 98%), rgb(31 55 91 / 94%)), repeating-linear-gradient(90deg, transparent 0 47px, rgb(255 255 255 / 4%) 48px); }
-.page-hero h1 { margin: 3px 0 8px; font-size: 30px; letter-spacing: -.03em; }
+.page-hero h2 { margin: 3px 0 8px; font-size: 30px; letter-spacing: -.03em; }
 .page-hero p { margin: 0; color: #cbd5e1; }
 .eyebrow { font-size: 11px; font-weight: 700; letter-spacing: .16em; }
-.summary-strip { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border: 1px solid var(--line); border-top: 0; background: white; }
+.summary-strip { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border: 1px solid var(--line); border-top: 0; background: var(--cw-paper); }
 .summary-strip > div { padding: 18px 24px; border-right: 1px solid var(--line); }
 .summary-strip > div:last-child { border-right: 0; }
 .summary-strip span { display: block; color: var(--muted); font-size: 12px; }
 .summary-strip strong { display: block; margin-top: 4px; color: var(--ink); font-size: 24px; }
-.summary-strip .is-good strong { color: #0f8b6d; }
-.summary-strip .is-risk strong { color: #c2413b; }
+.summary-strip .is-good strong { color: var(--cw-success); }
+.summary-strip .is-risk strong { color: var(--cw-danger); }
 .workspace-card { border: 0; border-radius: 0 0 16px 16px; }
 .toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 16px; color: var(--muted); font-size: 13px; }
 .toolbar > div { display: flex; gap: 8px; }
 .primary-cell strong, .primary-cell span, .endpoint-cell span, .endpoint-cell small, .cell-note { display: block; }
 .primary-cell strong { color: var(--ink); font-size: 14px; }
 .primary-cell span, .endpoint-cell small, .cell-note { margin-top: 4px; color: var(--muted); font-size: 11px; }
-.endpoint-cell span { color: #334155; }
-.lifecycle { color: #0f8b6d; font-size: 12px; font-weight: 700; letter-spacing: .04em; }
-.lifecycle.muted { color: #94a3b8; }
+.endpoint-cell span { color: var(--el-text-color-regular); }
+.lifecycle { color: var(--cw-success); font-size: 12px; font-weight: 700; letter-spacing: .04em; }
+.lifecycle.muted { color: var(--cw-text-muted); }
 .default-tag { display: block; width: fit-content; margin-top: 5px; }
 .pagination { margin-top: 18px; justify-content: flex-end; }
-.form-section { margin-bottom: 20px; padding: 18px; border: 1px solid var(--line); border-radius: 12px; background: #fbfcfe; }
+.form-section { margin-bottom: 20px; padding: 18px; border: 1px solid var(--line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
 .form-section-title { display: flex; gap: 11px; margin-bottom: 16px; }
 .form-section-title > span { display: grid; place-items: center; width: 28px; height: 28px; color: white; border-radius: 8px; background: var(--accent); font-size: 11px; font-weight: 700; }
 .form-section-title strong, .form-section-title small { display: block; }

--- a/customer-admin-web/src/views/aiconfig/ScheduledTaskManage.vue
+++ b/customer-admin-web/src/views/aiconfig/ScheduledTaskManage.vue
@@ -218,7 +218,6 @@ onMounted(() => {
       :closable="false"
       show-icon
       title="当前为内置调度模式：调度周期（cron）直接在本页配置，无需外部 XXL-JOB"
-      style="margin-bottom: 16px"
     >
       <template #default>
         <div>任务「启用」且填写了 cron 时按周期自动执行；cron 留空则仅可手动触发。</div>
@@ -231,7 +230,6 @@ onMounted(() => {
       :closable="false"
       show-icon
       title="当前为 XXL-JOB 调度模式：调度周期与启停在公司 XXL-JOB 控制台配置，本页 cron 仅保存展示"
-      style="margin-bottom: 16px"
     >
       <template #default>
         <div>执行器 JobHandler 填 <code>agentScheduledTask</code>，执行器参数填本页对应任务的「任务编码」。</div>
@@ -243,12 +241,14 @@ onMounted(() => {
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按任务编码/名称搜索" style="width: 240px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'scheduler:add'" type="primary" @click="openCreate">新建定时任务</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'scheduler:add'" class="cw-final-action" type="primary" @click="openCreate">新建定时任务</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的定时任务">
         <el-table-column prop="taskCode" label="任务编码" width="180" />
-        <el-table-column prop="taskName" label="任务名称" />
+        <el-table-column prop="taskName" label="任务名称" class-name="primary-column" />
         <el-table-column label="关联智能体" width="160">
           <template #default="{ row }: { row: ScheduledTaskVO }">
             {{ row.agentName || `#${row.agentId}` }}
@@ -260,7 +260,7 @@ onMounted(() => {
             <span v-else class="cron-empty">仅手动触发</span>
           </template>
         </el-table-column>
-        <el-table-column label="启用状态" width="100">
+        <el-table-column label="启用状态" width="100" align="center">
           <template #default="{ row }: { row: ScheduledTaskVO }">
             <el-switch
               v-permission="'scheduler:edit'"
@@ -294,7 +294,7 @@ onMounted(() => {
         v-model:page-size="query.size"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="handlePageChange"
       />
     </el-card>
@@ -317,7 +317,7 @@ onMounted(() => {
               :disabled="agent.status !== 1"
             >
               <span>{{ agent.agentName }}</span>
-              <span v-if="agent.status !== 1" style="float: right; color: #c0c4cc; font-size: 12px">已停用</span>
+              <span v-if="agent.status !== 1" style="float: right; color: var(--el-text-color-placeholder); font-size: 12px">已停用</span>
             </el-option>
           </el-select>
         </el-form-item>
@@ -341,7 +341,7 @@ onMounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleSubmit">保存任务</el-button>
       </template>
     </el-dialog>
 
@@ -368,7 +368,7 @@ onMounted(() => {
     </el-dialog>
 
     <el-drawer v-model="runsVisible" :title="`执行历史 · ${runsTaskName}`" size="640px">
-      <el-table v-loading="runsLoading" :data="runsList" style="width: 100%">
+      <el-table v-loading="runsLoading" :data="runsList" style="width: 100%" empty-text="暂无执行记录">
         <el-table-column label="触发方式" width="100">
           <template #default="{ row }: { row: ScheduledTaskRunVO }">
             <el-tag :type="row.triggerType === 'MANUAL' ? 'warning' : 'info'" size="small">
@@ -382,7 +382,7 @@ onMounted(() => {
             {{ row.costMs != null ? `${row.costMs} ms` : '-' }}
           </template>
         </el-table-column>
-        <el-table-column label="状态" width="80">
+        <el-table-column label="状态" width="80" align="center">
           <template #default="{ row }: { row: ScheduledTaskRunVO }">
             <el-tag :type="row.status === 'SUCCESS' ? 'success' : 'danger'" size="small">
               {{ row.status === 'SUCCESS' ? '成功' : '失败' }}
@@ -395,13 +395,12 @@ onMounted(() => {
           </template>
         </el-table-column>
       </el-table>
-      <el-empty v-if="!runsLoading && runsList.length === 0" description="还没有执行记录" />
       <el-pagination
         v-model:current-page="runsQuery.current"
         v-model:page-size="runsQuery.size"
         :total="runsTotal"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadRuns"
       />
     </el-drawer>
@@ -420,8 +419,26 @@ onMounted(() => {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .cron-empty {
@@ -448,5 +465,16 @@ onMounted(() => {
   word-break: break-word;
   max-height: 50vh;
   overflow-y: auto;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/aiconfig/SkillManage.vue
+++ b/customer-admin-web/src/views/aiconfig/SkillManage.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import type { FormInstance, UploadRequestOptions } from 'element-plus'
 import { createSkill, deleteSkill, downloadSkill, fetchSkillVersions, pageSkills, parseSkillUpload, updateSkill } from '@/api/skill'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { PageQuery, SkillSaveRequest, SkillVersionVO, SkillVO } from '@/types/api'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
 
@@ -23,7 +24,7 @@ const storageTargetOptions = [
 ]
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<SkillVO, PageQuery, SkillSaveRequest>({
@@ -127,15 +128,18 @@ onMounted(loadList)
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'skill:add'" type="primary" @click="openCreateWithReset">新建 Skill</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'skill:add'" class="cw-final-action" type="primary" @click="openCreateWithReset">新建 Skill</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="skillName" label="名称" />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的 Skill">
+        <el-table-column prop="skillName" label="名称" class-name="primary-column" />
         <el-table-column prop="skillCode" label="编码" width="160" />
         <el-table-column label="存储目标" width="200">
           <template #default="{ row }">
@@ -157,7 +161,7 @@ onMounted(loadList)
           </template>
         </el-table-column>
         <el-table-column prop="description" label="描述" show-overflow-tooltip />
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '禁用' }}</el-tag>
           </template>
@@ -177,7 +181,7 @@ onMounted(loadList)
               下载
             </el-button>
             <el-button v-permission="'skill:edit'" link type="primary" @click="openEditWithRow(row)">编辑</el-button>
-            <el-button v-permission="'skill:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'skill:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -187,7 +191,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -243,12 +247,12 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存 Skill</el-button>
       </template>
     </el-dialog>
 
     <el-dialog v-model="versionsVisible" :title="`不可变版本 · ${versionSkill?.skillName ?? ''}`" width="820px">
-      <el-table v-loading="versionsLoading" :data="versions" border>
+      <el-table v-loading="versionsLoading" :data="versions" border empty-text="暂无不可变版本">
         <el-table-column prop="versionNo" label="版本" width="90">
           <template #default="{ row }">v{{ row.versionNo }}</template>
         </el-table-column>
@@ -294,8 +298,26 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .preview-split {
@@ -322,7 +344,7 @@ onMounted(loadList)
 .preview-files {
   margin-top: 12px;
   border: 1px solid var(--el-border-color-lighter);
-  border-radius: 4px;
+  border-radius: var(--cw-radius-sm);
   overflow: hidden;
 }
 
@@ -340,7 +362,7 @@ onMounted(loadList)
   display: flex;
   flex-direction: column;
   border: 1px solid var(--el-border-color-lighter);
-  border-radius: 4px;
+  border-radius: var(--cw-radius-sm);
   overflow: hidden;
 }
 
@@ -372,5 +394,25 @@ onMounted(loadList)
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--el-text-color-primary);
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
+
+  .preview-split {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .preview-pane {
+    min-height: 240px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/aiconfig/SystemToolManage.vue
+++ b/customer-admin-web/src/views/aiconfig/SystemToolManage.vue
@@ -3,13 +3,14 @@ import { onMounted, ref } from 'vue'
 import type { FormInstance } from 'element-plus'
 import { fetchSystemTools, updateSystemTool } from '@/api/system-tool'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { PageQuery, SystemToolSaveRequest, SystemToolVO } from '@/types/api'
 
 const formRef = ref<FormInstance>()
 
 // 系统工具只有"编辑"能力（无新建/删除），只接 page/update 半套
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, list, total, query,
   dialogVisible, form,
   loadList, handleSearch, openEdit, handleSubmit,
 } = useCrudPage<SystemToolVO, PageQuery, SystemToolSaveRequest>({
@@ -41,17 +42,18 @@ onMounted(loadList)
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无系统工具">
         <el-table-column prop="toolCode" label="编码" width="160" />
-        <el-table-column prop="toolName" label="名称" width="180" />
+        <el-table-column prop="toolName" label="名称" width="180" class-name="primary-column" />
         <el-table-column prop="description" label="描述" show-overflow-tooltip />
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-switch
               v-model="row.enabled"
@@ -75,7 +77,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -97,7 +99,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存工具</el-button>
       </template>
     </el-dialog>
   </div>
@@ -106,7 +108,19 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 </style>

--- a/customer-admin-web/src/views/aiconfig/components/KnowledgeSourceDrawer.vue
+++ b/customer-admin-web/src/views/aiconfig/components/KnowledgeSourceDrawer.vue
@@ -283,7 +283,7 @@ function shortHash(hash: string | null) {
     <div v-loading="loading">
       <div class="section-title">
         <span>文档源</span>
-        <el-button v-permission="'knowledge-base:edit'" type="primary" @click="openCreateSource">新增文档源</el-button>
+        <el-button v-permission="'knowledge-base:edit'" class="cw-final-action" type="primary" @click="openCreateSource">新增文档源</el-button>
       </div>
       <el-table :data="sources" border>
         <el-table-column label="文档源" min-width="180">
@@ -381,7 +381,7 @@ function shortHash(hash: string | null) {
         </template>
         <el-form-item label="状态"><el-switch v-model="sourceForm.status" :active-value="1" :inactive-value="0" /></el-form-item>
       </el-form>
-      <template #footer><el-button @click="sourceDialogVisible = false">取消</el-button><el-button type="primary" @click="saveSource">保存</el-button></template>
+      <template #footer><el-button @click="sourceDialogVisible = false">取消</el-button><el-button class="cw-final-action" type="primary" @click="saveSource">保存文档源</el-button></template>
     </el-dialog>
 
     <el-dialog v-model="syncDialogVisible" title="提交文档同步批次" width="820px" append-to-body>
@@ -389,7 +389,7 @@ function shortHash(hash: string | null) {
         checkpoint 采用 CAS：expectedCheckpoint 必须等于服务端当前值，成功后才推进。全量快照只传 UPSERT，缺失文档自动生成 DELETE 修订。
       </el-alert>
       <el-input v-model="syncPayload" type="textarea" :rows="20" class="json-editor" />
-      <template #footer><el-button @click="syncDialogVisible = false">取消</el-button><el-button type="primary" :loading="syncing" @click="submitSync">提交同步</el-button></template>
+      <template #footer><el-button @click="syncDialogVisible = false">取消</el-button><el-button class="cw-final-action" type="primary" :loading="syncing" @click="submitSync">提交同步</el-button></template>
     </el-dialog>
 
     <el-dialog v-model="runsVisible" title="同步运行记录（最近 100 次）" width="1100px" append-to-body>

--- a/customer-admin-web/src/views/aiconfig/components/ModelCertificationPanel.vue
+++ b/customer-admin-web/src/views/aiconfig/components/ModelCertificationPanel.vue
@@ -217,7 +217,7 @@ function formatTime(value: string | null | undefined) {
             <el-checkbox v-model="form.requireStructuredOutput">结构化</el-checkbox>
           </el-form-item>
         </div>
-        <el-button v-permission="'model:certify'" type="primary" :loading="certifying" @click="certify">
+        <el-button v-permission="'model:certify'" class="cw-final-action" type="primary" :loading="certifying" @click="certify">
           运行上线认证
         </el-button>
       </el-form>
@@ -245,21 +245,21 @@ function formatTime(value: string | null | undefined) {
 </template>
 
 <style scoped>
-.certification-panel { color: #172033; }
-.cert-hero { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 18px 20px; border: 1px solid #dce5f0; border-radius: 12px; background: #f8fafc; }
-.cert-hero span, .cert-hero small { display: block; color: #64748b; font-size: 12px; }
+.certification-panel { color: var(--cw-text); }
+.cert-hero { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 18px 20px; border: 1px solid var(--cw-line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
+.cert-hero span, .cert-hero small { display: block; color: var(--cw-text-muted); font-size: 12px; }
 .cert-hero strong { display: block; margin: 4px 0; font-size: 24px; letter-spacing: .04em; }
-.cert-hero.is-passed { border-color: #a7e1d0; background: #effbf7; }
-.cert-hero.is-failed { border-color: #fecaca; background: #fff5f5; }
-.cert-hero.is-expired, .cert-hero.is-stale { border-color: #fde3aa; background: #fffaf0; }
+.cert-hero.is-passed { border-color: color-mix(in srgb, var(--cw-success) 42%, var(--cw-line)); background: color-mix(in srgb, var(--cw-success) 8%, var(--cw-paper)); }
+.cert-hero.is-failed { border-color: color-mix(in srgb, var(--cw-danger) 42%, var(--cw-line)); background: color-mix(in srgb, var(--cw-danger) 8%, var(--cw-paper)); }
+.cert-hero.is-expired, .cert-hero.is-stale { border-color: color-mix(in srgb, var(--cw-amber) 42%, var(--cw-line)); background: color-mix(in srgb, var(--cw-amber) 8%, var(--cw-paper)); }
 .evidence-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin: 14px 0; }
-.evidence-grid > div { padding: 13px; border: 1px solid #e2e8f0; border-radius: 10px; background: white; }
-.evidence-grid span { display: block; margin-bottom: 5px; color: #64748b; font-size: 11px; }
+.evidence-grid > div { padding: 13px; border: 1px solid var(--cw-line); border-radius: 10px; background: var(--cw-paper); }
+.evidence-grid span { display: block; margin-bottom: 5px; color: var(--cw-text-muted); font-size: 11px; }
 .evidence-grid strong { font-size: 13px; }
 .check-table { margin-top: 16px; }
-.cert-form { margin-top: 22px; padding: 18px; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc; }
+.cert-form { margin-top: 22px; padding: 18px; border: 1px solid var(--cw-line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
 .section-heading h3, .history-section h3 { margin: 0; }
-.section-heading p { margin: 5px 0 16px; color: #64748b; font-size: 13px; }
+.section-heading p { margin: 5px 0 16px; color: var(--cw-text-muted); font-size: 13px; }
 .form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 14px; }
 .history-section { margin-top: 22px; }
 .history-section h3 { margin-bottom: 12px; }

--- a/customer-admin-web/src/views/aiconfig/components/ModelExperimentPanel.vue
+++ b/customer-admin-web/src/views/aiconfig/components/ModelExperimentPanel.vue
@@ -216,7 +216,7 @@ function futureDateTimeValue(days: number) {
           <h2>模型在线实验</h2>
           <span>{{ experiments.length }} 个定义 · {{ runningCount }} 个期望 RUNNING · {{ activeCount }} 个运行时 ACTIVE</span>
         </div>
-        <el-button v-permission="'model-experiment:create'" type="primary" :loading="optionLoading" @click="openCreate">新建双臂实验</el-button>
+        <el-button v-permission="'model-experiment:create'" class="cw-final-action" type="primary" :loading="optionLoading" @click="openCreate">新建双臂实验</el-button>
       </div>
     </template>
 
@@ -337,7 +337,7 @@ function futureDateTimeValue(days: number) {
       </el-form>
       <template #footer>
         <el-button @click="createVisible = false">取消</el-button>
-        <el-button type="primary" :loading="saving" @click="createExperiment">创建草稿</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="saving" @click="createExperiment">创建草稿</el-button>
       </template>
     </el-dialog>
 
@@ -461,22 +461,22 @@ function futureDateTimeValue(days: number) {
 <style scoped>
 .experiment-card { margin-top: 20px; border: 0; border-radius: 16px; }
 .section-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; }
-.section-header h2 { margin: 2px 0 4px; color: #172033; font-size: 21px; }
-.section-header span { color: #64748b; font-size: 12px; }
-.eyebrow { margin: 0; color: #2457d6; font-size: 10px; font-weight: 800; letter-spacing: .15em; }
+.section-header h2 { margin: 2px 0 4px; color: var(--cw-text); font-size: 21px; }
+.section-header span { color: var(--cw-text-muted); font-size: 12px; }
+.eyebrow { margin: 0; color: var(--cw-cobalt); font-size: 10px; font-weight: 800; letter-spacing: .15em; }
 .runtime-alert { margin-bottom: 16px; }
 .filter-row { display: flex; gap: 10px; margin-bottom: 14px; }
 .primary-cell strong, .primary-cell span, .arm-cell span, .guardrail-cell span { display: block; }
 .status-cell { display: flex; align-items: flex-start; flex-direction: column; gap: 5px; }
-.primary-cell span, .arm-cell span, .guardrail-cell span, small { margin-top: 4px; color: #64748b; font-size: 11px; }
-.arm-cell span:first-child { color: #334155; }
+.primary-cell span, .arm-cell span, .guardrail-cell span, small { margin-top: 4px; color: var(--cw-text-muted); font-size: 11px; }
+.arm-cell span:first-child { color: var(--el-text-color-regular); }
 .form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); column-gap: 16px; }
 .full-row { grid-column: 1 / -1; }
-h3 { margin: 24px 0 12px; color: #172033; font-size: 15px; }
+h3 { margin: 24px 0 12px; color: var(--cw-text); font-size: 15px; }
 .arm-metrics { margin-top: 12px; }
 .effective-error { margin-top: 14px; }
 code { font-size: 11px; word-break: break-all; }
-.el-timeline p { margin: 5px 0 0; color: #64748b; }
+.el-timeline p { margin: 5px 0 0; color: var(--cw-text-muted); }
 @media (max-width: 760px) {
   .section-header { align-items: flex-start; flex-direction: column; }
   .filter-row, .form-grid { display: flex; flex-direction: column; }

--- a/customer-admin-web/src/views/aiconfig/components/ModelGovernanceDrawer.vue
+++ b/customer-admin-web/src/views/aiconfig/components/ModelGovernanceDrawer.vue
@@ -325,7 +325,7 @@ function healthTagType(status: string | null | undefined) {
                   style="width: 100%"
                 />
               </el-form-item>
-              <el-button v-permission="'model:edit'" type="primary" :loading="rotating" @click="rotateCredential">
+              <el-button v-permission="'model:edit'" class="cw-final-action" type="primary" :loading="rotating" @click="rotateCredential">
                 确认轮换
               </el-button>
             </el-form>
@@ -481,12 +481,12 @@ function healthTagType(status: string | null | undefined) {
 .section-heading h3,
 .rotation-panel h3 {
   margin: 0;
-  color: #172033;
+  color: var(--cw-text);
 }
 
 .eyebrow {
   margin: 0 0 4px;
-  color: #64748b;
+  color: var(--cw-text-muted);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: .14em;
@@ -504,9 +504,9 @@ function healthTagType(status: string | null | undefined) {
   gap: 10px;
   min-height: 66px;
   padding: 12px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--cw-line);
   border-radius: 10px;
-  background: #f8fafc;
+  background: var(--el-fill-color-extra-light);
 }
 
 .rail-dot {
@@ -514,38 +514,38 @@ function healthTagType(status: string | null | undefined) {
   height: 9px;
   margin-top: 5px;
   border-radius: 50%;
-  background: #94a3b8;
-  box-shadow: 0 0 0 4px #e2e8f0;
+  background: var(--cw-text-muted);
+  box-shadow: 0 0 0 4px var(--cw-line);
 }
 
-.rail-item.is-ready .rail-dot { background: #0f9f78; box-shadow: 0 0 0 4px #d1fae5; }
-.rail-item.is-danger .rail-dot { background: #dc4c4c; box-shadow: 0 0 0 4px #fee2e2; }
+.rail-item.is-ready .rail-dot { background: var(--cw-success); box-shadow: 0 0 0 4px color-mix(in srgb, var(--cw-success) 20%, transparent); }
+.rail-item.is-danger .rail-dot { background: var(--cw-danger); box-shadow: 0 0 0 4px color-mix(in srgb, var(--cw-danger) 20%, transparent); }
 .rail-label,
 .metric-grid span,
 .health-hero span {
   display: block;
   margin-bottom: 5px;
-  color: #64748b;
+  color: var(--cw-text-muted);
   font-size: 12px;
 }
 
-.rail-item strong { display: block; overflow: hidden; color: #25314a; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.rail-item strong { display: block; overflow: hidden; color: var(--cw-text); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
 .governance-tabs { --el-tabs-header-height: 48px; }
 .section-heading { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 14px 0; }
 .section-heading p,
-.rotation-panel p { margin: 5px 0 0; color: #64748b; font-size: 13px; }
+.rotation-panel p { margin: 5px 0 0; color: var(--cw-text-muted); font-size: 13px; }
 .split-heading { margin-top: 26px; }
 .section-body { margin-top: 16px; }
-.rotation-panel { margin-top: 22px; padding: 18px; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc; }
+.rotation-panel { margin-top: 22px; padding: 18px; border: 1px solid var(--cw-line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
 .rotation-panel .el-form { margin-top: 16px; }
 .health-hero { display: flex; align-items: center; justify-content: space-between; margin: 10px 0 16px; padding: 18px 20px; border-radius: 12px; color: white; background: linear-gradient(120deg, #172033, #344565); }
 .health-hero strong { display: block; font-size: 24px; letter-spacing: .04em; }
 .health-hero span { color: #cbd5e1; }
 .health-hero small { display: block; margin-top: 6px; color: #cbd5e1; }
 .metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-bottom: 18px; }
-.metric-grid > div { padding: 14px; border: 1px solid #e2e8f0; border-radius: 10px; background: #fff; }
-.metric-grid strong { color: #172033; font-size: 14px; }
-.health-override-panel { margin: 18px 0; padding: 18px; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc; }
+.metric-grid > div { padding: 14px; border: 1px solid var(--cw-line); border-radius: 10px; background: var(--cw-paper); }
+.metric-grid strong { color: var(--cw-text); font-size: 14px; }
+.health-override-panel { margin: 18px 0; padding: 18px; border: 1px solid var(--cw-line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
 .health-override-panel .section-heading { margin-top: 0; }
 
 @media (max-width: 760px) {

--- a/customer-admin-web/src/views/aiconfig/components/ModelRoutingPanel.vue
+++ b/customer-admin-web/src/views/aiconfig/components/ModelRoutingPanel.vue
@@ -307,7 +307,7 @@ function formatTime(value: string | null | undefined) {
         </div>
         <div class="header-actions">
           <span>{{ activeCount }} 个生效策略 / {{ policies.length }} 个策略</span>
-          <el-button v-permission="'model:edit'" type="primary" @click="openCreate">新建策略</el-button>
+          <el-button v-permission="'model:edit'" class="cw-final-action" type="primary" @click="openCreate">新建策略</el-button>
         </div>
       </div>
     </template>
@@ -448,7 +448,7 @@ function formatTime(value: string | null | undefined) {
       <template #footer>
         <el-button @click="editorVisible = false">取消</el-button>
         <el-button @click="validateDraft">校验冲突</el-button>
-        <el-button type="primary" :loading="saving" @click="saveDraft">{{ editorMode === 'create' ? '创建 v1 草稿' : '创建不可变版本' }}</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="saving" @click="saveDraft">{{ editorMode === 'create' ? '创建 v1 草稿' : '创建不可变版本' }}</el-button>
       </template>
     </el-dialog>
 
@@ -462,7 +462,7 @@ function formatTime(value: string | null | undefined) {
           <el-form-item label="能力要求"><el-checkbox v-model="dryRun.requiresTools">工具调用</el-checkbox><el-checkbox v-model="dryRun.requiresStructuredOutput">结构化输出</el-checkbox></el-form-item>
           <el-form-item label="配额降级"><el-switch v-model="dryRun.preferFallback" active-text="仅备用候选" inactive-text="常规规则" /></el-form-item>
         </div>
-        <el-button type="primary" :loading="dryRunLoading" @click="executeDryRun">执行 Dry-run</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="dryRunLoading" @click="executeDryRun">执行 Dry-run</el-button>
       </el-form>
 
       <section v-if="dryRunResult" class="dry-result" :class="{ 'is-closed': dryRunResult.failClosed }">
@@ -486,29 +486,29 @@ function formatTime(value: string | null | undefined) {
 <style scoped>
 .routing-panel { margin-top: 20px; border: 0; border-radius: 16px; }
 .panel-header, .header-actions, .drawer-title, .version-heading, .rules-heading, .dry-summary { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.panel-header h2, .drawer-title h2, .rules-heading h3 { margin: 2px 0 5px; color: #172033; }
-.panel-header p, .rules-heading p { margin: 0; color: #64748b; font-size: 13px; }
-.eyebrow { color: #2457d6 !important; font-size: 10px !important; font-weight: 700; letter-spacing: .15em; }
-.header-actions { flex-shrink: 0; color: #64748b; font-size: 12px; }
+.panel-header h2, .drawer-title h2, .rules-heading h3 { margin: 2px 0 5px; color: var(--cw-text); }
+.panel-header p, .rules-heading p { margin: 0; color: var(--cw-text-muted); font-size: 13px; }
+.eyebrow { color: var(--cw-cobalt) !important; font-size: 10px !important; font-weight: 700; letter-spacing: .15em; }
+.header-actions { flex-shrink: 0; color: var(--cw-text-muted); font-size: 12px; }
 .policy-table { margin-top: 14px; }
 .primary-cell strong, .primary-cell span { display: block; }
-.primary-cell span { margin-top: 3px; color: #64748b; font-size: 11px; }
-.version-card { margin-bottom: 14px; padding: 16px; border: 1px solid #e2e8f0; border-radius: 12px; background: #fbfcfe; }
+.primary-cell span { margin-top: 3px; color: var(--cw-text-muted); font-size: 11px; }
+.version-card { margin-bottom: 14px; padding: 16px; border: 1px solid var(--cw-line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
 .version-heading > div { display: flex; align-items: center; gap: 9px; }
 .version-heading > div > strong { font-size: 20px; }
-.version-heading > div > span { color: #64748b; font-size: 13px; }
-.version-meta { display: flex; flex-wrap: wrap; gap: 16px; margin: 8px 0 12px; color: #64748b; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
+.version-heading > div > span { color: var(--cw-text-muted); font-size: 13px; }
+.version-meta { display: flex; flex-wrap: wrap; gap: 16px; margin: 8px 0 12px; color: var(--cw-text-muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
 .policy-form-grid, .rule-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 14px; }
 .full-row { grid-column: 1 / -1; }
 .rules-heading { margin: 12px 0; }
-.rule-editor { margin-bottom: 12px; padding: 14px; border: 1px solid #e2e8f0; border-radius: 12px; background: #f8fafc; }
-.rule-index { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; color: #2457d6; font-size: 11px; letter-spacing: .08em; }
-.dry-result { margin-top: 18px; padding: 16px; border: 1px solid #a7e1d0; border-radius: 12px; background: #effbf7; }
-.dry-result.is-closed { border-color: #fecaca; background: #fff5f5; }
+.rule-editor { margin-bottom: 12px; padding: 14px; border: 1px solid var(--cw-line); border-radius: 12px; background: var(--el-fill-color-extra-light); }
+.rule-index { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; color: var(--cw-cobalt); font-size: 11px; letter-spacing: .08em; }
+.dry-result { margin-top: 18px; padding: 16px; border: 1px solid color-mix(in srgb, var(--cw-success) 42%, var(--cw-line)); border-radius: 12px; background: color-mix(in srgb, var(--cw-success) 8%, var(--cw-paper)); }
+.dry-result.is-closed { border-color: color-mix(in srgb, var(--cw-danger) 42%, var(--cw-line)); background: color-mix(in srgb, var(--cw-danger) 8%, var(--cw-paper)); }
 .dry-summary span, .dry-summary strong { display: block; }
-.dry-summary span { color: #64748b; font-size: 11px; letter-spacing: .1em; }
+.dry-summary span { color: var(--cw-text-muted); font-size: 11px; letter-spacing: .1em; }
 .dry-summary strong { margin-top: 3px; font-size: 18px; }
-.dry-result > p { color: #475569; font-size: 13px; }
+.dry-result > p { color: var(--el-text-color-regular); font-size: 13px; }
 @media (max-width: 760px) {
   .panel-header, .header-actions, .rules-heading { align-items: flex-start; flex-direction: column; }
   .policy-form-grid, .rule-grid { grid-template-columns: 1fr; }

--- a/customer-admin-web/src/views/contentguard/RateLimitRuleManage.vue
+++ b/customer-admin-web/src/views/contentguard/RateLimitRuleManage.vue
@@ -11,6 +11,7 @@ import {
   updateRateLimitRule,
 } from '@/api/contentGuard'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { PageQuery, RateLimitRuleSaveRequest, RateLimitRuleVO } from '@/types/api'
 
 const formRef = ref<FormInstance>()
@@ -18,7 +19,7 @@ const dimensions = ref<string[]>([])
 const algorithms = ref<string[]>([])
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<RateLimitRuleVO, PageQuery, RateLimitRuleSaveRequest>({
@@ -67,6 +68,7 @@ onMounted(async () => {
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-alert type="warning" :closable="false" show-icon class="notice">
       规则按<b>优先级升序首匹配即止</b>（不叠加），都不命中才落到客服端 yml 里的全局兜底参数。
       规则仅在客服端开启 <code>customer-work.security.rate-limit.rule-enabled=true</code> 且
@@ -87,12 +89,14 @@ onMounted(async () => {
           <el-option label="停用" :value="0" />
         </el-select>
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'rate-limit-rule:add'" type="primary" @click="openCreate">新增规则</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'rate-limit-rule:add'" class="cw-final-action" type="primary" @click="openCreate">新增规则</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的限流规则">
         <el-table-column prop="priority" label="优先级" width="90" sortable />
-        <el-table-column prop="ruleName" label="规则名" min-width="140" show-overflow-tooltip />
+        <el-table-column prop="ruleName" label="规则名" min-width="140" show-overflow-tooltip class-name="primary-column" />
         <el-table-column prop="pathPrefix" label="路径前缀" min-width="180" show-overflow-tooltip />
         <el-table-column label="计数维度" width="130">
           <template #default="{ row }">{{ dimensionLabels[row.dimension] ?? row.dimension }}</template>
@@ -103,7 +107,7 @@ onMounted(async () => {
         <el-table-column label="算法" width="110">
           <template #default="{ row }">{{ algorithmLabels[row.algorithm] ?? row.algorithm }}</template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.enabled ? 'success' : 'info'">{{ row.enabled ? '启用' : '停用' }}</el-tag>
           </template>
@@ -117,7 +121,7 @@ onMounted(async () => {
             <el-button v-permission="'rate-limit-rule:edit'" link type="primary" @click="handleToggle(row)">
               {{ row.enabled ? '停用' : '启用' }}
             </el-button>
-            <el-button v-permission="'rate-limit-rule:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'rate-limit-rule:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -127,7 +131,7 @@ onMounted(async () => {
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -179,7 +183,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存规则</el-button>
       </template>
     </el-dialog>
   </div>
@@ -192,9 +196,26 @@ onMounted(async () => {
 
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
   align-items: center;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .form-hint {
@@ -202,5 +223,16 @@ onMounted(async () => {
   font-size: 12px;
   color: var(--el-text-color-secondary);
   line-height: 1.6;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/contentguard/SensitiveHitLogBoard.vue
+++ b/customer-admin-web/src/views/contentguard/SensitiveHitLogBoard.vue
@@ -94,55 +94,58 @@ onMounted(handleSearch)
       片段列保留了命中处的原文，属敏感数据，请按内部合规要求使用。
     </el-alert>
 
-    <el-card class="filter-card">
-      <div class="toolbar">
+    <el-card class="filter-card" shadow="never">
+      <div class="filter-controls">
         <el-date-picker
           v-model="timeRange"
+          class="time-filter"
           type="datetimerange"
           range-separator="至"
           start-placeholder="开始时间"
           end-placeholder="结束时间"
-          style="width: 380px"
         />
-        <el-select v-model="query.direction" placeholder="全部方向" style="width: 140px" clearable>
+        <el-select v-model="query.direction" class="select-filter" placeholder="全部方向" clearable>
           <el-option label="用户输入" value="INBOUND" />
           <el-option label="模型输出" value="OUTBOUND" />
         </el-select>
-        <el-select v-model="query.action" placeholder="全部处置" style="width: 140px" clearable>
+        <el-select v-model="query.action" class="select-filter" placeholder="全部处置" clearable>
           <el-option label="拦截" value="BLOCK" />
           <el-option label="打码" value="MASK" />
           <el-option label="标记复核" value="REVIEW" />
         </el-select>
-        <el-input v-model="query.keyword" placeholder="按命中词搜索" style="width: 180px" clearable @keyup.enter="handleSearch" />
-        <el-input v-model="query.sessionId" placeholder="会话 ID" style="width: 180px" clearable @keyup.enter="handleSearch" />
+        <el-input v-model="query.keyword" class="text-filter" placeholder="按命中词搜索" clearable @keyup.enter="handleSearch" />
+        <el-input v-model="query.sessionId" class="text-filter" placeholder="会话 ID" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">查询</el-button>
       </div>
     </el-card>
 
-    <div class="stat-row">
-      <el-card v-loading="statsLoading" class="stat-card">
+    <div class="stat-row" aria-label="敏感词命中指标">
+      <div v-loading="statsLoading" class="stat-card">
         <div class="stat-label">命中总数</div>
         <div class="stat-value">{{ stats?.total ?? 0 }}</div>
-      </el-card>
-      <el-card v-loading="statsLoading" class="stat-card">
+      </div>
+      <div v-loading="statsLoading" class="stat-card danger-stat">
         <div class="stat-label">其中拦截</div>
         <div class="stat-value danger">{{ blockedCount }}</div>
-      </el-card>
-      <el-card v-loading="statsLoading" class="stat-card">
+      </div>
+      <div v-loading="statsLoading" class="stat-card warning-stat">
         <div class="stat-label">其中打码</div>
         <div class="stat-value warning">{{ maskedCount }}</div>
-      </el-card>
-      <el-card v-loading="statsLoading" class="stat-card">
+      </div>
+      <div v-loading="statsLoading" class="stat-card">
         <div class="stat-label">用户输入命中</div>
         <div class="stat-value">{{ inboundCount }}</div>
-      </el-card>
+      </div>
     </div>
 
     <div class="chart-row">
-      <el-card class="trend-card">
-        <div class="card-title">
-          命中趋势
-          <span class="granularity">（{{ stats?.trendGranularity === 'hour' ? '按小时' : '按天' }}）</span>
+      <el-card class="trend-card" shadow="never">
+        <div class="section-heading">
+          <div>
+            <span class="section-eyebrow">HIT TREND</span>
+            <strong>命中趋势</strong>
+          </div>
+          <span class="granularity">{{ stats?.trendGranularity === 'hour' ? '按小时' : '按天' }}</span>
         </div>
         <ContentGuardTrendChart
           :points="stats?.trend ?? []"
@@ -151,55 +154,70 @@ onMounted(handleSearch)
         />
       </el-card>
 
-      <el-card v-loading="statsLoading" class="top-card">
-        <div class="card-title">高频命中 Top 10</div>
+      <el-card v-loading="statsLoading" class="top-card" shadow="never">
+        <div class="section-heading">
+          <div>
+            <span class="section-eyebrow">FREQUENCY EVIDENCE</span>
+            <strong>高频命中 Top 10</strong>
+          </div>
+          <span class="evidence-count">{{ stats?.topWords?.length ?? 0 }} 项</span>
+        </div>
         <div v-if="!stats?.topWords?.length" class="empty-tip">暂无数据</div>
-        <div v-for="item in stats?.topWords ?? []" :key="item.label" class="top-item">
+        <div v-for="(item, index) in stats?.topWords ?? []" :key="item.label" class="top-item">
+          <span class="top-rank">{{ String(index + 1).padStart(2, '0') }}</span>
           <span class="top-label" :title="item.label">{{ item.label || '(空)' }}</span>
           <span class="top-count">{{ item.total }}</span>
         </div>
       </el-card>
     </div>
 
-    <el-card>
-      <div class="card-title">命中明细</div>
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column label="时间" width="180">
-          <template #default="{ row }">{{ formatTime(row.createdAtMs) }}</template>
-        </el-table-column>
-        <el-table-column label="方向" width="110">
-          <template #default="{ row }">{{ directionLabels[row.direction] ?? row.direction }}</template>
-        </el-table-column>
-        <el-table-column label="处置" width="110">
-          <template #default="{ row }">
-            <el-tag :type="actionMeta[row.action]?.type ?? 'info'">
-              {{ actionMeta[row.action]?.label ?? row.action }}
-            </el-tag>
-          </template>
-        </el-table-column>
-        <el-table-column label="命中词" min-width="180">
-          <template #default="{ row }">
-            <el-tag
-              v-for="item in summarizeSensitiveHitWords(row.words)"
-              :key="item.word"
-              size="small"
-              class="word-tag"
-            >
-              {{ item.word }}<span v-if="item.extraCount > 0" class="word-extra-count">+{{ item.extraCount }}</span>
-            </el-tag>
-          </template>
-        </el-table-column>
-        <el-table-column prop="agentName" label="智能体" width="140" show-overflow-tooltip />
-        <el-table-column prop="sessionId" label="会话 ID" width="160" show-overflow-tooltip />
-        <el-table-column prop="snippet" label="原文片段" min-width="220" show-overflow-tooltip />
-      </el-table>
+    <el-card class="detail-card" shadow="never">
+      <div class="section-heading detail-heading">
+        <div>
+          <span class="section-eyebrow">RAW EVIDENCE</span>
+          <strong>命中明细</strong>
+        </div>
+        <span class="detail-hint">命中词仅在展示层折叠，原始统计口径保持不变。</span>
+      </div>
+      <div class="table-scroll">
+        <el-table v-loading="loading" :data="list">
+          <el-table-column label="时间" width="180">
+            <template #default="{ row }">{{ formatTime(row.createdAtMs) }}</template>
+          </el-table-column>
+          <el-table-column label="方向" width="110">
+            <template #default="{ row }">{{ directionLabels[row.direction] ?? row.direction }}</template>
+          </el-table-column>
+          <el-table-column label="处置" width="110">
+            <template #default="{ row }">
+              <el-tag :type="actionMeta[row.action]?.type ?? 'info'">
+                {{ actionMeta[row.action]?.label ?? row.action }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="命中词" min-width="180">
+            <template #default="{ row }">
+              <el-tag
+                v-for="item in summarizeSensitiveHitWords(row.words)"
+                :key="item.word"
+                size="small"
+                class="word-tag"
+              >
+                {{ item.word }}<span v-if="item.extraCount > 0" class="word-extra-count">+{{ item.extraCount }}</span>
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column prop="agentName" label="智能体" width="140" show-overflow-tooltip />
+          <el-table-column prop="sessionId" label="会话 ID" width="160" show-overflow-tooltip />
+          <el-table-column prop="snippet" label="原文片段" min-width="220" show-overflow-tooltip />
+        </el-table>
+      </div>
 
       <el-pagination
         v-model:current-page="query.pageNum"
         v-model:page-size="query.pageSize"
+        class="pagination"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
         @current-change="loadList"
       />
     </el-card>
@@ -207,45 +225,97 @@ onMounted(handleSearch)
 </template>
 
 <style scoped>
+.page {
+  min-width: 0;
+}
+
 .notice {
   margin-bottom: 12px;
+  border: 1px solid color-mix(in srgb, var(--cw-cobalt) 28%, var(--cw-line));
+}
+
+.notice :deep(.el-alert__description) {
+  overflow-wrap: anywhere;
+  line-height: 1.6;
+}
+
+.notice code {
+  color: var(--cw-cobalt);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
 }
 
 .filter-card {
   margin-bottom: 12px;
+  border-color: var(--cw-line);
+  background: var(--cw-paper);
 }
 
-.toolbar {
+.filter-controls {
   display: flex;
-  gap: 8px;
   align-items: center;
   flex-wrap: wrap;
+  gap: 10px;
+}
+
+.time-filter {
+  width: 380px;
+}
+
+.select-filter {
+  width: 140px;
+}
+
+.text-filter {
+  width: 180px;
 }
 
 .stat-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 12px;
 }
 
+.stat-card {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  padding: 17px 18px 16px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.stat-card.danger-stat::before {
+  background: var(--cw-danger);
+}
+
+.stat-card.warning-stat::before {
+  background: var(--cw-amber);
+}
+
 .stat-label {
+  color: var(--cw-text-muted);
   font-size: 13px;
-  color: var(--el-text-color-secondary);
 }
 
 .stat-value {
   margin-top: 8px;
-  font-size: 26px;
-  font-weight: 600;
+  color: var(--cw-text);
+  font-size: clamp(23px, 2.3vw, 29px);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  letter-spacing: -0.025em;
 }
 
 .stat-value.danger {
-  color: var(--el-color-danger);
+  color: var(--cw-danger);
 }
 
 .stat-value.warning {
-  color: var(--el-color-warning);
+  color: var(--cw-amber);
 }
 
 .chart-row {
@@ -255,56 +325,154 @@ onMounted(handleSearch)
   margin-bottom: 12px;
 }
 
+.trend-card,
+.top-card,
+.detail-card {
+  min-width: 0;
+  border-color: var(--cw-line);
+  background: var(--cw-paper);
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  display: block;
+  color: var(--cw-text);
+  font-size: 15px;
+}
+
+.section-eyebrow {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--cw-cobalt);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.granularity {
+  padding: 4px 8px;
+  color: var(--cw-text-muted);
+  border: 1px solid var(--cw-line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cw-paper) 92%, var(--cw-cobalt));
+  font-size: 12px;
+}
+
+.evidence-count,
+.detail-hint {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+}
+
+.top-item {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 34px;
+  border-bottom: 1px solid var(--cw-line);
+}
+
+.top-item:last-child {
+  border-bottom: 0;
+}
+
+.top-rank {
+  color: var(--cw-cobalt);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.top-label {
+  overflow: hidden;
+  color: var(--cw-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.top-count {
+  color: var(--cw-text-muted);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+}
+
+.empty-tip {
+  color: var(--cw-text-muted);
+  font-size: 13px;
+  padding: 24px 0;
+  text-align: center;
+}
+
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.table-scroll :deep(.el-table) {
+  min-width: 1080px;
+}
+
+.word-tag {
+  margin: 2px 4px 2px 0;
+}
+
+.word-extra-count {
+  margin-left: 4px;
+  font-weight: 600;
+}
+
+.pagination {
+  width: 100%;
+  overflow-x: auto;
+}
+
 @media (max-width: 1100px) {
   .chart-row {
     grid-template-columns: 1fr;
   }
 }
 
-.card-title {
-  font-size: 15px;
-  font-weight: 600;
-  margin-bottom: 12px;
+@media (max-width: 767px) {
+  .filter-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .filter-controls :deep(.el-date-editor),
+  .filter-controls :deep(.el-input),
+  .filter-controls :deep(.el-select),
+  .filter-controls :deep(.el-button) {
+    width: 100%;
+  }
+
+  .stat-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .detail-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
 }
 
-.granularity {
-  font-size: 12px;
-  font-weight: 400;
-  color: var(--el-text-color-secondary);
-}
+@media (max-width: 480px) {
+  .stat-row {
+    grid-template-columns: 1fr;
+  }
 
-.top-item {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--el-border-color-lighter);
-}
-
-.top-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.top-count {
-  color: var(--el-text-color-secondary);
-  flex-shrink: 0;
-}
-
-.empty-tip {
-  color: var(--el-text-color-placeholder);
-  font-size: 13px;
-  padding: 24px 0;
-  text-align: center;
-}
-
-.word-tag {
-  margin-right: 4px;
-}
-
-.word-extra-count {
-  margin-left: 4px;
-  font-weight: 600;
+  .stat-card {
+    padding: 15px 16px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/contentguard/SensitiveWordManage.vue
+++ b/customer-admin-web/src/views/contentguard/SensitiveWordManage.vue
@@ -13,6 +13,7 @@ import {
   updateSensitiveWord,
 } from '@/api/contentGuard'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { SensitiveWordPageQuery, SensitiveWordSaveRequest, SensitiveWordVO } from '@/types/api'
 
 const formRef = ref<FormInstance>()
@@ -23,7 +24,7 @@ const importText = ref('')
 const importing = ref(false)
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<SensitiveWordVO, SensitiveWordPageQuery, SensitiveWordSaveRequest>({
@@ -102,6 +103,7 @@ onMounted(async () => {
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-alert type="info" :closable="false" show-icon class="notice">
       词库存放于客服端库，是客服链路与后台工作区共用的唯一真源。改动后由客服端轮询版本指纹自动生效
       （默认 60 秒内），无需重启任何服务。
@@ -127,26 +129,26 @@ onMounted(async () => {
           <el-option label="停用" :value="0" />
         </el-select>
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <div class="toolbar-right">
+        <div class="toolbar-actions">
           <el-button v-permission="'sensitive-word:add'" @click="importVisible = true">批量导入</el-button>
           <el-button @click="handleExport">导出</el-button>
-          <el-button v-permission="'sensitive-word:add'" type="primary" @click="openCreate">新增敏感词</el-button>
+          <el-button v-permission="'sensitive-word:add'" class="cw-final-action" type="primary" @click="openCreate">新增敏感词</el-button>
         </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="word" label="敏感词" min-width="180" show-overflow-tooltip />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的敏感词">
+        <el-table-column prop="word" label="敏感词" min-width="180" show-overflow-tooltip class-name="primary-column" />
         <el-table-column label="类目" width="120">
           <template #default="{ row }">{{ categoryLabels[row.category] ?? row.category }}</template>
         </el-table-column>
-        <el-table-column label="处置动作" width="120">
+        <el-table-column label="处置动作" width="120" align="center">
           <template #default="{ row }">
             <el-tag :type="actionMeta[row.action]?.type ?? 'info'">
               {{ actionMeta[row.action]?.label ?? row.action }}
             </el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.enabled ? 'success' : 'info'">{{ row.enabled ? '启用' : '停用' }}</el-tag>
           </template>
@@ -160,7 +162,7 @@ onMounted(async () => {
             <el-button v-permission="'sensitive-word:edit'" link type="primary" @click="handleToggle(row)">
               {{ row.enabled ? '停用' : '启用' }}
             </el-button>
-            <el-button v-permission="'sensitive-word:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'sensitive-word:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -170,7 +172,7 @@ onMounted(async () => {
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -197,7 +199,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存敏感词</el-button>
       </template>
     </el-dialog>
 
@@ -215,7 +217,7 @@ onMounted(async () => {
       <div class="form-hint import-count">待导入 {{ importLineCount }} 条</div>
       <template #footer>
         <el-button @click="importVisible = false">取消</el-button>
-        <el-button type="primary" :loading="importing" @click="handleImport">导入</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="importing" @click="handleImport">确认导入</el-button>
       </template>
     </el-dialog>
   </div>
@@ -228,15 +230,27 @@ onMounted(async () => {
 
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
   align-items: center;
 }
 
-.toolbar-right {
+.toolbar-actions {
   margin-left: auto;
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .form-hint {
@@ -253,5 +267,16 @@ onMounted(async () => {
 .import-count {
   margin-top: 8px;
   text-align: right;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/contentguard/SubjectQuotaManage.vue
+++ b/customer-admin-web/src/views/contentguard/SubjectQuotaManage.vue
@@ -33,6 +33,7 @@ const levelDialogVisible = ref(false)
 const levelDialogMode = ref<'create' | 'edit'>('create')
 const levelFormRef = ref<FormInstance>()
 const levelForm = reactive<SubjectQuotaLevelSaveRequest>(initLevelForm())
+const levelSubmitting = ref(false)
 
 function initLevelForm(): SubjectQuotaLevelSaveRequest {
   return {
@@ -73,12 +74,18 @@ function openLevelEdit(row: SubjectQuotaLevelVO) {
 }
 
 async function submitLevel() {
+  if (levelSubmitting.value) return
   if (!levelFormRef.value) return
-  await levelFormRef.value.validate()
-  await saveSubjectQuotaLevel({ ...levelForm })
-  ElMessage.success('已保存。后台档位立即生效，客服端档位最长 60 秒')
-  levelDialogVisible.value = false
-  await loadLevels()
+  levelSubmitting.value = true
+  try {
+    await levelFormRef.value.validate()
+    await saveSubjectQuotaLevel({ ...levelForm })
+    ElMessage.success('已保存。后台档位立即生效，客服端档位最长 60 秒')
+    levelDialogVisible.value = false
+    await loadLevels()
+  } finally {
+    levelSubmitting.value = false
+  }
 }
 
 async function removeLevel(row: SubjectQuotaLevelVO) {
@@ -215,7 +222,7 @@ onMounted(async () => {
       <el-tab-pane label="额度等级" name="levels">
         <el-card>
           <div class="toolbar">
-            <el-button v-permission="'subject-quota:level-edit'" type="primary" @click="openLevelCreate">
+            <el-button v-permission="'subject-quota:level-edit'" class="cw-final-action" type="primary" @click="openLevelCreate">
               新增等级
             </el-button>
             <el-button @click="loadLevels">刷新</el-button>
@@ -499,7 +506,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="levelDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="submitLevel">保存</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="levelSubmitting" @click="submitLevel">保存配额层级</el-button>
       </template>
     </el-dialog>
   </div>
@@ -507,7 +514,7 @@ onMounted(async () => {
 
 <style scoped>
 .page {
-  padding: 16px;
+  min-width: 0;
 }
 
 .notice {
@@ -522,7 +529,7 @@ onMounted(async () => {
 }
 
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
 }
 
@@ -532,8 +539,15 @@ onMounted(async () => {
 }
 
 .form-hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
   line-height: 1.5;
+}
+
+@media (max-width: 767px) {
+  .hint {
+    flex-basis: 100%;
+    line-height: 1.6;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/home/components/HomeAdmission.vue
+++ b/customer-admin-web/src/views/home/components/HomeAdmission.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import type { HomeAdmissionPresentation } from '../../homePresentation'
+import HomeServiceScene from './HomeServiceScene.vue'
+
+defineProps<{
+  displayName: string
+  username: string
+  presentation: HomeAdmissionPresentation
+}>()
+</script>
+
+<template>
+  <div class="admission-canvas">
+    <section class="admission-panel">
+      <div class="admission-copy">
+        <div class="admission-copy__topline">
+          <span>{{ presentation.eyebrow }}</span>
+          <span class="admission-status">{{ presentation.status }}</span>
+        </div>
+        <p class="admission-kicker">你好，{{ displayName }}</p>
+        <h1 id="home-title">{{ presentation.title }}</h1>
+        <p class="admission-description">{{ presentation.description }}</p>
+
+        <dl class="admission-account">
+          <div>
+            <dt>申请账号</dt>
+            <dd>{{ username }}</dd>
+          </div>
+          <div>
+            <dt>准入状态</dt>
+            <dd>{{ presentation.status }}</dd>
+          </div>
+        </dl>
+
+        <p class="admission-note">
+          <span aria-hidden="true">i</span>
+          {{ presentation.note }}
+        </p>
+      </div>
+
+      <HomeServiceScene
+        eyebrow="CONTROLLED ACCESS"
+        title="服务能力从可信准入开始。"
+        description="审核完成前，业务导航与历史工作保持隔离。"
+      />
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.admission-canvas {
+  display: grid;
+  width: min(100%, 1560px);
+  min-height: 100%;
+  margin: 0 auto;
+  padding: clamp(18px, 2.4vw, 36px);
+  place-items: center;
+  box-sizing: border-box;
+}
+
+.admission-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.48fr) minmax(320px, 0.82fr);
+  width: 100%;
+  min-height: min(650px, calc(100vh - 180px));
+  overflow: hidden;
+  border: 1px solid var(--cw-line-strong);
+  border-radius: calc(var(--cw-radius-lg) + 6px);
+  background: var(--home-paper, var(--cw-paper));
+  box-shadow: var(--cw-shadow-lg);
+  animation: home-admission-enter 480ms ease-out both;
+}
+
+.admission-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(40px, 5vw, 78px);
+  color: #ffffff;
+  background:
+    radial-gradient(circle at 90% 5%, color-mix(in srgb, var(--home-cobalt) 28%, transparent), transparent 35%),
+    linear-gradient(145deg, var(--home-ink), var(--home-ink-soft));
+}
+
+.admission-copy__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: rgb(235 243 250 / 68%);
+  font-size: 11px;
+  font-weight: 760;
+  line-height: 1.2;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.admission-status {
+  padding: 6px 9px;
+  border: 1px solid color-mix(in srgb, var(--home-amber) 34%, transparent);
+  border-radius: 999px;
+  color: var(--home-signal, var(--home-amber));
+  background: color-mix(in srgb, var(--home-amber) 9%, transparent);
+  letter-spacing: 0.08em;
+}
+
+.admission-kicker {
+  margin: clamp(54px, 9vh, 96px) 0 13px;
+  color: var(--home-on-ink-muted);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: 0.045em;
+}
+
+.admission-copy h1 {
+  max-width: 760px;
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(40px, 4.6vw, 66px);
+  font-weight: 760;
+  line-height: 1.06;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+.admission-description {
+  max-width: 650px;
+  margin: 26px 0 0;
+  color: rgb(225 235 244 / 72%);
+  font-size: 15px;
+  line-height: 1.85;
+}
+
+.admission-account {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-width: 640px;
+  margin: 42px 0 0;
+  padding: 22px 0;
+  border-top: 1px solid rgb(255 255 255 / 14%);
+  border-bottom: 1px solid rgb(255 255 255 / 14%);
+}
+
+.admission-account > div + div {
+  padding-left: 24px;
+  border-left: 1px solid rgb(255 255 255 / 14%);
+}
+
+.admission-account dt {
+  color: rgb(213 226 238 / 50%);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.admission-account dd {
+  margin: 8px 0 0;
+  overflow-wrap: anywhere;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.admission-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  max-width: 650px;
+  margin: 24px 0 0;
+  color: rgb(213 226 238 / 62%);
+  font-size: 11px;
+  line-height: 1.65;
+}
+
+.admission-note span {
+  display: grid;
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 28%);
+  border-radius: 50%;
+  color: #ffffff;
+  font-size: 10px;
+  font-style: normal;
+}
+
+@media (max-width: 1100px) {
+  .admission-panel {
+    grid-template-columns: minmax(0, 1.32fr) minmax(300px, 0.68fr);
+  }
+}
+
+@media (max-width: 820px) {
+  .admission-canvas {
+    padding: 16px;
+  }
+
+  .admission-panel {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .admission-copy {
+    min-height: 520px;
+  }
+}
+
+@media (max-width: 520px) {
+  .admission-canvas {
+    padding: 12px;
+  }
+
+  .admission-panel {
+    border-radius: var(--cw-radius-lg);
+  }
+
+  .admission-copy {
+    min-height: 0;
+    padding: 28px 22px;
+  }
+
+  .admission-copy__topline {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 9px;
+    font-size: 9px;
+    letter-spacing: 0.09em;
+  }
+
+  .admission-status {
+    align-self: flex-start;
+  }
+
+  .admission-kicker {
+    margin-top: 44px;
+  }
+
+  .admission-copy h1 {
+    font-size: clamp(36px, 11.5vw, 46px);
+    letter-spacing: -0.05em;
+  }
+
+  .admission-description {
+    margin-top: 20px;
+    font-size: 13px;
+    line-height: 1.75;
+  }
+
+  .admission-account {
+    grid-template-columns: 1fr;
+    margin-top: 30px;
+  }
+
+  .admission-account > div + div {
+    margin-top: 18px;
+    padding-top: 18px;
+    padding-left: 0;
+    border-top: 1px solid rgb(255 255 255 / 14%);
+    border-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .admission-panel {
+    animation: none;
+  }
+}
+
+@keyframes home-admission-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/customer-admin-web/src/views/home/components/HomeHero.vue
+++ b/customer-admin-web/src/views/home/components/HomeHero.vue
@@ -1,0 +1,449 @@
+<script setup lang="ts">
+import type { HomeEntry, HomeSnapshot } from '../../homePresentation'
+import HomeServiceScene from './HomeServiceScene.vue'
+
+defineProps<{
+  displayName: string
+  todayLabel: string
+  greeting: string
+  routesRegistered: boolean
+  snapshot: HomeSnapshot
+  primaryEntry?: HomeEntry
+}>()
+
+const emit = defineEmits<{
+  navigate: [path: string]
+}>()
+</script>
+
+<template>
+  <section class="home-hero" aria-label="工作台欢迎区">
+    <div class="welcome-panel">
+      <div class="welcome-panel__grid" aria-hidden="true" />
+
+      <div class="welcome-panel__content">
+        <div class="welcome-meta">
+          <span>{{ todayLabel }}</span>
+          <span class="welcome-meta__divider" aria-hidden="true" />
+          <span class="runtime-status" :class="{ 'runtime-status--ready': routesRegistered }">
+            <i aria-hidden="true" />
+            {{ routesRegistered ? '权限已同步' : '权限同步中' }}
+          </span>
+        </div>
+
+        <p class="welcome-kicker">{{ greeting }}，{{ displayName }}</p>
+        <h1 id="home-title">从一次判断开始，<br />让每次运行都有据可循。</h1>
+        <p class="welcome-summary">
+          这里不制造额外的业务数字，只汇总当前账号已经获得的权限入口与本次会话中的工作状态。
+        </p>
+
+        <button
+          v-if="primaryEntry"
+          type="button"
+          class="primary-entry"
+          :aria-label="`进入${primaryEntry.title}`"
+          @click="emit('navigate', primaryEntry.path)"
+        >
+          <span>进入 {{ primaryEntry.title }}</span>
+          <span class="primary-entry__arrow" aria-hidden="true">↗</span>
+        </button>
+
+        <dl class="signal-strip" aria-label="当前工作台状态">
+          <div>
+            <dt>{{ snapshot.availableEntryCount }}</dt>
+            <dd>可用入口</dd>
+            <small>来自权限菜单</small>
+          </div>
+          <div>
+            <dt>{{ snapshot.agentEntryCount }}</dt>
+            <dd>智能体入口</dd>
+            <small>当前可进入</small>
+          </div>
+          <div>
+            <dt>{{ snapshot.openTabCount }}</dt>
+            <dd>打开的工作</dd>
+            <small>可继续处理</small>
+          </div>
+        </dl>
+      </div>
+
+      <ol class="agent-loop" aria-label="智能体工作闭环">
+        <li><span>01</span><strong>感知</strong><small>识别上下文</small></li>
+        <li><span>02</span><strong>判断</strong><small>形成可解释决策</small></li>
+        <li><span>03</span><strong>执行</strong><small>调用业务能力</small></li>
+        <li><span>04</span><strong>验证</strong><small>沉淀运行证据</small></li>
+      </ol>
+    </div>
+
+    <HomeServiceScene
+      eyebrow="SERVICE CONTEXT"
+      title="AI 服务，最终回到真实客户。"
+      description="后台里的每次配置、执行与治理，都应该能够解释一次真实服务体验。"
+      :current-user="displayName"
+    />
+  </section>
+</template>
+
+<style scoped>
+.home-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.48fr) minmax(320px, 0.82fr);
+  min-height: 500px;
+  overflow: hidden;
+  border: 1px solid var(--cw-line-strong);
+  border-radius: calc(var(--cw-radius-lg) + 6px);
+  background: var(--home-paper, var(--cw-paper));
+  box-shadow: var(--cw-shadow-lg);
+  animation: home-hero-enter 480ms ease-out both;
+}
+
+.welcome-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 0;
+  overflow: hidden;
+  padding: clamp(34px, 4vw, 66px);
+  color: var(--home-on-ink);
+  background:
+    radial-gradient(circle at 77% 18%, color-mix(in srgb, var(--home-cobalt) 35%, transparent), transparent 36%),
+    radial-gradient(circle at 10% 100%, color-mix(in srgb, var(--home-success) 16%, transparent), transparent 34%),
+    linear-gradient(145deg, var(--home-ink) 0%, var(--home-ink-soft) 68%, var(--home-ink) 100%);
+}
+
+.welcome-panel__grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.26;
+  background-image:
+    linear-gradient(rgb(255 255 255 / 9%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255 255 255 / 9%) 1px, transparent 1px);
+  background-size: 44px 44px;
+  -webkit-mask-image: linear-gradient(to bottom right, transparent 12%, #000 76%);
+  mask-image: linear-gradient(to bottom right, transparent 12%, #000 76%);
+}
+
+.welcome-panel__content,
+.agent-loop {
+  position: relative;
+  z-index: 1;
+}
+
+.welcome-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: rgb(235 243 250 / 68%);
+  font-size: 11px;
+  font-weight: 760;
+  line-height: 1.2;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.welcome-meta__divider {
+  width: 28px;
+  height: 1px;
+  background: rgb(255 255 255 / 28%);
+}
+
+.runtime-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.runtime-status i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--home-amber);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--home-amber) 12%, transparent);
+}
+
+.runtime-status--ready i {
+  background: var(--home-success);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--home-success) 12%, transparent);
+}
+
+.welcome-kicker {
+  margin: clamp(46px, 7vh, 76px) 0 13px;
+  color: var(--home-on-ink-muted);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: 0.045em;
+}
+
+.welcome-panel h1 {
+  max-width: 860px;
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(42px, 5.2vw, 72px);
+  font-weight: 760;
+  line-height: 1.06;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+.welcome-summary {
+  max-width: 690px;
+  margin: 24px 0 0;
+  color: rgb(225 235 244 / 70%);
+  font-size: 15px;
+  line-height: 1.8;
+}
+
+.primary-entry {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  min-width: 240px;
+  max-width: 100%;
+  margin-top: 30px;
+  padding: 13px 14px 13px 18px;
+  border: 1px solid rgb(255 255 255 / 20%);
+  border-radius: var(--cw-radius-md);
+  color: #ffffff;
+  background: rgb(255 255 255 / 8%);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  text-align: left;
+  transition: border-color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+.primary-entry__arrow {
+  display: grid;
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: var(--cw-radius-sm);
+  color: var(--home-ink);
+  background: #ffffff;
+  font-size: 15px;
+}
+
+.signal-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 720px;
+  margin: clamp(34px, 5vh, 54px) 0 0;
+  padding: 0;
+  border-top: 1px solid rgb(255 255 255 / 13%);
+}
+
+.signal-strip > div {
+  min-width: 0;
+  padding: 22px 18px 0 0;
+}
+
+.signal-strip > div + div {
+  padding-left: 22px;
+  border-left: 1px solid rgb(255 255 255 / 13%);
+}
+
+.signal-strip dt {
+  color: #ffffff;
+  font-size: 28px;
+  font-weight: 760;
+  line-height: 1;
+}
+
+.signal-strip dd {
+  margin: 8px 0 0;
+  color: var(--home-on-ink-soft);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.signal-strip small {
+  display: block;
+  margin-top: 5px;
+  color: rgb(213 226 238 / 48%);
+  font-size: 10px;
+}
+
+.agent-loop {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  margin: 42px 0 0;
+  padding: 20px 0 0;
+  border-top: 1px solid rgb(255 255 255 / 13%);
+  list-style: none;
+}
+
+.agent-loop li {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+  padding-right: 18px;
+}
+
+.agent-loop li:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  width: 28px;
+  height: 1px;
+  background: linear-gradient(90deg, rgb(255 255 255 / 28%), transparent);
+}
+
+.agent-loop span {
+  color: var(--home-amber);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.agent-loop strong {
+  color: var(--home-on-ink-strong);
+  font-size: 12px;
+}
+
+.agent-loop small {
+  color: rgb(213 226 238 / 48%);
+  font-size: 10px;
+}
+
+.primary-entry:focus-visible {
+  outline: 3px solid var(--cw-focus-ring);
+  outline-offset: 3px;
+}
+
+@media (hover: hover) {
+  .primary-entry:hover {
+    border-color: rgb(255 255 255 / 42%);
+    background: rgb(255 255 255 / 13%);
+    transform: translateY(-1px);
+  }
+}
+
+@media (max-width: 1100px) {
+  .home-hero {
+    grid-template-columns: minmax(0, 1.32fr) minmax(300px, 0.68fr);
+  }
+
+  .welcome-panel {
+    padding: 40px;
+  }
+}
+
+@media (max-width: 820px) {
+  .home-hero {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .welcome-panel {
+    min-height: 560px;
+  }
+}
+
+@media (max-width: 520px) {
+  .home-hero {
+    border-radius: var(--cw-radius-lg);
+  }
+
+  .welcome-panel {
+    min-height: 0;
+    padding: 28px 22px;
+  }
+
+  .welcome-meta {
+    align-items: flex-start;
+    gap: 9px;
+    font-size: 9px;
+    letter-spacing: 0.09em;
+  }
+
+  .welcome-meta__divider {
+    width: 14px;
+    margin-top: 5px;
+  }
+
+  .welcome-kicker {
+    margin-top: 44px;
+  }
+
+  .welcome-panel h1 {
+    font-size: clamp(36px, 11.5vw, 46px);
+    letter-spacing: -0.05em;
+  }
+
+  .welcome-summary {
+    margin-top: 20px;
+    font-size: 13px;
+    line-height: 1.75;
+  }
+
+  .primary-entry {
+    width: 100%;
+    margin-top: 24px;
+  }
+
+  .signal-strip {
+    margin-top: 30px;
+  }
+
+  .signal-strip > div {
+    padding: 18px 8px 0 0;
+  }
+
+  .signal-strip > div + div {
+    padding-left: 10px;
+  }
+
+  .signal-strip dt {
+    font-size: 23px;
+  }
+
+  .signal-strip dd {
+    font-size: 10px;
+  }
+
+  .signal-strip small {
+    font-size: 8px;
+    line-height: 1.35;
+  }
+
+  .agent-loop {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px 10px;
+    margin-top: 32px;
+  }
+
+  .agent-loop li::after {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-hero {
+    animation: none;
+  }
+
+  .primary-entry {
+    transition: none;
+  }
+}
+
+@keyframes home-hero-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/customer-admin-web/src/views/home/components/HomeServiceScene.vue
+++ b/customer-admin-web/src/views/home/components/HomeServiceScene.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+defineProps<{
+  eyebrow: string
+  title: string
+  description: string
+  currentUser?: string
+}>()
+</script>
+
+<template>
+  <figure class="home-scene">
+    <img src="/home-cover.jpg" alt="客服人员在服务中心与客户沟通的场景" />
+    <div class="home-scene__scrim" aria-hidden="true" />
+    <figcaption>
+      <span>{{ eyebrow }}</span>
+      <strong>{{ title }}</strong>
+      <p>{{ description }}</p>
+      <small v-if="currentUser">当前登录 · {{ currentUser }}</small>
+    </figcaption>
+  </figure>
+</template>
+
+<style scoped>
+.home-scene {
+  position: relative;
+  min-width: 0;
+  min-height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--home-ink-soft, var(--cw-ink-elevated));
+}
+
+.home-scene img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 58% center;
+  transform: scale(1.01);
+}
+
+.home-scene__scrim {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgb(8 19 33 / 10%) 20%, rgb(8 19 33 / 88%) 100%),
+    linear-gradient(90deg, rgb(8 19 33 / 24%), transparent 44%);
+}
+
+.home-scene figcaption {
+  position: absolute;
+  right: clamp(24px, 3vw, 44px);
+  bottom: clamp(26px, 4vw, 50px);
+  left: clamp(24px, 3vw, 44px);
+  color: #ffffff;
+}
+
+.home-scene figcaption > span {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--home-signal, var(--home-amber));
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.home-scene figcaption strong {
+  display: block;
+  max-width: 360px;
+  font-size: clamp(24px, 2.3vw, 36px);
+  font-weight: 740;
+  line-height: 1.18;
+  letter-spacing: -0.035em;
+}
+
+.home-scene figcaption p {
+  max-width: 380px;
+  margin: 14px 0 0;
+  color: rgb(240 246 251 / 72%);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.home-scene figcaption small {
+  display: inline-block;
+  margin-top: 24px;
+  padding-top: 12px;
+  border-top: 1px solid rgb(255 255 255 / 24%);
+  color: rgb(240 246 251 / 62%);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 820px) {
+  .home-scene {
+    min-height: 340px;
+  }
+}
+
+@media (max-width: 520px) {
+  .home-scene {
+    min-height: 280px;
+  }
+
+  .home-scene figcaption {
+    right: 22px;
+    bottom: 24px;
+    left: 22px;
+  }
+
+  .home-scene figcaption strong {
+    font-size: 24px;
+  }
+}
+</style>

--- a/customer-admin-web/src/views/home/components/HomeWorkBoard.vue
+++ b/customer-admin-web/src/views/home/components/HomeWorkBoard.vue
@@ -1,0 +1,369 @@
+<script setup lang="ts">
+import type { HomeEntry, HomeSnapshot } from '../../homePresentation'
+
+defineProps<{
+  snapshot: HomeSnapshot
+}>()
+
+const emit = defineEmits<{
+  navigate: [path: string]
+}>()
+
+const sectionCode: Record<HomeEntry['sectionKey'], string> = {
+  overview: 'OVR',
+  agents: 'AGT',
+  build: 'BLD',
+  operate: 'OPS',
+  govern: 'GOV',
+  settings: 'SYS',
+}
+</script>
+
+<template>
+  <section class="work-board" aria-label="继续工作">
+    <article class="board-card board-card--recent">
+      <header class="board-card__header">
+        <div>
+          <span class="section-index">01</span>
+          <div>
+            <h2>继续最近的工作</h2>
+            <p>仅展示当前仍有权限访问的标签。</p>
+          </div>
+        </div>
+        <span class="record-count">{{ snapshot.recentTabs.length }} / 3</span>
+      </header>
+
+      <div v-if="snapshot.recentTabs.length" class="recent-list">
+        <button
+          v-for="tab in snapshot.recentTabs"
+          :key="tab.key"
+          type="button"
+          class="recent-item"
+          @click="emit('navigate', tab.path)"
+        >
+          <span class="recent-item__mark" aria-hidden="true" />
+          <span class="recent-item__content">
+            <strong>{{ tab.title }}</strong>
+            <small>{{ tab.path }}</small>
+          </span>
+          <span class="recent-item__action" aria-hidden="true">继续 ↗</span>
+        </button>
+      </div>
+      <div v-else class="board-empty">
+        <span aria-hidden="true">—</span>
+        <p>本次会话还没有可继续的工作，从右侧真实权限入口开始即可。</p>
+      </div>
+    </article>
+
+    <article class="board-card board-card--quick">
+      <header class="board-card__header">
+        <div>
+          <span class="section-index">02</span>
+          <div>
+            <h2>按生命周期进入</h2>
+            <p>每个分区先展示一个代表入口。</p>
+          </div>
+        </div>
+      </header>
+
+      <div v-if="snapshot.quickEntries.length" class="quick-grid">
+        <button
+          v-for="entry in snapshot.quickEntries"
+          :key="entry.key"
+          type="button"
+          class="quick-entry"
+          @click="emit('navigate', entry.path)"
+        >
+          <span class="quick-entry__code">{{ sectionCode[entry.sectionKey] }}</span>
+          <span class="quick-entry__body">
+            <strong>{{ entry.title }}</strong>
+            <small>{{ entry.sectionTitle }}</small>
+          </span>
+          <span class="quick-entry__arrow" aria-hidden="true">↗</span>
+        </button>
+      </div>
+      <div v-else class="board-empty board-empty--compact">
+        <span aria-hidden="true">—</span>
+        <p>当前账号尚未分配可用菜单，请联系管理员配置角色权限。</p>
+      </div>
+    </article>
+  </section>
+</template>
+
+<style scoped>
+.work-board {
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(360px, 0.82fr);
+  gap: 18px;
+  margin-top: 18px;
+  animation: home-board-enter 520ms 80ms ease-out both;
+}
+
+.board-card {
+  min-width: 0;
+  padding: clamp(22px, 2.4vw, 32px);
+  border: 1px solid var(--home-line, var(--cw-line));
+  border-radius: var(--cw-radius-lg);
+  background: var(--home-paper, var(--cw-paper));
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.board-card__header,
+.board-card__header > div {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.board-card__header > div {
+  justify-content: flex-start;
+}
+
+.section-index {
+  display: grid;
+  flex: 0 0 32px;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 1px solid var(--home-line, var(--cw-line));
+  border-radius: var(--cw-radius-md);
+  color: var(--home-cobalt);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.board-card h2 {
+  margin: 0;
+  color: var(--home-text, var(--cw-text));
+  font-size: 18px;
+  font-weight: 740;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.board-card__header p {
+  margin: 6px 0 0;
+  color: var(--home-muted, var(--cw-text-muted));
+  font-size: 11px;
+}
+
+.record-count {
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border-radius: var(--cw-radius-sm);
+  color: var(--home-muted, var(--cw-text-muted));
+  background: var(--home-canvas, var(--cw-canvas));
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.recent-list,
+.quick-grid {
+  display: grid;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.recent-item,
+.quick-entry {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid transparent;
+  border-radius: var(--cw-radius-md);
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: border-color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+.recent-item + .recent-item {
+  border-top-color: var(--home-line, var(--cw-line));
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.recent-item__mark {
+  flex: 0 0 8px;
+  width: 8px;
+  height: 8px;
+  margin-right: 13px;
+  border: 2px solid var(--home-paper, var(--cw-paper));
+  border-radius: 50%;
+  background: var(--home-cobalt);
+  box-shadow: 0 0 0 1px var(--home-cobalt);
+}
+
+.recent-item__content,
+.quick-entry__body {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.recent-item__content strong,
+.quick-entry__body strong {
+  overflow: hidden;
+  color: var(--home-text, var(--cw-text));
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-item__content small,
+.quick-entry__body small {
+  overflow: hidden;
+  color: var(--home-muted, var(--cw-text-muted));
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-item__action {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 16px;
+  color: var(--home-cobalt);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.quick-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.quick-entry {
+  position: relative;
+  align-items: flex-start;
+  min-height: 84px;
+  padding: 14px;
+  border-color: var(--home-line, var(--cw-line));
+  background: var(--home-canvas, var(--cw-canvas));
+}
+
+.quick-entry__code {
+  flex: 0 0 auto;
+  margin-right: 11px;
+  color: var(--home-cobalt);
+  font-size: 9px;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+}
+
+.quick-entry__arrow {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  color: var(--home-muted, var(--cw-text-muted));
+  font-size: 11px;
+}
+
+.board-empty {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 94px;
+  margin-top: 22px;
+  padding: 18px;
+  border: 1px dashed var(--home-line, var(--cw-line));
+  border-radius: var(--cw-radius-md);
+  color: var(--home-muted, var(--cw-text-muted));
+  background: var(--home-canvas, var(--cw-canvas));
+}
+
+.board-empty span {
+  color: var(--home-cobalt);
+  font-size: 20px;
+}
+
+.board-empty p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.board-empty--compact {
+  min-height: 82px;
+}
+
+.recent-item:focus-visible,
+.quick-entry:focus-visible {
+  outline: 3px solid var(--cw-focus-ring);
+  outline-offset: 3px;
+}
+
+@media (hover: hover) {
+  .recent-item:hover,
+  .quick-entry:hover {
+    border-color: color-mix(in srgb, var(--home-cobalt) 34%, var(--home-line, var(--cw-line)));
+    background: color-mix(in srgb, var(--home-cobalt) 6%, transparent);
+    transform: translateY(-1px);
+  }
+}
+
+@media (max-width: 1100px) {
+  .work-board {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .work-board {
+    gap: 12px;
+    margin-top: 12px;
+  }
+
+  .board-card {
+    padding: 20px 17px;
+    border-radius: var(--cw-radius-lg);
+  }
+
+  .board-card__header p,
+  .record-count {
+    display: none;
+  }
+
+  .recent-item {
+    padding-right: 6px;
+    padding-left: 6px;
+  }
+
+  .recent-item__action {
+    padding-left: 8px;
+  }
+
+  .quick-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .work-board {
+    animation: none;
+  }
+
+  .recent-item,
+  .quick-entry {
+    transition: none;
+  }
+}
+
+@keyframes home-board-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/customer-admin-web/src/views/homePresentation.test.ts
+++ b/customer-admin-web/src/views/homePresentation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import type { MenuNode } from '@/types/api'
+import type { TabItem } from '@/store/tabs'
+import { buildHomeAdmissionPresentation, buildHomeSnapshot } from './homePresentation'
+
+function node(overrides: Partial<MenuNode> & Pick<MenuNode, 'id' | 'name'>): MenuNode {
+  return {
+    path: null,
+    icon: null,
+    iconType: 'library',
+    permCode: null,
+    sort: null,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children: [],
+    ...overrides,
+  }
+}
+
+const tabs: TabItem[] = [
+  { key: '/home', title: '首页', fullPath: '/home', closable: false },
+  { key: '/workspace/service', title: '客服质检智能体', fullPath: '/workspace/service', closable: true },
+  { key: '/ops/eval', title: '评测中心', fullPath: '/ops/eval', closable: true },
+  { key: '/system/user', title: '已失效入口', fullPath: '/system/user', closable: true },
+]
+
+const menuTree: MenuNode[] = [
+  node({
+    id: 1,
+    name: '智能体工作区',
+    path: '/workspace',
+    permCode: 'workspace',
+    children: [node({
+      id: 11,
+      name: '客服质检智能体',
+      path: '/workspace/service',
+      agentCode: 'service',
+      dynamic: true,
+    })],
+  }),
+  node({
+    id: 2,
+    name: '运营闭环',
+    path: '/ops',
+    permCode: 'ops',
+    children: [node({ id: 21, name: '评测中心', path: '/ops/eval' })],
+  }),
+  node({
+    id: 3,
+    name: '内容风控',
+    path: '/contentguard',
+    permCode: 'contentguard',
+    children: [node({ id: 31, name: '命中看板', path: '/contentguard/hit-log' })],
+  }),
+]
+
+describe('buildHomeSnapshot', () => {
+  it('只使用当前菜单中的真实入口，并过滤已经失权的历史标签', () => {
+    const snapshot = buildHomeSnapshot({ approved: true, menuTree, tabs })
+
+    expect(snapshot.availableEntryCount).toBe(3)
+    expect(snapshot.agentEntryCount).toBe(1)
+    expect(snapshot.openTabCount).toBe(2)
+    expect(snapshot.quickEntries.map((entry) => entry.path)).toEqual([
+      '/workspace/service',
+      '/ops/eval',
+      '/contentguard/hit-log',
+    ])
+    expect(snapshot.recentTabs.map((tab) => tab.path)).toEqual(['/ops/eval', '/workspace/service'])
+  })
+
+  it('同一生命周期只先选一个代表入口，再用剩余入口补足快捷区', () => {
+    const tree = [node({
+      id: 4,
+      name: 'AI 配置',
+      path: '/aiconfig',
+      permCode: 'aiconfig',
+      children: [
+        node({ id: 41, name: '模型管理', path: '/aiconfig/model' }),
+        node({ id: 42, name: '智能体管理', path: '/aiconfig/agent' }),
+      ],
+    })]
+
+    const snapshot = buildHomeSnapshot({ approved: true, menuTree: tree, tabs: [] })
+
+    expect(snapshot.quickEntries.map((entry) => entry.path)).toEqual([
+      '/aiconfig/model',
+      '/aiconfig/agent',
+    ])
+  })
+
+  it('未通过审核时不遍历或暴露菜单、标签中的业务入口', () => {
+    const snapshot = buildHomeSnapshot({ approved: false, menuTree, tabs })
+
+    expect(snapshot).toEqual({
+      availableEntryCount: 0,
+      agentEntryCount: 0,
+      openTabCount: 0,
+      quickEntries: [],
+      recentTabs: [],
+    })
+  })
+})
+
+describe('buildHomeAdmissionPresentation', () => {
+  it('优先展示服务端返回的驳回原因', () => {
+    const presentation = buildHomeAdmissionPresentation('REJECTED', '申请信息需要补充')
+
+    expect(presentation.status).toBe('审核未通过')
+    expect(presentation.description).toBe('申请信息需要补充')
+  })
+
+  it('待审核状态不拼接任何业务入口信息', () => {
+    const presentation = buildHomeAdmissionPresentation('PENDING', null)
+
+    expect(presentation.status).toBe('等待审核')
+    expect(presentation.description).toContain('真实权限')
+    expect(JSON.stringify(presentation)).not.toContain('/workspace')
+  })
+})

--- a/customer-admin-web/src/views/homePresentation.ts
+++ b/customer-admin-web/src/views/homePresentation.ts
@@ -1,0 +1,157 @@
+import type { MenuNode, UserApprovalStatus } from '@/types/api'
+import type { TabItem } from '@/store/tabs'
+import {
+  buildNavigationCommands,
+  buildNavigationSections,
+  type NavigationCommand,
+  type NavigationSectionKey,
+} from '@/layouts/navigationModel'
+
+const HOME_PATH = '/home'
+const QUICK_ENTRY_LIMIT = 4
+const RECENT_TAB_LIMIT = 3
+
+const QUICK_SECTION_ORDER: readonly NavigationSectionKey[] = [
+  'agents',
+  'build',
+  'operate',
+  'govern',
+  'overview',
+  'settings',
+]
+
+export interface HomeEntry {
+  key: string
+  title: string
+  path: string
+  sectionTitle: string
+  sectionKey: NavigationSectionKey
+  dynamic: boolean
+}
+
+export interface HomeRecentTab {
+  key: string
+  title: string
+  path: string
+}
+
+export interface HomeSnapshot {
+  availableEntryCount: number
+  agentEntryCount: number
+  openTabCount: number
+  quickEntries: HomeEntry[]
+  recentTabs: HomeRecentTab[]
+}
+
+export interface HomeAdmissionPresentation {
+  eyebrow: string
+  status: string
+  title: string
+  description: string
+  note: string
+}
+
+interface HomeSnapshotInput {
+  approved: boolean
+  menuTree: MenuNode[]
+  tabs: TabItem[]
+}
+
+/** 准入态文案只依赖登录响应，不读取菜单或标签。 */
+export function buildHomeAdmissionPresentation(
+  approvalStatus: UserApprovalStatus,
+  approvalRemark: string | null,
+): HomeAdmissionPresentation {
+  if (approvalStatus === 'REJECTED') {
+    return {
+      eyebrow: 'ACCESS REVIEW · REJECTED',
+      status: '审核未通过',
+      title: '当前账号暂未获得工作台准入。',
+      description: approvalRemark || '管理员尚未通过本次申请，请联系管理员确认原因后重新处理。',
+      note: '驳回原因只对当前登录账号展示，业务菜单与历史工作不会在此状态下加载。',
+    }
+  }
+
+  return {
+    eyebrow: 'ACCESS REVIEW · PENDING',
+    status: '等待审核',
+    title: '申请已经提交，工作台正在等待管理员确认。',
+    description: '审核通过并分配角色后，系统会按你的真实权限开放对应工作入口。',
+    note: '等待期间无需重复提交。若长时间没有进展，请联系系统管理员。',
+  }
+}
+
+function toHomeEntry(command: NavigationCommand): HomeEntry {
+  return {
+    key: command.key,
+    title: command.title,
+    path: command.path,
+    sectionTitle: command.sectionTitle,
+    sectionKey: command.sectionKey,
+    dynamic: command.dynamic,
+  }
+}
+
+function selectQuickEntries(commands: NavigationCommand[]): HomeEntry[] {
+  const selected: NavigationCommand[] = []
+  const selectedPaths = new Set<string>()
+
+  for (const sectionKey of QUICK_SECTION_ORDER) {
+    const command = commands.find((item) => item.sectionKey === sectionKey && !selectedPaths.has(item.path))
+    if (!command) continue
+    selected.push(command)
+    selectedPaths.add(command.path)
+    if (selected.length === QUICK_ENTRY_LIMIT) return selected.map(toHomeEntry)
+  }
+
+  for (const command of commands) {
+    if (selectedPaths.has(command.path)) continue
+    selected.push(command)
+    selectedPaths.add(command.path)
+    if (selected.length === QUICK_ENTRY_LIMIT) break
+  }
+
+  return selected.map(toHomeEntry)
+}
+
+function tabMatchesCommand(tab: TabItem, command: NavigationCommand): boolean {
+  if (tab.fullPath === command.path) return true
+  if (command.path.includes('?')) return false
+  return tab.fullPath.split(/[?#]/)[0] === command.path
+}
+
+/**
+ * 首页只从后端已经按权限裁剪的菜单树与当前标签生成展示数据。
+ * 未通过审核时先返回空快照，避免旧 Pinia 状态把上一账号的业务入口带到准入页。
+ */
+export function buildHomeSnapshot(input: HomeSnapshotInput): HomeSnapshot {
+  if (!input.approved) {
+    return {
+      availableEntryCount: 0,
+      agentEntryCount: 0,
+      openTabCount: 0,
+      quickEntries: [],
+      recentTabs: [],
+    }
+  }
+
+  const sections = buildNavigationSections(input.menuTree)
+  const commands = buildNavigationCommands(sections).filter((command) => command.path !== HOME_PATH)
+  const agentEntryCount = sections.find((section) => section.key === 'agents')?.itemCount ?? 0
+
+  const authorizedTabs = input.tabs
+    .filter((tab) => tab.closable && commands.some((command) => tabMatchesCommand(tab, command)))
+
+  const recentTabs = authorizedTabs
+    .slice(-RECENT_TAB_LIMIT)
+    .reverse()
+    .map((tab) => ({ key: tab.key, title: tab.title, path: tab.fullPath }))
+
+  return {
+    availableEntryCount: commands.length,
+    agentEntryCount,
+    openTabCount: authorizedTabs.length,
+    quickEntries: selectQuickEntries(commands),
+    recentTabs,
+  }
+}

--- a/customer-admin-web/src/views/login/ChangePassword.vue
+++ b/customer-admin-web/src/views/login/ChangePassword.vue
@@ -31,12 +31,13 @@ const rules: FormRules = {
 }
 
 async function handleSubmit() {
-  const valid = await formRef.value?.validate().catch(() => false)
-  if (!valid) {
-    return
-  }
+  if (submitting.value) return
   submitting.value = true
   try {
+    const valid = await formRef.value?.validate().catch(() => false)
+    if (!valid) {
+      return
+    }
     await changePassword({ oldPassword: form.oldPassword, newPassword: form.newPassword })
     ElMessage.success('密码修改成功，请重新登录')
     auth.clear()
@@ -51,7 +52,11 @@ async function handleSubmit() {
   <div class="change-password-page">
     <el-card class="change-password-card">
       <template #header>
-        <div class="title">{{ auth.forceChangePassword ? '首次登录请修改密码' : '修改密码' }}</div>
+        <div class="card-heading">
+          <span>ACCOUNT SECURITY</span>
+          <h1>{{ auth.forceChangePassword ? '首次登录请修改密码' : '修改密码' }}</h1>
+          <p>{{ auth.forceChangePassword ? '完成凭据更新后，才会开放当前账号的工作区访问。' : '更新当前账号凭据，提交成功后需要重新登录。' }}</p>
+        </div>
       </template>
       <el-form ref="formRef" :model="form" :rules="rules" label-width="90px" @keyup.enter="handleSubmit" @submit.prevent>
         <el-form-item label="原密码" prop="oldPassword">
@@ -64,7 +69,7 @@ async function handleSubmit() {
           <el-input v-model="form.confirmPassword" type="password" show-password />
         </el-form-item>
         <el-form-item>
-          <el-button type="primary" :loading="submitting" @click="handleSubmit">确认修改</el-button>
+          <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">确认修改</el-button>
         </el-form-item>
       </el-form>
     </el-card>
@@ -74,22 +79,76 @@ async function handleSubmit() {
 
 <style scoped>
 .change-password-page {
+  box-sizing: border-box;
   height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: var(--el-bg-color-page);
+  padding: 28px 20px 18px;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--cw-line) 28%, transparent) 1px, transparent 1px) 0 0 / 32px 32px,
+    linear-gradient(color-mix(in srgb, var(--cw-line) 28%, transparent) 1px, transparent 1px) 0 0 / 32px 32px,
+    var(--cw-canvas);
 }
 
 .change-password-card {
-  width: 420px;
+  width: min(440px, 100%);
   margin-bottom: auto;
   margin-top: auto;
+  border-top: 3px solid var(--cw-amber);
 }
 
-.title {
-  font-size: 16px;
-  font-weight: 600;
+.card-heading span {
+  color: var(--cw-cobalt);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .16em;
+}
+
+.card-heading h1 {
+  margin: 6px 0 5px;
+  color: var(--cw-text);
+  font-size: 22px;
+  letter-spacing: -.02em;
+}
+
+.card-heading p {
+  margin: 0;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.55;
+}
+
+@media (max-width: 480px) {
+  .change-password-page {
+    justify-content: flex-start;
+    padding: 18px 12px 12px;
+  }
+
+  .change-password-card {
+    margin-top: 12px;
+  }
+
+  .change-password-card :deep(.el-form-item) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .change-password-card :deep(.el-form-item__label) {
+    width: auto !important;
+    justify-content: flex-start;
+  }
+
+  .change-password-card :deep(.el-form-item__content) {
+    margin-left: 0 !important;
+  }
+
+  .change-password-card .cw-final-action {
+    width: 100%;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -7,6 +7,7 @@ import { fetchLoginCarouselUrls } from '@/api/login-image'
 import FooterCopyright from '@/components/FooterCopyright.vue'
 import { useAuthStore } from '@/store/auth'
 import { useMenuStore } from '@/store/menu'
+import { useTabsStore } from '@/store/tabs'
 import { useThemeStore } from '@/store/theme'
 import type { LoginResponse, RegisterOptionsVO } from '@/types/api'
 import { chooseButtonTextColor } from '@/utils/themeContrast'
@@ -24,6 +25,7 @@ const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 const menuStore = useMenuStore()
+const tabsStore = useTabsStore()
 const themeStore = useThemeStore()
 
 const authSurfaceRef = ref<HTMLElement>()
@@ -185,6 +187,10 @@ async function handleSubmit() {
     } else {
       localStorage.removeItem(rememberKey)
     }
+    // 先回收上一账号的前端权限投影，再应用本次登录结果。强制改密、待审核、已拒绝账号
+    // 不会进入菜单 bootstrap，因此尤其不能继承旧账号的菜单路由与页签。
+    menuStore.reset()
+    tabsStore.reset()
     // 必须应用完整登录结果，保留昵称、强制改密与账号审核状态。
     auth.applyLoginResult(result, submission.credentials.username)
     if (result.forceChangePassword) {
@@ -192,7 +198,6 @@ async function handleSubmit() {
       await router.replace({ name: 'ChangePassword' })
       return
     }
-    menuStore.reset()
     const redirect = (route.query.redirect as string) || '/'
     await router.replace(redirect)
   } finally {

--- a/customer-admin-web/src/views/login/LoginSliderCaptcha.vue
+++ b/customer-admin-web/src/views/login/LoginSliderCaptcha.vue
@@ -614,8 +614,8 @@ defineExpose({ reset, requireVerification })
   box-sizing: border-box;
   place-items: center;
   border-radius: 6px;
-  background: linear-gradient(135deg, var(--el-color-primary), var(--el-color-primary-dark-2));
-  box-shadow: 0 5px 14px color-mix(in srgb, var(--el-color-primary) 28%, transparent);
+  background: linear-gradient(135deg, var(--theme-primary-solid, var(--el-color-primary)), var(--theme-primary-solid-active, var(--el-color-primary-dark-2)));
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--theme-primary-solid, var(--el-color-primary)) 28%, transparent);
   color: var(--captcha-thumb-text);
   cursor: grab;
   outline: none;
@@ -641,14 +641,16 @@ defineExpose({ reset, requireVerification })
 }
 
 .is-verified .captcha-handle {
-  background: linear-gradient(135deg, var(--el-color-success), var(--el-color-success-dark-2, #168d78));
-  box-shadow: 0 5px 14px color-mix(in srgb, var(--el-color-success) 24%, transparent);
+  color: var(--cw-on-success, #fff);
+  background: linear-gradient(135deg, var(--cw-success-solid, #16856a), var(--cw-success-solid-active, #127159));
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--cw-success-solid, #16856a) 24%, transparent);
   cursor: default;
 }
 
 .is-failed .captcha-handle {
-  background: linear-gradient(135deg, var(--el-color-danger-light-3), var(--el-color-danger));
-  box-shadow: 0 5px 14px color-mix(in srgb, var(--el-color-danger) 20%, transparent);
+  color: var(--cw-on-danger, #fff);
+  background: linear-gradient(135deg, var(--cw-danger-solid, #c2414b), var(--cw-danger-solid-active, #a63840));
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--cw-danger-solid, #c2414b) 20%, transparent);
   transition: background-color 160ms ease-out, box-shadow 160ms ease-out;
 }
 

--- a/customer-admin-web/src/views/login/RegisterPanel.vue
+++ b/customer-admin-web/src/views/login/RegisterPanel.vue
@@ -662,7 +662,7 @@ h1 {
 
 .register-steps li.active > span,
 .register-steps li.complete > span {
-  background: var(--el-color-primary);
+  background: var(--theme-primary-solid, var(--el-color-primary));
   color: var(--login-primary-text, #fff);
 }
 

--- a/customer-admin-web/src/views/ops/BadcaseReview.vue
+++ b/customer-admin-web/src/views/ops/BadcaseReview.vue
@@ -59,6 +59,14 @@ const query = reactive({
   pageSize: 20,
 })
 
+const currentPendingCount = computed(() => list.value.filter((item) => item.status === 'PENDING').length)
+const negativeFeedbackCount = computed(() => (
+  list.value.filter((item) => item.source === 'NEGATIVE_FEEDBACK').length
+))
+const qualityFailureCount = computed(() => (
+  list.value.filter((item) => item.source === 'QUALITY_FAILURE').length
+))
+
 async function loadList() {
   loading.value = true
   try {
@@ -179,7 +187,7 @@ onMounted(loadList)
 
 <template>
   <div class="badcase-review">
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
         <el-select v-model="query.status" placeholder="全部状态" clearable style="width: 130px">
           <el-option label="待筛选" value="PENDING" />
@@ -195,7 +203,32 @@ onMounted(loadList)
           筛选后可一键转知识库（治本）或转评测用例（防复发），两者不冲突
         </span>
       </div>
+    </el-card>
 
+    <div class="summary-row" v-loading="loading">
+      <div class="stat">
+        <strong>{{ total }}</strong>
+        <span>匹配记录</span>
+      </div>
+      <div class="stat stat-warning">
+        <strong>{{ currentPendingCount }}</strong>
+        <span>当前页待筛选</span>
+      </div>
+      <div class="stat stat-danger">
+        <strong>{{ negativeFeedbackCount }}</strong>
+        <span>当前页用户点踩</span>
+      </div>
+      <div class="stat">
+        <strong>{{ qualityFailureCount }}</strong>
+        <span>当前页质检不过</span>
+      </div>
+    </div>
+
+    <el-card shadow="never" class="list-card">
+      <div class="section-heading">
+        <strong>回流证据明细</strong>
+        <span>筛选原始信号后，可分别补知识与加入评测集，两个出口互不冲突</span>
+      </div>
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column label="发生时间" width="170">
           <template #default="{ row }">{{ formatTime(row.createdAtMs) }}</template>
@@ -319,6 +352,7 @@ onMounted(loadList)
             <el-form-item>
               <el-button
                 v-permission="'badcase:adopt'"
+                class="cw-final-action"
                 type="primary"
                 :loading="submitting"
                 @click="submitKnowledge"
@@ -368,6 +402,7 @@ onMounted(loadList)
             <el-form-item>
               <el-button
                 v-permission="'badcase:adopt'"
+                class="cw-final-action"
                 type="primary"
                 :loading="submitting"
                 @click="submitEvalCase"
@@ -392,6 +427,12 @@ onMounted(loadList)
 </template>
 
 <style scoped>
+.badcase-review {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .toolbar {
   display: flex;
   align-items: center;
@@ -400,9 +441,76 @@ onMounted(loadList)
   flex-wrap: wrap;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.stat strong {
+  display: block;
+  color: var(--cw-text);
+  font-size: 25px;
+  font-weight: 720;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.stat span {
+  display: block;
+  margin-top: 7px;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+}
+
+.stat-warning strong {
+  color: var(--cw-amber);
+}
+
+.stat-danger strong {
+  color: var(--cw-danger);
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
 }
 
 .source-hint {
@@ -410,7 +518,8 @@ onMounted(loadList)
 }
 
 .muted {
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted);
+  opacity: 0.72;
 }
 
 .section {
@@ -418,7 +527,8 @@ onMounted(loadList)
 }
 
 .section-title {
-  font-weight: 600;
+  color: var(--cw-text);
+  font-weight: 700;
   margin-bottom: 10px;
   display: flex;
   align-items: baseline;
@@ -428,5 +538,46 @@ onMounted(loadList)
 .pagination {
   margin-top: 12px;
   justify-content: flex-end;
+}
+
+@media (max-width: 1023px) {
+  .summary-row {
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .summary-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+
+  .source-hint {
+    display: block;
+    margin: 6px 0 0;
+  }
+
+  .badcase-review :deep(.el-drawer .el-form-item__label) {
+    width: 100% !important;
+    justify-content: flex-start;
+  }
+
+  .badcase-review :deep(.el-drawer .el-form-item__content) {
+    margin-left: 0 !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .summary-row {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/BusinessOutcomeBoard.vue
+++ b/customer-admin-web/src/views/ops/BusinessOutcomeBoard.vue
@@ -64,97 +64,127 @@ onMounted(() => loadData())
 
 <template>
   <div class="outcome-board">
-    <el-card shadow="never">
-      <template #header>
-        <div class="header">
-          <div>
-            <h2>业务结果与成本</h2>
-            <p>基于客服端真实调用、冻结价目、转人工和 CSAT 事实；代理指标与成本完整性均显式标注。</p>
-          </div>
-          <div class="toolbar">
-            <el-input v-model="query.agentCode" clearable placeholder="Agent 编码（可选）" style="width: 190px" />
-            <el-select v-model="query.days" style="width: 130px">
-              <el-option label="最近 1 天" :value="1" />
-              <el-option label="最近 7 天" :value="7" />
-              <el-option label="最近 30 天" :value="30" />
-              <el-option label="最近 90 天" :value="90" />
-            </el-select>
-            <el-button type="primary" :loading="loading" @click="loadData(true)">查询</el-button>
-          </div>
+    <el-card class="filter-card" shadow="never">
+      <div class="filter-head">
+        <div>
+          <h2>业务结果与成本</h2>
+          <p>基于客服端真实调用、冻结价目、转人工和 CSAT 事实；代理指标与成本完整性均显式标注。</p>
         </div>
-      </template>
-
-      <el-alert
-        type="warning"
-        :closable="false"
-        show-icon
-        title="自动解决是代理指标，不是用户确认的解决率"
-        :description="summary?.definitions.autoResolvedProxy || '技术调用全部成功且没有转人工事实，不能证明用户问题确已解决。'"
-      />
-
-      <div v-loading="loading" class="metric-grid">
-        <div class="metric"><strong>{{ valueOrDash(summary?.totalSessions) }}</strong><span>观测会话</span></div>
-        <div class="metric"><strong>{{ percent(summary?.successfulSessionRate) }}</strong><span>技术成功会话</span></div>
-        <div class="metric primary"><strong>{{ percent(summary?.autoResolvedProxyRate) }}</strong><span>自动解决代理率</span></div>
-        <div class="metric"><strong>{{ percent(summary?.handoffRate) }}</strong><span>转人工率</span></div>
-        <div class="metric"><strong>{{ valueOrDash(summary?.averageCsat, 2) }}</strong><span>平均 CSAT（1-5）</span></div>
-        <div class="metric"><strong>{{ percent(summary?.csatSatisfiedRate) }}</strong><span>满意率（≥4）</span></div>
-        <div class="metric"><strong>{{ valueOrDash(summary?.totalTokens) }}</strong><span>已上报 Token</span></div>
-        <div class="metric"><strong>{{ formatCost(summary?.totalCost, summary?.costCurrency) }}</strong><span>已结算模型成本</span></div>
-        <div class="metric primary"><strong>{{ formatCost(summary?.costPerAutoResolvedSession, summary?.costCurrency) }}</strong><span>单次自动解决代理成本</span></div>
-      </div>
-
-      <div class="availability-row">
-        <el-tag :type="availabilityType(summary?.tokenAvailability.status)">
-          Token {{ summary?.tokenAvailability.status || 'UNAVAILABLE' }}
-        </el-tag>
-        <span>{{ summary?.tokenAvailability.reason }}</span>
-        <el-tag type="info">Cost {{ summary?.costAvailability.status || 'UNAVAILABLE' }}</el-tag>
-        <span>{{ summary?.costAvailability.reason }}</span>
-        <el-tag :type="availabilityType(summary?.costPerAutoResolvedAvailability.status)">
-          Unit Cost {{ summary?.costPerAutoResolvedAvailability.status || 'UNAVAILABLE' }}
-        </el-tag>
-        <span>{{ summary?.costPerAutoResolvedAvailability.reason }}</span>
+        <div class="filter-controls">
+          <el-input v-model="query.agentCode" class="agent-filter" clearable placeholder="Agent 编码（可选）" />
+          <el-select v-model="query.days" class="day-filter">
+            <el-option label="最近 1 天" :value="1" />
+            <el-option label="最近 7 天" :value="7" />
+            <el-option label="最近 30 天" :value="30" />
+            <el-option label="最近 90 天" :value="90" />
+          </el-select>
+          <el-button type="primary" :loading="loading" @click="loadData(true)">查询</el-button>
+        </div>
       </div>
     </el-card>
 
-    <el-card shadow="never">
-      <template #header>
+    <el-alert
+      class="definition-alert"
+      type="warning"
+      :closable="false"
+      show-icon
+      title="自动解决是代理指标，不是用户确认的解决率"
+      :description="summary?.definitions.autoResolvedProxy || '技术调用全部成功且没有转人工事实，不能证明用户问题确已解决。'"
+    />
+
+    <div v-loading="loading" class="metric-grid" aria-label="业务结果指标">
+      <div class="metric"><strong>{{ valueOrDash(summary?.totalSessions) }}</strong><span>观测会话</span></div>
+      <div class="metric"><strong>{{ percent(summary?.successfulSessionRate) }}</strong><span>技术成功会话</span></div>
+      <div class="metric primary"><strong>{{ percent(summary?.autoResolvedProxyRate) }}</strong><span>自动解决代理率</span></div>
+      <div class="metric"><strong>{{ percent(summary?.handoffRate) }}</strong><span>转人工率</span></div>
+      <div class="metric"><strong>{{ valueOrDash(summary?.averageCsat, 2) }}</strong><span>平均 CSAT（1-5）</span></div>
+      <div class="metric"><strong>{{ percent(summary?.csatSatisfiedRate) }}</strong><span>满意率（≥4）</span></div>
+      <div class="metric"><strong>{{ valueOrDash(summary?.totalTokens) }}</strong><span>已上报 Token</span></div>
+      <div class="metric"><strong>{{ formatCost(summary?.totalCost, summary?.costCurrency) }}</strong><span>已结算模型成本</span></div>
+      <div class="metric primary"><strong>{{ formatCost(summary?.costPerAutoResolvedSession, summary?.costCurrency) }}</strong><span>单次自动解决代理成本</span></div>
+    </div>
+
+    <el-card v-loading="loading" class="evidence-card" shadow="never">
+      <div class="section-heading">
         <div>
-          <strong>会话结果下钻</strong>
-          <span class="hint">每行都能回到组成汇总指标的 session 事实</span>
+          <span class="section-eyebrow">DATA AVAILABILITY</span>
+          <strong>归因可用性证据</strong>
+        </div>
+        <span class="section-hint">先确认事实是否完整，再解释成本效率。</span>
+      </div>
+      <div class="availability-grid">
+        <div class="availability-item">
+          <div class="availability-title">
+            <span>Token 事实</span>
+            <el-tag :type="availabilityType(summary?.tokenAvailability.status)">
+              {{ summary?.tokenAvailability.status || 'UNAVAILABLE' }}
+            </el-tag>
+          </div>
+          <p>{{ summary?.tokenAvailability.reason || '暂无 Token 可用性说明' }}</p>
+        </div>
+        <div class="availability-item">
+          <div class="availability-title">
+            <span>成本事实</span>
+            <el-tag :type="availabilityType(summary?.costAvailability.status)">
+              {{ summary?.costAvailability.status || 'UNAVAILABLE' }}
+            </el-tag>
+          </div>
+          <p>{{ summary?.costAvailability.reason || '暂无成本可用性说明' }}</p>
+        </div>
+        <div class="availability-item">
+          <div class="availability-title">
+            <span>单次解决成本</span>
+            <el-tag :type="availabilityType(summary?.costPerAutoResolvedAvailability.status)">
+              {{ summary?.costPerAutoResolvedAvailability.status || 'UNAVAILABLE' }}
+            </el-tag>
+          </div>
+          <p>{{ summary?.costPerAutoResolvedAvailability.reason || '暂无单次解决成本说明' }}</p>
+        </div>
+      </div>
+    </el-card>
+
+    <el-card class="detail-card" shadow="never">
+      <template #header>
+        <div class="section-heading compact">
+          <div>
+            <span class="section-eyebrow">SESSION EVIDENCE</span>
+            <strong>会话结果下钻</strong>
+          </div>
+          <span class="section-hint">每行都能回到组成汇总指标的 session 事实</span>
         </div>
       </template>
-      <el-table v-loading="loading" :data="sessions" stripe>
-        <el-table-column prop="sessionId" label="Session" min-width="210" show-overflow-tooltip />
-        <el-table-column prop="agentCodes" label="Agent" min-width="150" show-overflow-tooltip />
-        <el-table-column label="最后调用" width="180">
-          <template #default="{ row }">{{ formatTime(row.lastCallAtMs) }}</template>
-        </el-table-column>
-        <el-table-column prop="callCount" label="调用数" width="80" />
-        <el-table-column label="技术成功" width="100">
-          <template #default="{ row }"><el-tag :type="row.successful ? 'success' : 'danger'">{{ row.successful ? '是' : '否' }}</el-tag></template>
-        </el-table-column>
-        <el-table-column label="转人工" width="90">
-          <template #default="{ row }"><el-tag :type="row.handedOff ? 'warning' : 'info'">{{ row.handedOff ? '是' : '否' }}</el-tag></template>
-        </el-table-column>
-        <el-table-column label="自动解决代理" width="130">
-          <template #default="{ row }"><el-tag :type="row.autoResolvedProxy ? 'success' : 'info'">{{ row.autoResolvedProxy ? '是' : '否' }}</el-tag></template>
-        </el-table-column>
-        <el-table-column label="Token" width="120">
-          <template #default="{ row }">{{ valueOrDash(row.totalTokens) }}</template>
-        </el-table-column>
-        <el-table-column label="模型成本" width="160">
-          <template #default="{ row }">
-            <el-tooltip :content="row.costAvailability.reason">
-              <span>{{ formatCost(row.modelCost, row.costCurrency) }}</span>
-            </el-tooltip>
-          </template>
-        </el-table-column>
-        <el-table-column label="CSAT" width="80">
-          <template #default="{ row }">{{ row.csatScore ?? '-' }}</template>
-        </el-table-column>
-      </el-table>
+      <div class="table-scroll">
+        <el-table v-loading="loading" :data="sessions" stripe>
+          <el-table-column prop="sessionId" label="Session" min-width="210" show-overflow-tooltip />
+          <el-table-column prop="agentCodes" label="Agent" min-width="150" show-overflow-tooltip />
+          <el-table-column label="最后调用" width="180">
+            <template #default="{ row }">{{ formatTime(row.lastCallAtMs) }}</template>
+          </el-table-column>
+          <el-table-column prop="callCount" label="调用数" width="80" />
+          <el-table-column label="技术成功" width="100">
+            <template #default="{ row }"><el-tag :type="row.successful ? 'success' : 'danger'">{{ row.successful ? '是' : '否' }}</el-tag></template>
+          </el-table-column>
+          <el-table-column label="转人工" width="90">
+            <template #default="{ row }"><el-tag :type="row.handedOff ? 'warning' : 'info'">{{ row.handedOff ? '是' : '否' }}</el-tag></template>
+          </el-table-column>
+          <el-table-column label="自动解决代理" width="130">
+            <template #default="{ row }"><el-tag :type="row.autoResolvedProxy ? 'success' : 'info'">{{ row.autoResolvedProxy ? '是' : '否' }}</el-tag></template>
+          </el-table-column>
+          <el-table-column label="Token" width="120">
+            <template #default="{ row }">{{ valueOrDash(row.totalTokens) }}</template>
+          </el-table-column>
+          <el-table-column label="模型成本" width="160">
+            <template #default="{ row }">
+              <el-tooltip :content="row.costAvailability.reason">
+                <span>{{ formatCost(row.modelCost, row.costCurrency) }}</span>
+              </el-tooltip>
+            </template>
+          </el-table-column>
+          <el-table-column label="CSAT" width="80">
+            <template #default="{ row }">{{ row.csatScore ?? '-' }}</template>
+          </el-table-column>
+        </el-table>
+      </div>
       <el-pagination
         v-model:current-page="query.page"
         v-model:page-size="query.size"
@@ -170,19 +200,232 @@ onMounted(() => loadData())
 </template>
 
 <style scoped>
-.outcome-board { display: flex; flex-direction: column; gap: 12px; }
-.header { display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; }
-.header h2 { margin: 0 0 6px; font-size: 20px; }
-.header p { margin: 0; color: var(--el-text-color-secondary); }
-.toolbar { display: flex; align-items: center; gap: 10px; }
-.metric-grid { display: grid; grid-template-columns: repeat(4, minmax(140px, 1fr)); gap: 12px; margin-top: 18px; }
-.metric { padding: 16px; border: 1px solid var(--el-border-color-lighter); border-radius: 8px; background: var(--el-fill-color-lighter); }
-.metric strong { display: block; font-size: 25px; line-height: 1.2; }
-.metric span { display: block; margin-top: 7px; color: var(--el-text-color-secondary); font-size: 12px; }
-.metric.primary strong { color: var(--el-color-primary); }
-.metric.unavailable strong { color: var(--el-text-color-placeholder); }
-.availability-row { display: grid; grid-template-columns: auto minmax(160px, 1fr) auto minmax(260px, 2fr); align-items: center; gap: 10px; margin-top: 16px; color: var(--el-text-color-secondary); font-size: 12px; }
-.hint { margin-left: 10px; color: var(--el-text-color-secondary); font-size: 12px; font-weight: 400; }
-.pagination { justify-content: flex-end; margin-top: 16px; }
-@media (max-width: 1000px) { .metric-grid { grid-template-columns: repeat(2, minmax(140px, 1fr)); } .availability-row { grid-template-columns: auto 1fr; } }
+.outcome-board {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.filter-card,
+.evidence-card,
+.detail-card {
+  border-color: var(--cw-line);
+  background: var(--cw-paper);
+}
+
+.filter-head,
+.filter-controls,
+.section-heading,
+.availability-title {
+  display: flex;
+  align-items: center;
+}
+
+.filter-head {
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.filter-head h2 {
+  margin: 0 0 6px;
+  color: var(--cw-text);
+  font-size: 20px;
+  line-height: 1.25;
+}
+
+.filter-head p {
+  max-width: 760px;
+  margin: 0;
+  color: var(--cw-text-muted);
+  line-height: 1.55;
+}
+
+.filter-controls {
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.agent-filter {
+  width: 190px;
+}
+
+.day-filter {
+  width: 130px;
+}
+
+.definition-alert {
+  border: 1px solid color-mix(in srgb, var(--cw-amber) 35%, var(--cw-line));
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metric {
+  min-width: 0;
+  padding: 17px 18px 16px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.metric strong {
+  display: block;
+  overflow: hidden;
+  color: var(--cw-text);
+  font-size: clamp(21px, 2vw, 27px);
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metric span {
+  display: block;
+  margin-top: 8px;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+}
+
+.metric.primary strong {
+  color: var(--cw-cobalt);
+}
+
+.section-heading {
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 14px;
+}
+
+.section-heading.compact {
+  margin-bottom: 0;
+}
+
+.section-heading strong {
+  display: block;
+  color: var(--cw-text);
+  font-size: 16px;
+}
+
+.section-eyebrow {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--cw-cobalt);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.section-hint {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  font-weight: 400;
+  text-align: right;
+}
+
+.availability-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.availability-item {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: color-mix(in srgb, var(--cw-paper) 94%, var(--cw-cobalt));
+}
+
+.availability-title {
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+.availability-item p {
+  margin: 10px 0 0;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.table-scroll :deep(.el-table) {
+  min-width: 1240px;
+}
+
+.pagination {
+  width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 1100px) {
+  .filter-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .filter-controls {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .availability-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 767px) {
+  .outcome-board {
+    gap: 12px;
+  }
+
+  .filter-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .filter-controls :deep(.el-input),
+  .filter-controls :deep(.el-select),
+  .filter-controls :deep(.el-button) {
+    width: 100%;
+  }
+
+  .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  .section-hint {
+    text-align: left;
+  }
+}
+
+@media (max-width: 480px) {
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric {
+    padding: 15px 16px;
+  }
+}
 </style>

--- a/customer-admin-web/src/views/ops/CsatBoard.vue
+++ b/customer-admin-web/src/views/ops/CsatBoard.vue
@@ -75,7 +75,7 @@ onMounted(loadData)
 
 <template>
   <div class="csat-board">
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
         <el-input v-model="query.scopeId" placeholder="租户码" style="width: 160px" />
         <el-select v-model="query.days" style="width: 130px">
@@ -86,35 +86,35 @@ onMounted(loadData)
         <el-button type="primary" :loading="loading" @click="loadData">查询</el-button>
         <span class="hint">CSAT 是按周看的指标，按天看噪声太大</span>
       </div>
-
-      <div v-loading="loading" class="stats">
-        <div class="stat">
-          <div class="stat-value stat-primary">{{ formatPercent(summary?.csat) }}</div>
-          <div class="stat-label">CSAT（4 分及以上占回收数）</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value" :class="{ 'stat-warn': responseRateTooLow }">
-            {{ formatPercent(summary?.responseRate) }}
-          </div>
-          <div class="stat-label">回收率（{{ summary?.answered ?? 0 }} / {{ summary?.invited ?? 0 }}）</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value">{{ formatScore(summary?.averageScore) }}</div>
-          <div class="stat-label">平均分（辅助看，主指标是 CSAT）</div>
-        </div>
-      </div>
-
-      <el-alert
-        v-if="responseRateTooLow"
-        class="section"
-        type="warning"
-        show-icon
-        :closable="false"
-        title="回收率偏低，上面的 CSAT 不可尽信"
-        description="愿意主动评价的往往是特别满意或特别不满的两头，中间的沉默大多数不在样本里。
-          此时这个分数更像是「两极用户的比例」而非整体满意度。"
-      />
     </el-card>
+
+    <div v-loading="loading" class="stats">
+      <div class="stat">
+        <div class="stat-value stat-primary">{{ formatPercent(summary?.csat) }}</div>
+        <div class="stat-label">CSAT（4 分及以上占回收数）</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value" :class="{ 'stat-warn': responseRateTooLow }">
+          {{ formatPercent(summary?.responseRate) }}
+        </div>
+        <div class="stat-label">回收率（{{ summary?.answered ?? 0 }} / {{ summary?.invited ?? 0 }}）</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">{{ formatScore(summary?.averageScore) }}</div>
+        <div class="stat-label">平均分（辅助看，主指标是 CSAT）</div>
+      </div>
+    </div>
+
+    <el-alert
+      v-if="responseRateTooLow"
+      class="section"
+      type="warning"
+      show-icon
+      :closable="false"
+      title="回收率偏低，上面的 CSAT 不可尽信"
+      description="愿意主动评价的往往是特别满意或特别不满的两头，中间的沉默大多数不在样本里。
+        此时这个分数更像是「两极用户的比例」而非整体满意度。"
+    />
 
     <el-card shadow="never">
       <div class="section-title">
@@ -151,7 +151,7 @@ onMounted(loadData)
 .csat-board {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .toolbar {
@@ -162,38 +162,57 @@ onMounted(loadData)
   flex-wrap: wrap;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .stats {
-  display: flex;
-  gap: 56px;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
 }
 
 .stat-value {
-  font-size: 30px;
-  font-weight: 600;
+  font-size: 27px;
+  font-weight: 720;
   line-height: 1.2;
+  font-variant-numeric: tabular-nums;
 }
 
 .stat-primary {
-  color: var(--el-color-primary);
+  color: var(--cw-cobalt);
 }
 
 .stat-warn {
-  color: var(--el-color-warning);
+  color: var(--cw-amber);
 }
 
 .stat-label {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
   margin-top: 4px;
 }
 
 .section {
-  margin-top: 16px;
+  margin: 0;
 }
 
 .section-title {
-  font-weight: 600;
+  color: var(--cw-text);
+  font-weight: 700;
   margin-bottom: 12px;
   display: flex;
   align-items: baseline;
@@ -201,12 +220,30 @@ onMounted(loadData)
 }
 
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
   font-weight: 400;
 }
 
 .muted {
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted);
+  opacity: 0.72;
+}
+
+@media (max-width: 767px) {
+  .stats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .section-title {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 480px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/DeadLetterBoard.vue
+++ b/customer-admin-web/src/views/ops/DeadLetterBoard.vue
@@ -76,24 +76,22 @@ onMounted(loadData)
 
 <template>
   <div class="dead-letter-board">
-    <el-card shadow="never" class="stat-card">
-      <div class="stats">
-        <div class="stat">
-          <div class="stat-value">{{ stats.PENDING ?? 0 }}</div>
-          <div class="stat-label">待重投（巡检器会自动补）</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value stat-danger">{{ stats.ABANDONED ?? 0 }}</div>
-          <div class="stat-label">已放弃（重试耗尽，需人工介入）</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value stat-success">{{ stats.SUCCEEDED ?? 0 }}</div>
-          <div class="stat-label">已补回（原本会丢的单）</div>
-        </div>
+    <div class="summary-row" v-loading="loading">
+      <div class="stat">
+        <div class="stat-value">{{ stats.PENDING ?? 0 }}</div>
+        <div class="stat-label">待重投（巡检器会自动补）</div>
       </div>
-    </el-card>
+      <div class="stat">
+        <div class="stat-value stat-danger">{{ stats.ABANDONED ?? 0 }}</div>
+        <div class="stat-label">已放弃（重试耗尽，需人工介入）</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value stat-success">{{ stats.SUCCEEDED ?? 0 }}</div>
+        <div class="stat-label">已补回（原本会丢的单）</div>
+      </div>
+    </div>
 
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
         <el-radio-group v-model="status" @change="loadData">
           <el-radio-button value="ABANDONED">已放弃</el-radio-button>
@@ -103,7 +101,13 @@ onMounted(loadData)
         <el-button :loading="loading" @click="loadData">刷新</el-button>
         <span class="hint">重试次数耗尽的不会被删除，留档才能捞出来手工补</span>
       </div>
+    </el-card>
 
+    <el-card shadow="never" class="list-card">
+      <div class="section-heading">
+        <strong>死信处置证据</strong>
+        <span>保留失败原因、重试轨迹和原始载荷，人工重开后由巡检器继续投递</span>
+      </div>
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column label="状态" width="100">
           <template #default="{ row }">
@@ -162,56 +166,133 @@ onMounted(loadData)
 .dead-letter-board {
   display: flex;
   flex-direction: column;
+  gap: 14px;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
   gap: 12px;
 }
 
-.stat-card :deep(.el-card__body) {
-  padding: 16px 20px;
-}
-
-.stats {
-  display: flex;
-  gap: 56px;
-  flex-wrap: wrap;
+.stat {
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
 }
 
 .stat-value {
-  font-size: 28px;
-  font-weight: 600;
+  color: var(--cw-text);
+  font-size: 25px;
+  font-weight: 720;
+  font-variant-numeric: tabular-nums;
   line-height: 1.2;
 }
 
 .stat-danger {
-  color: var(--el-color-danger);
+  color: var(--cw-danger);
 }
 
 .stat-success {
-  color: var(--el-color-success);
+  color: var(--cw-success);
 }
 
 .stat-label {
-  color: var(--el-text-color-secondary);
+  margin-top: 7px;
+  color: var(--cw-text-muted);
   font-size: 12px;
-  margin-top: 4px;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 12px;
   flex-wrap: wrap;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
 }
 
 .payload {
   margin: 0;
+  max-width: 100%;
+  overflow: auto;
+  padding: 10px 12px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-sm);
+  background: var(--cw-canvas);
+  color: var(--cw-text);
   font-size: 12px;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+@media (max-width: 767px) {
+  .summary-row {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+
+  .hint {
+    flex-basis: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .summary-row {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar :deep(.el-radio-group) {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .toolbar :deep(.el-radio-button__inner) {
+    width: 100%;
+    padding-inline: 8px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/EvalCenter.vue
+++ b/customer-admin-web/src/views/ops/EvalCenter.vue
@@ -67,32 +67,56 @@ const runs = ref<EvalRun[]>([])
 const datasetLoading = ref(false)
 const datasetCases = ref<EvalDatasetCase[]>([])
 const datasetVersions = ref<EvalDatasetRelease[]>([])
+let runRequestId = 0
+let datasetRequestId = 0
+let detailRequestId = 0
+let diffRequestId = 0
 
 const labels = computed(() => METRIC_LABELS[evalType.value])
+// 后端按持久化 seq 倒序返回；同毫秒内 createdAtMs 无法区分先后，首条才是真正的最新运行。
+const latestRun = computed(() => runs.value[0] ?? null)
 
 async function loadRuns() {
+  const requestId = ++runRequestId
+  const selectedType = evalType.value
   loading.value = true
   try {
-    runs.value = await listRuns(evalType.value)
+    const nextRuns = await listRuns(selectedType)
+    if (requestId === runRequestId && evalType.value === selectedType) {
+      runs.value = nextRuns
+    }
   } finally {
-    loading.value = false
+    if (requestId === runRequestId) {
+      loading.value = false
+    }
   }
 }
 
 function handleTypeChange() {
   detailVisible.value = false
+  diffVisible.value = false
+  cancelDetailRequest()
+  cancelVersionDiffRequest()
   return Promise.all([loadRuns(), loadDatasetGovernance()])
 }
 
 async function loadDatasetGovernance() {
+  const requestId = ++datasetRequestId
+  const selectedType = evalType.value
   datasetLoading.value = true
   try {
-    ;[datasetCases.value, datasetVersions.value] = await Promise.all([
-      listDatasetCases(evalType.value),
-      listDatasetVersions(evalType.value),
+    const [nextCases, nextVersions] = await Promise.all([
+      listDatasetCases(selectedType),
+      listDatasetVersions(selectedType),
     ])
+    if (requestId === datasetRequestId && evalType.value === selectedType) {
+      datasetCases.value = nextCases
+      datasetVersions.value = nextVersions
+    }
   } finally {
-    datasetLoading.value = false
+    if (requestId === datasetRequestId) {
+      datasetLoading.value = false
+    }
   }
 }
 
@@ -115,8 +139,11 @@ function formatTime(ms: number): string {
 // ---------- 触发评测 ----------
 
 async function handleRun() {
+  if (running.value) return
+  const selectedType = evalType.value
   const label = labels.value
-  const isQuality = evalType.value === 'QUALITY'
+  const isQuality = selectedType === 'QUALITY'
+  running.value = true
   try {
     const { value: remark } = await ElMessageBox.prompt(
       isQuality
@@ -131,8 +158,7 @@ async function handleRun() {
         inputValidator: () => true,
       },
     )
-    running.value = true
-    const comparison = await triggerEval(evalType.value, remark || undefined)
+    const comparison = await triggerEval(selectedType, remark || undefined)
     ElMessage.success(
       comparison.regressions.length > 0
         ? `评测完成，发现 ${comparison.regressions.length} 个回归用例，请查看详情`
@@ -157,14 +183,27 @@ const detailLoading = ref(false)
 const comparison = ref<EvalComparison | null>(null)
 
 async function openDetail(run: EvalRun) {
+  const requestId = ++detailRequestId
+  const runId = run.runId
   detailVisible.value = true
   detailLoading.value = true
   comparison.value = null
   try {
-    comparison.value = await getComparison(run.runId)
+    const nextComparison = await getComparison(runId)
+    if (requestId === detailRequestId && detailVisible.value && nextComparison.current.runId === runId) {
+      comparison.value = nextComparison
+    }
   } finally {
-    detailLoading.value = false
+    if (requestId === detailRequestId) {
+      detailLoading.value = false
+    }
   }
+}
+
+function cancelDetailRequest() {
+  detailRequestId += 1
+  detailLoading.value = false
+  comparison.value = null
 }
 
 /** 原始指标字典转成可渲染的行；归一化后的主/次指标已单独展示，这里给的是未折算的原值。 */
@@ -190,6 +229,7 @@ const caseForm = reactive<EvalDatasetCaseInput>({
   originRef: null,
 })
 const diffVisible = ref(false)
+const diffLoading = ref(false)
 const datasetDiff = ref<EvalDatasetDiff | null>(null)
 
 function openCreateCase() {
@@ -300,8 +340,28 @@ async function openVersionDiff(row: EvalDatasetRelease, index: number) {
     ElMessage.info('没有更早版本可比较')
     return
   }
-  datasetDiff.value = await diffDatasetVersions(previous.releaseId, row.releaseId)
+  const requestId = ++diffRequestId
+  const fromReleaseId = previous.releaseId
+  const toReleaseId = row.releaseId
+  datasetDiff.value = null
   diffVisible.value = true
+  diffLoading.value = true
+  try {
+    const nextDiff = await diffDatasetVersions(fromReleaseId, toReleaseId)
+    if (requestId === diffRequestId && diffVisible.value) {
+      datasetDiff.value = nextDiff
+    }
+  } finally {
+    if (requestId === diffRequestId) {
+      diffLoading.value = false
+    }
+  }
+}
+
+function cancelVersionDiffRequest() {
+  diffRequestId += 1
+  diffLoading.value = false
+  datasetDiff.value = null
 }
 
 function reviewTagType(status: string) {
@@ -315,9 +375,9 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
 
 <template>
   <div class="eval-center">
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
-        <el-radio-group v-model="evalType" @change="handleTypeChange">
+        <el-radio-group v-model="evalType" :disabled="running" @change="handleTypeChange">
           <el-radio-button value="INTENT">意图路由</el-radio-button>
           <el-radio-button value="QUALITY">回复质量</el-radio-button>
         </el-radio-group>
@@ -325,6 +385,7 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
         <div class="spacer" />
         <el-button
           v-permission="'eval:run'"
+          class="cw-final-action"
           type="primary"
           :loading="running"
           @click="handleRun"
@@ -333,7 +394,32 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
         </el-button>
         <el-button :loading="loading" @click="loadRuns">刷新</el-button>
       </div>
+    </el-card>
 
+    <div class="summary-row" v-loading="loading">
+      <div class="stat">
+        <strong>{{ runs.length }}</strong>
+        <span>当前类型运行记录</span>
+      </div>
+      <div class="stat">
+        <strong>{{ formatPercent(latestRun?.primaryMetric) }}</strong>
+        <span>最新{{ labels.primary }}</span>
+      </div>
+      <div class="stat">
+        <strong>{{ formatPercent(latestRun?.secondaryMetric) }}</strong>
+        <span>最新{{ labels.secondary }}</span>
+      </div>
+      <div class="stat" :class="{ 'stat-danger': (latestRun?.failedCaseIds.length ?? 0) > 0 }">
+        <strong>{{ latestRun?.failedCaseIds.length ?? 0 }}</strong>
+        <span>最新失败用例</span>
+      </div>
+    </div>
+
+    <el-card shadow="never" class="trend-card">
+      <div class="section-heading">
+        <strong>评测趋势</strong>
+        <span>先看指标方向，再到运行明细确认失败与版本变化</span>
+      </div>
       <EvalTrendChart
         :runs="runs"
         :loading="loading"
@@ -387,7 +473,7 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
             <el-button v-permission="'eval:dataset-edit'" @click="importCases">导入 JSON</el-button>
             <el-button @click="exportCases">导出 JSON</el-button>
             <el-button v-permission="'eval:dataset-edit'" @click="createVersion">创建命名版本</el-button>
-            <el-button v-permission="'eval:dataset-edit'" type="primary" @click="openCreateCase">新增用例</el-button>
+            <el-button v-permission="'eval:dataset-edit'" class="cw-final-action" type="primary" @click="openCreateCase">新增用例</el-button>
           </div>
         </div>
       </template>
@@ -464,11 +550,11 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
       </el-form>
       <template #footer>
         <el-button @click="caseDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="saveCase">保存</el-button>
+        <el-button class="cw-final-action" type="primary" @click="saveCase">保存用例</el-button>
       </template>
     </el-dialog>
 
-    <el-dialog v-model="diffVisible" title="数据集版本差异" width="min(760px, 94vw)">
+    <el-dialog v-model="diffVisible" v-loading="diffLoading" title="数据集版本差异" width="min(760px, 94vw)" @close="cancelVersionDiffRequest">
       <template v-if="datasetDiff">
         <el-descriptions :column="3" border>
           <el-descriptions-item label="新增">{{ datasetDiff.addedCaseIds.length }}</el-descriptions-item>
@@ -479,7 +565,7 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
       </template>
     </el-dialog>
 
-    <el-drawer v-model="detailVisible" title="运行详情与版本对比" size="620px">
+    <el-drawer v-model="detailVisible" title="运行详情与版本对比" size="620px" @close="cancelDetailRequest">
       <div v-loading="detailLoading">
         <template v-if="comparison">
           <el-descriptions :column="2" border>
@@ -589,7 +675,7 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
 .eval-center {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .toolbar {
@@ -600,13 +686,76 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
   flex-wrap: wrap;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .spacer {
   flex: 1;
 }
 
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.stat strong {
+  display: block;
+  color: var(--cw-text);
+  font-size: 25px;
+  font-weight: 720;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.stat span {
+  display: block;
+  margin-top: 7px;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+}
+
+.stat-danger strong {
+  color: var(--cw-danger);
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
 }
 
 .dataset-header,
@@ -628,7 +777,7 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
 }
 
 .dataset-header span {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
 }
 
@@ -636,8 +785,10 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
   max-height: 420px;
   overflow: auto;
   padding: 12px;
-  border-radius: 6px;
-  background: var(--el-fill-color-light);
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-sm);
+  background: var(--cw-canvas);
+  color: var(--cw-text);
   font-size: 12px;
   white-space: pre-wrap;
   word-break: break-all;
@@ -672,7 +823,52 @@ onMounted(() => void Promise.all([loadRuns(), loadDatasetGovernance()]))
   padding-left: 18px;
   font-size: 13px;
   line-height: 1.8;
-  color: var(--el-text-color-regular);
+  color: var(--cw-text);
   word-break: break-all;
+}
+
+@media (max-width: 1023px) {
+  .summary-row {
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .summary-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+
+  .dataset-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dataset-actions > .el-button {
+    flex: 1 1 calc(50% - 5px);
+    margin-left: 0;
+  }
+
+  .eval-center :deep(.el-dialog .el-descriptions) {
+    overflow-x: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .summary-row {
+    grid-template-columns: 1fr;
+  }
+
+  .dataset-actions > .el-button {
+    flex-basis: 100%;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/KnowledgeGapBoard.vue
+++ b/customer-admin-web/src/views/ops/KnowledgeGapBoard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
 import ImprovementClosurePanel from '@/components/ImprovementClosurePanel.vue'
@@ -21,6 +21,9 @@ const list = ref<KnowledgeGap[]>([])
 const scopeId = ref('default')
 const closureVisible = ref(false)
 const closureGap = ref<KnowledgeGap | null>(null)
+const totalMisses = computed(() => list.value.reduce((sum, item) => sum + item.missCount, 0))
+const urgentGapCount = computed(() => list.value.filter((item) => item.missCount >= 10).length)
+const recurringGapCount = computed(() => list.value.filter((item) => item.missCount >= 3).length)
 
 async function loadList() {
   loading.value = true
@@ -105,12 +108,37 @@ onMounted(loadList)
         补进去的内容会直接影响线上回答，请写成知识的样子，不要照抄用户的口语化提问。"
     />
 
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
         <el-input v-model="scopeId" placeholder="租户码" style="width: 180px" />
         <el-button type="primary" :loading="loading" @click="loadList">查询</el-button>
       </div>
+    </el-card>
 
+    <div class="summary-row" v-loading="loading">
+      <div class="stat">
+        <strong>{{ list.length }}</strong>
+        <span>知识盲区</span>
+      </div>
+      <div class="stat">
+        <strong>{{ totalMisses }}</strong>
+        <span>累计未命中</span>
+      </div>
+      <div class="stat stat-danger">
+        <strong>{{ urgentGapCount }}</strong>
+        <span>高优先级（≥10 次）</span>
+      </div>
+      <div class="stat stat-warning">
+        <strong>{{ recurringGapCount }}</strong>
+        <span>反复出现（≥3 次）</span>
+      </div>
+    </div>
+
+    <el-card shadow="never" class="list-card">
+      <div class="section-heading">
+        <strong>未命中证据明细</strong>
+        <span>按真实提问频次排序，补知识后可继续进入治理闭环验证是否复发</span>
+      </div>
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column label="未命中" width="100">
           <template #default="{ row }">
@@ -174,7 +202,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" :loading="submitting" @click="submitFill">补进知识库</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="submitFill">补进知识库</el-button>
       </template>
     </el-dialog>
 
@@ -192,17 +220,119 @@ onMounted(loadList)
 .knowledge-gap-board {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 12px;
+  margin-bottom: 0;
+}
+
+.filter-card .toolbar {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .origin {
   margin-bottom: 16px;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.stat strong {
+  display: block;
+  color: var(--cw-text);
+  font-size: 25px;
+  font-weight: 720;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.stat span {
+  display: block;
+  margin-top: 7px;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+}
+
+.stat-danger strong {
+  color: var(--cw-danger);
+}
+
+.stat-warning strong {
+  color: var(--cw-amber);
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+@media (max-width: 1023px) {
+  .summary-row {
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .summary-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+
+  .knowledge-gap-board :deep(.el-dialog .el-form-item__label) {
+    width: 100% !important;
+    justify-content: flex-start;
+  }
+
+  .knowledge-gap-board :deep(.el-dialog .el-form-item__content) {
+    margin-left: 0 !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .summary-row {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/PromptVersionBoard.vue
+++ b/customer-admin-web/src/views/ops/PromptVersionBoard.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { listPromptVersions, type PromptVersion } from '@/api/ops'
+import { diffPromptLines } from './promptLineDiff'
 
 // 提示词版本看板：版本历史 + 两版全文比对。
 //
@@ -12,6 +13,10 @@ import { listPromptVersions, type PromptVersion } from '@/api/ops'
 const loading = ref(false)
 const list = ref<PromptVersion[]>([])
 const selected = ref<PromptVersion[]>([])
+const latestVersion = computed(() => list.value.reduce<PromptVersion | null>(
+  (latest, item) => (!latest || item.capturedAtMs > latest.capturedAtMs ? item : latest),
+  null,
+))
 
 async function loadList() {
   loading.value = true
@@ -49,23 +54,14 @@ function openDiff() {
   diffVisible.value = true
 }
 
-/** 逐行差异标记：提示词是纯文本，行级比对足以看出改了哪几句。 */
-function diffLines(source: string, other: string) {
-  const otherLines = new Set(other.split('\n'))
-  return source.split('\n').map((line) => ({ text: line, changed: !otherLines.has(line) }))
-}
-
-const leftLines = computed(() =>
+/** 提示词是纯文本，行级 LCS 足以稳定呈现增删、重排和重复行。 */
+const lineDiff = computed(() =>
   leftVersion.value && rightVersion.value
-    ? diffLines(leftVersion.value.content, rightVersion.value.content)
-    : [],
+    ? diffPromptLines(leftVersion.value.content, rightVersion.value.content)
+    : { left: [], right: [] },
 )
-
-const rightLines = computed(() =>
-  leftVersion.value && rightVersion.value
-    ? diffLines(rightVersion.value.content, leftVersion.value.content)
-    : [],
-)
+const leftLines = computed(() => lineDiff.value.left)
+const rightLines = computed(() => lineDiff.value.right)
 
 onMounted(loadList)
 </script>
@@ -81,13 +77,38 @@ onMounted(loadList)
         评测报告里的 promptFingerprint 就是它：指标掉了先比这一位，没变就别再对着提示词逐字找原因。"
     />
 
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
         <el-button type="primary" :loading="loading" @click="loadList">刷新</el-button>
         <el-button :disabled="selected.length !== 2" @click="openDiff">对比选中两版</el-button>
         <span class="hint">勾选两版即可比对全文差异</span>
       </div>
+    </el-card>
 
+    <div class="summary-row" v-loading="loading">
+      <div class="stat">
+        <strong>{{ list.length }}</strong>
+        <span>运行时版本</span>
+      </div>
+      <div class="stat stat-code">
+        <strong>{{ latestVersion?.fingerprint ?? '—' }}</strong>
+        <span>最新内容指纹</span>
+      </div>
+      <div class="stat">
+        <strong>{{ latestVersion?.length ?? 0 }}</strong>
+        <span>最新版本字数</span>
+      </div>
+      <div class="stat" :class="{ 'is-ready': selected.length === 2 }">
+        <strong>{{ selected.length }} / 2</strong>
+        <span>已选对比版本</span>
+      </div>
+    </div>
+
+    <el-card shadow="never" class="list-card">
+      <div class="section-heading">
+        <strong>运行时提示词证据</strong>
+        <span>指纹对应评测报告中的 promptFingerprint，可直接定位指标变化前后的实际内容</span>
+      </div>
       <el-table
         v-loading="loading"
         :data="list"
@@ -150,7 +171,7 @@ onMounted(loadList)
 .prompt-version-board {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .toolbar {
@@ -160,9 +181,83 @@ onMounted(loadList)
   margin-bottom: 12px;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  min-height: 88px;
+  min-width: 0;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
+}
+
+.stat strong {
+  display: block;
+  overflow: hidden;
+  color: var(--cw-text);
+  font-size: 25px;
+  font-weight: 720;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stat span {
+  display: block;
+  margin-top: 7px;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+}
+
+.stat-code strong {
+  color: var(--cw-cobalt);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 16px;
+  line-height: 30px;
+}
+
+.stat.is-ready strong {
+  color: var(--cw-success);
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
 }
 
 .diff {
@@ -172,7 +267,8 @@ onMounted(loadList)
 }
 
 .diff-title {
-  font-weight: 600;
+  color: var(--cw-text);
+  font-weight: 700;
   margin-bottom: 8px;
   display: flex;
   align-items: center;
@@ -182,8 +278,10 @@ onMounted(loadList)
 .diff-body {
   margin: 0;
   padding: 12px;
-  background: var(--el-fill-color-light);
-  border-radius: 4px;
+  border: 1px solid var(--cw-line);
+  background: var(--cw-canvas);
+  border-radius: var(--cw-radius-sm);
+  color: var(--cw-text);
   font-size: 12px;
   line-height: 1.7;
   white-space: pre-wrap;
@@ -193,14 +291,49 @@ onMounted(loadList)
 }
 
 .line-removed {
-  background: var(--el-color-danger-light-8);
+  background: color-mix(in srgb, var(--cw-danger) 16%, transparent);
   display: inline-block;
   width: 100%;
 }
 
 .line-added {
-  background: var(--el-color-success-light-8);
+  background: color-mix(in srgb, var(--cw-success) 16%, transparent);
   display: inline-block;
   width: 100%;
+}
+
+@media (max-width: 1023px) {
+  .summary-row {
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .summary-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+
+  .diff {
+    grid-template-columns: 1fr;
+  }
+
+  .diff-body {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 480px) {
+  .summary-row {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/SemanticCacheBoard.vue
+++ b/customer-admin-web/src/views/ops/SemanticCacheBoard.vue
@@ -22,31 +22,47 @@ const scopes = ref<SemanticCacheScope[]>([])
 // 分区键是用户级隔离键（形如 u42），运营手填是猜不出来的，故进页面先把实际存在的分区拉回来。
 // 留空而不是预填 'default'：预填一个多半查不到东西的值，只会让人以为"缓存没在工作"。
 const scopeId = ref('')
+let scopesRequestId = 0
+let listRequestId = 0
 
 /** 拉分区列表并默认选中条目最多的那个——运营多半就是想看它。 */
 async function loadScopes() {
+  const requestId = ++scopesRequestId
   scopesLoading.value = true
   try {
-    scopes.value = await listCacheScopes()
-    if (!scopeId.value && scopes.value.length > 0) {
-      scopeId.value = scopes.value[0].scopeId
+    const rows = await listCacheScopes()
+    if (requestId === scopesRequestId) {
+      scopes.value = rows
+      if (!scopeId.value) {
+        scopeId.value = rows[0]?.scopeId ?? ''
+      }
     }
   } finally {
-    scopesLoading.value = false
+    if (requestId === scopesRequestId) {
+      scopesLoading.value = false
+    }
   }
 }
 
 async function loadList() {
+  const requestId = ++listRequestId
+  const requestedScope = scopeId.value
   // 没有任何分区时不必空跑一次查询
-  if (!scopeId.value) {
+  if (!requestedScope) {
     list.value = []
+    loading.value = false
     return
   }
   loading.value = true
   try {
-    list.value = await listCacheEntries(scopeId.value)
+    const rows = await listCacheEntries(requestedScope)
+    if (requestId === listRequestId && scopeId.value === requestedScope) {
+      list.value = rows
+    }
   } finally {
-    loading.value = false
+    if (requestId === listRequestId) {
+      loading.value = false
+    }
   }
 }
 
@@ -60,14 +76,8 @@ function formatTime(ms: number): string {
   return ms ? new Date(ms).toLocaleString('zh-CN', { hour12: false }) : '-'
 }
 
-/** 复用率 = 命中次数 / 条目数：低于 1 说明多数条目从没被用过，缓存在白占容量。 */
-const reuseRate = computed(() => {
-  if (list.value.length === 0) return 0
-  const hits = list.value.reduce((sum, entry) => sum + entry.hitCount, 0)
-  return hits / list.value.length
-})
-
 const totalHits = computed(() => list.value.reduce((sum, entry) => sum + entry.hitCount, 0))
+const zeroHitCount = computed(() => list.value.filter((entry) => entry.hitCount === 0).length)
 
 async function handleEvict(row: SemanticCacheEntry) {
   try {
@@ -78,6 +88,10 @@ async function handleEvict(row: SemanticCacheEntry) {
     )
     await evictCacheEntry(row.id)
     ElMessage.success('已删除')
+    // 列表只返回前 50 条；仅当当前结果确实只有这一条时，才可判定分区已被删空。
+    if (list.value.length === 1) {
+      scopeId.value = ''
+    }
     await reload()
   } catch (error) {
     if (error !== 'cancel') throw error
@@ -115,26 +129,22 @@ onMounted(reload)
         两个用户都问「我的订单到哪了」时语义高度相似但答案完全不同，无差别缓存会造成数据泄露。"
     />
 
-    <el-card shadow="never" class="stat-card">
-      <div class="stats">
-        <div class="stat">
-          <div class="stat-value">{{ list.length }}</div>
-          <div class="stat-label">缓存条目</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value">{{ totalHits }}</div>
-          <div class="stat-label">累计命中（省下的模型调用）</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value" :class="{ 'stat-warn': reuseRate < 1 }">
-            {{ reuseRate.toFixed(2) }}
-          </div>
-          <div class="stat-label">平均复用次数（低于 1 说明多数条目从没被用过）</div>
-        </div>
+    <div class="stats" v-loading="loading">
+      <div class="stat">
+        <div class="stat-value">{{ list.length }}</div>
+        <div class="stat-label">当前列表条目</div>
       </div>
-    </el-card>
+      <div class="stat">
+        <div class="stat-value">{{ totalHits }}</div>
+        <div class="stat-label">当前列表累计命中</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value" :class="{ 'stat-warn': zeroHitCount > 0 }">{{ zeroHitCount }}</div>
+        <div class="stat-label">当前列表零命中条目</div>
+      </div>
+    </div>
 
-    <el-card shadow="never">
+    <el-card shadow="never" class="filter-card">
       <div class="toolbar">
         <!-- filterable + allow-create：分区多时能搜，也允许手填一个列表外的分区
              （列表有 100 条上限，长尾分区不在里面） -->
@@ -156,7 +166,7 @@ onMounted(reload)
           />
         </el-select>
         <el-button type="primary" :loading="loading" @click="loadList">查询</el-button>
-        <el-button :loading="scopesLoading" @click="loadScopes">刷新分区</el-button>
+        <el-button :loading="scopesLoading" @click="reload">刷新分区</el-button>
         <span v-if="!scopesLoading && scopes.length === 0" class="hint">
           当前还没有任何缓存分区
         </span>
@@ -171,7 +181,13 @@ onMounted(reload)
           清空该分区
         </el-button>
       </div>
+    </el-card>
 
+    <el-card shadow="never" class="list-card">
+      <div class="section-heading">
+        <strong>缓存证据明细</strong>
+        <span>按实际命中次数识别有效复用与长期占用容量的低价值条目</span>
+      </div>
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column label="命中" width="90" sortable :sort-by="'hitCount'">
           <template #default="{ row }">
@@ -209,33 +225,39 @@ onMounted(reload)
   gap: 12px;
 }
 
-.stat-card :deep(.el-card__body) {
-  padding: 16px 20px;
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
+  gap: 12px;
 }
 
-.stats {
-  display: flex;
-  gap: 48px;
-  flex-wrap: wrap;
+.stat {
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
 }
 
 .stat-value {
   font-size: 26px;
-  font-weight: 600;
+  font-weight: 720;
   line-height: 1.2;
+  font-variant-numeric: tabular-nums;
 }
 
 .stat-warn {
-  color: var(--el-color-warning);
+  color: var(--cw-amber);
 }
 
 .hint {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
 }
 
 .stat-label {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
   margin-top: 4px;
 }
@@ -248,7 +270,60 @@ onMounted(reload)
   flex-wrap: wrap;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .spacer {
   flex: 1;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+@media (max-width: 767px) {
+  .stats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .spacer {
+    display: none;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+}
+
+@media (max-width: 480px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/ops/promptLineDiff.test.ts
+++ b/customer-admin-web/src/views/ops/promptLineDiff.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { diffPromptLines } from './promptLineDiff'
+
+describe('diffPromptLines', () => {
+  it('A/B 重排时保留原始顺序，并稳定标记移动的行', () => {
+    expect(diffPromptLines('A\nB', 'B\nA')).toEqual({
+      left: [
+        { text: 'A', changed: true },
+        { text: 'B', changed: false },
+      ],
+      right: [
+        { text: 'B', changed: false },
+        { text: 'A', changed: true },
+      ],
+    })
+  })
+
+  it('重复行按出现次数逐一匹配，不会被去重', () => {
+    expect(diffPromptLines('规则\n规则\n结束', '规则\n结束')).toEqual({
+      left: [
+        { text: '规则', changed: false },
+        { text: '规则', changed: true },
+        { text: '结束', changed: false },
+      ],
+      right: [
+        { text: '规则', changed: false },
+        { text: '结束', changed: false },
+      ],
+    })
+  })
+
+  it('增删混合时分别标记删除行和新增行，并保留公共行', () => {
+    expect(diffPromptLines('开头\n旧约束\n公共规则\n待删除', '开头\n新约束\n公共规则\n新增说明')).toEqual({
+      left: [
+        { text: '开头', changed: false },
+        { text: '旧约束', changed: true },
+        { text: '公共规则', changed: false },
+        { text: '待删除', changed: true },
+      ],
+      right: [
+        { text: '开头', changed: false },
+        { text: '新约束', changed: true },
+        { text: '公共规则', changed: false },
+        { text: '新增说明', changed: true },
+      ],
+    })
+  })
+})

--- a/customer-admin-web/src/views/ops/promptLineDiff.ts
+++ b/customer-admin-web/src/views/ops/promptLineDiff.ts
@@ -1,0 +1,66 @@
+export interface PromptDiffLine {
+  text: string
+  changed: boolean
+}
+
+export interface PromptLineDiff {
+  left: PromptDiffLine[]
+  right: PromptDiffLine[]
+}
+
+/**
+ * 基于最长公共子序列生成行级差异。
+ *
+ * 同一份 LCS 对齐同时产出左右两侧结果，保证行顺序和重复次数都不会被集合去重破坏。
+ * 多个最长子序列等价时固定优先消费左侧行，使结果在相同输入下保持稳定。
+ */
+export function diffPromptLines(leftText: string, rightText: string): PromptLineDiff {
+  const leftLines = leftText.split('\n')
+  const rightLines = rightText.split('\n')
+  const lcsLengths = Array.from(
+    { length: leftLines.length + 1 },
+    () => new Uint32Array(rightLines.length + 1),
+  )
+
+  for (let leftIndex = leftLines.length - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = rightLines.length - 1; rightIndex >= 0; rightIndex -= 1) {
+      lcsLengths[leftIndex][rightIndex] = leftLines[leftIndex] === rightLines[rightIndex]
+        ? lcsLengths[leftIndex + 1][rightIndex + 1] + 1
+        : Math.max(lcsLengths[leftIndex + 1][rightIndex], lcsLengths[leftIndex][rightIndex + 1])
+    }
+  }
+
+  const left: PromptDiffLine[] = []
+  const right: PromptDiffLine[] = []
+  let leftIndex = 0
+  let rightIndex = 0
+
+  while (leftIndex < leftLines.length && rightIndex < rightLines.length) {
+    if (leftLines[leftIndex] === rightLines[rightIndex]) {
+      left.push({ text: leftLines[leftIndex], changed: false })
+      right.push({ text: rightLines[rightIndex], changed: false })
+      leftIndex += 1
+      rightIndex += 1
+      continue
+    }
+
+    if (lcsLengths[leftIndex + 1][rightIndex] >= lcsLengths[leftIndex][rightIndex + 1]) {
+      left.push({ text: leftLines[leftIndex], changed: true })
+      leftIndex += 1
+    } else {
+      right.push({ text: rightLines[rightIndex], changed: true })
+      rightIndex += 1
+    }
+  }
+
+  while (leftIndex < leftLines.length) {
+    left.push({ text: leftLines[leftIndex], changed: true })
+    leftIndex += 1
+  }
+  while (rightIndex < rightLines.length) {
+    right.push({ text: rightLines[rightIndex], changed: true })
+    rightIndex += 1
+  }
+
+  return { left, right }
+}

--- a/customer-admin-web/src/views/project/ProjectManage.vue
+++ b/customer-admin-web/src/views/project/ProjectManage.vue
@@ -122,17 +122,19 @@ loadList()
       <div class="toolbar">
         <el-input v-model="keyword" placeholder="按项目名搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button type="primary" @click="openCreate">新建 Project</el-button>
+        <div class="toolbar-actions">
+          <el-button class="cw-final-action" type="primary" @click="openCreate">新建 Project</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column label="项目名称">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="还没有项目，点击“新建 Project”开始整理会话">
+        <el-table-column label="项目名称" class-name="primary-column">
           <template #default="{ row }">
             <el-link type="primary" :underline="false" @click="openDetail(row)">{{ row.projectName }}</el-link>
           </template>
         </el-table-column>
         <el-table-column prop="description" label="描述" show-overflow-tooltip />
-        <el-table-column label="会话数" width="90">
+        <el-table-column label="会话数" width="90" align="center">
           <template #default="{ row }">
             <el-tag size="small">{{ row.sessionCount }}</el-tag>
           </template>
@@ -146,7 +148,6 @@ loadList()
         </el-table-column>
       </el-table>
 
-      <el-empty v-if="!loading && list.length === 0" description="还没有项目，点右上角新建一个" />
     </el-card>
 
     <el-dialog v-model="dialogVisible" :title="dialogMode === 'create' ? '新建 Project' : '编辑 Project'" width="480px">
@@ -160,12 +161,12 @@ loadList()
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleSubmit">保存 Project</el-button>
       </template>
     </el-dialog>
 
     <el-drawer v-model="detailVisible" :title="detailProject ? `Project · ${detailProject.projectName}` : 'Project'" size="480px">
-      <el-table v-loading="detailLoading" :data="detailSessions" style="width: 100%">
+      <el-table v-loading="detailLoading" :data="detailSessions" style="width: 100%" empty-text="还没有会话，去对话页把会话加入这个项目">
         <el-table-column label="会话">
           <template #default="{ row }: { row: ProjectSessionVO }">
             <template v-if="row.stale">
@@ -188,7 +189,6 @@ loadList()
           </template>
         </el-table-column>
       </el-table>
-      <el-empty v-if="!detailLoading && detailSessions.length === 0" description="还没有会话，去对话页把会话加入这个项目" />
     </el-drawer>
   </div>
 </template>
@@ -196,8 +196,26 @@ loadList()
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .session-preview {
@@ -212,5 +230,16 @@ loadList()
   margin-top: 4px;
   font-size: 12px;
   color: var(--el-text-color-secondary);
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/sql/SqlDatasourceManage.vue
+++ b/customer-admin-web/src/views/sql/SqlDatasourceManage.vue
@@ -9,13 +9,14 @@ import {
   updateSqlDatasource,
 } from '@/api/sql'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { PageQuery, SqlDatasourceSaveRequest, SqlDatasourceVO } from '@/types/api'
 
 const testingId = ref<number | null>(null)
 const formRef = ref<FormInstance>()
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<SqlDatasourceVO, PageQuery, SqlDatasourceSaveRequest>({
@@ -57,21 +58,24 @@ onMounted(loadList)
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按数据源名称搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'sql-datasource:add'" type="primary" @click="openCreate">新建数据源</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'sql-datasource:add'" class="cw-final-action" type="primary" @click="openCreate">新建数据源</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="name" label="名称" width="160" />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的数据源">
+        <el-table-column prop="name" label="名称" width="160" class-name="primary-column" />
         <el-table-column prop="username" label="用户名" width="120" />
         <el-table-column label="密码" width="120">
           <template #default="{ row }">{{ row.passwordMasked }}</template>
         </el-table-column>
         <el-table-column prop="jdbcUrl" label="JDBC URL" show-overflow-tooltip />
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.enabled ? 'success' : 'info'">{{ row.enabled ? '启用' : '禁用' }}</el-tag>
           </template>
@@ -81,7 +85,7 @@ onMounted(loadList)
           <template #default="{ row }">
             <el-button link type="primary" :loading="testingId === row.id" @click="handleTest(row)">测试连接</el-button>
             <el-button v-permission="'sql-datasource:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
-            <el-button v-permission="'sql-datasource:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'sql-datasource:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -91,7 +95,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -119,7 +123,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存数据源</el-button>
       </template>
     </el-dialog>
   </div>
@@ -128,7 +132,36 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/sql/SqlDefineManage.vue
+++ b/customer-admin-web/src/views/sql/SqlDefineManage.vue
@@ -18,6 +18,7 @@ import {
   updateSqlFieldTransform,
 } from '@/api/sql'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type {
   PageQuery,
   SqlDatasourceVO,
@@ -53,7 +54,7 @@ async function loadDatasourceOptions() {
 const formRef = ref<FormInstance>()
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible: drawerVisible, dialogMode: drawerMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<SqlDefineVO, PageQuery, SqlDefineSaveRequest>({
@@ -108,6 +109,7 @@ async function loadParams() {
 const paramFormVisible = ref(false)
 const paramFormRef = ref<FormInstance>()
 const editingParamId = ref<number | null>(null)
+const paramSubmitting = ref(false)
 const paramForm = reactive<SqlDefineParamSaveRequest>({
   paramName: '', paramDesc: '', paramType: 'STRING', dateFormat: '', required: false,
   defaultValue: '', dropDown: '', isPageNum: false, isPageSize: false, sort: 0,
@@ -136,23 +138,29 @@ function openParamEdit(row: SqlDefineParamVO) {
 }
 
 async function handleParamSubmit() {
-  const valid = await paramFormRef.value?.validate().catch(() => false)
-  if (!valid || !paramsDefineId.value) {
-    return
+  if (paramSubmitting.value) return
+  paramSubmitting.value = true
+  try {
+    const valid = await paramFormRef.value?.validate().catch(() => false)
+    if (!valid || !paramsDefineId.value) {
+      return
+    }
+    // 日期格式仅 DATETIME 类型有意义，类型切走后清空，避免后端校验拒绝
+    if (paramForm.paramType !== 'DATETIME') {
+      paramForm.dateFormat = ''
+    }
+    if (editingParamId.value) {
+      await updateSqlDefineParam(paramsDefineId.value, editingParamId.value, paramForm)
+      ElMessage.success('保存成功')
+    } else {
+      await createSqlDefineParam(paramsDefineId.value, paramForm)
+      ElMessage.success('新增成功')
+    }
+    paramFormVisible.value = false
+    await loadParams()
+  } finally {
+    paramSubmitting.value = false
   }
-  // 日期格式仅 DATETIME 类型有意义，类型切走后清空，避免后端校验拒绝
-  if (paramForm.paramType !== 'DATETIME') {
-    paramForm.dateFormat = ''
-  }
-  if (editingParamId.value) {
-    await updateSqlDefineParam(paramsDefineId.value, editingParamId.value, paramForm)
-    ElMessage.success('保存成功')
-  } else {
-    await createSqlDefineParam(paramsDefineId.value, paramForm)
-    ElMessage.success('新增成功')
-  }
-  paramFormVisible.value = false
-  await loadParams()
 }
 
 async function handleParamDelete(row: SqlDefineParamVO) {
@@ -190,6 +198,7 @@ async function loadTransforms() {
 const transformFormVisible = ref(false)
 const transformFormRef = ref<FormInstance>()
 const editingTransformId = ref<number | null>(null)
+const transformSubmitting = ref(false)
 const transformForm = reactive<SqlFieldTransformSaveRequest>({
   fieldName: '', transformType: 'DATE_FORMAT', transformConfig: '',
 })
@@ -215,19 +224,25 @@ function transformConfigPlaceholder() {
 }
 
 async function handleTransformSubmit() {
-  const valid = await transformFormRef.value?.validate().catch(() => false)
-  if (!valid || !transformsDefineId.value) {
-    return
+  if (transformSubmitting.value) return
+  transformSubmitting.value = true
+  try {
+    const valid = await transformFormRef.value?.validate().catch(() => false)
+    if (!valid || !transformsDefineId.value) {
+      return
+    }
+    if (editingTransformId.value) {
+      await updateSqlFieldTransform(transformsDefineId.value, editingTransformId.value, transformForm)
+      ElMessage.success('保存成功')
+    } else {
+      await createSqlFieldTransform(transformsDefineId.value, transformForm)
+      ElMessage.success('新增成功')
+    }
+    transformFormVisible.value = false
+    await loadTransforms()
+  } finally {
+    transformSubmitting.value = false
   }
-  if (editingTransformId.value) {
-    await updateSqlFieldTransform(transformsDefineId.value, editingTransformId.value, transformForm)
-    ElMessage.success('保存成功')
-  } else {
-    await createSqlFieldTransform(transformsDefineId.value, transformForm)
-    ElMessage.success('新增成功')
-  }
-  transformFormVisible.value = false
-  await loadTransforms()
 }
 
 async function handleTransformDelete(row: SqlFieldTransformVO) {
@@ -246,11 +261,12 @@ onMounted(() => {
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按 defineKey/描述搜索" style="width: 240px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'sql-define:add'" type="primary" @click="openCreate">新建 SQL 定义</el-button>
+        <el-button v-permission="'sql-define:add'" class="cw-final-action" type="primary" @click="openCreate">新建 SQL 定义</el-button>
       </div>
 
       <el-table v-loading="loading" :data="list" style="width: 100%">
@@ -275,7 +291,7 @@ onMounted(() => {
             <el-button link type="primary" @click="openTransforms(row)">列转换器</el-button>
             <el-button v-permission="'sql-define:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
             <el-button v-permission="'sql-define:add'" link type="primary" @click="handleCopy(row)">复制</el-button>
-            <el-button v-permission="'sql-define:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'sql-define:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -335,14 +351,14 @@ onMounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="drawerVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存定义</el-button>
       </template>
     </el-drawer>
 
     <!-- 参数配置 -->
     <el-dialog v-model="paramsDialogVisible" :title="`参数配置 · ${paramsDefineKey}`" width="900px">
       <div class="toolbar">
-        <el-button type="primary" @click="openParamCreate">新增参数</el-button>
+        <el-button class="cw-final-action" type="primary" @click="openParamCreate">新增参数</el-button>
       </div>
       <el-table v-loading="paramsLoading" :data="paramsList" style="width: 100%" size="small">
         <el-table-column prop="paramName" label="参数名" width="130" />
@@ -424,14 +440,14 @@ onMounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="paramFormVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleParamSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="paramSubmitting" @click="handleParamSubmit">保存参数</el-button>
       </template>
     </el-dialog>
 
     <!-- 列转换器 -->
     <el-dialog v-model="transformsDialogVisible" :title="`列转换器 · ${transformsDefineKey}`" width="700px">
       <div class="toolbar">
-        <el-button type="primary" @click="openTransformCreate">新增转换器</el-button>
+        <el-button class="cw-final-action" type="primary" @click="openTransformCreate">新增转换器</el-button>
       </div>
       <el-table v-loading="transformsLoading" :data="transformsList" style="width: 100%" size="small">
         <el-table-column prop="fieldName" label="列名" width="140" />
@@ -469,7 +485,7 @@ onMounted(() => {
       </el-form>
       <template #footer>
         <el-button @click="transformFormVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleTransformSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="transformSubmitting" @click="handleTransformSubmit">保存转换器</el-button>
       </template>
     </el-dialog>
   </div>
@@ -485,17 +501,25 @@ onMounted(() => {
 .form-tip {
   margin-left: 12px;
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
 }
 
 .param-date-format {
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   line-height: 1.2;
 }
 
 .sql-textarea :deep(textarea) {
-  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 13px;
+}
+
+@media (max-width: 767px) {
+  .form-tip {
+    display: block;
+    margin: 6px 0 0;
+    line-height: 1.5;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/sql/SqlQueryView.vue
+++ b/customer-admin-web/src/views/sql/SqlQueryView.vue
@@ -19,6 +19,8 @@ const result = ref<SqlQueryResultVO | null>(null)
 const paramValues = reactive<Record<string, unknown>>({})
 const pageNum = ref(1)
 const pageSize = ref(DEFAULT_PAGE_SIZE)
+let metaRequestId = 0
+let queryRequestId = 0
 
 /** 排除分页标记参数后的表单参数，按 sort 升序渲染。 */
 const formParams = computed(() =>
@@ -87,11 +89,19 @@ function buildParams(): Record<string, unknown> {
 
 async function runQuery() {
   if (!meta.value) return
+  const requestId = ++queryRequestId
+  const defineKey = meta.value.defineKey
+  const params = buildParams()
   executing.value = true
   try {
-    result.value = await executeSqlQuery({ defineKey: meta.value.defineKey, params: buildParams() })
+    const nextResult = await executeSqlQuery({ defineKey, params })
+    if (requestId === queryRequestId && route.query.defineKey === defineKey) {
+      result.value = nextResult
+    }
   } finally {
-    executing.value = false
+    if (requestId === queryRequestId) {
+      executing.value = false
+    }
   }
 }
 
@@ -139,24 +149,37 @@ async function handleExport() {
 }
 
 async function load() {
+  const requestId = ++metaRequestId
   const defineKey = route.query.defineKey as string | undefined
+  // 路由切换立即作废旧查询，旧响应不得覆盖新报表或提前关闭 loading。
+  queryRequestId += 1
+  executing.value = false
   meta.value = null
   result.value = null
   loadError.value = null
   if (!defineKey) {
+    metaLoading.value = false
     return
   }
   metaLoading.value = true
   try {
-    meta.value = await fetchSqlQueryMeta(defineKey)
+    const nextMeta = await fetchSqlQueryMeta(defineKey)
+    if (requestId !== metaRequestId || route.query.defineKey !== defineKey) {
+      return
+    }
+    meta.value = nextMeta
     resetParamValues()
-    if (meta.value.autoLoad) {
+    if (nextMeta.autoLoad) {
       await runQuery()
     }
   } catch (e) {
-    loadError.value = (e as { message?: string })?.message || '加载查询配置失败'
+    if (requestId === metaRequestId) {
+      loadError.value = (e as { message?: string })?.message || '加载查询配置失败'
+    }
   } finally {
-    metaLoading.value = false
+    if (requestId === metaRequestId) {
+      metaLoading.value = false
+    }
   }
 }
 
@@ -173,7 +196,9 @@ watch(() => route.query.defineKey, load, { immediate: true })
 
         <template v-if="meta">
           <div class="page-header">
-            <h3>{{ meta.sqlDescribe || meta.defineKey }}</h3>
+            <span>QUERY CONTRACT</span>
+            <h2>{{ meta.sqlDescribe || meta.defineKey }}</h2>
+            <code>{{ meta.defineKey }}</code>
           </div>
 
           <el-form :model="paramValues" inline class="param-form">
@@ -222,7 +247,7 @@ watch(() => route.query.defineKey, load, { immediate: true })
 
           <div v-if="result" class="result-meta">耗时 {{ result.useMillis }} ms，共 {{ result.rows.length }} 行</div>
 
-          <el-table v-loading="executing" :data="result?.rows ?? []" style="width: 100%" border>
+          <el-table v-if="result" v-loading="executing" :data="result.rows" style="width: 100%" border>
             <el-table-column
               v-for="col in result?.columns ?? []"
               :key="col"
@@ -232,6 +257,7 @@ watch(() => route.query.defineKey, load, { immediate: true })
               min-width="120"
             />
           </el-table>
+          <el-empty v-if="!result && !executing" description="设置查询条件后执行，结果与耗时会保留在当前工作面" :image-size="72" />
           <el-empty v-if="result && result.rows.length === 0" description="没有查询到数据" />
 
           <div v-if="result" class="pagination-bar">
@@ -259,13 +285,29 @@ watch(() => route.query.defineKey, load, { immediate: true })
 
 <style scoped>
 .page-header {
-  margin-bottom: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--cw-line);
 }
 
-.page-header h3 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
+.page-header > span {
+  color: var(--cw-cobalt);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .14em;
+}
+
+.page-header h2 {
+  margin: 5px 0 6px;
+  color: var(--cw-text);
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -.02em;
+}
+
+.page-header code {
+  color: var(--cw-text-muted);
+  font-size: 12px;
 }
 
 .param-form {
@@ -275,7 +317,7 @@ watch(() => route.query.defineKey, load, { immediate: true })
 .result-meta {
   margin-bottom: 8px;
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
 }
 
 .pagination-bar {
@@ -291,7 +333,20 @@ watch(() => route.query.defineKey, load, { immediate: true })
 }
 
 .simple-pager-current {
-  color: var(--el-text-color-regular);
+  color: var(--cw-text-muted);
   font-size: 13px;
+}
+
+@media (max-width: 767px) {
+  .pagination-bar,
+  .simple-pager {
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .simple-pager {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/AgentCallStats.vue
+++ b/customer-admin-web/src/views/system/AgentCallStats.vue
@@ -43,11 +43,15 @@ const SESSION_TYPE_OPTIONS: Array<{ label: string; value: 'CHAT' | 'VIBE_CODING'
 ]
 
 /** 分段耗时类型元信息：展示名 + 统一配色，明细表迷你条形图与详情抽屉标签共用。 */
-const SEGMENT_KIND_META: Record<AgentCallSegmentKind, { label: string; color: string }> = {
-  MODEL: { label: '大模型', color: '#f59e0b' },
-  TOOL: { label: '工具', color: '#67c23a' },
-  MCP: { label: 'MCP', color: '#409eff' },
-  SKILL: { label: 'Skill', color: '#8b5cf6' },
+const SEGMENT_KIND_META: Record<AgentCallSegmentKind, {
+  label: string
+  color: string
+  tagType: 'warning' | 'success' | 'primary' | 'info'
+}> = {
+  MODEL: { label: '大模型', color: 'var(--cw-amber)', tagType: 'warning' },
+  TOOL: { label: '工具', color: 'var(--cw-success)', tagType: 'success' },
+  MCP: { label: 'MCP', color: 'var(--cw-cobalt)', tagType: 'primary' },
+  SKILL: { label: 'Skill', color: 'var(--cw-brand-logo-start)', tagType: 'info' },
 }
 
 interface FilterState {
@@ -416,7 +420,7 @@ onMounted(() => {
 
 <template>
   <div class="page">
-    <el-card class="filter-card">
+    <el-card class="filter-card" shadow="never">
       <div class="toolbar">
         <el-select v-model="filters.source" placeholder="来源" style="width: 160px">
           <el-option v-for="opt in SOURCE_OPTIONS" :key="opt.value" :label="opt.label" :value="opt.value" />
@@ -471,7 +475,7 @@ onMounted(() => {
       </div>
     </div>
 
-    <el-card class="trend-card">
+    <el-card class="trend-card" shadow="never">
       <div class="trend-header">
         <span class="trend-title">调用趋势</span>
         <el-radio-group v-model="trendGranularityMode" size="small">
@@ -483,7 +487,11 @@ onMounted(() => {
       <AgentCallTrendChart :points="trendPoints" :granularity="effectiveGranularity" :loading="trendLoading" />
     </el-card>
 
-    <el-card>
+    <el-card class="list-card" shadow="never">
+      <div class="section-heading">
+        <strong>调用证据明细</strong>
+        <span>每条记录可继续下钻耗时、Token、成本、运行配置与安全重放证据</span>
+      </div>
       <el-table v-loading="loading" :data="list" style="width: 100%">
         <el-table-column prop="username" label="用户名" width="110">
           <template #default="{ row }: { row: AgentCallStatsRow }">{{ row.username || '—' }}</template>
@@ -684,7 +692,7 @@ onMounted(() => {
               <el-table-column prop="seq" label="序号" width="60" />
               <el-table-column label="类型" width="90">
                 <template #default="{ row }: { row: AgentCallStatsSegment }">
-                  <el-tag :color="SEGMENT_KIND_META[row.kind].color" style="color: #fff; border: none">
+                  <el-tag :type="SEGMENT_KIND_META[row.kind].tagType">
                     {{ SEGMENT_KIND_META[row.kind].label }}
                   </el-tag>
                 </template>
@@ -815,7 +823,7 @@ onMounted(() => {
 .page {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
 }
 
 .toolbar {
@@ -824,10 +832,18 @@ onMounted(() => {
   gap: 8px;
 }
 
+.filter-card .toolbar {
+  margin-bottom: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .filter-tip {
   margin-top: 8px;
   font-size: 12px;
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted);
 }
 
 .summary-row {
@@ -837,22 +853,45 @@ onMounted(() => {
 }
 
 .stat-card {
-  background: var(--el-bg-color);
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 8px;
-  padding: 14px 16px;
+  min-height: 88px;
+  padding: 15px 16px 14px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-xs);
 }
 
 .stat-label {
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   margin-bottom: 6px;
 }
 
 .stat-value {
   font-size: 22px;
-  font-weight: 600;
-  color: var(--el-text-color-primary);
+  font-weight: 700;
+  color: var(--cw-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.section-heading strong {
+  color: var(--cw-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.section-heading span {
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  text-align: right;
 }
 
 .trend-header {
@@ -864,8 +903,8 @@ onMounted(() => {
 
 .trend-title {
   font-size: 14px;
-  font-weight: 600;
-  color: var(--el-text-color-primary);
+  font-weight: 700;
+  color: var(--cw-text);
 }
 
 .segment-bar {
@@ -884,7 +923,8 @@ onMounted(() => {
 }
 
 .muted {
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted);
+  opacity: 0.72;
   font-size: 12px;
 }
 
@@ -895,18 +935,19 @@ onMounted(() => {
 .detail-block-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--el-text-color-primary);
+  color: var(--cw-text);
   margin-bottom: 8px;
 }
 
 .detail-text {
   white-space: pre-wrap;
   word-break: break-word;
-  background: var(--el-fill-color-lighter);
-  border-radius: 6px;
+  border: 1px solid var(--cw-line);
+  background: var(--cw-canvas);
+  border-radius: var(--cw-radius-sm);
   padding: 10px 12px;
   font-size: 13px;
-  color: var(--el-text-color-regular);
+  color: var(--cw-text);
   max-height: 240px;
   overflow-y: auto;
 }
@@ -937,7 +978,7 @@ onMounted(() => {
   position: relative;
   flex: 1;
   height: 10px;
-  background: var(--el-fill-color-light);
+  background: var(--cw-canvas);
   border-radius: 3px;
 }
 
@@ -952,7 +993,7 @@ onMounted(() => {
   width: 64px;
   flex-shrink: 0;
   text-align: right;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
 }
 
 .replay-summary {
@@ -961,6 +1002,7 @@ onMounted(() => {
 
 .replay-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin: 16px 0 10px;
 }
@@ -972,10 +1014,41 @@ onMounted(() => {
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
-  border-radius: 6px;
-  background: var(--el-fill-color-lighter);
-  color: var(--el-text-color-regular);
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-sm);
+  background: var(--cw-canvas);
+  color: var(--cw-text);
   font-size: 12px;
   line-height: 1.5;
+}
+
+@media (max-width: 767px) {
+  .section-heading,
+  .trend-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-heading span {
+    text-align: left;
+  }
+
+  .timeline-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 64px;
+  }
+
+  .timeline-name {
+    width: auto;
+  }
+
+  .timeline-track {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .timeline-ms {
+    width: auto;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/AiCodingAudit.vue
+++ b/customer-admin-web/src/views/system/AiCodingAudit.vue
@@ -2,6 +2,7 @@
 import { onMounted } from 'vue'
 import { pageAiCodingAudit } from '@/api/aiCodingAudit'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { AiCodingAuditLog, AiCodingAuditQuery } from '@/types/api'
 
 /** 操作类型 -> 中文展示与标签色（与后端 AiCodingOperation 枚举一一对应）。 */
@@ -15,7 +16,7 @@ const OPERATION_META: Record<string, { label: string; tag: 'primary' | 'success'
 
 // 只读审计日志：无新建/编辑/删除能力，只接列表半套
 const {
-  loading, list, total, query,
+  loading, loadError, list, total, query,
   loadList, handleSearch,
 } = useCrudPage<AiCodingAuditLog, AiCodingAuditQuery, Record<string, never>>({
   page: pageAiCodingAudit,
@@ -47,6 +48,7 @@ onMounted(loadList)
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按操作人搜索" style="width: 180px" clearable @keyup.enter="handleSearch" />
@@ -57,7 +59,7 @@ onMounted(loadList)
         <el-button type="primary" @click="handleSearch">搜索</el-button>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无 AI 编码审计记录">
         <el-table-column prop="createTime" label="时间" width="170" />
         <el-table-column prop="username" label="操作人" width="100" />
         <el-table-column label="操作类型" width="140">
@@ -65,7 +67,7 @@ onMounted(loadList)
             <el-tag :type="operationTag(row.operation)">{{ operationLabel(row.operation) }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column prop="agentCode" label="智能体" width="110" />
+        <el-table-column prop="agentCode" label="智能体" width="110" class-name="primary-column" />
         <el-table-column prop="sessionId" label="会话ID" width="150" show-overflow-tooltip />
         <el-table-column label="变更文件" min-width="160">
           <template #default="{ row }">
@@ -93,7 +95,7 @@ onMounted(loadList)
             <span v-else class="muted">—</span>
           </template>
         </el-table-column>
-        <el-table-column label="结果" width="90">
+        <el-table-column label="结果" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.result === 1 ? 'success' : 'danger'">{{ row.result === 1 ? '成功' : '失败' }}</el-tag>
           </template>
@@ -106,7 +108,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -116,8 +118,18 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 .changed-files {
   color: var(--el-color-primary);

--- a/customer-admin-web/src/views/system/BillingManage.vue
+++ b/customer-admin-web/src/views/system/BillingManage.vue
@@ -54,6 +54,7 @@ async function loadTenants() {
 
 const quotaTenant = ref('')
 const quotaLoading = ref(false)
+const quotaSubmitting = ref(false)
 const quotas = ref<TenantQuotaVO[]>([])
 
 async function loadQuota() {
@@ -92,14 +93,20 @@ function openQuotaDialog(row?: TenantQuotaVO) {
 }
 
 async function submitQuota() {
+  if (quotaSubmitting.value) return
   if (!quotaForm.tenantId) {
     ElMessage.warning('请先选择租户')
     return
   }
-  await saveQuota(quotaForm)
-  ElMessage.success('配额已保存')
-  quotaDialogVisible.value = false
-  await loadQuota()
+  quotaSubmitting.value = true
+  try {
+    await saveQuota(quotaForm)
+    ElMessage.success('配额已保存')
+    quotaDialogVisible.value = false
+    await loadQuota()
+  } finally {
+    quotaSubmitting.value = false
+  }
 }
 
 async function removeQuota(row: TenantQuotaVO) {
@@ -116,6 +123,7 @@ async function removeQuota(row: TenantQuotaVO) {
 // ---------- 单价 ----------
 
 const priceLoading = ref(false)
+const priceSubmitting = ref(false)
 const prices = ref<ModelPriceVO[]>([])
 
 async function loadPrice() {
@@ -154,14 +162,20 @@ function openPriceDialog() {
 }
 
 async function submitPrice() {
+  if (priceSubmitting.value) return
   if (!priceForm.modelName) {
     ElMessage.warning('请填写模型名')
     return
   }
-  await createPrice(priceForm)
-  ElMessage.success('单价已新增')
-  priceDialogVisible.value = false
-  await loadPrice()
+  priceSubmitting.value = true
+  try {
+    await createPrice(priceForm)
+    ElMessage.success('单价已新增')
+    priceDialogVisible.value = false
+    await loadPrice()
+  } finally {
+    priceSubmitting.value = false
+  }
 }
 
 async function removePrice(row: ModelPriceVO) {
@@ -347,6 +361,7 @@ onMounted(async () => {
             </el-select>
             <el-button
               v-permission="'billing:quota-edit'"
+              class="cw-final-action"
               type="primary"
               :disabled="!quotaTenant"
               @click="openQuotaDialog()"
@@ -402,7 +417,7 @@ onMounted(async () => {
         <!-- 单价 -->
         <el-tab-pane v-if="crossTenantAuthority" label="模型单价" name="price">
           <div class="toolbar">
-            <el-button v-permission="'billing:price-edit'" type="primary" @click="openPriceDialog">
+            <el-button v-permission="'billing:price-edit'" class="cw-final-action" type="primary" @click="openPriceDialog">
               新增单价
             </el-button>
             <span class="tip">调价请新增一条生效记录，不要改旧记录——历史账单要按当时的价格算得回去。</span>
@@ -658,7 +673,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="quotaDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="submitQuota">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="quotaSubmitting" @click="submitQuota">保存配额</el-button>
       </template>
     </el-dialog>
 
@@ -694,7 +709,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="priceDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="submitPrice">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="priceSubmitting" @click="submitPrice">保存价格</el-button>
       </template>
     </el-dialog>
   </div>
@@ -711,21 +726,33 @@ onMounted(async () => {
 .tip {
   margin-top: 12px;
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   line-height: 1.7;
 }
 
 .form-tip {
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
 }
 
 .forecast-card {
   margin-bottom: 20px;
+  overflow-x: auto;
 }
 
 .section-title {
   margin: 24px 0 12px;
+  color: var(--cw-text);
   font-size: 15px;
+}
+
+@media (max-width: 767px) {
+  .page :deep(.el-tabs__nav-wrap) {
+    padding-inline: 2px;
+  }
+
+  .forecast-card :deep(.el-descriptions__body) {
+    min-width: 680px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/ConfigVersionManage.vue
+++ b/customer-admin-web/src/views/system/ConfigVersionManage.vue
@@ -378,7 +378,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="grayVisible = false">取消</el-button>
-        <el-button type="primary" @click="submitGray">创建安全灰度任务</el-button>
+        <el-button class="cw-final-action" type="primary" @click="submitGray">创建安全灰度任务</el-button>
       </template>
     </el-dialog>
 
@@ -409,6 +409,7 @@ onMounted(async () => {
 
 .approval-card {
   margin-top: 16px;
+  border-top: 3px solid var(--cw-cobalt);
 }
 
 .card-head {
@@ -419,7 +420,7 @@ onMounted(async () => {
 
 .hash-line {
   margin-top: 4px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
 }
@@ -427,13 +428,13 @@ onMounted(async () => {
 .tip {
   margin-top: 12px;
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   line-height: 1.7;
 }
 
 .form-tip {
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   line-height: 1.6;
 }
 
@@ -443,32 +444,33 @@ onMounted(async () => {
   align-items: center;
   margin-bottom: 12px;
   font-size: 13px;
-  color: var(--el-text-color-regular);
+  color: var(--cw-text-muted);
 }
 
 .diff-body {
   max-height: 65vh;
   overflow: auto;
-  border: 1px solid var(--el-border-color);
-  border-radius: 4px;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  background: var(--cw-paper);
 }
 
 .diff-row {
   display: grid;
   grid-template-columns: 56px 1fr 1fr;
-  border-bottom: 1px solid var(--el-border-color-lighter);
+  border-bottom: 1px solid var(--cw-line);
 }
 
 .diff-row.changed {
-  background: var(--el-color-warning-light-9);
+  background: color-mix(in srgb, var(--cw-amber) 12%, var(--cw-paper));
 }
 
 .diff-no {
   padding: 2px 8px;
-  color: var(--el-text-color-placeholder);
+  color: var(--cw-text-muted);
   text-align: right;
   font-size: 12px;
-  border-right: 1px solid var(--el-border-color-lighter);
+  border-right: 1px solid var(--cw-line);
 }
 
 .diff-cell {
@@ -476,8 +478,16 @@ onMounted(async () => {
   padding: 2px 8px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
+  color: var(--cw-text);
   white-space: pre-wrap;
   word-break: break-all;
-  border-right: 1px solid var(--el-border-color-lighter);
+  border-right: 1px solid var(--cw-line);
+}
+
+@media (max-width: 767px) {
+  .card-head {
+    align-items: flex-start;
+    gap: 8px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/DevToolboxView.vue
+++ b/customer-admin-web/src/views/system/DevToolboxView.vue
@@ -57,16 +57,18 @@ watch(
     <div class="devtoolbox-sidebar">
       <el-input v-model="search" placeholder="搜索工具" clearable :prefix-icon="'Search'" class="devtoolbox-search" />
       <el-scrollbar class="devtoolbox-list">
-        <div
+        <button
           v-for="tool in filteredTools"
           :key="tool.key"
+          type="button"
           class="devtoolbox-item"
           :class="{ active: tool.key === activeKey }"
+          :aria-pressed="tool.key === activeKey"
           @click="selectTool(tool.key)"
         >
           <div class="devtoolbox-item-label">{{ tool.label }}</div>
           <div class="devtoolbox-item-desc">{{ tool.description }}</div>
-        </div>
+        </button>
         <el-empty v-if="filteredTools.length === 0" description="没有匹配的工具" :image-size="60" />
       </el-scrollbar>
     </div>
@@ -99,7 +101,7 @@ watch(
   gap: 10px;
   background: var(--el-bg-color);
   border: 1px solid var(--el-border-color-lighter);
-  border-radius: 8px;
+  border-radius: var(--cw-radius-md);
   padding: 12px;
   height: 100%;
   min-height: 0;
@@ -115,10 +117,17 @@ watch(
 }
 
 .devtoolbox-item {
+  position: relative;
+  width: 100%;
   padding: 8px 10px;
-  border-radius: 6px;
+  color: inherit;
+  text-align: left;
+  border: 0;
+  border-radius: var(--cw-radius-sm);
+  background: transparent;
   cursor: pointer;
   margin-bottom: 4px;
+  font: inherit;
   transition: background-color 0.15s ease;
 }
 
@@ -127,12 +136,18 @@ watch(
 }
 
 .devtoolbox-item.active {
-  background: var(--theme-primary-lighter, var(--el-color-primary-light-9));
+  background: color-mix(in srgb, var(--cw-cobalt) 10%, var(--cw-paper));
+  box-shadow: inset 3px 0 var(--cw-cobalt);
 }
 
 .devtoolbox-item.active .devtoolbox-item-label {
-  color: var(--theme-primary, var(--el-color-primary));
+  color: var(--cw-cobalt);
   font-weight: 600;
+}
+
+.devtoolbox-item:focus-visible {
+  outline: 2px solid var(--cw-focus-ring);
+  outline-offset: -2px;
 }
 
 .devtoolbox-item-label {
@@ -159,5 +174,15 @@ watch(
 .panel-title {
   font-size: 15px;
   font-weight: 600;
+}
+
+@media (max-width: 767px) {
+  .devtoolbox-sidebar {
+    padding: 10px;
+  }
+
+  .devtoolbox-list {
+    max-height: 220px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/DictManage.vue
+++ b/customer-admin-web/src/views/system/DictManage.vue
@@ -57,6 +57,7 @@ const typeDialogVisible = ref(false)
 const typeDialogMode = ref<'create' | 'edit'>('create')
 const typeFormRef = ref<FormInstance>()
 const editingTypeId = ref<number | null>(null)
+const typeSubmitting = ref(false)
 const typeForm = reactive<DictTypeSaveRequest>({ dictType: '', typeName: '', remark: '', enabled: true })
 
 const typeRules: FormRules = {
@@ -84,16 +85,22 @@ function openEditType(row: DictTypeVO) {
 }
 
 async function submitType() {
-  await typeFormRef.value?.validate()
-  if (typeDialogMode.value === 'create') {
-    await createDictType({ ...typeForm })
-    ElMessage.success('类型已创建')
-  } else if (editingTypeId.value != null) {
-    await updateDictType(editingTypeId.value, { ...typeForm })
-    ElMessage.success('类型已更新')
+  if (typeSubmitting.value) return
+  typeSubmitting.value = true
+  try {
+    await typeFormRef.value?.validate()
+    if (typeDialogMode.value === 'create') {
+      await createDictType({ ...typeForm })
+      ElMessage.success('类型已创建')
+    } else if (editingTypeId.value != null) {
+      await updateDictType(editingTypeId.value, { ...typeForm })
+      ElMessage.success('类型已更新')
+    }
+    typeDialogVisible.value = false
+    await loadTypes()
+  } finally {
+    typeSubmitting.value = false
   }
-  typeDialogVisible.value = false
-  await loadTypes()
 }
 
 async function handleDeleteType(row: DictTypeVO) {
@@ -113,17 +120,26 @@ async function handleDeleteType(row: DictTypeVO) {
 
 const itemLoading = ref(false)
 const items = ref<DictItemVO[]>([])
+let itemRequestId = 0
 
 async function loadItems() {
-  if (!activeType.value) {
+  const requestId = ++itemRequestId
+  const selectedType = activeType.value?.dictType
+  if (!selectedType) {
     items.value = []
+    itemLoading.value = false
     return
   }
   itemLoading.value = true
   try {
-    items.value = await listDictItems(activeType.value.dictType)
+    const nextItems = await listDictItems(selectedType)
+    if (requestId === itemRequestId && activeType.value?.dictType === selectedType) {
+      items.value = nextItems
+    }
   } finally {
-    itemLoading.value = false
+    if (requestId === itemRequestId) {
+      itemLoading.value = false
+    }
   }
 }
 
@@ -133,6 +149,7 @@ const itemDialogVisible = ref(false)
 const itemDialogMode = ref<'create' | 'edit'>('create')
 const itemFormRef = ref<FormInstance>()
 const editingItemId = ref<number | null>(null)
+const itemSubmitting = ref(false)
 const itemForm = reactive<DictItemSaveRequest>({ itemKey: '', itemLabel: '', sort: 0, enabled: true, remark: '' })
 
 const itemRules: FormRules = {
@@ -158,18 +175,24 @@ function openEditItem(row: DictItemVO) {
 }
 
 async function submitItem() {
-  await itemFormRef.value?.validate()
-  if (itemDialogMode.value === 'create') {
-    if (!activeType.value) return
-    await createDictItem(activeType.value.dictType, { ...itemForm })
-    ElMessage.success('字典项已创建')
-  } else if (editingItemId.value != null) {
-    await updateDictItem(editingItemId.value, { ...itemForm })
-    ElMessage.success('字典项已更新')
+  if (itemSubmitting.value) return
+  itemSubmitting.value = true
+  try {
+    await itemFormRef.value?.validate()
+    if (itemDialogMode.value === 'create') {
+      if (!activeType.value) return
+      await createDictItem(activeType.value.dictType, { ...itemForm })
+      ElMessage.success('字典项已创建')
+    } else if (editingItemId.value != null) {
+      await updateDictItem(editingItemId.value, { ...itemForm })
+      ElMessage.success('字典项已更新')
+    }
+    itemDialogVisible.value = false
+    await loadItems()
+    await refreshTypeCounts()
+  } finally {
+    itemSubmitting.value = false
   }
-  itemDialogVisible.value = false
-  await loadItems()
-  await refreshTypeCounts()
 }
 
 async function toggleItem(row: DictItemVO) {
@@ -217,7 +240,7 @@ onMounted(loadTypes)
         <template #header>
           <div class="panel-header">
             <span>字典类型</span>
-            <el-button v-permission="'dict:add'" type="primary" size="small" @click="openCreateType">新增类型</el-button>
+            <el-button v-permission="'dict:add'" class="cw-final-action" type="primary" size="small" @click="openCreateType">新增类型</el-button>
           </div>
         </template>
         <el-input v-model="typeKeyword" placeholder="按编码或名称过滤" clearable class="type-filter" />
@@ -230,10 +253,16 @@ onMounted(loadTypes)
         >
           <el-table-column label="类型" min-width="140">
             <template #default="{ row }">
-              <div class="type-cell">
+              <button
+                type="button"
+                class="type-cell"
+                :aria-label="`选择字典类型 ${row.typeName}`"
+                :aria-pressed="row.id === activeType?.id"
+                @click.stop="selectType(row)"
+              >
                 <span class="type-name">{{ row.typeName }}</span>
                 <span class="type-code">{{ row.dictType }}</span>
-              </div>
+              </button>
             </template>
           </el-table-column>
           <el-table-column label="项数" width="60" align="center">
@@ -321,7 +350,7 @@ onMounted(loadTypes)
       </el-form>
       <template #footer>
         <el-button @click="typeDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="submitType">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="typeSubmitting" @click="submitType">保存类型</el-button>
       </template>
     </el-dialog>
 
@@ -350,7 +379,7 @@ onMounted(loadTypes)
       </el-form>
       <template #footer>
         <el-button @click="itemDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="submitItem">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="itemSubmitting" @click="submitItem">保存字典项</el-button>
       </template>
     </el-dialog>
   </div>
@@ -362,14 +391,14 @@ onMounted(loadTypes)
 }
 
 .layout {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);
   gap: 12px;
   align-items: flex-start;
 }
 
 .type-panel {
-  width: 420px;
-  flex-shrink: 0;
+  width: auto;
 }
 
 .item-panel {
@@ -390,7 +419,24 @@ onMounted(loadTypes)
 .type-cell {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  padding: 4px 2px;
+  color: inherit;
+  text-align: left;
+  border: 0;
+  border-radius: var(--cw-radius-sm);
+  background: transparent;
   cursor: pointer;
+  font: inherit;
+}
+
+.type-cell:hover {
+  background: var(--el-fill-color-light);
+}
+
+.type-cell:focus-visible {
+  outline: 2px solid var(--cw-focus-ring);
+  outline-offset: 1px;
 }
 
 .type-name {
@@ -398,11 +444,22 @@ onMounted(loadTypes)
 }
 
 .type-code {
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
 }
 
 :deep(.active-row) {
-  background: var(--el-color-primary-light-9);
+  background: color-mix(in srgb, var(--cw-cobalt) 9%, var(--cw-paper));
+}
+
+@media (max-width: 767px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .type-panel,
+  .item-panel {
+    width: 100%;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/LoginImageManage.vue
+++ b/customer-admin-web/src/views/system/LoginImageManage.vue
@@ -105,7 +105,7 @@ async function handleDelete(row: LoginCarouselImageVO) {
       <template #header>
         <div class="page-header">
           <div>
-            <span class="page-title">登录页图片</span>
+            <span class="page-title">轮播素材</span>
             <span class="page-subtitle">上传多张图片作为登录页轮播背景，登录页实时获取；全部禁用或为空时回退内置默认图</span>
           </div>
           <el-upload
@@ -113,7 +113,7 @@ async function handleDelete(row: LoginCarouselImageVO) {
             :http-request="handleUpload"
             accept="image/png,image/jpeg,image/webp"
           >
-            <el-button v-permission="'login-image:add'" type="primary">上传图片</el-button>
+            <el-button v-permission="'login-image:add'" class="cw-final-action" type="primary">上传图片</el-button>
           </el-upload>
         </div>
       </template>
@@ -177,6 +177,7 @@ async function handleDelete(row: LoginCarouselImageVO) {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
 }
 
 .page-title {
@@ -199,7 +200,7 @@ async function handleDelete(row: LoginCarouselImageVO) {
 .image-preview {
   width: 100%;
   height: 160px;
-  border-radius: 4px;
+  border-radius: var(--cw-radius-sm);
   display: block;
 }
 
@@ -247,5 +248,34 @@ async function handleDelete(row: LoginCarouselImageVO) {
   margin-top: 16px;
   font-size: 12px;
   color: var(--el-text-color-secondary);
+  line-height: 1.6;
+}
+
+@media (max-width: 767px) {
+  .page-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .page-subtitle {
+    display: block;
+    margin: 6px 0 0;
+    line-height: 1.5;
+  }
+
+  .page-header :deep(.el-upload),
+  .page-header :deep(.el-button) {
+    width: 100%;
+  }
+
+  .image-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .image-actions {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/MenuManage.vue
+++ b/customer-admin-web/src/views/system/MenuManage.vue
@@ -27,6 +27,9 @@ const ICON_NAMES = Object.keys(ElementPlusIconsVue)
 
 const loading = ref(false)
 const tree = ref<PermissionVO[]>([])
+const submitting = ref(false)
+const publishing = ref(false)
+const reordering = ref(false)
 /** 有未发布的改动（增删改/拖拽都会置位），点"发布"广播给其它在线用户后清零，只是本地 UI 提示，不影响任何实际行为。 */
 const dirty = ref(false)
 const treeProps = { label: 'permName', children: 'children' }
@@ -117,20 +120,26 @@ async function handleIconUpload(options: UploadRequestOptions) {
 }
 
 async function handleSubmit() {
-  const valid = await formRef.value?.validate().catch(() => false)
-  if (!valid) {
-    return
+  if (submitting.value) return
+  submitting.value = true
+  try {
+    const valid = await formRef.value?.validate().catch(() => false)
+    if (!valid) {
+      return
+    }
+    if (dialogMode.value === 'create') {
+      await createMenuNode(form)
+      ElMessage.success('新建成功')
+    } else if (editingId.value) {
+      await updateMenuNode(editingId.value, form)
+      ElMessage.success('保存成功')
+    }
+    dirty.value = true
+    dialogVisible.value = false
+    await loadTree()
+  } finally {
+    submitting.value = false
   }
-  if (dialogMode.value === 'create') {
-    await createMenuNode(form)
-    ElMessage.success('新建成功')
-  } else if (editingId.value) {
-    await updateMenuNode(editingId.value, form)
-    ElMessage.success('保存成功')
-  }
-  dirty.value = true
-  dialogVisible.value = false
-  await loadTree()
 }
 
 async function handleDelete(node: PermissionVO) {
@@ -162,19 +171,39 @@ function flattenForReorder(nodes: PermissionVO[], parentId: number): MenuReorder
 }
 
 async function handleNodeDrop() {
+  if (reordering.value) return
   // el-tree 拖拽后已经把新顺序写回了 tree.value（受控 :data），这里整树摊平重新计算 parentId/sort
   // 一次性提交，不做增量 diff——菜单树节点量小，简单可靠比抠性能更重要。
-  await reorderMenuNodes(flattenForReorder(tree.value, 0))
-  ElMessage.success('顺序已调整')
-  dirty.value = true
-  await loadTree()
+  reordering.value = true
+  try {
+    await reorderMenuNodes(flattenForReorder(tree.value, 0))
+    ElMessage.success('顺序已调整')
+    dirty.value = true
+    await loadTree()
+  } catch (error) {
+    // el-tree 已乐观改写本地树；持久化失败时必须回读服务端真值，避免展示并不存在的顺序。
+    try {
+      await loadTree()
+    } catch {
+      // 原始 reorder 错误由请求层负责展示并继续向上传递。
+    }
+    throw error
+  } finally {
+    reordering.value = false
+  }
 }
 
 // ---------- 发布 ----------
 async function handlePublish() {
-  await publishMenu()
-  dirty.value = false
-  ElMessage.success('已发布，其它在线用户的菜单将在下次轮询时自动刷新')
+  if (publishing.value) return
+  publishing.value = true
+  try {
+    await publishMenu()
+    dirty.value = false
+    ElMessage.success('已发布，其它在线用户的菜单将在下次轮询时自动刷新')
+  } finally {
+    publishing.value = false
+  }
 }
 
 // ---------- 变更记录 ----------
@@ -212,8 +241,8 @@ onMounted(loadTree)
   <div class="page">
     <el-card>
       <div class="toolbar">
-        <el-button v-permission="'menu:add'" type="primary" @click="openCreateRoot">新增根菜单</el-button>
-        <el-button v-permission="'menu:edit'" type="success" :disabled="!dirty" @click="handlePublish">
+        <el-button v-permission="'menu:add'" class="cw-final-action" type="primary" @click="openCreateRoot">新增根菜单</el-button>
+        <el-button v-permission="'menu:edit'" class="cw-final-action" type="primary" :disabled="!dirty" :loading="publishing" @click="handlePublish">
           发布<el-badge v-if="dirty" is-dot class="publish-badge" />
         </el-button>
         <el-button v-permission="'menu:view'" @click="openChangeLog()">变更记录</el-button>
@@ -224,7 +253,7 @@ onMounted(loadTree)
         :data="tree"
         :props="treeProps"
         node-key="id"
-        draggable
+        :draggable="!reordering"
         default-expand-all
         :allow-drop="allowDrop"
         @node-drop="handleNodeDrop"
@@ -281,16 +310,19 @@ onMounted(loadTree)
               <el-tab-pane label="图标库" name="library">
                 <el-input v-model="iconSearch" placeholder="搜索图标名" clearable style="margin-bottom: 8px" />
                 <div class="icon-grid">
-                  <div
+                  <button
                     v-for="name in filteredIconNames"
                     :key="name"
+                    type="button"
                     class="icon-grid-item"
                     :class="{ active: form.icon === name && form.iconType === 'library' }"
                     :title="name"
+                    :aria-label="`选择图标 ${name}`"
+                    :aria-pressed="form.icon === name && form.iconType === 'library'"
                     @click="selectLibraryIcon(name)"
                   >
                     <el-icon><component :is="name" /></el-icon>
-                  </div>
+                  </button>
                 </div>
               </el-tab-pane>
               <el-tab-pane label="上传图片" name="image">
@@ -307,7 +339,7 @@ onMounted(loadTree)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存菜单</el-button>
       </template>
     </el-dialog>
 
@@ -362,6 +394,7 @@ onMounted(loadTree)
   align-items: center;
   gap: 8px;
   width: 100%;
+  min-height: 38px;
   padding-right: 8px;
 }
 
@@ -395,7 +428,8 @@ onMounted(loadTree)
   white-space: nowrap;
 }
 
-.tree-node:hover .node-actions {
+.tree-node:hover .node-actions,
+.tree-node:focus-within .node-actions {
   display: inline-flex;
 }
 
@@ -448,6 +482,9 @@ onMounted(loadTree)
   border-radius: 4px;
   cursor: pointer;
   border: 1px solid transparent;
+  color: inherit;
+  background: transparent;
+  font: inherit;
 }
 
 .icon-grid-item:hover {
@@ -458,6 +495,11 @@ onMounted(loadTree)
   border-color: var(--el-color-primary);
   color: var(--el-color-primary);
   background: var(--el-color-primary-light-9);
+}
+
+.icon-grid-item:focus-visible {
+  outline: 2px solid var(--cw-focus-ring);
+  outline-offset: 1px;
 }
 
 .upload-tip {
@@ -491,5 +533,41 @@ onMounted(loadTree)
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+@media (max-width: 767px) {
+  .tree-node {
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-block: 5px;
+  }
+
+  .node-name {
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .node-code {
+    flex-basis: calc(100% - 28px);
+    margin-left: 28px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .node-actions {
+    display: inline-flex;
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    margin-left: 28px;
+  }
+
+  .icon-picker,
+  .snapshot-pair {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 </style>

--- a/customer-admin-web/src/views/system/OperationLog.vue
+++ b/customer-admin-web/src/views/system/OperationLog.vue
@@ -35,12 +35,12 @@ onMounted(loadList)
         <el-button type="primary" @click="handleSearch">搜索</el-button>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无操作日志">
         <el-table-column prop="username" label="操作人" width="120" />
-        <el-table-column prop="operation" label="操作内容" width="160" />
+        <el-table-column prop="operation" label="操作内容" width="160" class-name="primary-column" />
         <el-table-column prop="target" label="操作对象" width="140" />
         <el-table-column prop="ip" label="IP" width="140" />
-        <el-table-column label="结果" width="90">
+        <el-table-column label="结果" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.result === 1 ? 'success' : row.result === 2 ? 'warning' : 'danger'">
               {{ row.result === 1 ? '成功' : row.result === 2 ? '待确认' : '失败' }}
@@ -60,7 +60,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -70,7 +70,19 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 </style>

--- a/customer-admin-web/src/views/system/RoleManage.vue
+++ b/customer-admin-web/src/views/system/RoleManage.vue
@@ -5,6 +5,7 @@ import { createRole, deleteRole, pageRoles, updateRole } from '@/api/role'
 import { permissionTree } from '@/api/permission'
 import { fetchCurrentView } from '@/api/tenant'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type { DataScope, PageQuery, PermissionVO, RoleSaveRequest, RoleVO } from '@/types/api'
 
 // 数据范围选项。ALL 只对控制面角色开放——普通租户管理员能在自己租户里建角色，
@@ -32,7 +33,7 @@ const treeRef = ref<TreeInstance>()
 const treeProps = { label: 'permName', children: 'children' }
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch,
   openCreate: openCreateBase, openEdit: openEditBase,
@@ -80,25 +81,28 @@ onMounted(async () => {
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按角色名搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'role:add'" type="primary" @click="openCreate">新建角色</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'role:add'" class="cw-final-action" type="primary" @click="openCreate">新建角色</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="roleName" label="角色名称" />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的角色">
+        <el-table-column prop="roleName" label="角色名称" class-name="primary-column" />
         <el-table-column prop="roleCode" label="角色编码" />
         <el-table-column prop="remark" label="备注" show-overflow-tooltip />
-        <el-table-column label="数据范围" width="130">
+        <el-table-column label="数据范围" width="130" align="center">
           <template #default="{ row }">
             <el-tag :type="row.dataScope === 'SELF' ? 'info' : row.dataScope === 'ALL' ? 'danger' : 'warning'" disable-transitions>
               {{ DATA_SCOPE_LABELS[row.dataScope as DataScope] ?? row.dataScope }}
             </el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '禁用' }}</el-tag>
           </template>
@@ -119,6 +123,7 @@ onMounted(async () => {
               v-permission="'role:delete'"
               link
               type="danger"
+              :loading="deletingId === row.id"
               :disabled="row.roleCode === 'super_admin' || (row.controlPlane && !crossTenantAuthority)"
               @click="handleDelete(row)"
             >
@@ -133,7 +138,7 @@ onMounted(async () => {
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -168,13 +173,13 @@ onMounted(async () => {
             :props="treeProps"
             node-key="id"
             show-checkbox
-            style="width: 100%; max-height: 320px; overflow: auto; border: 1px solid #eee; padding: 8px"
+            style="width: 100%; max-height: 320px; overflow: auto; border: 1px solid var(--cw-line); padding: 8px"
           />
         </el-form-item>
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存角色</el-button>
       </template>
     </el-dialog>
   </div>
@@ -183,8 +188,37 @@ onMounted(async () => {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 
 .form-tip {

--- a/customer-admin-web/src/views/system/SloManage.vue
+++ b/customer-admin-web/src/views/system/SloManage.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import {
   acknowledgeSloAlert,
   evaluateSloPolicy,
+  getSloAlertSummary,
   listSloAlertEvents,
   listSloAlerts,
   listSloPolicies,
@@ -11,6 +12,7 @@ import {
   type SloAlert,
   type SloAlertEvent,
   type SloAlertStatus,
+  type SloAlertSummary,
   type SloEvaluation,
   type SloPolicy,
   type SloPolicySaveRequest,
@@ -33,6 +35,7 @@ const STATUS_LABELS: Record<SloEvaluation['status'], string> = {
 const loading = ref(false)
 const policies = ref<SloPolicy[]>([])
 const alerts = ref<SloAlert[]>([])
+const alertSummary = ref<SloAlertSummary>({ openCount: 0, acknowledgedCount: 0 })
 const dialogVisible = ref(false)
 const evaluationVisible = ref(false)
 const eventVisible = ref(false)
@@ -41,7 +44,19 @@ const alertEvents = ref<SloAlertEvent[]>([])
 const activeAlert = ref<SloAlert | null>(null)
 const evaluatingId = ref<number | null>(null)
 const acknowledgingId = ref<number | null>(null)
+const eventLoadingId = ref<number | null>(null)
 const alertStatus = ref<SloAlertStatus | undefined>(undefined)
+const saving = ref(false)
+let loadRequestId = 0
+let eventRequestId = 0
+
+const enabledPolicyCount = computed(() => policies.value.filter((item) => item.enabled).length)
+const healthyPolicyCount = computed(() => (
+  policies.value.filter((item) => item.lastEvaluationStatus === 'HEALTHY').length
+))
+// 顶部指标由服务端直接聚合事实表，不能被下方筛选或 200 条明细上限污染。
+const openAlertCount = computed(() => alertSummary.value.openCount)
+const acknowledgedAlertCount = computed(() => alertSummary.value.acknowledgedCount)
 
 const emptyForm = (): SloPolicySaveRequest => ({
   policyName: '',
@@ -59,30 +74,53 @@ const emptyForm = (): SloPolicySaveRequest => ({
 const form = reactive<SloPolicySaveRequest>(emptyForm())
 
 async function loadPolicies() {
+  const requestId = ++loadRequestId
   loading.value = true
   try {
-    const [policyRows, alertRows] = await Promise.all([
+    const [policyRows, alertRows, summary] = await Promise.all([
       listSloPolicies(),
       listSloAlerts(alertStatus.value),
+      getSloAlertSummary(),
     ])
-    policies.value = policyRows
-    alerts.value = alertRows
+    if (requestId === loadRequestId) {
+      policies.value = policyRows
+      alerts.value = alertRows
+      alertSummary.value = summary
+    }
   } finally {
-    loading.value = false
+    if (requestId === loadRequestId) {
+      loading.value = false
+    }
   }
 }
 
 function openCreate() {
+  // Object.assign 不会移除编辑态遗留的可选 id；必须显式删除，避免“新建”误走服务端 upsert 更新旧策略。
+  delete form.id
   Object.assign(form, emptyForm())
   dialogVisible.value = true
 }
 
 function openEdit(row: SloPolicy) {
-  Object.assign(form, row)
+  Object.assign(form, {
+    id: row.id,
+    policyName: row.policyName,
+    scopeType: row.scopeType,
+    scopeKey: row.scopeKey,
+    availabilityTarget: row.availabilityTarget,
+    latencyTarget: row.latencyTarget,
+    latencyThresholdMs: row.latencyThresholdMs,
+    shortWindowMinutes: row.shortWindowMinutes,
+    longWindowMinutes: row.longWindowMinutes,
+    minimumSampleCount: row.minimumSampleCount,
+    burnRateThreshold: row.burnRateThreshold,
+    enabled: row.enabled,
+  })
   dialogVisible.value = true
 }
 
 async function submit() {
+  if (saving.value) return
   if (!form.policyName.trim()) {
     ElMessage.warning('请填写策略名称')
     return
@@ -99,13 +137,19 @@ async function submit() {
     ElMessage.warning('最低样本数必须大于 0')
     return
   }
-  await saveSloPolicy({ ...form, scopeKey: form.scopeType === 'TENANT' ? null : form.scopeKey })
-  ElMessage.success('SLO 策略已保存')
-  dialogVisible.value = false
-  await loadPolicies()
+  saving.value = true
+  try {
+    await saveSloPolicy({ ...form, scopeKey: form.scopeType === 'TENANT' ? null : form.scopeKey })
+    ElMessage.success('SLO 策略已保存')
+    dialogVisible.value = false
+    await loadPolicies()
+  } finally {
+    saving.value = false
+  }
 }
 
 async function evaluate(row: SloPolicy) {
+  if (evaluatingId.value !== null) return
   evaluatingId.value = row.id
   try {
     evaluation.value = await evaluateSloPolicy(row.id)
@@ -117,25 +161,42 @@ async function evaluate(row: SloPolicy) {
     }
     await loadPolicies()
   } finally {
-    evaluatingId.value = null
+    if (evaluatingId.value === row.id) {
+      evaluatingId.value = null
+    }
   }
 }
 
 async function acknowledge(row: SloAlert) {
+  if (acknowledgingId.value !== null) return
   acknowledgingId.value = row.id
   try {
     await acknowledgeSloAlert(row.id)
     ElMessage.success('告警已确认')
     await loadPolicies()
   } finally {
-    acknowledgingId.value = null
+    if (acknowledgingId.value === row.id) {
+      acknowledgingId.value = null
+    }
   }
 }
 
 async function showEvents(row: SloAlert) {
+  const requestId = ++eventRequestId
   activeAlert.value = row
-  alertEvents.value = await listSloAlertEvents(row.id)
+  alertEvents.value = []
   eventVisible.value = true
+  eventLoadingId.value = row.id
+  try {
+    const events = await listSloAlertEvents(row.id)
+    if (requestId === eventRequestId && activeAlert.value?.id === row.id) {
+      alertEvents.value = events
+    }
+  } finally {
+    if (requestId === eventRequestId) {
+      eventLoadingId.value = null
+    }
+  }
 }
 
 function percent(value: number) {
@@ -165,14 +226,33 @@ onMounted(loadPolicies)
 
 <template>
   <div class="slo-page">
-    <el-card shadow="never">
+    <div class="summary-row" v-loading="loading">
+      <div class="stat">
+        <strong>{{ enabledPolicyCount }}</strong>
+        <span>启用策略</span>
+      </div>
+      <div class="stat">
+        <strong>{{ healthyPolicyCount }}</strong>
+        <span>最近评估健康</span>
+      </div>
+      <div class="stat stat-danger">
+        <strong>{{ openAlertCount }}</strong>
+        <span>全部待确认</span>
+      </div>
+      <div class="stat stat-warning">
+        <strong>{{ acknowledgedAlertCount }}</strong>
+        <span>全部已确认待恢复</span>
+      </div>
+    </div>
+
+    <el-card shadow="never" class="policy-card">
       <template #header>
         <div class="header">
           <div>
             <h2>SLO 错误预算</h2>
             <p>多副本通过数据库租约周期评估；短、长窗口同时超限打开告警，恢复后自动闭环并可靠投递通知。</p>
           </div>
-          <el-button v-permission="'slo:edit'" type="primary" @click="openCreate">新建策略</el-button>
+          <el-button v-permission="'slo:edit'" class="cw-final-action" type="primary" @click="openCreate">新建策略</el-button>
         </div>
       </template>
 
@@ -213,7 +293,7 @@ onMounted(loadPolicies)
         </el-table-column>
         <el-table-column label="操作" width="160" fixed="right">
           <template #default="{ row }">
-            <el-button v-permission="'slo:evaluate'" link type="primary" :loading="evaluatingId === row.id" @click="evaluate(row)">
+            <el-button v-permission="'slo:evaluate'" link type="primary" :loading="evaluatingId === row.id" :disabled="evaluatingId !== null && evaluatingId !== row.id" @click="evaluate(row)">
               立即评估
             </el-button>
             <el-button v-permission="'slo:edit'" link @click="openEdit(row)">编辑</el-button>
@@ -257,9 +337,10 @@ onMounted(loadPolicies)
               link
               type="primary"
               :loading="acknowledgingId === row.id"
+              :disabled="acknowledgingId !== null && acknowledgingId !== row.id"
               @click="acknowledge(row)"
             >确认</el-button>
-            <el-button link @click="showEvents(row)">事件</el-button>
+            <el-button link :loading="eventLoadingId === row.id" @click="showEvents(row)">事件</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -300,12 +381,12 @@ onMounted(loadPolicies)
         <el-form-item label="燃烧率阈值"><el-input-number v-model="form.burnRateThreshold" :min="0.01" :step="0.5" :precision="2" /></el-form-item>
         <el-form-item label="启用"><el-switch v-model="form.enabled" /></el-form-item>
       </el-form>
-      <template #footer><el-button @click="dialogVisible = false">取消</el-button><el-button type="primary" @click="submit">保存</el-button></template>
+      <template #footer><el-button @click="dialogVisible = false">取消</el-button><el-button class="cw-final-action" type="primary" :loading="saving" @click="submit">保存策略</el-button></template>
     </el-dialog>
 
     <el-dialog v-model="evaluationVisible" title="错误预算评估结果" width="760px">
       <template v-if="evaluation">
-        <el-descriptions :column="3" border>
+        <el-descriptions :column="3" border class="evaluation-summary">
           <el-descriptions-item label="策略">{{ evaluation.policyName }}</el-descriptions-item>
           <el-descriptions-item label="状态"><el-tag :type="statusType(evaluation.status)">{{ STATUS_LABELS[evaluation.status] }}</el-tag></el-descriptions-item>
           <el-descriptions-item label="评估时间">{{ evaluation.evaluatedAt }}</el-descriptions-item>
@@ -323,7 +404,7 @@ onMounted(loadPolicies)
       </template>
     </el-dialog>
 
-    <el-dialog v-model="eventVisible" :title="`${activeAlert?.policyName || 'SLO'} · 状态事件`" width="720px">
+    <el-dialog v-model="eventVisible" v-loading="eventLoadingId !== null" :title="`${activeAlert?.policyName || 'SLO'} · 状态事件`" width="720px">
       <el-timeline>
         <el-timeline-item v-for="item in alertEvents" :key="item.id" :timestamp="item.occurredAt" placement="top">
           <strong>{{ item.eventType }}</strong>
@@ -336,16 +417,40 @@ onMounted(loadPolicies)
 </template>
 
 <style scoped>
-.slo-page { padding: 20px; }
+.slo-page { display: flex; flex-direction: column; gap: 14px; }
+.summary-row { display: grid; grid-template-columns: repeat(4, minmax(150px, 1fr)); gap: 12px; }
+.stat { min-height: 88px; padding: 15px 16px 14px; border: 1px solid var(--cw-line); border-radius: var(--cw-radius-md); background: var(--cw-paper); box-shadow: var(--cw-shadow-xs); }
+.stat strong { display: block; color: var(--cw-text); font-size: 25px; font-weight: 720; font-variant-numeric: tabular-nums; line-height: 1.2; }
+.stat span { display: block; margin-top: 7px; color: var(--cw-text-muted); font-size: 12px; }
+.stat-danger strong { color: var(--cw-danger); }
+.stat-warning strong { color: var(--cw-amber); }
 .header { display: flex; align-items: center; justify-content: space-between; gap: 24px; }
-.header h2 { margin: 0 0 6px; font-size: 20px; }
-.header p { margin: 0; color: var(--el-text-color-secondary); }
+.header h2 { margin: 0 0 6px; color: var(--cw-text); font-size: 18px; }
+.header p { max-width: 820px; margin: 0; color: var(--cw-text-muted); line-height: 1.55; }
 .scope-key { margin-left: 8px; font-family: ui-monospace, monospace; }
-.hint { margin-left: 10px; color: var(--el-text-color-secondary); }
+.hint { margin-left: 10px; color: var(--cw-text-muted); }
 .split { margin: 0 10px; }
 .result-table { margin-top: 18px; }
-.alert-card { margin-top: 18px; }
-.subtle { margin-top: 4px; color: var(--el-text-color-secondary); font-size: 12px; }
-.evaluation-error { max-width: 260px; margin-top: 4px; color: var(--el-color-danger); font-size: 12px; white-space: normal; }
+.subtle { margin-top: 4px; color: var(--cw-text-muted); font-size: 12px; }
+.evaluation-error { max-width: 260px; margin-top: 4px; color: var(--cw-danger); font-size: 12px; white-space: normal; }
 .event-rate { margin-left: 14px; }
+
+@media (max-width: 1023px) {
+  .summary-row { grid-template-columns: repeat(2, minmax(150px, 1fr)); }
+  .header { align-items: flex-start; flex-wrap: wrap; }
+}
+
+@media (max-width: 767px) {
+  .summary-row { grid-template-columns: 1fr 1fr; }
+  .header { flex-direction: column; gap: 12px; }
+  .header > .el-button,
+  .header > .el-select { width: 100%; }
+  .evaluation-summary { overflow-x: auto; }
+  .event-rate,
+  .subtle { display: block; margin: 5px 0 0; }
+}
+
+@media (max-width: 480px) {
+  .summary-row { grid-template-columns: 1fr; }
+}
 </style>

--- a/customer-admin-web/src/views/system/TenantManage.vue
+++ b/customer-admin-web/src/views/system/TenantManage.vue
@@ -161,18 +161,20 @@ onMounted(loadList)
           <el-option label="已退租" value="TERMINATED" />
         </el-select>
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'tenant:add'" type="primary" @click="openCreate">新建租户</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'tenant:add'" class="cw-final-action" type="primary" @click="openCreate">新建租户</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的租户">
         <el-table-column prop="tenantCode" label="租户编码" width="160">
           <template #default="{ row }">
             {{ row.tenantCode }}
             <el-tag v-if="row.reserved" size="small" type="info" style="margin-left: 6px">系统保留</el-tag>
           </template>
         </el-table-column>
-        <el-table-column prop="tenantName" label="租户名称" />
-        <el-table-column label="状态" width="100">
+        <el-table-column prop="tenantName" label="租户名称" class-name="primary-column" />
+        <el-table-column label="状态" width="100" align="center">
           <template #default="{ row }">
             <el-tag :type="STATUS_LABELS[row.status]?.type ?? 'info'">
               {{ STATUS_LABELS[row.status]?.text ?? row.status }}
@@ -235,7 +237,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -275,7 +277,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="submit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="submit">保存租户</el-button>
       </template>
     </el-dialog>
   </div>
@@ -284,8 +286,37 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 
 .form-tip {

--- a/customer-admin-web/src/views/system/UserManage.vue
+++ b/customer-admin-web/src/views/system/UserManage.vue
@@ -13,6 +13,7 @@ import { pageRoles } from '@/api/role'
 import { fetchCurrentView } from '@/api/tenant'
 import { useAuthStore } from '@/store/auth'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import type {
   RoleVO,
   UserApprovalRoleOption,
@@ -50,7 +51,7 @@ const reviewTenantMode = ref<'existing' | 'new'>('existing')
 const reviewNewTenant = reactive({ tenantCode: '', tenantName: '' })
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit: openEditCrud, handleSubmit, handleDelete,
 } = useCrudPage<UserVO, UserPageQuery, UserSaveRequest>({
@@ -207,6 +208,7 @@ onMounted(async () => {
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按用户名搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
@@ -220,11 +222,13 @@ onMounted(async () => {
           <el-option label="已拒绝" value="REJECTED" />
         </el-select>
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'user:add'" type="primary" @click="openCreate">新建用户</el-button>
+        <div class="toolbar-actions">
+          <el-button v-permission="'user:add'" class="cw-final-action" type="primary" @click="openCreate">新建用户</el-button>
+        </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="username" label="用户名" />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的用户">
+        <el-table-column prop="username" label="用户名" class-name="primary-column" />
         <el-table-column prop="tenantId" label="归属租户" min-width="120" />
         <el-table-column prop="nickname" label="昵称" />
         <el-table-column label="邮箱" min-width="160" show-overflow-tooltip>
@@ -233,12 +237,12 @@ onMounted(async () => {
         <el-table-column label="角色">
           <template #default="{ row }">{{ row.roleNames?.join('、') || '-' }}</template>
         </el-table-column>
-        <el-table-column label="状态" width="90">
+        <el-table-column label="状态" width="90" align="center">
           <template #default="{ row }">
             <el-tag :type="row.status === 1 ? 'success' : 'info'">{{ row.status === 1 ? '启用' : '禁用' }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="审核状态" width="100">
+        <el-table-column label="审核状态" width="100" align="center">
           <template #default="{ row }">
             <el-tag :type="approvalTagType(row.approvalStatus)">{{ approvalText(row.approvalStatus) }}</el-tag>
           </template>
@@ -258,7 +262,7 @@ onMounted(async () => {
               {{ row.approvalStatus === 'PENDING' ? '审核' : '重新审核' }}
             </el-button>
             <el-button v-permission="'user:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
-            <el-button v-permission="'user:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'user:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -268,7 +272,7 @@ onMounted(async () => {
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -307,7 +311,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存用户</el-button>
       </template>
     </el-dialog>
 
@@ -400,7 +404,7 @@ onMounted(async () => {
       </el-form>
       <template #footer>
         <el-button @click="reviewDialogVisible = false">取消</el-button>
-        <el-button type="primary" :loading="reviewSubmitting" @click="submitReview">确认审核</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="reviewSubmitting" @click="submitReview">确认审核</el-button>
       </template>
     </el-dialog>
   </div>
@@ -409,8 +413,37 @@ onMounted(async () => {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 
 .review-user {

--- a/customer-admin-web/src/views/ticket/UserOrderManage.vue
+++ b/customer-admin-web/src/views/ticket/UserOrderManage.vue
@@ -130,8 +130,8 @@ async function handleCancelSubmit() {
         <el-button v-permission="'user-order:view'" type="primary" @click="handleSearch">查询</el-button>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="orderId" label="订单号" width="160" show-overflow-tooltip />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的订单">
+        <el-table-column prop="orderId" label="订单号" width="160" show-overflow-tooltip class-name="primary-column" />
         <el-table-column label="用户" width="160">
           <template #default="{ row }: { row: OrderVO }">
             <div>{{ row.username || '-' }}</div>
@@ -140,7 +140,7 @@ async function handleCancelSubmit() {
         </el-table-column>
         <el-table-column prop="productName" label="商品" show-overflow-tooltip />
         <el-table-column prop="amount" label="金额" width="100" />
-        <el-table-column label="状态" width="100">
+        <el-table-column label="状态" width="100" align="center">
           <template #default="{ row }: { row: OrderVO }">
             <el-tag :type="orderTagType(row.status)" size="small">{{ row.status }}</el-tag>
           </template>
@@ -157,14 +157,12 @@ async function handleCancelSubmit() {
         </el-table-column>
       </el-table>
 
-      <el-empty v-if="!loading && list.length === 0" description="暂无订单数据" />
-
       <el-pagination
         v-model:current-page="query.pageNum"
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="handlePageChange"
       />
     </el-card>
@@ -198,7 +196,7 @@ async function handleCancelSubmit() {
       </el-form>
       <template #footer>
         <el-button @click="addressDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleAddressSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleAddressSubmit">确认改址</el-button>
       </template>
     </el-dialog>
 
@@ -210,7 +208,7 @@ async function handleCancelSubmit() {
       </el-form>
       <template #footer>
         <el-button @click="cancelDialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleCancelSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" @click="handleCancelSubmit">确认取消</el-button>
       </template>
     </el-dialog>
   </div>
@@ -219,8 +217,20 @@ async function handleCancelSubmit() {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 
 .sub-text {

--- a/customer-admin-web/src/views/ticket/UserTicketManage.vue
+++ b/customer-admin-web/src/views/ticket/UserTicketManage.vue
@@ -170,16 +170,16 @@ onUnmounted(() => {
         <el-button type="primary" @click="handleSearch">刷新</el-button>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的用户工单">
         <el-table-column prop="id" label="工单号" width="90" />
-        <el-table-column prop="title" label="标题" show-overflow-tooltip />
+        <el-table-column prop="title" label="标题" show-overflow-tooltip class-name="primary-column" />
         <el-table-column prop="userId" label="用户" width="140" show-overflow-tooltip />
-        <el-table-column label="状态" width="120">
+        <el-table-column label="状态" width="120" align="center">
           <template #default="{ row }: { row: TicketVO }">
             <el-tag :type="STATUS_TAG_TYPE[row.status]" size="small">{{ STATUS_LABELS[row.status] }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="优先级" width="90">
+        <el-table-column label="优先级" width="90" align="center">
           <template #default="{ row }: { row: TicketVO }">
             <el-tag :type="PRIORITY_TAG_TYPE[row.priority]" size="small">{{ PRIORITY_LABELS[row.priority] }}</el-tag>
           </template>
@@ -214,7 +214,7 @@ onUnmounted(() => {
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="handlePageChange"
       />
     </el-card>
@@ -233,7 +233,19 @@ onUnmounted(() => {
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 </style>

--- a/customer-admin-web/src/views/ticket/components/TicketChatPanel.vue
+++ b/customer-admin-web/src/views/ticket/components/TicketChatPanel.vue
@@ -520,8 +520,8 @@ const categoryOptions = Object.entries(CATEGORY_LABELS) as [TicketCategory, stri
 }
 
 .message-row.agent .bubble {
-  background: var(--theme-primary, var(--el-color-primary));
-  color: #fff;
+  background: var(--theme-primary-solid, var(--el-color-primary));
+  color: var(--cw-on-primary, #fff);
 }
 
 .bot-badge {
@@ -531,7 +531,7 @@ const categoryOptions = Object.entries(CATEGORY_LABELS) as [TicketCategory, stri
 }
 
 .message-row.agent .bot-badge {
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--cw-on-primary, #fff);
 }
 
 .content {

--- a/customer-admin-web/src/views/workbench/WorkbenchSiteManage.vue
+++ b/customer-admin-web/src/views/workbench/WorkbenchSiteManage.vue
@@ -10,6 +10,7 @@ import {
   updateWorkbenchSite,
 } from '@/api/workbench'
 import { useCrudPage } from '@/composables/useCrudPage'
+import CrudLoadState from '@/components/CrudLoadState.vue'
 import { copyText } from '@/views/system/devtools/composables/useCopy'
 import { parseUserscript } from '@/utils/scriptImport'
 import WorkbenchTokenDialog from './WorkbenchTokenDialog.vue'
@@ -22,7 +23,7 @@ const formRef = ref<FormInstance>()
 const secretLoadingId = ref<number | null>(null)
 
 const {
-  loading, list, total, query,
+  loading, loadError, submitting, deletingId, list, total, query,
   dialogVisible, dialogMode, form,
   loadList, handleSearch, openCreate, openEdit, handleSubmit, handleDelete,
 } = useCrudPage<WorkbenchSiteVO, PageQuery, WorkbenchSiteSaveRequest>({
@@ -152,19 +153,20 @@ onMounted(loadList)
 
 <template>
   <div class="page">
+    <CrudLoadState :error="loadError" :has-stale-data="list.length > 0" :loading="loading" @retry="loadList" />
     <el-card>
       <div class="toolbar">
         <el-input v-model="query.keyword" placeholder="按名称/分类搜索" style="width: 220px" clearable @keyup.enter="handleSearch" />
         <el-button type="primary" @click="handleSearch">搜索</el-button>
-        <el-button v-permission="'workbench-site:add'" type="primary" @click="openCreate">新增站点</el-button>
-        <div class="toolbar-right">
+        <div class="toolbar-actions">
           <el-button @click="tokenDialogVisible = true">我的令牌</el-button>
           <el-button type="success" @click="openScriptDialog">生成登录脚本</el-button>
+          <el-button v-permission="'workbench-site:add'" class="cw-final-action" type="primary" @click="openCreate">新增站点</el-button>
         </div>
       </div>
 
-      <el-table v-loading="loading" :data="list" style="width: 100%">
-        <el-table-column prop="name" label="名称" width="160" show-overflow-tooltip />
+      <el-table v-loading="loading" :data="list" class="data-table" empty-text="暂无符合条件的工作台站点">
+        <el-table-column prop="name" label="名称" width="160" show-overflow-tooltip class-name="primary-column" />
         <el-table-column label="分类" width="110">
           <template #default="{ row }">
             <el-tag v-if="row.category" type="info">{{ row.category }}</el-tag>
@@ -201,7 +203,7 @@ onMounted(loadList)
           <template #default="{ row }">
             <el-button link type="primary" @click="openSite(row)">打开</el-button>
             <el-button v-permission="'workbench-site:edit'" link type="primary" @click="openEdit(row)">编辑</el-button>
-            <el-button v-permission="'workbench-site:delete'" link type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button v-permission="'workbench-site:delete'" link type="danger" :loading="deletingId === row.id" @click="handleDelete(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -211,7 +213,7 @@ onMounted(loadList)
         v-model:page-size="query.pageSize"
         :total="total"
         layout="total, prev, pager, next"
-        style="margin-top: 16px; justify-content: flex-end"
+        class="pagination"
         @current-change="loadList"
       />
     </el-card>
@@ -290,7 +292,7 @@ onMounted(loadList)
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="handleSubmit">确定</el-button>
+        <el-button class="cw-final-action" type="primary" :loading="submitting" @click="handleSubmit">保存站点</el-button>
       </template>
     </el-dialog>
 
@@ -354,13 +356,24 @@ onMounted(loadList)
 <style scoped>
 .toolbar {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
 }
-.toolbar-right {
+.toolbar-actions {
   margin-left: auto;
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+}
+.data-table {
+  min-width: 0;
+  max-width: 100%;
+}
+:deep(.primary-column .cell) {
+  color: var(--cw-text);
+  font-weight: 650;
 }
 .advanced-title {
   color: var(--el-text-color-secondary);
@@ -378,5 +391,16 @@ onMounted(loadList)
 }
 .import-textarea :deep(textarea) {
   font-family: var(--el-font-family-mono, monospace);
+}
+
+@media (max-width: 767px) {
+  .toolbar-actions {
+    margin-left: 0;
+  }
+
+  .toolbar-actions > .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/workbench/WorkbenchSqlConsole.vue
+++ b/customer-admin-web/src/views/workbench/WorkbenchSqlConsole.vue
@@ -16,7 +16,10 @@ const sql = ref('')
 const executing = ref(false)
 const exporting = ref(false)
 const result = ref<SqlQueryResultVO | null>(null)
+const executedQuery = ref<{ datasourceId: number; sql: string } | null>(null)
 const sqlInputRef = ref<{ textarea?: HTMLTextAreaElement } | null>(null)
+let databaseRequestId = 0
+let queryRequestId = 0
 
 // ===== 左侧库树（库列表 + 点库懒加载表）=====
 interface DbNode {
@@ -34,34 +37,51 @@ const filteredDatabases = computed(() => {
   const kw = dbFilter.value.trim().toLowerCase()
   return kw ? databases.value.filter((d) => d.name.toLowerCase().includes(kw)) : databases.value
 })
+const resultOutdated = computed(() => {
+  const snapshot = executedQuery.value
+  return Boolean(snapshot && (snapshot.datasourceId !== datasourceId.value || snapshot.sql !== sql.value))
+})
 
 async function loadDatasources() {
   datasources.value = await listAllSqlDatasources()
 }
 
 async function loadDatabases() {
+  const requestId = ++databaseRequestId
+  const selectedDatasourceId = datasourceId.value
   databases.value = []
-  if (!datasourceId.value) {
+  if (!selectedDatasourceId) {
+    treeLoading.value = false
     return
   }
   treeLoading.value = true
   try {
-    const names = await listAdhocDatabases(datasourceId.value)
-    databases.value = names.map((name) => ({ name, expanded: false, loading: false, loaded: false, tables: [] }))
+    const names = await listAdhocDatabases(selectedDatasourceId)
+    if (requestId === databaseRequestId && datasourceId.value === selectedDatasourceId) {
+      databases.value = names.map((name) => ({ name, expanded: false, loading: false, loaded: false, tables: [] }))
+    }
   } finally {
-    treeLoading.value = false
+    if (requestId === databaseRequestId) {
+      treeLoading.value = false
+    }
   }
 }
 
 async function toggleDb(db: DbNode) {
   db.expanded = !db.expanded
-  if (db.expanded && !db.loaded && datasourceId.value) {
+  const selectedDatasourceId = datasourceId.value
+  if (db.expanded && !db.loaded && selectedDatasourceId) {
     db.loading = true
     try {
-      db.tables = await listAdhocTables(datasourceId.value, db.name)
-      db.loaded = true
+      const tables = await listAdhocTables(selectedDatasourceId, db.name)
+      if (datasourceId.value === selectedDatasourceId && databases.value.includes(db)) {
+        db.tables = tables
+        db.loaded = true
+      }
     } finally {
-      db.loading = false
+      if (databases.value.includes(db)) {
+        db.loading = false
+      }
     }
   }
 }
@@ -140,24 +160,34 @@ function validate(): boolean {
 }
 
 async function runQuery() {
-  if (!validate()) {
+  if (executing.value || !validate()) {
     return
   }
+  const requestId = ++queryRequestId
+  const snapshot = { datasourceId: datasourceId.value!, sql: sql.value }
   executing.value = true
   try {
-    result.value = await executeAdhocSql({ datasourceId: datasourceId.value!, sql: sql.value })
+    const nextResult = await executeAdhocSql(snapshot)
+    if (requestId === queryRequestId && datasourceId.value === snapshot.datasourceId) {
+      result.value = nextResult
+      executedQuery.value = snapshot
+    }
   } finally {
-    executing.value = false
+    if (requestId === queryRequestId) {
+      executing.value = false
+    }
   }
 }
 
 async function handleExport() {
-  if (!validate()) {
+  if (exporting.value || !result.value || !executedQuery.value) {
     return
   }
+  const snapshot = executedQuery.value
   exporting.value = true
   try {
-    await exportAdhocSql({ datasourceId: datasourceId.value!, sql: sql.value })
+    // 导出必须绑定产生当前结果表的执行快照，不能读取用户随后编辑但尚未执行的 SQL。
+    await exportAdhocSql(snapshot)
   } finally {
     exporting.value = false
   }
@@ -172,9 +202,12 @@ function onKeydown(e: KeyboardEvent) {
 
 // 切换数据源：清空结果并重载库树
 watch(datasourceId, () => {
+  queryRequestId += 1
+  executing.value = false
   result.value = null
+  executedQuery.value = null
   dbFilter.value = ''
-  loadDatabases()
+  void loadDatabases()
 })
 
 onMounted(loadDatasources)
@@ -207,23 +240,24 @@ onMounted(loadDatasources)
             <el-empty v-if="!datasourceId" :image-size="60" description="请先选择数据源" />
             <template v-else>
               <div v-for="db in filteredDatabases" :key="db.name" class="db-block">
-                <div class="db-node" @click="toggleDb(db)">
+                <button type="button" class="db-node" :aria-expanded="db.expanded" @click="toggleDb(db)">
                   <span class="toggle">{{ db.expanded ? '▾' : '▸' }}</span>
                   <span class="db-name" :title="db.name">{{ db.name }}</span>
-                </div>
+                </button>
                 <div v-if="db.expanded" class="table-list">
                   <div v-if="db.loading" class="hint">加载中…</div>
                   <div v-else-if="db.tables.length === 0" class="hint">（无表）</div>
-                  <div
+                  <button
                     v-for="t in db.tables"
                     v-else
                     :key="t"
+                    type="button"
                     class="table-node"
                     :title="`点击插入 ${db.name}.${t}`"
                     @click="insertTable(db.name, t)"
                   >
                     {{ t }}
-                  </div>
+                  </button>
                 </div>
               </div>
               <el-empty v-if="filteredDatabases.length === 0" :image-size="60" description="无匹配数据库" />
@@ -242,7 +276,7 @@ onMounted(loadDatasources)
           />
 
           <div class="toolbar">
-            <el-button type="primary" :loading="executing" @click="runQuery">执行（Ctrl+Enter）</el-button>
+            <el-button class="cw-final-action" type="primary" :loading="executing" @click="runQuery">执行（Ctrl+Enter）</el-button>
             <el-button :disabled="!sql.trim()" @click="formatSql">格式化 SQL</el-button>
             <el-button
               v-permission="'sql-console:export'"
@@ -266,6 +300,7 @@ onMounted(loadDatasources)
 
           <div v-if="result" class="result-meta">
             耗时 {{ result.useMillis }} ms，返回 {{ result.rows.length }} 行<span v-if="result.rows.length >= 2000">（已达 2000 行上限，可能被截断）</span>
+            <span v-if="resultOutdated" class="result-outdated"> · SQL 已修改，结果与导出仍对应上一次执行</span>
           </div>
 
           <el-table
@@ -296,11 +331,13 @@ onMounted(loadDatasources)
 .console-body {
   display: flex;
   min-height: 560px;
+  background: var(--cw-paper);
 }
 .sidebar {
   width: 260px;
   flex-shrink: 0;
-  border-right: 1px solid var(--el-border-color-lighter);
+  border-right: 1px solid var(--cw-line);
+  background: color-mix(in srgb, var(--cw-paper) 94%, var(--cw-cobalt));
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -317,16 +354,22 @@ onMounted(loadDatasources)
   display: flex;
   align-items: center;
   gap: 4px;
+  width: 100%;
   padding: 4px 2px;
+  color: var(--cw-text);
+  text-align: left;
+  border: 0;
+  background: transparent;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--cw-radius-sm);
+  font: inherit;
 }
 .db-node:hover {
   background: var(--el-fill-color-light);
 }
 .toggle {
   width: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   flex-shrink: 0;
 }
 .db-name {
@@ -338,21 +381,32 @@ onMounted(loadDatasources)
   padding-left: 18px;
 }
 .table-node {
+  display: block;
+  width: 100%;
   padding: 3px 6px;
   cursor: pointer;
   color: var(--el-text-color-regular);
-  border-radius: 4px;
+  text-align: left;
+  border: 0;
+  border-radius: var(--cw-radius-sm);
+  background: transparent;
+  font: inherit;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .table-node:hover {
-  background: var(--el-fill-color-light);
-  color: var(--el-color-primary);
+  background: color-mix(in srgb, var(--cw-cobalt) 9%, var(--cw-paper));
+  color: var(--cw-cobalt);
+}
+.db-node:focus-visible,
+.table-node:focus-visible {
+  outline: 2px solid var(--cw-focus-ring);
+  outline-offset: -2px;
 }
 .hint {
   padding: 3px 6px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
   font-size: 12px;
 }
 .main {
@@ -366,12 +420,35 @@ onMounted(loadDatasources)
   margin-bottom: 12px;
 }
 .sql-input :deep(textarea) {
-  font-family: var(--el-font-family-mono, monospace);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 13px;
 }
 .result-meta {
   margin-top: 12px;
   font-size: 12px;
-  color: var(--el-text-color-secondary);
+  color: var(--cw-text-muted);
+}
+.result-outdated {
+  color: var(--cw-amber);
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .console-body {
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .sidebar {
+    flex: none;
+    width: auto;
+    max-height: 300px;
+    border-right: 0;
+    border-bottom: 1px solid var(--cw-line);
+  }
+
+  .main {
+    padding: 10px;
+  }
 }
 </style>

--- a/customer-admin-web/src/views/workbench/WorkbenchTokenDialog.vue
+++ b/customer-admin-web/src/views/workbench/WorkbenchTokenDialog.vue
@@ -87,7 +87,7 @@ watch(visible, (v) => {
   <el-dialog v-model="visible" title="我的令牌" width="720px">
     <div class="toolbar">
       <span class="hint">令牌供 ScriptCat 脚本回调工作台取密码使用，绑定你的账号，可随时吊销。</span>
-      <el-button type="primary" @click="openCreate">新建令牌</el-button>
+      <el-button class="cw-final-action" type="primary" @click="openCreate">新建令牌</el-button>
     </div>
 
     <el-table v-loading="loading" :data="tokens" style="width: 100%">
@@ -146,7 +146,7 @@ watch(visible, (v) => {
       <template #footer>
         <template v-if="!plaintextToken">
           <el-button @click="createFormVisible = false">取消</el-button>
-          <el-button type="primary" :loading="creating" @click="submitCreate">生成</el-button>
+          <el-button class="cw-final-action" type="primary" :loading="creating" @click="submitCreate">生成令牌</el-button>
         </template>
         <el-button v-else type="primary" @click="createFormVisible = false">我已保存</el-button>
       </template>

--- a/customer-admin-web/src/views/workspace/WorkspaceEmpty.vue
+++ b/customer-admin-web/src/views/workspace/WorkspaceEmpty.vue
@@ -8,19 +8,138 @@ const auth = useAuthStore()
 
 <template>
   <div class="workspace-empty">
-    <el-empty description="还没有已启用的智能体">
-      <el-button v-if="auth.hasPermission('agent:add')" type="primary" @click="router.push('/aiconfig/agent')">
-        去新建智能体
+    <section class="empty-panel" aria-labelledby="workspace-empty-title">
+      <div class="empty-mark" aria-hidden="true"><span>01</span><span>02</span><span>03</span></div>
+      <span class="eyebrow">AGENT WORKSPACE</span>
+      <h1 id="workspace-empty-title">还没有可进入的智能体</h1>
+      <p>工作区只呈现已经启用并对当前账号可见的智能体，避免把未发布能力误当成可用服务。</p>
+      <div class="empty-flow" aria-label="智能体进入工作区的三个阶段">
+        <span>装配能力</span><i aria-hidden="true"></i><span>验证运行</span><i aria-hidden="true"></i><span>启用发布</span>
+      </div>
+      <el-button v-if="auth.hasPermission('agent:add')" class="cw-final-action" type="primary" @click="router.push('/aiconfig/agent')">
+        创建并配置智能体
       </el-button>
-    </el-empty>
+      <small v-else>请联系有权限的管理员启用并授权智能体。</small>
+    </section>
   </div>
 </template>
 
 <style scoped>
 .workspace-empty {
-  height: 100%;
+  box-sizing: border-box;
+  min-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 28px;
+  background:
+    radial-gradient(circle at 85% 16%, color-mix(in srgb, var(--cw-cobalt) 14%, transparent), transparent 30%),
+    var(--cw-canvas);
+}
+
+.empty-panel {
+  width: min(620px, 100%);
+  padding: clamp(28px, 6vw, 52px);
+  text-align: center;
+  border: 1px solid var(--cw-line);
+  border-top: 3px solid var(--cw-amber);
+  border-radius: var(--cw-radius-lg);
+  background: var(--cw-paper);
+  box-shadow: var(--cw-shadow-sm);
+}
+
+.empty-mark {
+  display: inline-grid;
+  grid-template-columns: repeat(3, 30px);
+  gap: 5px;
+  margin-bottom: 18px;
+}
+
+.empty-mark span {
+  display: grid;
+  place-items: center;
+  height: 30px;
+  color: var(--cw-text-muted);
+  border: 1px solid var(--cw-line);
+  border-radius: 50%;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.empty-mark span:last-child {
+  color: #1e1608;
+  border-color: var(--cw-amber-solid);
+  background: var(--cw-amber-solid);
+}
+
+.eyebrow {
+  display: block;
+  color: var(--cw-cobalt);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .16em;
+}
+
+.empty-panel h1 {
+  margin: 8px 0 10px;
+  color: var(--cw-text);
+  font-size: clamp(24px, 4vw, 32px);
+  letter-spacing: -.03em;
+}
+
+.empty-panel p {
+  max-width: 470px;
+  margin: 0 auto;
+  color: var(--cw-text-muted);
+  line-height: 1.7;
+}
+
+.empty-flow {
+  display: grid;
+  grid-template-columns: auto 1fr auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  margin: 28px 0;
+  color: var(--cw-text-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.empty-flow i {
+  height: 1px;
+  background: linear-gradient(90deg, var(--cw-line), var(--cw-cobalt));
+}
+
+.empty-panel small {
+  display: block;
+  color: var(--cw-text-muted);
+}
+
+@media (max-width: 480px) {
+  .workspace-empty {
+    align-items: flex-start;
+    padding: 14px 12px;
+  }
+
+  .empty-panel {
+    padding: 28px 20px;
+  }
+
+  .empty-flow {
+    grid-template-columns: 1fr;
+    gap: 7px;
+    margin: 22px 0;
+  }
+
+  .empty-flow i {
+    width: 1px;
+    height: 12px;
+    margin: 0 auto;
+    background: linear-gradient(var(--cw-line), var(--cw-cobalt));
+  }
+
+  .cw-final-action {
+    width: 100%;
+  }
 }
 </style>

--- a/customer-admin-web/tests/e2e/admin-shell.e2e.ts
+++ b/customer-admin-web/tests/e2e/admin-shell.e2e.ts
@@ -1,0 +1,457 @@
+import { expect, test } from './fixtures/adminTestFixture'
+import { SQL_REPORT_MENU_TITLE, SQL_REPORT_PATH } from './fixtures/adminRoutes'
+
+type RgbColor = readonly [number, number, number]
+
+function parseCssColor(rawColor: string): RgbColor {
+  const color = rawColor.trim().toLowerCase()
+  const hex = color.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i)?.[1]
+  if (hex) {
+    const expanded = hex.length === 3
+      ? hex.split('').map((channel) => channel + channel).join('')
+      : hex
+    return [
+      Number.parseInt(expanded.slice(0, 2), 16),
+      Number.parseInt(expanded.slice(2, 4), 16),
+      Number.parseInt(expanded.slice(4, 6), 16),
+    ]
+  }
+
+  const rgb = color.match(/^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i)
+  if (rgb) {
+    return [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])]
+  }
+  throw new Error(`Unsupported CSS color: ${rawColor}`)
+}
+
+function relativeLuminance(color: RgbColor): number {
+  const [red, green, blue] = color.map((channel) => {
+    const normalized = channel / 255
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = relativeLuminance(parseCssColor(foreground))
+  const backgroundLuminance = relativeLuminance(parseCssColor(background))
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance)
+  const darker = Math.min(foregroundLuminance, backgroundLuminance)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+test.describe('后台壳层契约', () => {
+  test('六段生命周期导航消费动态菜单，页面标题优先采用服务端菜单名', async ({ page }) => {
+    await page.goto('/system/user', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.locator('.layout')).toBeVisible()
+    const lifecycleNavigation = page.getByRole('navigation', { name: '智能体生命周期导航' })
+    await expect(lifecycleNavigation).toBeVisible()
+    await expect(lifecycleNavigation.getByRole('button')).toHaveCount(6)
+    for (const section of ['总览', '智能体', '构建', '运营', '治理', '设置']) {
+      await expect(lifecycleNavigation.getByRole('button', { name: section, exact: true })).toBeVisible()
+    }
+
+    await expect(lifecycleNavigation.getByRole('button', { name: '设置', exact: true }))
+      .toHaveAttribute('aria-current', 'true')
+    await expect(page.locator('#cw-page-title')).toHaveText('成员与身份（服务端菜单）')
+
+    await lifecycleNavigation.getByRole('button', { name: '智能体', exact: true }).click()
+    await expect(page.getByRole('menuitem', { name: 'Java 智能体', exact: true })).toBeVisible()
+  })
+
+  test('Home、Workspace 空态和动态 Workspace 都不重复渲染页面上下文头', async ({ page }) => {
+    await page.goto('/home', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.layout-main--home')).toBeVisible()
+    await expect(page.locator('.cw-page-context')).toHaveCount(0)
+
+    await page.goto('/workspace', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.workspace-empty')).toBeVisible()
+    await expect(page.locator('.cw-page-context')).toHaveCount(0)
+
+    await page.goto('/workspace/java-assistant', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.workspace-view')).toBeVisible()
+    await expect(page.locator('.cw-page-context')).toHaveCount(0)
+  })
+
+  for (const admissionCase of [
+    {
+      status: 'PENDING',
+      statusText: '等待审核',
+      title: '申请已经提交，工作台正在等待管理员确认。',
+      remark: null,
+    },
+    {
+      status: 'REJECTED',
+      statusText: '审核未通过',
+      title: '当前账号暂未获得工作台准入。',
+      remark: '缺少可验证的准入材料，请补充后重新申请。',
+    },
+  ] as const) {
+    test(`未审核准入 ${admissionCase.status} 阻断手工业务路由且不加载菜单与页面数据`, async ({ page }) => {
+      await page.addInitScript(({ status, remark }) => {
+        localStorage.setItem('admin-approval-status', status)
+        if (remark) {
+          localStorage.setItem('admin-approval-remark', remark)
+        } else {
+          localStorage.removeItem('admin-approval-remark')
+        }
+      }, { status: admissionCase.status, remark: admissionCase.remark })
+
+      const requestedApiPaths: string[] = []
+      page.on('request', (request) => {
+        const url = new URL(request.url())
+        if (url.pathname.startsWith('/api/')) {
+          requestedApiPaths.push(url.pathname)
+        }
+      })
+
+      await page.goto('/system/user', { waitUntil: 'domcontentloaded' })
+
+      await expect(page).toHaveURL(/\/home$/)
+      await expect(page.getByRole('heading', { name: admissionCase.title })).toBeVisible()
+      await expect(page.getByText(admissionCase.statusText, { exact: true }).first()).toBeVisible()
+      if (admissionCase.remark) {
+        await expect(page.getByText(admissionCase.remark, { exact: true })).toBeVisible()
+      }
+      expect(requestedApiPaths.filter((path) => (
+        path === '/api/menu/routes' || path === '/api/system/user'
+      ))).toEqual([])
+      for (const businessMenu of [
+        '成员与身份（服务端菜单）',
+        'Java 智能体',
+        '模型管理',
+        '调用统计',
+      ]) {
+        await expect(page.getByRole('menuitem', { name: businessMenu, exact: true })).toHaveCount(0)
+      }
+      await expect(page.locator('.quick-entry')).toHaveCount(0)
+    })
+  }
+
+  test('SQL 报表首次进入与刷新后都保留 defineKey，并按完整菜单路径解析标题', async ({ page }) => {
+    await page.goto(SQL_REPORT_PATH, { waitUntil: 'domcontentloaded' })
+
+    await expect(page).toHaveURL(new RegExp(`${SQL_REPORT_PATH.replace('?', '\\?')}$`))
+    await expect(page.locator('#cw-page-title')).toHaveText(SQL_REPORT_MENU_TITLE)
+    await expect(page.getByRole('heading', { name: '资金对账演示报表' })).toBeVisible()
+
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(new RegExp(`${SQL_REPORT_PATH.replace('?', '\\?')}$`))
+    await expect(page.locator('#cw-page-title')).toHaveText(SQL_REPORT_MENU_TITLE)
+    await expect(page.getByRole('heading', { name: '资金对账演示报表' })).toBeVisible()
+  })
+
+  test('Element Plus 表格使用具体中文空态', async ({ page }) => {
+    await page.goto('/system/user', { waitUntil: 'domcontentloaded' })
+
+    const emptyText = page.locator('.el-table__empty-text').first()
+    await expect(emptyText).toBeVisible()
+    await expect(emptyText).toHaveText('暂无符合条件的用户')
+    await expect(page.getByText('No Data', { exact: true })).toHaveCount(0)
+  })
+
+  test('暗色主题在刷新后保持，并继续使用统一的工作面语义色', async ({ page }) => {
+    await page.goto('/system/dict', { waitUntil: 'domcontentloaded' })
+
+    await page.getByLabel('切换到暗色模式', { exact: true }).click()
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await expect(page.getByLabel('切换到亮色模式', { exact: true })).toBeVisible()
+
+    const beforeReload = await page.evaluate(() => ({
+      mode: localStorage.getItem('customer-admin-theme-mode'),
+      canvas: getComputedStyle(document.documentElement).getPropertyValue('--cw-canvas').trim(),
+      paper: getComputedStyle(document.documentElement).getPropertyValue('--cw-paper').trim(),
+    }))
+    expect(beforeReload.mode).toBe('dark')
+    expect(beforeReload.canvas).toBe('#09111f')
+    expect(beforeReload.paper).toBe('#101a2b')
+
+    const semanticColors = await page.evaluate(() => {
+      const styles = getComputedStyle(document.documentElement)
+      return {
+        paper: styles.getPropertyValue('--cw-paper').trim(),
+        successForeground: styles.getPropertyValue('--el-color-success').trim(),
+        warningForeground: styles.getPropertyValue('--el-color-warning').trim(),
+        dangerForeground: styles.getPropertyValue('--el-color-danger').trim(),
+        successSolid: styles.getPropertyValue('--cw-success-solid').trim(),
+        warningSolid: styles.getPropertyValue('--cw-amber-solid').trim(),
+        dangerSolid: styles.getPropertyValue('--cw-danger-solid').trim(),
+        onSuccess: styles.getPropertyValue('--cw-on-success').trim(),
+        onWarning: styles.getPropertyValue('--cw-on-warning').trim(),
+        onDanger: styles.getPropertyValue('--cw-on-danger').trim(),
+      }
+    })
+    for (const type of ['Success', 'Warning', 'Danger'] as const) {
+      const key = type.toLowerCase() as 'success' | 'warning' | 'danger'
+      expect(
+        contrastRatio(semanticColors[`${key}Foreground`], semanticColors.paper),
+        `${key} foreground`,
+      ).toBeGreaterThanOrEqual(4.5)
+      expect(
+        contrastRatio(semanticColors[`${key}Solid`], semanticColors[`on${type}`]),
+        `${key} solid`,
+      ).toBeGreaterThanOrEqual(4.5)
+    }
+
+    await page.goto('/workbench/site', { waitUntil: 'domcontentloaded' })
+    const successButton = page.getByRole('button', { name: '生成登录脚本', exact: true })
+    await expect(successButton).toBeVisible()
+    const successButtonColors = await successButton.evaluate((button) => {
+      const styles = getComputedStyle(button)
+      return { color: styles.color, background: styles.backgroundColor }
+    })
+    expect(contrastRatio(successButtonColors.color, successButtonColors.background)).toBeGreaterThanOrEqual(4.5)
+
+    await page.goto('/system/dict', { waitUntil: 'domcontentloaded' })
+
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await expect(page.locator('#cw-page-title')).toHaveText('字典管理')
+  })
+
+  test('auto 主题在暗色系统下冷启动与刷新保持，并实时跟随系统切亮', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('customer-admin-theme-mode', 'auto')
+    })
+    await page.emulateMedia({ colorScheme: 'dark' })
+    await page.goto('/system/dict', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    expect(await page.evaluate(() => localStorage.getItem('customer-admin-theme-mode'))).toBe('auto')
+
+    const darkColors = await page.evaluate(() => {
+      const styles = getComputedStyle(document.documentElement)
+      return {
+        paper: styles.getPropertyValue('--cw-paper').trim(),
+        cobalt: styles.getPropertyValue('--cw-cobalt').trim(),
+        success: styles.getPropertyValue('--cw-success').trim(),
+        danger: styles.getPropertyValue('--cw-danger').trim(),
+      }
+    })
+    for (const token of ['cobalt', 'success', 'danger'] as const) {
+      const ratio = contrastRatio(darkColors[token], darkColors.paper)
+      expect(
+        ratio,
+        `dark --cw-${token} ${darkColors[token]} on --cw-paper ${darkColors.paper}`,
+      ).toBeGreaterThanOrEqual(4.5)
+    }
+
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    expect(await page.evaluate(() => localStorage.getItem('customer-admin-theme-mode'))).toBe('auto')
+
+    await page.emulateMedia({ colorScheme: 'light' })
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+    await expect(page.getByLabel('切换到暗色模式', { exact: true })).toBeVisible()
+    expect(await page.evaluate(() => localStorage.getItem('customer-admin-theme-mode'))).toBe('auto')
+  })
+
+  test('明亮品牌色在亮暗模式下拆分为可访问前景与全状态实心色', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('customer-admin-theme-color', '#f59e0b')
+      localStorage.setItem('customer-admin-theme-mode', 'light')
+    })
+    await page.goto('/workspace/java-assistant', { waitUntil: 'domcontentloaded' })
+
+    const assertThemeContrast = async () => {
+      const colors = await page.evaluate(() => {
+        const styles = getComputedStyle(document.documentElement)
+        return {
+          foreground: styles.getPropertyValue('--theme-primary').trim(),
+          surface: styles.getPropertyValue('--cw-paper').trim(),
+          solid: styles.getPropertyValue('--theme-primary-solid').trim(),
+          hover: styles.getPropertyValue('--theme-primary-solid-hover').trim(),
+          active: styles.getPropertyValue('--theme-primary-solid-active').trim(),
+          onSolid: styles.getPropertyValue('--cw-on-primary').trim(),
+        }
+      })
+      expect(contrastRatio(colors.foreground, colors.surface), 'primary foreground').toBeGreaterThanOrEqual(4.5)
+      for (const state of ['solid', 'hover', 'active'] as const) {
+        expect(contrastRatio(colors[state], colors.onSolid), `primary ${state}`).toBeGreaterThanOrEqual(4.5)
+      }
+
+      const newSession = page.locator('.new-session-btn')
+      await expect(newSession).toBeVisible()
+      const normal = await newSession.evaluate((button) => {
+        const styles = getComputedStyle(button)
+        return { color: styles.color, background: styles.backgroundColor }
+      })
+      expect(contrastRatio(normal.color, normal.background), 'new session normal').toBeGreaterThanOrEqual(4.5)
+      await newSession.hover()
+      const hovered = await newSession.evaluate((button) => {
+        const styles = getComputedStyle(button)
+        return { color: styles.color, background: styles.backgroundColor }
+      })
+      expect(contrastRatio(hovered.color, hovered.background), 'new session hover').toBeGreaterThanOrEqual(4.5)
+    }
+
+    const assertCheckedControlContrast = async () => {
+      await page.goto('/ops/dead-letter', { waitUntil: 'domcontentloaded' })
+      const checkedRadio = page.locator('.el-radio-button__original-radio:checked + .el-radio-button__inner').first()
+      await expect(checkedRadio).toBeVisible()
+      const colors = await checkedRadio.evaluate((control) => {
+        const styles = getComputedStyle(control)
+        return { color: styles.color, background: styles.backgroundColor }
+      })
+      expect(contrastRatio(colors.color, colors.background), 'checked radio button').toBeGreaterThanOrEqual(4.5)
+    }
+
+    const assertTagContrast = async () => {
+      await page.evaluate(() => {
+        document.querySelector('#theme-tag-contrast-probe')?.remove()
+        const probe = document.createElement('div')
+        probe.id = 'theme-tag-contrast-probe'
+        probe.setAttribute('aria-hidden', 'true')
+        probe.style.cssText = 'position:fixed;left:-10000px;top:0;'
+        for (const type of ['primary', 'success', 'warning', 'danger', 'info']) {
+          for (const effect of ['light', 'plain', 'dark']) {
+            const tag = document.createElement('span')
+            tag.className = `el-tag el-tag--${type} el-tag--${effect}`
+            tag.dataset.tagContrast = `${type}-${effect}`
+            tag.textContent = `${type}-${effect}`
+            probe.appendChild(tag)
+          }
+        }
+        document.body.appendChild(probe)
+      })
+
+      for (const type of ['primary', 'success', 'warning', 'danger', 'info']) {
+        for (const effect of ['light', 'plain', 'dark']) {
+          const label = `${type}-${effect}`
+          const colors = await page.locator(`[data-tag-contrast="${label}"]`).evaluate((tag) => {
+            const styles = getComputedStyle(tag)
+            return { color: styles.color, background: styles.backgroundColor }
+          })
+          expect(
+            contrastRatio(colors.color, colors.background),
+            `${label} tag`,
+          ).toBeGreaterThanOrEqual(4.5)
+        }
+      }
+    }
+
+    await assertThemeContrast()
+    await assertCheckedControlContrast()
+    await assertTagContrast()
+    await page.goto('/workspace/java-assistant', { waitUntil: 'domcontentloaded' })
+    await page.getByLabel('切换到暗色模式', { exact: true }).click()
+    await expect(page.locator('html')).toHaveClass(/dark/)
+    await assertThemeContrast()
+    await assertCheckedControlContrast()
+    await assertTagContrast()
+  })
+
+  for (const pageTemplate of [
+    { path: '/system/user', template: 'list', readySelector: '.layout-main > .page' },
+    { path: '/ops/csat', template: 'dashboard', readySelector: '.layout-main > .csat-board' },
+    { path: '/workbench/sql-console', template: 'console', readySelector: '.layout-main > .page' },
+  ] as const) {
+    test(`${pageTemplate.template} 代表页把正确母版绑定到内容容器`, async ({ page }) => {
+      await page.goto(pageTemplate.path, { waitUntil: 'domcontentloaded' })
+
+      await expect(page.locator(pageTemplate.readySelector)).toBeVisible()
+      await expect(page.locator('.layout-main')).toHaveAttribute('data-page-template', pageTemplate.template)
+    })
+  }
+
+  test('404 直接访问展示路由缺口并可回到工作首页', async ({ page }) => {
+    await page.goto('/missing-admin-route', { waitUntil: 'domcontentloaded' })
+
+    expect(new URL(page.url()).pathname).toBe('/missing-admin-route')
+    await expect(page.getByRole('heading', { name: '这条工作路径没有可用页面' })).toBeVisible()
+    await expect(page.getByText('404 / ROUTE GAP', { exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: '返回工作首页', exact: true }).click()
+    await expect(page).toHaveURL(/\/home$/)
+    await expect(page.locator('.layout-main--home')).toBeVisible()
+  })
+
+  test('Workspace 离开后返回保留未发送草稿，且不重复请求首屏会话', async ({ page }) => {
+    let sessionListRequests = 0
+    page.on('request', (request) => {
+      const url = new URL(request.url())
+      if (request.method() === 'GET' && url.pathname === '/api/workspace/java-assistant/chat/sessions') {
+        sessionListRequests += 1
+      }
+    })
+
+    await page.goto('/workspace/java-assistant', { waitUntil: 'domcontentloaded' })
+    const composer = page.getByPlaceholder('输入消息，回车发送；⌘/Ctrl+V 可粘贴截图或文件作为附件')
+    await expect(composer).toBeVisible()
+    // Chat 与 VibeCoding 面板各自维护历史侧栏，首次挂载的两次请求是当前基线；
+    // KeepAlive 契约关心的是离开/返回不能在该基线上继续增加。
+    await expect.poll(() => sessionListRequests).toBe(2)
+    const initialSessionListRequests = sessionListRequests
+    await composer.fill('这是未发送的 KeepAlive 草稿')
+
+    const lifecycleNavigation = page.getByRole('navigation', { name: '智能体生命周期导航' })
+    await lifecycleNavigation.getByRole('button', { name: '设置', exact: true }).click()
+    await page.getByRole('menuitem', { name: '系统管理', exact: true }).click()
+    await page.getByRole('menuitem', { name: '成员与身份（服务端菜单）', exact: true }).click()
+    await expect(page.locator('#cw-page-title')).toHaveText('成员与身份（服务端菜单）')
+
+    await lifecycleNavigation.getByRole('button', { name: '智能体', exact: true }).click()
+    await page.getByRole('menuitem', { name: 'Java 智能体', exact: true }).click()
+    await expect(page.locator('.workspace-view')).toBeVisible()
+    await expect(composer).toHaveValue('这是未发送的 KeepAlive 草稿')
+    expect(sessionListRequests).toBe(initialSessionListRequests)
+  })
+
+  test('390px 顶栏不溢出，移动导航可完整打开并由 Escape 恢复焦点', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    // 本用例显式切成控制面视角，确保移动顶栏连同租户入口一起参与宽度验收。
+    await page.route('**/api/tenant/current-view', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json; charset=utf-8',
+        body: JSON.stringify({
+          code: 0,
+          message: 'success',
+          data: { userTenantId: 'default', effectiveTenantId: 'default', crossTenantAuthority: true },
+          timestamp: Date.UTC(2026, 7, 30, 10, 0, 0),
+        }),
+      })
+    })
+    await page.goto('/system/user', { waitUntil: 'domcontentloaded' })
+
+    const aside = page.locator('.layout-aside')
+    await expect.poll(() => aside.evaluate((element) => element.getBoundingClientRect().width)).toBe(0)
+
+    for (const label of [
+      '打开导航菜单',
+      '搜索菜单、智能体或配置',
+      '切换到暗色模式',
+      '打开站内消息',
+      '打开用户菜单',
+    ]) {
+      await expect(page.getByLabel(label, { exact: true })).toBeVisible()
+    }
+    await expect(page.getByRole('combobox', { name: '租户视角' })).toBeVisible()
+    const overflow = await page.locator('.layout-header').evaluate((header) => ({
+      headerRight: header.getBoundingClientRect().right,
+      viewportWidth: window.innerWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+    }))
+    expect(overflow.headerRight).toBeLessThanOrEqual(overflow.viewportWidth)
+    expect(overflow.documentScrollWidth).toBeLessThanOrEqual(overflow.viewportWidth)
+
+    const trigger = page.locator('.navigation-toggle')
+    await expect(trigger).toHaveAccessibleName('打开导航菜单')
+    await trigger.click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await expect(trigger).toHaveAccessibleName('关闭导航菜单')
+    const navigationDialog = page.getByRole('dialog', { name: '页面导航' })
+    await expect(navigationDialog).toBeVisible()
+    await expect(navigationDialog.locator('.primary-rail')).toBeVisible()
+    await expect(navigationDialog.locator('.context-pane')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.locator('#lifecycle-navigation-shell')).toBeHidden()
+    await expect(trigger).toBeFocused()
+    await expect(trigger).toHaveAccessibleName('打开导航菜单')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+  })
+})

--- a/customer-admin-web/tests/e2e/fixtures/adminRoutes.ts
+++ b/customer-admin-web/tests/e2e/fixtures/adminRoutes.ts
@@ -1,0 +1,220 @@
+export interface AdminMenuNode {
+  id: number
+  name: string
+  path: string | null
+  icon: string | null
+  iconType: 'library' | 'image' | null
+  permCode: string | null
+  sort: number | null
+  agentCode: string | null
+  capabilities: string[] | null
+  dynamic: boolean
+  children: AdminMenuNode[]
+}
+
+export interface StaticRouteCase {
+  path: string
+  menuTitle: string
+  readySelector: string
+}
+
+/**
+ * 与 src/router/component-map.ts 一一对应的 41 个静态业务路由。
+ * 这里刻意显式列举，不从生产映射动态推导：新增页面时，E2E 必须先补 fixture 和挂载断言。
+ */
+export const STATIC_ROUTE_CASES: readonly StaticRouteCase[] = [
+  { path: '/system/user', menuTitle: '成员与身份（服务端菜单）', readySelector: '.layout-main > .page' },
+  { path: '/system/role', menuTitle: '角色管理', readySelector: '.layout-main > .page' },
+  { path: '/system/log', menuTitle: '操作日志', readySelector: '.layout-main > .page' },
+  { path: '/system/ai-audit', menuTitle: 'AI 审计', readySelector: '.layout-main > .page' },
+  { path: '/system/agent-call-stats', menuTitle: '调用统计', readySelector: '.layout-main > .page' },
+  { path: '/system/menu', menuTitle: '菜单管理', readySelector: '.layout-main > .page' },
+  { path: '/system/devtools', menuTitle: '开发者工具箱', readySelector: '.layout-main > .devtoolbox-page' },
+  { path: '/system/login-image', menuTitle: '登录页图片', readySelector: '.layout-main > .login-image-page' },
+  { path: '/system/dict', menuTitle: '字典管理', readySelector: '.layout-main > .page' },
+  { path: '/system/tenant', menuTitle: '租户管理', readySelector: '.layout-main > .page' },
+  { path: '/system/billing', menuTitle: '计费中心', readySelector: '.layout-main > .page' },
+  { path: '/system/config-version', menuTitle: '配置版本', readySelector: '.layout-main > .page' },
+  { path: '/system/slo', menuTitle: 'SLO 管理', readySelector: '.layout-main > .slo-page' },
+  { path: '/aiconfig/model', menuTitle: '模型管理', readySelector: '.layout-main > .modelops-page' },
+  { path: '/aiconfig/mcp', menuTitle: 'MCP 管理', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/skill', menuTitle: 'Skill 管理', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/agent', menuTitle: '智能体管理', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/system-tool', menuTitle: '系统工具', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/knowledge-base', menuTitle: '知识库', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/scheduled-task', menuTitle: '定时任务', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/agent-task', menuTitle: '智能体任务', readySelector: '.layout-main > .page' },
+  { path: '/ops/eval', menuTitle: '评测中心', readySelector: '.layout-main > .eval-center' },
+  { path: '/ops/badcase', menuTitle: 'Badcase 管理', readySelector: '.layout-main > .badcase-review' },
+  { path: '/ops/semantic-cache', menuTitle: '语义缓存', readySelector: '.layout-main > .semantic-cache-board' },
+  { path: '/ops/prompt-version', menuTitle: 'Prompt 版本', readySelector: '.layout-main > .prompt-version-board' },
+  { path: '/ops/csat', menuTitle: '满意度分析', readySelector: '.layout-main > .csat-board' },
+  { path: '/ops/knowledge-gap', menuTitle: '知识缺口', readySelector: '.layout-main > .knowledge-gap-board' },
+  { path: '/ops/dead-letter', menuTitle: '死信处理', readySelector: '.layout-main > .dead-letter-board' },
+  { path: '/ops/business-outcome', menuTitle: '业务结果', readySelector: '.layout-main > .outcome-board' },
+  { path: '/contentguard/sensitive-word', menuTitle: '敏感词库', readySelector: '.layout-main > .page' },
+  { path: '/contentguard/rate-limit', menuTitle: '限流规则', readySelector: '.layout-main > .page' },
+  { path: '/contentguard/hit-log', menuTitle: '命中看板', readySelector: '.layout-main > .page' },
+  { path: '/contentguard/subject-quota', menuTitle: '主体配额', readySelector: '.layout-main > .page' },
+  { path: '/aiconfig/channel-robot', menuTitle: '渠道机器人', readySelector: '.layout-main > .page' },
+  { path: '/ticket/user-ticket', menuTitle: '客服工单', readySelector: '.layout-main > .page' },
+  { path: '/ticket/user-order', menuTitle: '用户订单', readySelector: '.layout-main > .page' },
+  { path: '/project', menuTitle: '项目管理', readySelector: '.layout-main > .page' },
+  { path: '/sql/datasource', menuTitle: '数据源', readySelector: '.layout-main > .page' },
+  { path: '/sql/define', menuTitle: 'SQL 定义', readySelector: '.layout-main > .page' },
+  { path: '/workbench/site', menuTitle: '内网工作台', readySelector: '.layout-main > .page' },
+  { path: '/workbench/sql-console', menuTitle: 'SQL 客户端', readySelector: '.layout-main > .page' },
+] as const
+
+export const SQL_REPORT_PATH = '/sql/query?defineKey=e2e-report'
+export const SQL_REPORT_MENU_TITLE = '资金对账演示'
+
+let nextMenuId = 1000
+
+function leaf(route: StaticRouteCase, sort: number): AdminMenuNode {
+  return {
+    id: nextMenuId++,
+    name: route.menuTitle,
+    path: route.path,
+    icon: 'Document',
+    iconType: 'library',
+    permCode: `e2e:${route.path.slice(1).replaceAll('/', ':')}`,
+    sort,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children: [],
+  }
+}
+
+function routes(...paths: string[]): StaticRouteCase[] {
+  return paths.map((path) => {
+    const route = STATIC_ROUTE_CASES.find((candidate) => candidate.path === path)
+    if (!route) throw new Error(`E2E menu references an unknown static route: ${path}`)
+    return route
+  })
+}
+
+function branch(
+  name: string,
+  permCode: string,
+  sort: number,
+  routeCases: StaticRouteCase[],
+  icon = 'Folder',
+): AdminMenuNode {
+  return {
+    id: nextMenuId++,
+    name,
+    path: null,
+    icon,
+    iconType: 'library',
+    permCode,
+    sort,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children: routeCases.map((route, index) => leaf(route, index + 1)),
+  }
+}
+
+/** 后端菜单的真实层级形状；六个生命周期分区都有数据，且包含 query 与动态工作区节点。 */
+export function buildAdminMenuTree(): AdminMenuNode[] {
+  nextMenuId = 1000
+
+  const workbench = branch('我的工作台', 'workbench', 1, routes(
+    '/system/devtools',
+    '/workbench/site',
+    '/workbench/sql-console',
+  ), 'Suitcase')
+  workbench.children.push({
+    id: nextMenuId++,
+    name: SQL_REPORT_MENU_TITLE,
+    path: SQL_REPORT_PATH,
+    icon: 'DataAnalysis',
+    iconType: 'library',
+    permCode: 'sql-query:e2e-report',
+    sort: 4,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children: [],
+  })
+
+  const workspace: AdminMenuNode = {
+    id: nextMenuId++,
+    name: '智能体工作区',
+    path: '/workspace',
+    icon: 'Cpu',
+    iconType: 'library',
+    permCode: 'workspace',
+    sort: 2,
+    agentCode: null,
+    capabilities: null,
+    dynamic: false,
+    children: [{
+      id: nextMenuId++,
+      name: 'Java 智能体',
+      path: '/workspace/java-assistant',
+      icon: 'Monitor',
+      iconType: 'library',
+      permCode: 'workspace:java-assistant',
+      sort: 1,
+      agentCode: 'java-assistant',
+      capabilities: ['chat', 'vibecoding'],
+      dynamic: true,
+      children: [],
+    }],
+  }
+
+  const project = leaf(routes('/project')[0], 4)
+  project.permCode = 'project'
+
+  return [
+    workbench,
+    workspace,
+    branch('AI 配置', 'aiconfig', 3, routes(
+      '/aiconfig/model',
+      '/aiconfig/mcp',
+      '/aiconfig/skill',
+      '/aiconfig/agent',
+      '/aiconfig/system-tool',
+      '/aiconfig/knowledge-base',
+      '/aiconfig/scheduled-task',
+      '/aiconfig/agent-task',
+      '/aiconfig/channel-robot',
+    ), 'Cpu'),
+    project,
+    branch('SQL 配置', 'sql-config', 5, routes('/sql/datasource', '/sql/define'), 'Coin'),
+    branch('监控大屏', 'monitor:view', 6, routes('/system/agent-call-stats'), 'TrendCharts'),
+    branch('运营闭环', 'ops', 7, routes(
+      '/ops/eval',
+      '/ops/badcase',
+      '/ops/semantic-cache',
+      '/ops/prompt-version',
+      '/ops/csat',
+      '/ops/knowledge-gap',
+      '/ops/dead-letter',
+      '/ops/business-outcome',
+    ), 'DataAnalysis'),
+    branch('客服工单', 'ticket', 8, routes('/ticket/user-ticket', '/ticket/user-order'), 'Service'),
+    branch('内容风控', 'contentguard', 9, routes(
+      '/contentguard/sensitive-word',
+      '/contentguard/rate-limit',
+      '/contentguard/hit-log',
+      '/contentguard/subject-quota',
+    ), 'Lock'),
+    branch('系统管理', 'system', 10, routes(
+      '/system/user',
+      '/system/role',
+      '/system/log',
+      '/system/ai-audit',
+      '/system/menu',
+      '/system/login-image',
+      '/system/dict',
+      '/system/tenant',
+      '/system/billing',
+      '/system/config-version',
+      '/system/slo',
+    ), 'Setting'),
+  ]
+}

--- a/customer-admin-web/tests/e2e/fixtures/adminTestFixture.ts
+++ b/customer-admin-web/tests/e2e/fixtures/adminTestFixture.ts
@@ -1,0 +1,371 @@
+import {
+  expect,
+  test as base,
+  type BrowserContext,
+  type ConsoleMessage,
+  type Page,
+  type Route,
+  type WebSocketRoute,
+} from '@playwright/test'
+import { LOGIN_E2E_ORIGIN } from '../loginTestEnvironment'
+import { buildAdminMenuTree } from './adminRoutes'
+
+const API_PREFIX = '/api'
+const FIXED_TIMESTAMP = Date.UTC(2026, 7, 30, 10, 0, 0)
+const LOCAL_HOST = new URL(LOGIN_E2E_ORIGIN).host
+
+const pageResult = { pageNum: 1, pageSize: 20, total: 0, list: [] }
+const mpPageResult = { current: 1, size: 20, total: 0, records: [] }
+
+type FixtureValue = unknown | ((url: URL) => unknown)
+
+interface ApiFixture {
+  method: string
+  path: string
+  value: FixtureValue
+}
+
+export interface AdminHarness {
+  unknownApiRequests: string[]
+  forbiddenModelRequests: string[]
+  externalRequests: string[]
+  externalSockets: string[]
+  pageErrors: string[]
+  consoleErrors: string[]
+}
+
+function successResult(data: unknown) {
+  return { code: 0, message: 'success', data, timestamp: FIXED_TIMESTAMP }
+}
+
+/**
+ * 只登记页面首屏允许访问的契约。未知路径不得返回“万能空数组”，否则新增调用会被假绿掩盖。
+ */
+const API_FIXTURES: readonly ApiFixture[] = [
+  // 登录后壳层
+  { method: 'GET', path: '/auth/permissions', value: [] },
+  { method: 'GET', path: '/menu/routes', value: () => buildAdminMenuTree() },
+  { method: 'GET', path: '/menu/version', value: 1 },
+  {
+    method: 'GET',
+    path: '/tenant/current-view',
+    value: { userTenantId: 'default', effectiveTenantId: 'default', crossTenantAuthority: false },
+  },
+  { method: 'GET', path: '/message/unread-count', value: 0 },
+  { method: 'GET', path: '/workspace/java-assistant/chat/sessions', value: pageResult },
+  { method: 'GET', path: '/workspace/java-assistant/vibecoding/sandbox-mode', value: { mode: 'local' } },
+
+  // 系统管理
+  { method: 'GET', path: '/system/user', value: pageResult },
+  { method: 'GET', path: '/system/role', value: pageResult },
+  { method: 'GET', path: '/system/permission/tree', value: [] },
+  { method: 'GET', path: '/system/log', value: pageResult },
+  { method: 'GET', path: '/workspace/ai-coding-audit', value: pageResult },
+  { method: 'GET', path: '/agent-call-stats/page', value: { total: 0, rows: [] } },
+  {
+    method: 'GET',
+    path: '/agent-call-stats/summary',
+    value: {
+      totalCalls: 0,
+      avgDurationMs: 0,
+      maxDurationMs: 0,
+      avgModelMs: 0,
+      avgToolMs: 0,
+      avgMcpMs: 0,
+      avgSkillMs: 0,
+      totalTokens: 0,
+      avgTotalTokens: 0,
+      inputTokens: 0,
+      cachedTokens: 0,
+      cacheHitRate: 0,
+    },
+  },
+  { method: 'GET', path: '/agent-call-stats/trend', value: [] },
+  { method: 'GET', path: '/system/menu/tree', value: [] },
+  { method: 'GET', path: '/system/login-image', value: [] },
+  { method: 'GET', path: '/dict/types', value: [] },
+  { method: 'GET', path: '/dict/options/order_status', value: [] },
+  { method: 'GET', path: '/tenant/page', value: pageResult },
+  { method: 'GET', path: '/tenant/options', value: [] },
+  { method: 'GET', path: '/billing/bill', value: [] },
+  { method: 'GET', path: '/billing/reconciliation', value: [] },
+  { method: 'GET', path: '/billing/forecast', value: null },
+  { method: 'GET', path: '/billing/alerts', value: [] },
+  { method: 'GET', path: '/config-version/page', value: pageResult },
+  { method: 'GET', path: '/governance/changes', value: [] },
+  { method: 'GET', path: '/slo/policies', value: [] },
+  { method: 'GET', path: '/slo/alerts', value: [] },
+  { method: 'GET', path: '/slo/alerts/summary', value: { openCount: 0, acknowledgedCount: 0 } },
+
+  // AI 配置
+  { method: 'GET', path: '/aiconfig/model', value: pageResult },
+  { method: 'GET', path: '/aiconfig/model/asset-options', value: [] },
+  { method: 'GET', path: '/aiconfig/model-routing-policies', value: [] },
+  { method: 'GET', path: '/aiconfig/model-experiments', value: [] },
+  { method: 'GET', path: '/aiconfig/mcp', value: pageResult },
+  { method: 'GET', path: '/aiconfig/skill', value: pageResult },
+  { method: 'GET', path: '/aiconfig/agent', value: pageResult },
+  { method: 'GET', path: '/system-tool', value: pageResult },
+  { method: 'GET', path: '/aiconfig/knowledge-base/page', value: pageResult },
+  { method: 'GET', path: '/aiconfig/knowledge-base/options', value: [] },
+  { method: 'GET', path: '/aiconfig/scheduled-task/page', value: mpPageResult },
+  { method: 'GET', path: '/aiconfig/agent-task/page', value: mpPageResult },
+  { method: 'GET', path: '/aiconfig/agent-task/statuses', value: [] },
+  { method: 'GET', path: '/channel-robots/page', value: mpPageResult },
+
+  // 运营闭环
+  { method: 'GET', path: '/eval/runs', value: [] },
+  { method: 'GET', path: '/eval/datasets/INTENT/cases', value: [] },
+  { method: 'GET', path: '/eval/datasets/INTENT/versions', value: [] },
+  { method: 'GET', path: '/eval/datasets/QUALITY/cases', value: [] },
+  { method: 'GET', path: '/eval/datasets/QUALITY/versions', value: [] },
+  { method: 'GET', path: '/badcase/page', value: pageResult },
+  { method: 'GET', path: '/ops/semantic-cache/scopes', value: [] },
+  { method: 'GET', path: '/ops/prompt-version/list', value: [] },
+  {
+    method: 'GET',
+    path: '/ops/csat/summary',
+    value: { invited: 0, answered: 0, satisfied: 0, totalScore: 0, csat: 0, responseRate: 0, averageScore: 0 },
+  },
+  { method: 'GET', path: '/ops/csat/list', value: [] },
+  { method: 'GET', path: '/ops/knowledge-gap/top', value: [] },
+  { method: 'GET', path: '/ops/dead-letter/list', value: [] },
+  { method: 'GET', path: '/ops/dead-letter/stats', value: {} },
+  {
+    method: 'GET',
+    path: '/business-outcomes/summary',
+    value: {
+      tenantId: 'default',
+      agentCode: null,
+      fromMs: FIXED_TIMESTAMP,
+      toMs: FIXED_TIMESTAMP,
+      generatedAtMs: FIXED_TIMESTAMP,
+      dataSource: 'e2e-fixture',
+      totalSessions: 0,
+      successfulSessions: 0,
+      successfulSessionRate: 0,
+      autoResolvedProxySessions: 0,
+      autoResolvedProxyRate: 0,
+      handoffSessions: 0,
+      handoffRate: 0,
+      totalCalls: 0,
+      totalTokens: null,
+      tokenAvailability: { status: 'UNAVAILABLE', reason: 'fixture empty state' },
+      csatInvitedSessions: 0,
+      csatRespondedSessions: 0,
+      csatResponseRate: 0,
+      averageCsat: null,
+      csatSatisfiedRate: 0,
+      totalCost: null,
+      costCurrency: null,
+      costPerAutoResolvedSession: null,
+      costAvailability: { status: 'UNAVAILABLE', reason: 'fixture empty state' },
+      costPerAutoResolvedAvailability: { status: 'UNAVAILABLE', reason: 'fixture empty state' },
+      definitions: {
+        observedSession: 'fixture',
+        successfulSession: 'fixture',
+        autoResolvedProxy: 'fixture',
+        handoffSession: 'fixture',
+        csat: 'fixture',
+        token: 'fixture',
+        cost: 'fixture',
+      },
+    },
+  },
+  { method: 'GET', path: '/business-outcomes/sessions', value: { total: 0, page: 1, size: 20, records: [] } },
+
+  // 内容治理
+  { method: 'GET', path: '/contentguard/sensitive-word/page', value: pageResult },
+  { method: 'GET', path: '/contentguard/sensitive-word/categories', value: [] },
+  { method: 'GET', path: '/contentguard/sensitive-word/actions', value: [] },
+  { method: 'GET', path: '/contentguard/rate-limit-rule/page', value: pageResult },
+  { method: 'GET', path: '/contentguard/rate-limit-rule/dimensions', value: [] },
+  { method: 'GET', path: '/contentguard/rate-limit-rule/algorithms', value: [] },
+  { method: 'GET', path: '/contentguard/hit-log/page', value: pageResult },
+  {
+    method: 'GET',
+    path: '/contentguard/hit-log/stats',
+    value: { total: 0, byAction: [], byDirection: [], topWords: [], trend: [], trendGranularity: 'day' },
+  },
+  { method: 'GET', path: '/subject-quota/levels', value: [] },
+  { method: 'GET', path: '/subject-quota/users', value: pageResult },
+  { method: 'GET', path: '/subject-quota/admin-users', value: pageResult },
+  { method: 'GET', path: '/subject-quota/hits', value: [] },
+  { method: 'GET', path: '/subject-quota/hits/rank', value: [] },
+
+  // 工单、项目、SQL 与工作台
+  { method: 'GET', path: '/ticket/page', value: { total: 0, items: [] } },
+  {
+    method: 'GET',
+    path: '/ticket/ws-credential',
+    value: {
+      token: 'fixture-ticket-token',
+      wsUrl: LOGIN_E2E_ORIGIN.replace(/^http/, 'ws') + '/fixture-ticket',
+      expiresAtMs: FIXED_TIMESTAMP + 60_000,
+      agentId: 'fixture-agent',
+    },
+  },
+  { method: 'GET', path: '/ticket/orders/page', value: { total: 0, items: [] } },
+  { method: 'GET', path: '/workspace/project', value: [] },
+  { method: 'GET', path: '/sql/datasource', value: pageResult },
+  { method: 'GET', path: '/sql/datasource/all', value: [] },
+  { method: 'GET', path: '/sql/define', value: pageResult },
+  {
+    method: 'GET',
+    path: '/sql/query/meta',
+    value: (url) => ({
+      defineKey: url.searchParams.get('defineKey') ?? '',
+      sqlDescribe: '资金对账演示报表',
+      autoLoad: false,
+      hasCountSql: false,
+      params: [],
+    }),
+  },
+  { method: 'GET', path: '/workbench/site', value: pageResult },
+]
+
+const API_FIXTURE_BY_KEY = new Map(
+  API_FIXTURES.map((fixture) => [`${fixture.method} ${fixture.path}`, fixture.value] as const),
+)
+
+const FORBIDDEN_MODEL_PATHS = [
+  /\/chat\/stream$/,
+  /\/vibecoding\/(?:generate|review|commit-message|pr-description)$/,
+  /^\/knowledge\/ask$/,
+  /^\/eval\/run$/,
+  /^\/aiconfig\/model\/[^/]+\/(?:test-connectivity|health-checks|certifications)$/,
+]
+
+async function fulfillJson(route: Route, data: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json; charset=utf-8',
+    body: JSON.stringify(successResult(data)),
+  })
+}
+
+function recordConsoleError(message: ConsoleMessage, harness: AdminHarness) {
+  if (message.type() === 'error') harness.consoleErrors.push(message.text())
+}
+
+export async function installFailClosedNetwork(context: BrowserContext, harness: AdminHarness) {
+  await context.route('**/*', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const method = request.method().toUpperCase()
+
+    if (url.origin !== LOGIN_E2E_ORIGIN) {
+      harness.externalRequests.push(`${method} ${url.toString()}`)
+      await route.abort('blockedbyclient')
+      return
+    }
+
+    if (!url.pathname.startsWith(`${API_PREFIX}/`)) {
+      await route.continue()
+      return
+    }
+
+    const apiPath = url.pathname.slice(API_PREFIX.length)
+    const requestLabel = `${method} ${apiPath}${url.search}`
+    if (FORBIDDEN_MODEL_PATHS.some((pattern) => pattern.test(apiPath))) {
+      harness.forbiddenModelRequests.push(requestLabel)
+      await route.abort('blockedbyclient')
+      return
+    }
+
+    const fixture = API_FIXTURE_BY_KEY.get(`${method} ${apiPath}`)
+    if (fixture === undefined) {
+      harness.unknownApiRequests.push(requestLabel)
+      await route.abort('blockedbyclient')
+      return
+    }
+
+    const value = typeof fixture === 'function' ? fixture(url) : fixture
+    await fulfillJson(route, value)
+  })
+
+  await context.routeWebSocket('**/*', async (route: WebSocketRoute) => {
+    const url = new URL(route.url())
+
+    if (url.host !== LOCAL_HOST) {
+      harness.externalSockets.push(url.toString())
+      await route.close({ code: 1008, reason: 'Blocked by E2E network boundary' })
+      return
+    }
+
+    const apiPath = url.pathname.startsWith(`${API_PREFIX}/`)
+      ? url.pathname.slice(API_PREFIX.length)
+      : url.pathname
+    if (FORBIDDEN_MODEL_PATHS.some((pattern) => pattern.test(apiPath))) {
+      harness.forbiddenModelRequests.push(`WS ${apiPath}${url.search}`)
+      await route.close({ code: 1008, reason: 'Model calls are forbidden in E2E' })
+      return
+    }
+
+    // routeWebSocket 默认不连接真实服务端；保留一个浏览器内的空实现供页面完成挂载。
+    route.onMessage(() => {})
+  })
+}
+
+async function installBrowserState(context: BrowserContext) {
+  await context.addInitScript((allowedOrigin) => {
+    // Context 脚本也会在初始 about:blank 与 popup 中执行；这些文档不可访问 localStorage。
+    if (window.location.origin !== allowedOrigin) return
+
+    localStorage.setItem('admin-token', 'admin-shell-e2e-token')
+    localStorage.setItem('admin-nickname', 'E2E 管理员')
+    localStorage.setItem('admin-username', 'admin-shell-e2e')
+    localStorage.setItem('admin-force-change-password', 'false')
+    localStorage.setItem('admin-approval-status', 'APPROVED')
+    if (!localStorage.getItem('customer-admin-theme-mode')) {
+      localStorage.setItem('customer-admin-theme-mode', 'light')
+    }
+    if (!localStorage.getItem('customer-admin-theme-color')) {
+      localStorage.setItem('customer-admin-theme-color', '#3e63dd')
+    }
+  }, LOGIN_E2E_ORIGIN)
+}
+
+function bindPageObservers(context: BrowserContext, harness: AdminHarness) {
+  const observe = (page: Page) => {
+    page.on('pageerror', (error) => harness.pageErrors.push(error.message))
+    page.on('console', (message) => recordConsoleError(message, harness))
+  }
+
+  context.pages().forEach(observe)
+  context.on('page', observe)
+}
+
+export function createAdminHarness(): AdminHarness {
+  return {
+    unknownApiRequests: [],
+    forbiddenModelRequests: [],
+    externalRequests: [],
+    externalSockets: [],
+    pageErrors: [],
+    consoleErrors: [],
+  }
+}
+
+export const test = base.extend<{ adminHarness: AdminHarness }>({
+  adminHarness: [async ({ context }, use) => {
+    const harness = createAdminHarness()
+
+    bindPageObservers(context, harness)
+    await installBrowserState(context)
+    await installFailClosedNetwork(context, harness)
+
+    await use(harness)
+    // 让挂载阶段已经排队的 Promise/请求进入监听器，再执行统一收尾断言。
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(harness.forbiddenModelRequests, 'E2E 不得触发真实模型、生成或流式接口').toEqual([])
+    expect(harness.externalRequests, 'E2E 不得访问本地 Vite 之外的 HTTP(S) 地址').toEqual([])
+    expect(harness.externalSockets, 'E2E 不得建立本地 Vite 之外的 WebSocket').toEqual([])
+    expect(harness.unknownApiRequests, '存在未显式登记的 API；请补真实契约，不要加万能兜底').toEqual([])
+    expect(harness.pageErrors, '页面运行时不得抛出未处理异常').toEqual([])
+    expect(harness.consoleErrors, '页面控制台不得出现 error').toEqual([])
+  }, { auto: true }],
+})
+
+export { expect }

--- a/customer-admin-web/tests/e2e/network-boundary.e2e.ts
+++ b/customer-admin-web/tests/e2e/network-boundary.e2e.ts
@@ -1,0 +1,61 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { expect, test } from '@playwright/test'
+import { createAdminHarness, installFailClosedNetwork } from './fixtures/adminTestFixture'
+import { LOGIN_E2E_ORIGIN } from './loginTestEnvironment'
+
+test('BrowserContext 网络边界覆盖 popup 首请求与 popup WebSocket，且不会触达真实端口', async ({ browser }) => {
+  let httpHits = 0
+  let upgradeHits = 0
+  const trapServer = createServer((_request, response) => {
+    httpHits += 1
+    response.writeHead(204).end()
+  })
+  trapServer.on('upgrade', (_request, socket) => {
+    upgradeHits += 1
+    socket.destroy()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    trapServer.once('error', reject)
+    trapServer.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = trapServer.address() as AddressInfo
+  const httpTarget = `http://127.0.0.1:${address.port}/popup-boundary`
+  const socketTarget = `ws://127.0.0.1:${address.port}/socket-boundary`
+  const context = await browser.newContext({
+    baseURL: LOGIN_E2E_ORIGIN,
+    serviceWorkers: 'block',
+  })
+  const harness = createAdminHarness()
+
+  try {
+    await installFailClosedNetwork(context, harness)
+    const page = await context.newPage()
+    await page.setContent('<main>network boundary probe</main>')
+
+    const blockedPopupPromise = context.waitForEvent('page')
+    await page.evaluate((url) => window.open(url, '_blank'), httpTarget)
+    await blockedPopupPromise
+
+    await expect.poll(() => harness.externalRequests).toEqual([`GET ${httpTarget}`])
+
+    const socketPopupPromise = context.waitForEvent('page')
+    await page.evaluate(() => window.open('about:blank', '_blank'))
+    const socketPopup = await socketPopupPromise
+    await socketPopup.evaluate((url) => {
+      const probeSocket = new WebSocket(url)
+      probeSocket.addEventListener('error', () => {})
+    }, socketTarget)
+
+    await expect.poll(() => harness.externalSockets).toEqual([socketTarget])
+    await expect.poll(() => ({ httpHits, upgradeHits })).toEqual({ httpHits: 0, upgradeHits: 0 })
+    expect(context.serviceWorkers()).toEqual([])
+  } finally {
+    await context.close()
+    await new Promise<void>((resolve, reject) => {
+      trapServer.close((error) => error ? reject(error) : resolve())
+    })
+  }
+})

--- a/customer-admin-web/tests/e2e/route-smoke.e2e.ts
+++ b/customer-admin-web/tests/e2e/route-smoke.e2e.ts
@@ -1,0 +1,27 @@
+import { expect, test } from './fixtures/adminTestFixture'
+import { STATIC_ROUTE_CASES } from './fixtures/adminRoutes'
+
+test.describe('41 个静态业务路由挂载 smoke', () => {
+  for (const routeCase of STATIC_ROUTE_CASES) {
+    test(`${routeCase.path} 可挂载且不落入 404`, async ({ page }) => {
+      await page.goto(routeCase.path, { waitUntil: 'domcontentloaded' })
+
+      expect(new URL(page.url()).pathname).toBe(routeCase.path)
+      await expect(page.locator(routeCase.readySelector)).toBeVisible()
+      await expect(page.locator('#cw-page-title')).toHaveText(routeCase.menuTitle)
+      await expect(page.locator('.not-found')).toHaveCount(0)
+
+      // 同一次挂载切到真实移动断点，证明页面宽表只在自己的工作区横向滚动，
+      // 不会把整个文档撑出视口。这样新增路由不能只靠桌面 smoke 混过门禁。
+      await page.setViewportSize({ width: 390, height: 844 })
+      await expect(page.locator(routeCase.readySelector)).toBeVisible()
+      const mobileGeometry = await page.evaluate(() => ({
+        viewportWidth: window.innerWidth,
+        documentWidth: document.documentElement.scrollWidth,
+        bodyWidth: document.body.scrollWidth,
+      }))
+      expect(mobileGeometry.documentWidth, 'document should not overflow at 390px').toBeLessThanOrEqual(mobileGeometry.viewportWidth)
+      expect(mobileGeometry.bodyWidth, 'body should not overflow at 390px').toBeLessThanOrEqual(mobileGeometry.viewportWidth)
+    })
+  }
+})

--- a/customer-admin-web/vite.config.ts
+++ b/customer-admin-web/vite.config.ts
@@ -49,6 +49,11 @@ export default defineConfig({
   optimizeDeps: {
     include: ['element-plus/es', '@element-plus/icons-vue', ...elementPlusStyleDeps],
   },
+  // Vitest 在 Node 池里若把 Element Plus 外部化，会由原生 ESM 直接加载其 CSS side effect，
+  // 从而报 Unknown file extension ".css"。交给 Vite 转换后，组件逻辑与 CRUD composable 才能稳定单测。
+  ssr: {
+    noExternal: ['element-plus'],
+  },
   server: {
     port: 5174,
     // 监听所有网卡（不只是 127.0.0.1），局域网内其它设备才能通过本机 IP（如 10.123.45.678:5174）访问；


### PR DESCRIPTION
## 改动概览

- 建立“深墨生命周期轨道 + 安静数据工作面 + Agent Loop 证据轨迹”的统一视觉系统，覆盖 48 条后台页面路径。
- 重构六阶段生命周期导航、上下文导航、顶栏、页签、面包屑、全局搜索、租户切换与移动端抽屉。
- 将业务页面归并为列表、看板、控制台、Workspace/Auth 五类母版，统一密度、空态、加载、失败、过期数据、操作反馈和响应式边界。
- 拆分主题前景色、实心交互色与 on-color，覆盖亮暗模式、八个品牌预设、语义按钮、Tag 和选中控件的 WCAG AA 对比度。
- 修复请求竞态、删除取消、菜单回滚、未审核路由准入、Workspace KeepAlive、SQL 导出快照、Prompt diff 与 Eval 最新记录等交互正确性问题。
- 新增租户级 SLO 告警汇总接口，顶部指标直接聚合事实表，不再受明细筛选和 200 条窗口影响。

## 验证

- npm run test:unit：166/166 通过
- npm run test:e2e：79/79 通过；fail-closed 网络边界未触发外部模型、HTTP 或 WebSocket
- npm run build：通过
- git diff --check：通过
- JDK 17 Maven clean test：3580 tests，0 failures，0 errors，6 skipped（排除本机 Redis 状态不匹配的 RedisSessionPersistenceTest）

## 环境边界

首次不排除执行仅在 RedisSessionPersistenceTest.saveGetDelete_overRedis 失败，错误为 Runtime Failed to save state: demo-state；其余模块通过。该用例依赖本机 Redis 状态，最终全量代码门禁在显式排除此环境用例后通过。