### PR TITLE
feat(admin): add puzzle captcha login

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/controller/AuthController.java
@@ -61,14 +61,14 @@ public class AuthController {
         return Result.success(authService.login(request, client.ip(), client.userAgent()));
     }
 
-    /** 下发登录滑块 challenge；签发限流、TTL 与指纹绑定均由独立服务负责。 */
+    /** 下发登录拼图 challenge；签发限流、TTL 与指纹绑定均由独立服务负责。 */
     @PostMapping("/login-captcha/challenge")
     public Result<LoginCaptchaChallengeResponse> loginCaptchaChallenge(HttpServletRequest httpRequest) {
         ClientContext client = clientContextOf(httpRequest);
         return Result.success(loginCaptchaService.issueChallenge(client.ip(), client.userAgent()));
     }
 
-    /** 校验一次滑动轨迹并签发仅能消费一次的登录 proof。 */
+    /** 校验一次拼图落点与轨迹，并签发仅能消费一次的登录 proof。 */
     @PostMapping("/login-captcha/verify")
     public Result<LoginCaptchaProofResponse> verifyLoginCaptcha(
         @Valid @RequestBody LoginCaptchaVerifyRequest request, HttpServletRequest httpRequest) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaChallengeResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaChallengeResponse.java
@@ -1,5 +1,18 @@
 package com.richard.fyoung.customeradmin.auth.dto;
 
-/** 登录滑块 challenge。 */
-public record LoginCaptchaChallengeResponse(String challengeId, int ttlSeconds) {
+/**
+ * 登录拼图 challenge。
+ *
+ * <p>目标横坐标是服务端秘密，响应只提供渲染所需的图片和尺寸。</p>
+ */
+public record LoginCaptchaChallengeResponse(
+    String challengeId,
+    int ttlSeconds,
+    String backgroundImage,
+    String puzzlePieceImage,
+    int canvasWidth,
+    int canvasHeight,
+    int pieceWidth,
+    int pieceHeight,
+    int pieceY) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProofResponse.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProofResponse.java
@@ -1,5 +1,5 @@
 package com.richard.fyoung.customeradmin.auth.dto;
 
-/** 登录滑块核验通过后签发的一次性 proof。 */
+/** 登录拼图核验通过后签发的一次性 proof。 */
 public record LoginCaptchaProofResponse(String proof, int ttlSeconds) {
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProtocol.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaProtocol.java
@@ -1,7 +1,7 @@
 package com.richard.fyoung.customeradmin.auth.dto;
 
 /**
- * 登录滑块前后端共同遵守的固定协议边界。
+ * 登录拼图前后端共同遵守的固定协议边界。
  *
  * <p>这些值决定请求结构与交互行为，不作为运行期配置开放；修改时必须同步前端并按接口变更评审。
  * 运维侧只允许调整 TTL、签发限流和进程内容量等不改变协议的数据。</p>
@@ -19,7 +19,8 @@ public final class LoginCaptchaProtocol {
     public static final long MIN_DURATION_MS = 300L;
     public static final long MAX_DURATION_MS = 8_000L;
     public static final int START_X_MAX = 20;
-    public static final int END_X_MIN = 980;
+    /** 最终轨迹点与显式放置位置允许的归一化坐标误差。 */
+    public static final int ENDPOINT_PLACEMENT_TOLERANCE = 12;
     public static final int MIN_DISTINCT_X = 5;
     public static final int MIN_INTERMEDIATE_POINTS = 4;
     public static final long MAX_INITIAL_TIME_MS = 100L;

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaVerifyRequest.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/dto/LoginCaptchaVerifyRequest.java
@@ -2,15 +2,21 @@ package com.richard.fyoung.customeradmin.auth.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-/** 登录滑块轨迹核验请求。 */
+/** 登录拼图落点与轨迹核验请求。 */
 public record LoginCaptchaVerifyRequest(
     @NotBlank(message = "challengeId 不能为空")
     @Size(max = 128, message = "challengeId 长度不能超过 128") String challengeId,
+    @NotNull(message = "placementX 不能为空")
+    @Min(value = LoginCaptchaProtocol.TRACK_MIN_X, message = "placementX 不能小于 0")
+    @Max(value = LoginCaptchaProtocol.TRACK_MAX_X, message = "placementX 不能大于 1000")
+    Integer placementX,
     @NotNull(message = "trajectory 不能为空")
     @Size(min = LoginCaptchaProtocol.MIN_POINTS, max = LoginCaptchaProtocol.MAX_POINTS,
         message = "trajectory 点数必须在 6 到 80 之间")

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfig.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
  * （它只有 {@code @ConfigurationProperties}，没有 {@code @Component}），删掉会在启动时报
  * {@code NoSuchBeanDefinitionException}——本项目在批量重构配置类时踩过这个坑。</p>
  *
- * <p>计数器与注册验证码延续原有 Redis 运行期降级策略。登录滑块更严格：仅在启动时
+ * <p>计数器与注册验证码延续原有 Redis 运行期降级策略。登录拼图更严格：仅在启动时
  * 没有 Redisson Bean 才选用进程内存储；一旦选用 Redis，请求期异常直接失败关闭，
  * 防止 challenge/proof 因跨存储切换而复活。</p>
  * @author owlzhangfq@gmail.com

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/CaptchaService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/CaptchaService.java
@@ -34,8 +34,6 @@ public class CaptchaService {
     private static final char[] ALPHABET = "34679ACDEFGHJKLMNPQRTUVWXY".toCharArray();
 
     private static final String IMAGE_FORMAT = "png";
-    private static final String DATA_URI_PREFIX = "data:image/png;base64,";
-
     private final CaptchaStore store;
     private final RegistrationGuardProperties.Captcha config;
     private final SecureRandom random = new SecureRandom();
@@ -50,7 +48,7 @@ public class CaptchaService {
         String answer = randomText(config.getLength());
         String captchaId = UUID.randomUUID().toString().replace("-", "");
         store.save(captchaId, answer.toLowerCase(Locale.ROOT), config.getTtlSeconds());
-        return new CaptchaChallenge(captchaId, DATA_URI_PREFIX + render(answer), config.getTtlSeconds());
+        return new CaptchaChallenge(captchaId, PngDataUri.PREFIX + render(answer), config.getTtlSeconds());
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStore.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 /**
- * 登录滑块的进程内存储，供没有 Redisson Bean 的单实例部署在启动时选用。
+ * 登录拼图的进程内存储，供没有 Redisson Bean 的单实例部署在启动时选用。
  *
  * <p>消费通过 {@link ConcurrentHashMap#compute(Object, java.util.function.BiFunction)} 完成，
  * 同一键的指纹判断与删除不可被并发请求拆开。challenge/proof 各自用容量锁串行完成

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaProperties.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaProperties.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.auth.guard;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,9 +8,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * 登录滑块验证码参数。
+ * 登录拼图验证码参数。
  *
- * <p>登录滑块与注册图形验证码是两份独立凭据：前者保护密码与 LDAP 认证入口，
+ * <p>登录拼图与注册图形验证码是两份独立凭据：前者保护密码与 LDAP 认证入口，
  * 后者保护匿名注册及邮件发送，不能共用开关、存储或错误码。</p>
  * @author owlzhangfq@gmail.com
  */
@@ -31,9 +32,14 @@ public class LoginCaptchaProperties {
     @Positive
     private int maxIssuePerWindow = 30;
 
-    /** 单个来源 IP 在窗口内最多提交的轨迹校验次数。 */
+    /**
+     * 单个来源 IP 在窗口内最多提交的拼图校验次数。
+     *
+     * <p>校验次数必须远小于 challenge 签发数：刷新题目只消耗图片签发额度，
+     * 真正提交落点才消耗这里的猜测预算。</p>
+     */
     @Positive
-    private int maxVerifyPerWindow = 120;
+    private int maxVerifyPerWindow = 3;
 
     /** 单个来源 IP 在窗口内最多尝试消费的登录 proof 次数。 */
     @Positive
@@ -50,4 +56,12 @@ public class LoginCaptchaProperties {
     /** 参与指纹计算的 User-Agent 最大字符数。 */
     @Positive
     private int maxUserAgentLength = 512;
+
+    /**
+     * 验证预算窗口不得短于 challenge 生命周期，否则攻击者可预签发题目并跨窗口叠加猜测次数。
+     */
+    @AssertTrue(message = "rate-limit-window-seconds 不能小于 challenge-ttl-seconds")
+    public boolean isRateLimitWindowCoveringChallengeLifetime() {
+        return rateLimitWindowSeconds >= challengeTtlSeconds;
+    }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaService.java
@@ -21,13 +21,13 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * 登录滑块的 challenge → proof → 登录消费链路。
+ * 登录拼图的 challenge → proof → 登录消费链路。
  *
  * <p>proof 是 32 字节随机数的 Base64URL 表达；存储只接收其 SHA-256 摘要。
  * challenge 与 proof 都绑定来源 IP 和归一化 User-Agent 的摘要，并且只能成功消费一次。</p>
  *
- * <p>这套基础轨迹约束能拦截直接绕过、重放与简单瞬移，不宣称能够识别人类：
- * 客户端轨迹本身没有服务端秘密，脚本仍可构造满足约束的数据。</p>
+ * <p>challenge 保存随机缺口坐标与服务端容差，客户端只能从图片识别目标；核验同时检查
+ * 放置位置、轨迹终点、时序与采样质量。这不是强身份认证，公网入口仍应叠加网关风控。</p>
  * @author owlzhangfq@gmail.com
  */
 @Slf4j
@@ -46,6 +46,7 @@ public class LoginCaptchaService {
     private final WindowCounter counter;
     private final Clock clock;
     private final SecureRandom random;
+    private final LoginPuzzleImageGenerator imageGenerator;
 
     public LoginCaptchaService(LoginCaptchaStore store, LoginCaptchaProperties properties,
                                WindowCounter counter) {
@@ -54,11 +55,18 @@ public class LoginCaptchaService {
 
     LoginCaptchaService(LoginCaptchaStore store, LoginCaptchaProperties properties,
                         WindowCounter counter, Clock clock, SecureRandom random) {
+        this(store, properties, counter, clock, random, new LoginPuzzleImageGenerator(random));
+    }
+
+    LoginCaptchaService(LoginCaptchaStore store, LoginCaptchaProperties properties,
+                        WindowCounter counter, Clock clock, SecureRandom random,
+                        LoginPuzzleImageGenerator imageGenerator) {
         this.store = store;
         this.properties = properties;
         this.counter = counter;
         this.clock = clock;
         this.random = random;
+        this.imageGenerator = imageGenerator;
     }
 
     /** 签发独立 challenge；按来源 IP 做滑动窗口限流。 */
@@ -69,8 +77,17 @@ public class LoginCaptchaService {
         long now = clock.millis();
         long expireAtMs = expireAt(now, properties.getChallengeTtlSeconds());
         String challengeId = randomToken(CHALLENGE_ID_BYTES);
+        LoginPuzzleImageGenerator.GeneratedPuzzle puzzle;
+        try {
+            puzzle = imageGenerator.generate();
+        } catch (Exception e) {
+            log.error("login puzzle image generation failed, code={}",
+                "LOGIN-CAPTCHA-IMAGE-GENERATE-FAIL", e);
+            throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
+        }
         LoginCaptchaStore.ChallengeState state = new LoginCaptchaStore.ChallengeState(
-            fingerprint(clientIp, userAgent), now, expireAtMs);
+            fingerprint(clientIp, userAgent), now, expireAtMs,
+            puzzle.targetXNormalized(), puzzle.toleranceNormalized());
         try {
             store.saveChallenge(challengeId, state, properties.getChallengeTtlSeconds());
         } catch (Exception e) {
@@ -78,7 +95,7 @@ public class LoginCaptchaService {
                 "LOGIN-CAPTCHA-CHALLENGE-PERSIST-FAIL", e);
             throw new BizException(ResultCode.LOGIN_CAPTCHA_UNAVAILABLE);
         }
-        return new LoginCaptchaChallengeResponse(challengeId, properties.getChallengeTtlSeconds());
+        return puzzle.toResponse(challengeId, properties.getChallengeTtlSeconds());
     }
 
     /** 原子消费 challenge，轨迹满足约束后签发一次性 proof。 */
@@ -104,9 +121,10 @@ public class LoginCaptchaService {
 
         long now = clock.millis();
         LoginCaptchaStore.ChallengeState challenge = consumed.state();
-        if (challenge.expireAtMs() <= now
+        if (!validChallengeState(challenge, now)
             || now - challenge.issuedAtMs() < LoginCaptchaProtocol.MIN_DURATION_MS
-            || !validTrajectory(request.trajectory())) {
+            || !validPlacement(request.placementX(), challenge)
+            || !validTrajectory(request.trajectory(), request.placementX())) {
             throw invalid();
         }
 
@@ -146,9 +164,28 @@ public class LoginCaptchaService {
         }
     }
 
-    private boolean validTrajectory(List<SliderTrackPoint> points) {
+    private boolean validChallengeState(LoginCaptchaStore.ChallengeState challenge, long now) {
+        return challenge.issuedAtMs() >= 0
+            && challenge.issuedAtMs() <= now
+            && challenge.expireAtMs() > now
+            && challenge.expireAtMs() > challenge.issuedAtMs()
+            && challenge.targetXNormalized() >= LoginCaptchaProtocol.TRACK_MIN_X
+            && challenge.targetXNormalized() <= LoginCaptchaProtocol.TRACK_MAX_X
+            && challenge.toleranceNormalized() > 0
+            && challenge.toleranceNormalized() <= LoginCaptchaProtocol.TRACK_MAX_X;
+    }
+
+    private boolean validPlacement(Integer placementX, LoginCaptchaStore.ChallengeState challenge) {
+        return placementX != null
+            && placementX >= LoginCaptchaProtocol.TRACK_MIN_X
+            && placementX <= LoginCaptchaProtocol.TRACK_MAX_X
+            && Math.abs(placementX - challenge.targetXNormalized()) <= challenge.toleranceNormalized();
+    }
+
+    private boolean validTrajectory(List<SliderTrackPoint> points, Integer placementX) {
         if (points == null || points.size() < LoginCaptchaProtocol.MIN_POINTS
-            || points.size() > LoginCaptchaProtocol.MAX_POINTS) {
+            || points.size() > LoginCaptchaProtocol.MAX_POINTS
+            || placementX == null) {
             return false;
         }
         SliderTrackPoint first = points.get(0);
@@ -156,7 +193,7 @@ public class LoginCaptchaService {
         if (first == null || last == null
             || first.x() > LoginCaptchaProtocol.START_X_MAX
             || first.t() < 0 || first.t() > LoginCaptchaProtocol.MAX_INITIAL_TIME_MS
-            || last.x() < LoginCaptchaProtocol.END_X_MIN
+            || Math.abs(last.x() - placementX) > LoginCaptchaProtocol.ENDPOINT_PLACEMENT_TOLERANCE
             || last.t() < LoginCaptchaProtocol.MIN_DURATION_MS
             || last.t() > LoginCaptchaProtocol.MAX_DURATION_MS) {
             return false;
@@ -179,7 +216,7 @@ public class LoginCaptchaService {
             distinctX.add(point.x());
             if (index > 0 && index < points.size() - 1
                 && point.x() > LoginCaptchaProtocol.START_X_MAX
-                && point.x() < LoginCaptchaProtocol.END_X_MIN) {
+                && point.x() < placementX - LoginCaptchaProtocol.ENDPOINT_PLACEMENT_TOLERANCE) {
                 intermediatePoints++;
             }
         }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaStore.java
@@ -1,7 +1,7 @@
 package com.richard.fyoung.customeradmin.auth.guard;
 
 /**
- * 登录滑块 challenge/proof 的一次性存储。
+ * 登录拼图 challenge/proof 的一次性存储。
  *
  * <p>实现必须保证：指纹匹配时读取与删除是同一个原子操作；指纹不匹配时不删除，
  * 避免第三方仅凭 challengeId 或 proof 摘要让真实用户的凭据失效。分布式实现的任何
@@ -20,7 +20,9 @@ public interface LoginCaptchaStore {
     /** @param proofHash proof 明文的 SHA-256 十六进制摘要。 */
     ConsumeResult<ProofState> consumeProof(String proofHash, String fingerprint);
 
-    record ChallengeState(String fingerprint, long issuedAtMs, long expireAtMs) {
+    /** 图片不进入存储，只保存核验所需的服务端秘密与生命周期信息。 */
+    record ChallengeState(String fingerprint, long issuedAtMs, long expireAtMs,
+                          int targetXNormalized, int toleranceNormalized) {
     }
 
     record ProofState(String fingerprint, long expireAtMs) {

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginPuzzleImageGenerator.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/LoginPuzzleImageGenerator.java
@@ -1,0 +1,302 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaChallengeResponse;
+
+import javax.imageio.ImageIO;
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.LinearGradientPaint;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.CubicCurve2D;
+import java.awt.geom.Path2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.SplittableRandom;
+
+/**
+ * 登录拼图图片生成器。
+ *
+ * <p>背景图和拼图块都在 JVM 内生成，不依赖外部 URL。目标横坐标只出现在返回给服务层的
+ * 内部结果中，图片响应仅包含缺口本身；存储层不会接触 PNG 大对象。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class LoginPuzzleImageGenerator {
+
+    static final int CANVAS_WIDTH = 320;
+    static final int CANVAS_HEIGHT = 160;
+    static final int PIECE_WIDTH = 56;
+    static final int PIECE_HEIGHT = 56;
+
+    private static final int MIN_TARGET_X = 64;
+    private static final int MAX_TARGET_X = 256;
+    private static final int MIN_PIECE_Y = 22;
+    private static final int MAX_PIECE_Y = 82;
+    private static final int SERVER_TOLERANCE_PIXELS = 3;
+    private static final float SHAPE_SCALE_X = PIECE_WIDTH / 64.0F;
+    private static final float SHAPE_SCALE_Y = PIECE_HEIGHT / 64.0F;
+
+    private final SecureRandom random;
+
+    LoginPuzzleImageGenerator(SecureRandom random) {
+        this.random = Objects.requireNonNull(random, "random");
+    }
+
+    GeneratedPuzzle generate() {
+        int targetX = randomBetween(MIN_TARGET_X, MAX_TARGET_X);
+        int pieceY = randomBetween(MIN_PIECE_Y, MAX_PIECE_Y);
+        long sceneSeed = random.nextLong();
+        int pieceVariant = random.nextInt(4);
+
+        BufferedImage source = renderAgentTrajectoryBackground(sceneSeed);
+        Shape localPieceShape = createPieceShape(pieceVariant);
+        BufferedImage piece = renderPiece(source, localPieceShape, targetX, pieceY);
+        BufferedImage background = renderBackgroundWithGap(source, localPieceShape, targetX, pieceY);
+
+        int movableWidth = CANVAS_WIDTH - PIECE_WIDTH;
+        int targetXNormalized = normalizePixel(targetX, movableWidth);
+        int toleranceNormalized = Math.max(1,
+            (int) Math.ceil(SERVER_TOLERANCE_PIXELS * 1_000.0D / movableWidth));
+        return new GeneratedPuzzle(
+            toPngDataUri(background),
+            toPngDataUri(piece),
+            CANVAS_WIDTH,
+            CANVAS_HEIGHT,
+            PIECE_WIDTH,
+            PIECE_HEIGHT,
+            pieceY,
+            targetXNormalized,
+            toleranceNormalized);
+    }
+
+    private BufferedImage renderAgentTrajectoryBackground(long sceneSeed) {
+        SplittableRandom sceneRandom = new SplittableRandom(sceneSeed);
+        BufferedImage image = new BufferedImage(CANVAS_WIDTH, CANVAS_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            configure(graphics);
+            Color start = vary(new Color(105, 79, 213), sceneRandom);
+            Color middle = vary(new Color(77, 103, 218), sceneRandom);
+            Color end = vary(new Color(48, 139, 215), sceneRandom);
+            graphics.setPaint(new LinearGradientPaint(
+                0, 0, CANVAS_WIDTH, CANVAS_HEIGHT,
+                new float[]{0.0F, 0.52F, 1.0F},
+                new Color[]{start, middle, end}));
+            graphics.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+            drawMicroTexture(graphics, sceneRandom);
+            drawGrid(graphics, sceneRandom);
+            drawAgentTrajectory(graphics, sceneRandom);
+            drawGlowNodes(graphics, sceneRandom);
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+
+    private void drawMicroTexture(Graphics2D graphics, SplittableRandom sceneRandom) {
+        for (int index = 0; index < 180; index++) {
+            int x = sceneRandom.nextInt(CANVAS_WIDTH);
+            int y = sceneRandom.nextInt(CANVAS_HEIGHT);
+            int size = 1 + sceneRandom.nextInt(3);
+            int alpha = 7 + sceneRandom.nextInt(17);
+            graphics.setColor(new Color(225, 235, 255, alpha));
+            graphics.fillOval(x, y, size, size);
+        }
+    }
+
+    private void drawGrid(Graphics2D graphics, SplittableRandom sceneRandom) {
+        graphics.setStroke(new BasicStroke(1.0F));
+        graphics.setColor(new Color(255, 255, 255, 30));
+        int offset = sceneRandom.nextInt(48);
+        int forwardSpacing = 31 + sceneRandom.nextInt(8);
+        int backwardSpacing = 42 + sceneRandom.nextInt(10);
+        for (int x = -CANVAS_HEIGHT + offset; x < CANVAS_WIDTH; x += forwardSpacing) {
+            graphics.drawLine(x, 0, x + CANVAS_HEIGHT, CANVAS_HEIGHT);
+        }
+        graphics.setColor(new Color(255, 255, 255, 20));
+        for (int x = offset; x < CANVAS_WIDTH + CANVAS_HEIGHT; x += backwardSpacing) {
+            graphics.drawLine(x, 0, x - CANVAS_HEIGHT, CANVAS_HEIGHT);
+        }
+    }
+
+    private void drawAgentTrajectory(Graphics2D graphics, SplittableRandom sceneRandom) {
+        graphics.setStroke(new BasicStroke(2.2F, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        graphics.setColor(new Color(231, 238, 255, 142));
+        double shift = sceneRandom.nextDouble(-8.0D, 8.0D);
+        graphics.draw(new CubicCurve2D.Double(
+            23, 112 + shift,
+            82 + sceneRandom.nextDouble(-12.0D, 12.0D), 17 + shift,
+            145 + sceneRandom.nextDouble(-12.0D, 12.0D), 146 - shift,
+            211, 53 + shift));
+        graphics.draw(new CubicCurve2D.Double(
+            211, 53 + shift,
+            243 + sceneRandom.nextDouble(-10.0D, 10.0D), 13 - shift,
+            276 + sceneRandom.nextDouble(-10.0D, 10.0D), 91 + shift,
+            304, 34 - shift));
+
+        graphics.setStroke(new BasicStroke(1.2F, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        graphics.setColor(new Color(218, 229, 255, 82));
+        graphics.draw(new CubicCurve2D.Double(
+            15, 38 - shift,
+            89 + sceneRandom.nextDouble(-15.0D, 15.0D), 128 + shift,
+            176 + sceneRandom.nextDouble(-15.0D, 15.0D), 17 - shift,
+            296, 126 + shift));
+    }
+
+    private void drawGlowNodes(Graphics2D graphics, SplittableRandom sceneRandom) {
+        int[][] nodes = {
+            {29, 105}, {91, 57}, {151, 103}, {211, 53}, {269, 78}, {304, 34}
+        };
+        for (int[] node : nodes) {
+            int x = node[0] + sceneRandom.nextInt(-5, 6);
+            int y = node[1] + sceneRandom.nextInt(-5, 6);
+            graphics.setColor(new Color(255, 255, 255, 28));
+            graphics.fillOval(x - 9, y - 9, 18, 18);
+            graphics.setColor(new Color(255, 255, 255, 172));
+            graphics.setStroke(new BasicStroke(1.4F));
+            graphics.drawOval(x - 4, y - 4, 8, 8);
+            graphics.setColor(new Color(35, 52, 133, 170));
+            graphics.fillOval(x - 2, y - 2, 4, 4);
+        }
+    }
+
+    private Shape createPieceShape(int variant) {
+        Path2D path = new Path2D.Double();
+        path.moveTo(1, 1);
+        path.lineTo(23, 1);
+        path.curveTo(21, 4, 21, 8, 23, 11);
+        path.curveTo(26, 16, 34, 16, 37, 11);
+        path.curveTo(39, 8, 39, 4, 37, 1);
+        path.lineTo(63, 1);
+        path.lineTo(63, 24);
+        path.curveTo(60, 22, 56, 22, 53, 24);
+        path.curveTo(48, 27, 48, 35, 53, 38);
+        path.curveTo(56, 40, 60, 40, 63, 38);
+        path.lineTo(63, 63);
+        path.lineTo(39, 63);
+        path.curveTo(41, 60, 41, 56, 39, 53);
+        path.curveTo(36, 48, 28, 48, 25, 53);
+        path.curveTo(23, 56, 23, 60, 25, 63);
+        path.lineTo(1, 63);
+        path.lineTo(1, 39);
+        path.curveTo(4, 41, 8, 41, 11, 39);
+        path.curveTo(16, 36, 16, 28, 11, 25);
+        path.curveTo(8, 23, 4, 23, 1, 25);
+        path.closePath();
+        Shape scaled = AffineTransform.getScaleInstance(SHAPE_SCALE_X, SHAPE_SCALE_Y)
+            .createTransformedShape(path);
+        if (variant == 0) {
+            return scaled;
+        }
+        return AffineTransform.getRotateInstance(
+            Math.PI * variant / 2.0D, PIECE_WIDTH / 2.0D, PIECE_HEIGHT / 2.0D)
+            .createTransformedShape(scaled);
+    }
+
+    private BufferedImage renderPiece(BufferedImage source, Shape localPieceShape,
+                                      int targetX, int pieceY) {
+        BufferedImage piece = new BufferedImage(PIECE_WIDTH, PIECE_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = piece.createGraphics();
+        try {
+            configure(graphics);
+            graphics.setComposite(AlphaComposite.Src);
+            graphics.setClip(localPieceShape);
+            graphics.drawImage(source, -targetX, -pieceY, null);
+            graphics.setClip(null);
+            graphics.setComposite(AlphaComposite.SrcOver);
+            graphics.setColor(new Color(255, 255, 255, 224));
+            graphics.setStroke(new BasicStroke(1.6F));
+            graphics.draw(localPieceShape);
+        } finally {
+            graphics.dispose();
+        }
+        return piece;
+    }
+
+    private BufferedImage renderBackgroundWithGap(BufferedImage source, Shape localPieceShape,
+                                                   int targetX, int pieceY) {
+        BufferedImage background = new BufferedImage(
+            CANVAS_WIDTH, CANVAS_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = background.createGraphics();
+        try {
+            configure(graphics);
+            graphics.drawImage(source, 0, 0, null);
+            Shape targetShape = AffineTransform.getTranslateInstance(targetX, pieceY)
+                .createTransformedShape(localPieceShape);
+            graphics.setColor(new Color(18, 28, 82, 156));
+            graphics.fill(targetShape);
+            graphics.setColor(new Color(255, 255, 255, 184));
+            graphics.setStroke(new BasicStroke(1.4F));
+            graphics.draw(targetShape);
+        } finally {
+            graphics.dispose();
+        }
+        return background;
+    }
+
+    private void configure(Graphics2D graphics) {
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+            RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+    }
+
+    private String toPngDataUri(BufferedImage image) {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            if (!ImageIO.write(image, "png", output)) {
+                throw new IllegalStateException("PNG writer is unavailable");
+            }
+            return PngDataUri.PREFIX + Base64.getEncoder().encodeToString(output.toByteArray());
+        } catch (IOException e) {
+            throw new IllegalStateException("login puzzle image generation failed", e);
+        }
+    }
+
+    private int randomBetween(int min, int max) {
+        return min + random.nextInt(max - min + 1);
+    }
+
+    private int normalizePixel(int pixel, int movableWidth) {
+        return (int) Math.round(pixel * 1_000.0D / movableWidth);
+    }
+
+    private Color vary(Color color, SplittableRandom sceneRandom) {
+        int delta = sceneRandom.nextInt(-8, 9);
+        return new Color(
+            clampColor(color.getRed() + delta),
+            clampColor(color.getGreen() + delta),
+            clampColor(color.getBlue() + delta));
+    }
+
+    private int clampColor(int value) {
+        return Math.max(0, Math.min(255, value));
+    }
+
+    record GeneratedPuzzle(String backgroundImage, String puzzlePieceImage,
+                           int canvasWidth, int canvasHeight,
+                           int pieceWidth, int pieceHeight, int pieceY,
+                           int targetXNormalized, int toleranceNormalized) {
+
+        LoginCaptchaChallengeResponse toResponse(String challengeId, int ttlSeconds) {
+            return new LoginCaptchaChallengeResponse(
+                challengeId,
+                ttlSeconds,
+                backgroundImage,
+                puzzlePieceImage,
+                canvasWidth,
+                canvasHeight,
+                pieceWidth,
+                pieceHeight,
+                pieceY);
+        }
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/PngDataUri.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/PngDataUri.java
@@ -1,0 +1,14 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+/**
+ * PNG Data URI 协议常量。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+final class PngDataUri {
+
+    static final String PREFIX = "data:image/png;base64,";
+
+    private PngDataUri() {
+    }
+}

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStore.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStore.java
@@ -10,7 +10,7 @@ import java.time.Duration;
 import java.util.List;
 
 /**
- * 登录滑块的 Redis 存储。
+ * 登录拼图的 Redis 存储。
  *
  * <p>匹配消费用 Lua 在 Redis 内完成“读取指纹、匹配、删除”：匹配时原子消费，
  * 不匹配时保留原值。实例一旦在启动阶段选用 Redis，所有读写异常都必须向上抛；
@@ -23,9 +23,26 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
     private static final String KEY_PREFIX = "cw:admin:login-captcha:";
     private static final String CHALLENGE_KEY_PREFIX = KEY_PREFIX + "challenge:";
     private static final String PROOF_KEY_PREFIX = KEY_PREFIX + "proof:";
+    private static final String CHALLENGE_STATE_VERSION = "v2";
     private static final String FINGERPRINT_MISMATCH = "__FINGERPRINT_MISMATCH__";
+    private static final String MALFORMED_STATE = "__MALFORMED_STATE__";
 
-    private static final String CONSUME_IF_FINGERPRINT_MATCHES_SCRIPT =
+    private static final String CONSUME_VERSIONED_CHALLENGE_SCRIPT =
+        "local value = redis.call('GET', KEYS[1]) "
+            + "if not value then return nil end "
+            + "local versionPrefix = ARGV[1] .. ':' "
+            + "if string.sub(value, 1, string.len(versionPrefix)) ~= versionPrefix then "
+            + "  return '__MALFORMED_STATE__' "
+            + "end "
+            + "local fingerprintPrefix = versionPrefix .. ARGV[2] .. ':' "
+            + "if string.sub(value, 1, string.len(fingerprintPrefix)) ~= fingerprintPrefix then "
+            + "  return '__FINGERPRINT_MISMATCH__' "
+            + "end "
+            + "redis.call('DEL', KEYS[1]) "
+            + "return value";
+
+    /** proof 状态结构未变，保留旧脚本和编码以支持新旧节点滚动升级。 */
+    private static final String CONSUME_PROOF_IF_FINGERPRINT_MATCHES_SCRIPT =
         "local value = redis.call('GET', KEYS[1]) "
             + "if not value then return nil end "
             + "local prefix = ARGV[1] .. ':' "
@@ -49,18 +66,23 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
 
     @Override
     public ConsumeResult<ChallengeState> consumeChallenge(String challengeId, String fingerprint) {
-        String encoded = consume(CHALLENGE_KEY_PREFIX + challengeId, fingerprint);
+        String encoded = consume(
+            CONSUME_VERSIONED_CHALLENGE_SCRIPT,
+            CHALLENGE_KEY_PREFIX + challengeId,
+            CHALLENGE_STATE_VERSION,
+            fingerprint);
         if (encoded == null) {
             return ConsumeResult.notFound();
         }
         if (FINGERPRINT_MISMATCH.equals(encoded)) {
             return ConsumeResult.fingerprintMismatch();
         }
+        if (MALFORMED_STATE.equals(encoded)) {
+            throw malformed("challenge", "LOGIN-CAPTCHA-CHALLENGE-STATE-VERSION-INVALID");
+        }
         ChallengeState state = decodeChallenge(encoded);
         if (state == null) {
-            log.error("login captcha challenge state is malformed, code={}",
-                "LOGIN-CAPTCHA-CHALLENGE-STATE-INVALID");
-            throw new IllegalStateException("login captcha challenge state is malformed");
+            throw malformed("challenge", "LOGIN-CAPTCHA-CHALLENGE-STATE-INVALID");
         }
         return ConsumeResult.matched(state);
     }
@@ -73,7 +95,10 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
 
     @Override
     public ConsumeResult<ProofState> consumeProof(String proofHash, String fingerprint) {
-        String encoded = consume(PROOF_KEY_PREFIX + proofHash, fingerprint);
+        String encoded = consume(
+            CONSUME_PROOF_IF_FINGERPRINT_MATCHES_SCRIPT,
+            PROOF_KEY_PREFIX + proofHash,
+            fingerprint);
         if (encoded == null) {
             return ConsumeResult.notFound();
         }
@@ -82,19 +107,17 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
         }
         ProofState state = decodeProof(encoded);
         if (state == null) {
-            log.error("login captcha proof state is malformed, code={}",
-                "LOGIN-CAPTCHA-PROOF-STATE-INVALID");
-            throw new IllegalStateException("login captcha proof state is malformed");
+            throw malformed("proof", "LOGIN-CAPTCHA-PROOF-STATE-INVALID");
         }
         return ConsumeResult.matched(state);
     }
 
-    private String consume(String key, String fingerprint) {
+    private String consume(String script, String key, Object... arguments) {
         return redisson.getScript(StringCodec.INSTANCE).eval(
             RScript.Mode.READ_WRITE,
-            CONSUME_IF_FINGERPRINT_MATCHES_SCRIPT,
+            script,
             RScript.ReturnType.VALUE,
-            List.of(key), fingerprint);
+            List.of(key), arguments);
     }
 
     private RBucket<String> bucket(String key) {
@@ -102,7 +125,9 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
     }
 
     private String encode(ChallengeState state) {
-        return state.fingerprint() + ":" + state.issuedAtMs() + ":" + state.expireAtMs();
+        return CHALLENGE_STATE_VERSION + ":" + state.fingerprint() + ":" + state.issuedAtMs()
+            + ":" + state.expireAtMs() + ":" + state.targetXNormalized()
+            + ":" + state.toleranceNormalized();
     }
 
     private String encode(ProofState state) {
@@ -111,11 +136,22 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
 
     private ChallengeState decodeChallenge(String value) {
         String[] parts = value.split(":", -1);
-        if (parts.length != 3) {
+        if (parts.length != 6 || !CHALLENGE_STATE_VERSION.equals(parts[0])
+            || parts[1].isBlank()) {
             return null;
         }
         try {
-            return new ChallengeState(parts[0], Long.parseLong(parts[1]), Long.parseLong(parts[2]));
+            long issuedAtMs = Long.parseLong(parts[2]);
+            long expireAtMs = Long.parseLong(parts[3]);
+            int targetXNormalized = Integer.parseInt(parts[4]);
+            int toleranceNormalized = Integer.parseInt(parts[5]);
+            if (issuedAtMs < 0 || expireAtMs <= issuedAtMs
+                || targetXNormalized < 0 || targetXNormalized > 1_000
+                || toleranceNormalized <= 0 || toleranceNormalized > 1_000) {
+                return null;
+            }
+            return new ChallengeState(parts[1], issuedAtMs, expireAtMs,
+                targetXNormalized, toleranceNormalized);
         } catch (NumberFormatException e) {
             return null;
         }
@@ -123,13 +159,19 @@ public class RedissonLoginCaptchaStore implements LoginCaptchaStore {
 
     private ProofState decodeProof(String value) {
         String[] parts = value.split(":", -1);
-        if (parts.length != 2) {
+        if (parts.length != 2 || parts[0].isBlank()) {
             return null;
         }
         try {
-            return new ProofState(parts[0], Long.parseLong(parts[1]));
+            long expireAtMs = Long.parseLong(parts[1]);
+            return expireAtMs > 0 ? new ProofState(parts[0], expireAtMs) : null;
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    private IllegalStateException malformed(String stateType, String errorCode) {
+        log.error("login captcha {} state is malformed, code={}", stateType, errorCode);
+        return new IllegalStateException("login captcha " + stateType + " state is malformed");
     }
 }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/common/result/ResultCode.java
@@ -40,7 +40,7 @@ public enum ResultCode {
     PASSWORD_TOO_WEAK(30011, "密码强度不足，请至少包含字母与数字且不少于 8 位"),
     EMAIL_CODE_INVALID(30012, "邮箱验证码错误"),
     EMAIL_CODE_REISSUE_REQUIRED(30013, "邮箱验证码已失效，请重新获取"),
-    LOGIN_CAPTCHA_INVALID(30014, "拖动验证码无效或已过期，请重新验证"),
+    LOGIN_CAPTCHA_INVALID(30014, "拼图验证无效或已过期，请重新验证"),
 
     // 4xxxx 外部依赖类
     MODEL_TEST_TIMEOUT(40001, "模型连通性测试超时"),
@@ -116,8 +116,8 @@ public enum ResultCode {
     // 前端据此提示"稍后再试"，而不是把它混进注册频率里让人以为是自己点太快
     EMAIL_CODE_TOO_FREQUENT(40052, "验证码获取过于频繁，请稍后再试"),
     EMAIL_CODE_SEND_FAILED(40053, "验证码发送失败，请稍后重试"),
-    LOGIN_CAPTCHA_TOO_FREQUENT(40054, "拖动验证请求过于频繁，请稍后再试"),
-    LOGIN_CAPTCHA_UNAVAILABLE(40055, "拖动验证码服务暂不可用，请稍后重试"),
+    LOGIN_CAPTCHA_TOO_FREQUENT(40054, "拼图验证请求过于频繁，请稍后再试"),
+    LOGIN_CAPTCHA_UNAVAILABLE(40055, "拼图验证服务暂不可用，请稍后重试"),
 
     // 5xxxx 系统兜底
     SYSTEM_ERROR(50000, "系统繁忙，请稍后重试");

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerLoginCaptchaTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/controller/AuthControllerLoginCaptchaTest.java
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/** 登录滑块匿名接口、请求契约及同一来源上下文传递。 */
+/** 登录拼图匿名接口、请求契约及同一来源上下文传递。 */
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = AuthControllerLoginCaptchaTest.WebMvcTestConfig.class)
@@ -73,7 +73,7 @@ class AuthControllerLoginCaptchaTest {
     @Test
     void challenge_shouldBeAnonymousAndExposeStableContract() throws Exception {
         when(loginCaptchaService.issueChallenge(CLIENT_IP, USER_AGENT))
-            .thenReturn(new LoginCaptchaChallengeResponse("challenge-id", 120));
+            .thenReturn(challengeResponse());
 
         mockMvc.perform(post("/api/auth/login-captcha/challenge")
                 .accept(MediaType.APPLICATION_JSON)
@@ -82,7 +82,18 @@ class AuthControllerLoginCaptchaTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value(0))
             .andExpect(jsonPath("$.data.challengeId").value("challenge-id"))
-            .andExpect(jsonPath("$.data.ttlSeconds").value(120));
+            .andExpect(jsonPath("$.data.ttlSeconds").value(120))
+            .andExpect(jsonPath("$.data.backgroundImage").value("data:image/png;base64,YmFja2dyb3VuZA=="))
+            .andExpect(jsonPath("$.data.puzzlePieceImage").value("data:image/png;base64,cGllY2U="))
+            .andExpect(jsonPath("$.data.canvasWidth").value(320))
+            .andExpect(jsonPath("$.data.canvasHeight").value(160))
+            .andExpect(jsonPath("$.data.pieceWidth").value(56))
+            .andExpect(jsonPath("$.data.pieceHeight").value(56))
+            .andExpect(jsonPath("$.data.pieceY").value(52))
+            .andExpect(jsonPath("$.data.targetX").doesNotExist())
+            .andExpect(jsonPath("$.data.targetXNormalized").doesNotExist())
+            .andExpect(jsonPath("$.data.tolerance").doesNotExist())
+            .andExpect(jsonPath("$.data.toleranceNormalized").doesNotExist());
 
         verify(loginCaptchaService).issueChallenge(CLIENT_IP, USER_AGENT);
     }
@@ -91,7 +102,7 @@ class AuthControllerLoginCaptchaTest {
     void challenge_shouldKeepSameSourceForChangingForgedHeadersFromUntrustedPeer() throws Exception {
         String directPeer = "192.0.2.44";
         when(loginCaptchaService.issueChallenge(directPeer, USER_AGENT))
-            .thenReturn(new LoginCaptchaChallengeResponse("challenge-id", 120));
+            .thenReturn(challengeResponse());
 
         for (String forgedIp : java.util.List.of(CLIENT_IP, "198.51.100.99")) {
             mockMvc.perform(post("/api/auth/login-captcha/challenge")
@@ -120,10 +131,10 @@ class AuthControllerLoginCaptchaTest {
                 .header("X-Forwarded-For", CLIENT_IP)
                 .header("User-Agent", USER_AGENT)
                 .content("""
-                    {"challengeId":"challenge-id","trajectory":[
-                      {"x":0,"y":0,"t":0},{"x":120,"y":1,"t":60},
-                      {"x":320,"y":-1,"t":120},{"x":560,"y":2,"t":190},
-                      {"x":800,"y":0,"t":260},{"x":1000,"y":1,"t":340}
+                    {"challengeId":"challenge-id","placementX":620,"trajectory":[
+                      {"x":0,"y":0,"t":0},{"x":100,"y":1,"t":60},
+                      {"x":220,"y":-1,"t":120},{"x":340,"y":2,"t":190},
+                      {"x":480,"y":0,"t":260},{"x":620,"y":1,"t":340}
                     ]}
                     """))
             .andExpect(status().isOk())
@@ -131,7 +142,13 @@ class AuthControllerLoginCaptchaTest {
             .andExpect(jsonPath("$.data.proof").value("opaque-proof"))
             .andExpect(jsonPath("$.data.ttlSeconds").value(120));
 
-        verify(loginCaptchaService).verify(any(), eq(CLIENT_IP), eq(USER_AGENT));
+        org.mockito.ArgumentCaptor<com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaVerifyRequest> request =
+            org.mockito.ArgumentCaptor.forClass(
+                com.richard.fyoung.customeradmin.auth.dto.LoginCaptchaVerifyRequest.class);
+        verify(loginCaptchaService).verify(request.capture(), eq(CLIENT_IP), eq(USER_AGENT));
+        org.junit.jupiter.api.Assertions.assertEquals(620, request.getValue().placementX());
+        org.junit.jupiter.api.Assertions.assertEquals(620,
+            request.getValue().trajectory().get(request.getValue().trajectory().size() - 1).x());
     }
 
     @Test
@@ -141,7 +158,7 @@ class AuthControllerLoginCaptchaTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("User-Agent", USER_AGENT)
                 .content("""
-                    {"challengeId":"challenge-id","trajectory":[
+                    {"challengeId":"challenge-id","placementX":620,"trajectory":[
                       {"x":0,"y":0,"t":0},{"x":120,"y":1,"t":60},
                       {"x":320,"y":-1,"t":120},{"x":560,"y":2,"t":190},
                       {"x":800,"y":0,"t":260},{"x":1001,"y":1,"t":340}
@@ -150,6 +167,23 @@ class AuthControllerLoginCaptchaTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.code").value(30001))
             .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("trajectory[5].x")));
+
+        verify(loginCaptchaService, never()).verify(any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidPlacementPayloads")
+    void verify_invalidPlacement_shouldFailBeforeService(String placementJson) throws Exception {
+        mockMvc.perform(post("/api/auth/login-captcha/verify")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("User-Agent", USER_AGENT)
+                .content("{\"challengeId\":\"challenge-id\"," + placementJson + "\"trajectory\":["
+                    + "{\"x\":0,\"y\":0,\"t\":0},{\"x\":100,\"y\":1,\"t\":60},"
+                    + "{\"x\":220,\"y\":0,\"t\":120},{\"x\":340,\"y\":0,\"t\":190},"
+                    + "{\"x\":480,\"y\":0,\"t\":260},{\"x\":620,\"y\":0,\"t\":340}]}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(30001));
 
         verify(loginCaptchaService, never()).verify(any(), any(), any());
     }
@@ -218,6 +252,22 @@ class AuthControllerLoginCaptchaTest {
             Arguments.of("/api/auth/sso-login", loginPayload("u".repeat(257), "password")),
             Arguments.of("/api/auth/sso-login", loginPayload("richard", "p".repeat(257))),
             Arguments.of("/api/auth/sso-login", loginPayload("richard", "password", "p".repeat(257))));
+    }
+
+    private static Stream<Arguments> invalidPlacementPayloads() {
+        return Stream.of(
+            Arguments.of(""),
+            Arguments.of("\"placementX\":-1,"),
+            Arguments.of("\"placementX\":1001,"),
+            Arguments.of("\"placementX\":null,"));
+    }
+
+    private static LoginCaptchaChallengeResponse challengeResponse() {
+        return new LoginCaptchaChallengeResponse(
+            "challenge-id", 120,
+            "data:image/png;base64,YmFja2dyb3VuZA==",
+            "data:image/png;base64,cGllY2U=",
+            320, 160, 56, 56, 52);
     }
 
     private static String loginPayload(String username, String password) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfigLoginCaptchaTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/AuthGuardConfigLoginCaptchaTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/** 登录滑块存储只允许在启动选型时二选一。 */
+/** 登录拼图存储只允许在启动选型时二选一。 */
 class AuthGuardConfigLoginCaptchaTest {
 
     private final AuthGuardConfig config = new AuthGuardConfig();

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/InMemoryLoginCaptchaStoreTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** 进程内登录滑块凭据存储的过期、容量与一次性消费语义。 */
+/** 进程内登录拼图凭据存储的过期、容量与一次性消费语义。 */
 class InMemoryLoginCaptchaStoreTest {
 
     private static final String FINGERPRINT = "fingerprint";
@@ -168,7 +168,7 @@ class InMemoryLoginCaptchaStoreTest {
     }
 
     private LoginCaptchaStore.ChallengeState challenge(String fingerprint, long expireAtMs) {
-        return new LoginCaptchaStore.ChallengeState(fingerprint, 0L, expireAtMs);
+        return new LoginCaptchaStore.ChallengeState(fingerprint, 0L, expireAtMs, 620, 25);
     }
 
     private LoginCaptchaStore.ProofState proof(String fingerprint, long expireAtMs) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaPropertiesTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaPropertiesTest.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** 登录滑块运维配置必须在启动期失败，而不是把错误推迟到请求期。 */
+/** 登录拼图运维配置必须在启动期失败，而不是把错误推迟到请求期。 */
 class LoginCaptchaPropertiesTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -21,7 +21,24 @@ class LoginCaptchaPropertiesTest {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(LoginCaptchaProperties.class);
+            LoginCaptchaProperties properties = context.getBean(LoginCaptchaProperties.class);
+            assertThat(properties.getMaxVerifyPerWindow()).isEqualTo(3);
+            assertThat(properties.getRateLimitWindowSeconds()).isEqualTo(3_600);
+            assertThat(properties.isRateLimitWindowCoveringChallengeLifetime()).isTrue();
         });
+    }
+
+    @Test
+    void verifyWindowShorterThanChallengeLifetime_shouldFailStartupValidation() {
+        contextRunner
+            .withPropertyValues(
+                "admin.login-captcha.challenge-ttl-seconds=121",
+                "admin.login-captcha.rate-limit-window-seconds=120")
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(BindValidationException.class);
+            });
     }
 
     @ParameterizedTest

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginCaptchaServiceTest.java
@@ -45,15 +45,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/** 登录滑块从 challenge 到 proof 的安全边界。 */
+/** 登录拼图从 challenge 到 proof 的安全边界。 */
 class LoginCaptchaServiceTest {
 
     private static final String IP = "203.0.113.31";
     private static final String USER_AGENT = "Mozilla/5.0 customer-admin-test";
+    private static final int TARGET_X = 620;
+    private static final int TARGET_TOLERANCE = 12;
 
     private MutableClock clock;
     private LoginCaptchaProperties properties;
     private WindowCounter counter;
+    private LoginPuzzleImageGenerator imageGenerator;
     private LoginCaptchaService service;
 
     @BeforeEach
@@ -62,8 +65,32 @@ class LoginCaptchaServiceTest {
         properties = new LoginCaptchaProperties();
         counter = mock(WindowCounter.class);
         when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(true);
+        imageGenerator = mock(LoginPuzzleImageGenerator.class);
+        when(imageGenerator.generate()).thenReturn(generatedPuzzle());
         service = new LoginCaptchaService(new InMemoryLoginCaptchaStore(100, clock), properties,
-            counter, clock, new SecureRandom());
+            counter, clock, new SecureRandom(), imageGenerator);
+    }
+
+    @Test
+    void issueChallenge_shouldReturnPuzzleAssetsAndPersistOnlyServerSecret() {
+        LoginCaptchaStore store = mock(LoginCaptchaStore.class);
+        LoginCaptchaService localService = serviceWith(store);
+
+        LoginCaptchaChallengeResponse challenge = localService.issueChallenge(IP, USER_AGENT);
+
+        assertEquals("data:image/png;base64,YmFja2dyb3VuZA==", challenge.backgroundImage());
+        assertEquals("data:image/png;base64,cGllY2U=", challenge.puzzlePieceImage());
+        assertEquals(320, challenge.canvasWidth());
+        assertEquals(160, challenge.canvasHeight());
+        assertEquals(56, challenge.pieceWidth());
+        assertEquals(56, challenge.pieceHeight());
+        assertEquals(52, challenge.pieceY());
+        org.mockito.ArgumentCaptor<LoginCaptchaStore.ChallengeState> state =
+            org.mockito.ArgumentCaptor.forClass(LoginCaptchaStore.ChallengeState.class);
+        verify(store).saveChallenge(eq(challenge.challengeId()), state.capture(),
+            eq(properties.getChallengeTtlSeconds()));
+        assertEquals(TARGET_X, state.getValue().targetXNormalized());
+        assertEquals(TARGET_TOLERANCE, state.getValue().toleranceNormalized());
     }
 
     @Test
@@ -83,7 +110,7 @@ class LoginCaptchaServiceTest {
     void verify_shouldIssue32ByteBase64UrlProofAndStoreOnlyItsSha256() throws Exception {
         InMemoryLoginCaptchaStore store = spy(new InMemoryLoginCaptchaStore(100, clock));
         LoginCaptchaService localService = new LoginCaptchaService(
-            store, properties, counter, clock, new SecureRandom());
+            store, properties, counter, clock, new SecureRandom(), imageGenerator);
         LoginCaptchaChallengeResponse challenge = localService.issueChallenge(IP, USER_AGENT);
         clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
 
@@ -131,7 +158,8 @@ class LoginCaptchaServiceTest {
         LoginCaptchaChallengeResponse challenge = issue();
         clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
         List<SliderTrackPoint> teleport = List.of(
-            point(0, 0), point(0, 80), point(0, 160), point(0, 240), point(0, 320), point(1000, 400));
+            point(0, 0), point(0, 80), point(0, 160), point(0, 240), point(0, 320),
+            point(TARGET_X, 400));
 
         assertInvalid(() -> service.verify(request(challenge, teleport), IP, USER_AGENT));
         assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
@@ -142,7 +170,8 @@ class LoginCaptchaServiceTest {
         LoginCaptchaChallengeResponse challenge = issue();
         clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
         List<SliderTrackPoint> incomplete = new ArrayList<>(validTrajectory());
-        incomplete.set(incomplete.size() - 1, point(LoginCaptchaProtocol.END_X_MIN - 1, 400));
+        incomplete.set(incomplete.size() - 1,
+            point(TARGET_X - LoginCaptchaProtocol.ENDPOINT_PLACEMENT_TOLERANCE - 1, 400));
 
         assertInvalid(() -> service.verify(request(challenge, incomplete), IP, USER_AGENT));
         assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
@@ -164,8 +193,8 @@ class LoginCaptchaServiceTest {
         LoginCaptchaChallengeResponse challenge = issue();
         clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
         List<SliderTrackPoint> sparse = List.of(
-            point(0, 0), point(10, 80), point(200, 160), point(500, 240), point(800, 320),
-            point(1000, 400));
+            point(0, 0), point(10, 80), point(12, 160), point(14, 240), point(16, 320),
+            point(TARGET_X, 400));
 
         assertInvalid(() -> service.verify(request(challenge, sparse), IP, USER_AGENT));
         assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
@@ -203,6 +232,39 @@ class LoginCaptchaServiceTest {
     }
 
     @Test
+    void verify_shouldRejectPlacementOutsideServerTargetToleranceAndConsumeChallenge() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        int wrongPlacement = TARGET_X + TARGET_TOLERANCE + 1;
+
+        assertInvalid(() -> service.verify(
+            request(challenge, wrongPlacement, validTrajectory(wrongPlacement)), IP, USER_AGENT));
+        assertInvalid(() -> service.verify(request(challenge, validTrajectory()), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldAcceptPlacementAtServerToleranceBoundary() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        int boundaryPlacement = TARGET_X + TARGET_TOLERANCE;
+
+        assertNotNull(service.verify(
+            request(challenge, boundaryPlacement, validTrajectory(boundaryPlacement)), IP, USER_AGENT));
+    }
+
+    @Test
+    void verify_shouldRejectTrajectoryEndpointThatDiffersFromPlacement() {
+        LoginCaptchaChallengeResponse challenge = issue();
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+        List<SliderTrackPoint> mismatched = new ArrayList<>(validTrajectory());
+        mismatched.set(mismatched.size() - 1,
+            point(TARGET_X - LoginCaptchaProtocol.ENDPOINT_PLACEMENT_TOLERANCE - 1, 400));
+
+        assertInvalid(() -> service.verify(
+            request(challenge, TARGET_X, mismatched), IP, USER_AGENT));
+    }
+
+    @Test
     void consumeProof_shouldBeOneTimeAndKeepProofOnFingerprintMismatch() {
         LoginCaptchaProofResponse proof = verifiedProof();
 
@@ -230,6 +292,16 @@ class LoginCaptchaServiceTest {
     }
 
     @Test
+    void issueChallenge_shouldMapImageGenerationFailureToUnavailableWithoutPersisting() {
+        LoginCaptchaStore store = mock(LoginCaptchaStore.class);
+        when(imageGenerator.generate()).thenThrow(new IllegalStateException("png unavailable"));
+
+        assertUnavailable(() -> serviceWith(store).issueChallenge(IP, USER_AGENT));
+
+        verify(store, never()).saveChallenge(anyString(), any(), anyInt());
+    }
+
+    @Test
     void verify_shouldMapChallengeConsumeFailureToUnavailable() {
         LoginCaptchaStore failingStore = mock(LoginCaptchaStore.class);
         LoginCaptchaService failingService = serviceWith(failingStore);
@@ -251,7 +323,9 @@ class LoginCaptchaServiceTest {
         clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
         when(failingStore.consumeChallenge(eq(challenge.challengeId()), anyString()))
             .thenReturn(LoginCaptchaStore.ConsumeResult.matched(
-                new LoginCaptchaStore.ChallengeState("fingerprint", issuedAt, clock.millis() + 10_000L)));
+                new LoginCaptchaStore.ChallengeState(
+                    "fingerprint", issuedAt, clock.millis() + 10_000L,
+                    TARGET_X, TARGET_TOLERANCE)));
         doThrow(new IllegalStateException("redis timeout")).when(failingStore)
             .saveProof(anyString(), any(), anyInt());
 
@@ -316,7 +390,8 @@ class LoginCaptchaServiceTest {
         properties.setMaxVerifyPerWindow(7);
         when(counter.tryAcquireSliding(anyString(), anyInt(), anyInt())).thenReturn(false);
         LoginCaptchaVerifyRequest request = new LoginCaptchaVerifyRequest(
-            Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[16]), validTrajectory());
+            Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[16]),
+            TARGET_X, validTrajectory());
 
         BizException error = assertThrows(BizException.class,
             () -> serviceWith(store).verify(request, IP, USER_AGENT));
@@ -326,6 +401,40 @@ class LoginCaptchaServiceTest {
         verify(counter).tryAcquireSliding(
             eq("admin:login-captcha:verify:" + sha256(IP)),
             eq(7), eq(properties.getRateLimitWindowSeconds()));
+    }
+
+    @Test
+    void verify_shouldAllowOnlyThreeAttemptsPerHourAcrossSuccessFailureAndUserAgentChanges() {
+        InMemoryLoginCaptchaStore store = spy(new InMemoryLoginCaptchaStore(100, clock));
+        LoginCaptchaService localService = new LoginCaptchaService(
+            store, properties, counter, clock, new SecureRandom(), imageGenerator);
+        when(counter.tryAcquireSliding(
+            org.mockito.ArgumentMatchers.startsWith("admin:login-captcha:verify:"),
+            eq(3), eq(3_600)))
+            .thenReturn(true, true, true, false);
+        List<LoginCaptchaChallengeResponse> challenges = List.of(
+            localService.issueChallenge(IP, USER_AGENT),
+            localService.issueChallenge(IP, USER_AGENT),
+            localService.issueChallenge(IP, USER_AGENT),
+            localService.issueChallenge(IP, USER_AGENT));
+        clock.advance(LoginCaptchaProtocol.MIN_DURATION_MS);
+
+        assertNotNull(localService.verify(
+            request(challenges.get(0), validTrajectory()), IP, USER_AGENT));
+        int wrongPlacement = TARGET_X + TARGET_TOLERANCE + 1;
+        assertInvalid(() -> localService.verify(
+            request(challenges.get(1), wrongPlacement, validTrajectory(wrongPlacement)),
+            IP, USER_AGENT));
+        assertInvalid(() -> localService.verify(
+            request(challenges.get(2), validTrajectory()), IP, "rotated-user-agent"));
+
+        BizException exhausted = assertThrows(BizException.class, () -> localService.verify(
+            request(challenges.get(3), validTrajectory()), IP, USER_AGENT));
+        assertEquals(ResultCode.LOGIN_CAPTCHA_TOO_FREQUENT, exhausted.getResultCode());
+        verify(counter, times(4)).tryAcquireSliding(
+            org.mockito.ArgumentMatchers.startsWith("admin:login-captcha:verify:"),
+            eq(3), eq(3_600));
+        verify(store, times(3)).consumeChallenge(anyString(), anyString());
     }
 
     @Test
@@ -350,7 +459,8 @@ class LoginCaptchaServiceTest {
     }
 
     private LoginCaptchaService serviceWith(LoginCaptchaStore store) {
-        return new LoginCaptchaService(store, properties, counter, clock, new SecureRandom());
+        return new LoginCaptchaService(
+            store, properties, counter, clock, new SecureRandom(), imageGenerator);
     }
 
     private LoginCaptchaProofResponse verifiedProof() {
@@ -361,12 +471,23 @@ class LoginCaptchaServiceTest {
 
     private LoginCaptchaVerifyRequest request(LoginCaptchaChallengeResponse challenge,
                                               List<SliderTrackPoint> trajectory) {
-        return new LoginCaptchaVerifyRequest(challenge.challengeId(), trajectory);
+        return request(challenge, TARGET_X, trajectory);
+    }
+
+    private LoginCaptchaVerifyRequest request(LoginCaptchaChallengeResponse challenge,
+                                              int placementX,
+                                              List<SliderTrackPoint> trajectory) {
+        return new LoginCaptchaVerifyRequest(challenge.challengeId(), placementX, trajectory);
     }
 
     private List<SliderTrackPoint> validTrajectory() {
-        return List.of(point(0, 0), point(120, 50), point(300, 120),
-            point(520, 210), point(760, 320), point(1000, 400));
+        return validTrajectory(TARGET_X);
+    }
+
+    private List<SliderTrackPoint> validTrajectory(int placementX) {
+        return List.of(point(0, 0), point(placementX * 16 / 100, 50),
+            point(placementX * 35 / 100, 120), point(placementX * 55 / 100, 210),
+            point(placementX * 78 / 100, 320), point(placementX, 400));
     }
 
     private SliderTrackPoint point(int x, long timeMs) {
@@ -382,25 +503,25 @@ class LoginCaptchaServiceTest {
         initialPointTooLate.set(1, trackPoint(120, 0, 150));
 
         List<SliderTrackPoint> durationTooShort = mutableValidTrajectory();
-        durationTooShort.set(1, trackPoint(120, 0, 40));
-        durationTooShort.set(2, trackPoint(300, 0, 90));
-        durationTooShort.set(3, trackPoint(520, 0, 150));
-        durationTooShort.set(4, trackPoint(760, 0, 220));
-        durationTooShort.set(5, trackPoint(1000, 0, 299));
+        durationTooShort.set(1, trackPoint(100, 0, 40));
+        durationTooShort.set(2, trackPoint(220, 0, 90));
+        durationTooShort.set(3, trackPoint(340, 0, 150));
+        durationTooShort.set(4, trackPoint(480, 0, 220));
+        durationTooShort.set(5, trackPoint(TARGET_X, 0, 299));
 
         List<SliderTrackPoint> durationTooLong = mutableValidTrajectory();
-        durationTooLong.set(5, trackPoint(1000, 0, 8_001));
+        durationTooLong.set(5, trackPoint(TARGET_X, 0, 8_001));
 
         List<SliderTrackPoint> tooManyPoints = IntStream.rangeClosed(0, 80)
-            .mapToObj(index -> trackPoint(index * 1_000 / 80, 0, index * 10L))
+            .mapToObj(index -> trackPoint(index * TARGET_X / 80, 0, index * 10L))
             .toList();
 
         List<SliderTrackPoint> yTooLarge = mutableValidTrajectory();
         yTooLarge.set(3, trackPoint(520, 1_001, 210));
 
         List<SliderTrackPoint> nullIntermediate = new ArrayList<>(
-            Arrays.asList(trackPoint(0, 0, 0), trackPoint(120, 0, 50), null,
-                trackPoint(520, 0, 210), trackPoint(760, 0, 320), trackPoint(1000, 0, 400)));
+            Arrays.asList(trackPoint(0, 0, 0), trackPoint(100, 0, 50), null,
+                trackPoint(340, 0, 210), trackPoint(480, 0, 320), trackPoint(TARGET_X, 0, 400)));
 
         return Stream.of(
             Arguments.of("起点超过 20", startTooFar),
@@ -413,9 +534,16 @@ class LoginCaptchaServiceTest {
     }
 
     private static List<SliderTrackPoint> mutableValidTrajectory() {
-        return new ArrayList<>(List.of(trackPoint(0, 0, 0), trackPoint(120, 0, 50),
-            trackPoint(300, 0, 120), trackPoint(520, 0, 210), trackPoint(760, 0, 320),
-            trackPoint(1000, 0, 400)));
+        return new ArrayList<>(List.of(trackPoint(0, 0, 0), trackPoint(100, 0, 50),
+            trackPoint(220, 0, 120), trackPoint(340, 0, 210), trackPoint(480, 0, 320),
+            trackPoint(TARGET_X, 0, 400)));
+    }
+
+    private LoginPuzzleImageGenerator.GeneratedPuzzle generatedPuzzle() {
+        return new LoginPuzzleImageGenerator.GeneratedPuzzle(
+            "data:image/png;base64,YmFja2dyb3VuZA==",
+            "data:image/png;base64,cGllY2U=",
+            320, 160, 56, 56, 52, TARGET_X, TARGET_TOLERANCE);
     }
 
     private static SliderTrackPoint trackPoint(int x, int y, long timeMs) {

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginPuzzleImageGeneratorTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/LoginPuzzleImageGeneratorTest.java
@@ -1,0 +1,133 @@
+package com.richard.fyoung.customeradmin.auth.guard;
+
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** JVM 内拼图素材生成的尺寸、透明通道与服务端秘密边界。 */
+class LoginPuzzleImageGeneratorTest {
+
+    private static final String PNG_PREFIX = "data:image/png;base64,";
+
+    @Test
+    void generate_shouldCreateFixedSizePngAssetsAndKeepSecretCoordinateInternal() throws Exception {
+        LoginPuzzleImageGenerator.GeneratedPuzzle puzzle =
+            new LoginPuzzleImageGenerator(new SecureRandom()).generate();
+
+        assertEquals(LoginPuzzleImageGenerator.CANVAS_WIDTH, puzzle.canvasWidth());
+        assertEquals(LoginPuzzleImageGenerator.CANVAS_HEIGHT, puzzle.canvasHeight());
+        assertEquals(LoginPuzzleImageGenerator.PIECE_WIDTH, puzzle.pieceWidth());
+        assertEquals(LoginPuzzleImageGenerator.PIECE_HEIGHT, puzzle.pieceHeight());
+        assertTrue(puzzle.pieceY() >= 0);
+        assertTrue(puzzle.pieceY() + puzzle.pieceHeight() <= puzzle.canvasHeight());
+        assertTrue(puzzle.targetXNormalized() > 0 && puzzle.targetXNormalized() < 1_000);
+        assertEquals(12, puzzle.toleranceNormalized(), "±3px 应向上换算为 12 个归一化单位");
+
+        BufferedImage background = decode(puzzle.backgroundImage());
+        BufferedImage piece = decode(puzzle.puzzlePieceImage());
+        assertEquals(puzzle.canvasWidth(), background.getWidth());
+        assertEquals(puzzle.canvasHeight(), background.getHeight());
+        assertEquals(puzzle.pieceWidth(), piece.getWidth());
+        assertEquals(puzzle.pieceHeight(), piece.getHeight());
+
+        int transparentPixels = 0;
+        int opaquePixels = 0;
+        for (int y = 0; y < piece.getHeight(); y++) {
+            for (int x = 0; x < piece.getWidth(); x++) {
+                int alpha = piece.getRGB(x, y) >>> 24;
+                if (alpha == 0) {
+                    transparentPixels++;
+                }
+                if (alpha > 0) {
+                    opaquePixels++;
+                }
+            }
+        }
+        assertTrue(transparentPixels > 0, "拼图块外部必须保持透明");
+        assertTrue(opaquePixels > 0, "拼图块本体必须包含背景像素");
+    }
+
+    @Test
+    void generate_shouldCoverConfiguredTargetBoundsWithoutTouchingCanvasEdges() {
+        LoginPuzzleImageGenerator.GeneratedPuzzle minimum =
+            new LoginPuzzleImageGenerator(new BoundarySecureRandom(false, 11L)).generate();
+        LoginPuzzleImageGenerator.GeneratedPuzzle maximum =
+            new LoginPuzzleImageGenerator(new BoundarySecureRandom(true, 22L)).generate();
+
+        assertEquals(242, minimum.targetXNormalized(),
+            "64px 在 264px 可移动行程中应归一化为 242");
+        assertEquals(970, maximum.targetXNormalized(),
+            "256px 在 264px 可移动行程中应归一化为 970");
+        assertEquals(22, minimum.pieceY());
+        assertEquals(82, maximum.pieceY());
+        assertEquals(12, minimum.toleranceNormalized());
+        assertEquals(12, maximum.toleranceNormalized());
+    }
+
+    @Test
+    void generate_shouldAddHighEntropySceneEvenForSameTargetAndShape() {
+        LoginPuzzleImageGenerator.GeneratedPuzzle first =
+            new LoginPuzzleImageGenerator(new BoundarySecureRandom(false, 101L)).generate();
+        LoginPuzzleImageGenerator.GeneratedPuzzle second =
+            new LoginPuzzleImageGenerator(new BoundarySecureRandom(false, 202L)).generate();
+
+        assertEquals(first.targetXNormalized(), second.targetXNormalized());
+        assertEquals(first.pieceY(), second.pieceY());
+        assertNotEquals(first.backgroundImage(), second.backgroundImage(),
+            "场景随机种子不能退化成有限模板集合");
+        assertNotEquals(first.puzzlePieceImage(), second.puzzlePieceImage(),
+            "拼图块纹理也必须随高熵背景变化");
+    }
+
+    @Test
+    void toResponse_shouldExposeRenderingDataButNotServerTarget() {
+        LoginPuzzleImageGenerator.GeneratedPuzzle puzzle =
+            new LoginPuzzleImageGenerator(new SecureRandom()).generate();
+
+        var response = puzzle.toResponse("challenge-id", 120);
+
+        assertEquals("challenge-id", response.challengeId());
+        assertEquals(120, response.ttlSeconds());
+        assertEquals(puzzle.backgroundImage(), response.backgroundImage());
+        assertEquals(puzzle.puzzlePieceImage(), response.puzzlePieceImage());
+        assertEquals(9, response.getClass().getRecordComponents().length,
+            "公开 challenge 合同不得增加 targetX 或 tolerance");
+    }
+
+    private BufferedImage decode(String dataUri) throws Exception {
+        assertTrue(dataUri.startsWith(PNG_PREFIX));
+        byte[] png = Base64.getDecoder().decode(dataUri.substring(PNG_PREFIX.length()));
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(png));
+        assertNotNull(image);
+        return image;
+    }
+
+    private static final class BoundarySecureRandom extends SecureRandom {
+        private final boolean maximum;
+        private final long sceneSeed;
+
+        private BoundarySecureRandom(boolean maximum, long sceneSeed) {
+            this.maximum = maximum;
+            this.sceneSeed = sceneSeed;
+        }
+
+        @Override
+        public int nextInt(int bound) {
+            return maximum ? bound - 1 : 0;
+        }
+
+        @Override
+        public long nextLong() {
+            return sceneSeed;
+        }
+    }
+}

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreIntegrationTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreIntegrationTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
- * Redis 登录滑块存储的真服务门禁，覆盖 Lua 原子消费、TTL、并发重放与故障关闭。
+ * Redis 登录拼图存储的真服务门禁，覆盖 Lua 原子消费、TTL、并发重放与故障关闭。
  *
  * <p>真实 Redis 用例在服务不可达或鉴权不匹配时按仓库惯例跳过；故障关闭用例使用本进程
  * black-hole 端口独立执行，不依赖外部 Redis 的可用状态。</p>
@@ -91,7 +91,8 @@ class RedissonLoginCaptchaStoreIntegrationTest {
             long now = System.currentTimeMillis();
             try {
                 store.saveChallenge(mismatchId,
-                    new LoginCaptchaStore.ChallengeState(FINGERPRINT, now, now + 10_000), 10);
+                    new LoginCaptchaStore.ChallengeState(
+                        FINGERPRINT, now, now + 10_000, 620, 25), 10);
 
                 assertEquals(LoginCaptchaStore.ConsumeStatus.FINGERPRINT_MISMATCH,
                     store.consumeChallenge(mismatchId, "other-fingerprint").status());
@@ -102,7 +103,8 @@ class RedissonLoginCaptchaStoreIntegrationTest {
                     store.consumeChallenge(mismatchId, FINGERPRINT).status());
 
                 store.saveChallenge(expiringId,
-                    new LoginCaptchaStore.ChallengeState(FINGERPRINT, now, now + 2_000), 2);
+                    new LoginCaptchaStore.ChallengeState(
+                        FINGERPRINT, now, now + 2_000, 620, 25), 2);
                 store.saveProof(expiringProofHash,
                     new LoginCaptchaStore.ProofState(FINGERPRINT, now + 2_000), 2);
                 assertRedisTtl(challengeBucket, "challenge");
@@ -168,6 +170,24 @@ class RedissonLoginCaptchaStoreIntegrationTest {
                 executor.shutdownNow();
                 assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "并发测试线程未正常退出");
                 proofBucket.delete();
+            }
+        }
+
+        @Test
+        void challenge_shouldFailClosedForLegacyUnversionedRedisValue() {
+            String challengeId = UUID.randomUUID().toString();
+            RBucket<String> challengeBucket = bucket("challenge:", challengeId);
+            long now = System.currentTimeMillis();
+            try {
+                challengeBucket.set(
+                    FINGERPRINT + ":" + now + ":" + (now + 10_000), Duration.ofSeconds(10));
+
+                assertThrows(IllegalStateException.class,
+                    () -> store.consumeChallenge(challengeId, FINGERPRINT));
+                assertTrue(challengeBucket.isExists(),
+                    "旧格式没有通过版本校验时不得被误当成匹配 challenge 消费");
+            } finally {
+                challengeBucket.delete();
             }
         }
 

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/auth/guard/RedissonLoginCaptchaStoreTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/** Redis 登录滑块存储的原子消费与请求期 fail-closed 边界。 */
+/** Redis 登录拼图存储的原子消费与请求期 fail-closed 边界。 */
 class RedissonLoginCaptchaStoreTest {
 
     private static final String FINGERPRINT = "fingerprint";
@@ -43,19 +43,21 @@ class RedissonLoginCaptchaStoreTest {
     void consumeChallenge_shouldUseAtomicLuaScriptForMatchingFingerprint() {
         when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
         when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
-            org.mockito.ArgumentMatchers.<List<Object>>any(), eq(FINGERPRINT)))
-            .thenReturn(FINGERPRINT + ":100:200");
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq("v2"), eq(FINGERPRINT)))
+            .thenReturn("v2:" + FINGERPRINT + ":100:200:620:25");
 
         LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ChallengeState> result =
             store.consumeChallenge("challenge-id", FINGERPRINT);
 
         assertEquals(LoginCaptchaStore.ConsumeStatus.MATCHED, result.status());
-        assertEquals(new LoginCaptchaStore.ChallengeState(FINGERPRINT, 100L, 200L), result.state());
+        assertEquals(new LoginCaptchaStore.ChallengeState(
+            FINGERPRINT, 100L, 200L, 620, 25), result.state());
         ArgumentCaptor<String> lua = ArgumentCaptor.forClass(String.class);
         verify(script).eval(eq(RScript.Mode.READ_WRITE), lua.capture(), eq(RScript.ReturnType.VALUE),
-            eq(List.of("cw:admin:login-captcha:challenge:challenge-id")), eq(FINGERPRINT));
+            eq(List.of("cw:admin:login-captcha:challenge:challenge-id")), eq("v2"), eq(FINGERPRINT));
         assertTrue(lua.getValue().contains("redis.call('DEL', KEYS[1])"));
         assertTrue(lua.getValue().contains("return '__FINGERPRINT_MISMATCH__'"));
+        assertTrue(lua.getValue().contains("return '__MALFORMED_STATE__'"));
     }
 
     @Test
@@ -103,7 +105,8 @@ class RedissonLoginCaptchaStoreTest {
             .when(bucket).set(anyString(), eq(Duration.ofSeconds(60)));
 
         assertThrows(IllegalStateException.class, () -> store.saveChallenge(
-            "challenge-id", new LoginCaptchaStore.ChallengeState(FINGERPRINT, 100L, 200L), 60));
+            "challenge-id", new LoginCaptchaStore.ChallengeState(
+                FINGERPRINT, 100L, 200L, 620, 25), 60));
     }
 
     @Test
@@ -124,10 +127,62 @@ class RedissonLoginCaptchaStoreTest {
     void consumeChallenge_shouldPropagateMalformedPersistedState() {
         when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
         when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
-            org.mockito.ArgumentMatchers.<List<Object>>any(), eq(FINGERPRINT)))
-            .thenReturn(FINGERPRINT + ":malformed");
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq("v2"), eq(FINGERPRINT)))
+            .thenReturn("v2:" + FINGERPRINT + ":malformed");
 
         assertThrows(IllegalStateException.class,
             () -> store.consumeChallenge("challenge-id", FINGERPRINT));
+    }
+
+    @Test
+    void consumeChallenge_shouldFailClosedForLegacyUnversionedState() {
+        when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq("v2"), eq(FINGERPRINT)))
+            .thenReturn("__MALFORMED_STATE__");
+
+        assertThrows(IllegalStateException.class,
+            () -> store.consumeChallenge("legacy-challenge", FINGERPRINT));
+    }
+
+    @Test
+    void saveChallenge_shouldPersistExplicitVersionAndOnlyCompactServerState() {
+        @SuppressWarnings("unchecked")
+        RBucket<String> bucket = mock(RBucket.class);
+        when(redisson.<String>getBucket(
+            "cw:admin:login-captcha:challenge:challenge-id", StringCodec.INSTANCE))
+            .thenReturn(bucket);
+        LoginCaptchaStore.ChallengeState state = new LoginCaptchaStore.ChallengeState(
+            FINGERPRINT, 100L, 200L, 620, 25);
+
+        store.saveChallenge("challenge-id", state, 60);
+
+        verify(bucket).set(eq("v2:" + FINGERPRINT + ":100:200:620:25"),
+            eq(Duration.ofSeconds(60)));
+    }
+
+    @Test
+    void proof_shouldKeepLegacyEncodingAndLuaContractForRollingUpgradeCompatibility() {
+        @SuppressWarnings("unchecked")
+        RBucket<String> bucket = mock(RBucket.class);
+        when(redisson.<String>getBucket(
+            "cw:admin:login-captcha:proof:proof-hash", StringCodec.INSTANCE))
+            .thenReturn(bucket);
+        when(redisson.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(eq(RScript.Mode.READ_WRITE), anyString(), eq(RScript.ReturnType.VALUE),
+            org.mockito.ArgumentMatchers.<List<Object>>any(), eq(FINGERPRINT)))
+            .thenReturn(FINGERPRINT + ":200");
+
+        store.saveProof("proof-hash", new LoginCaptchaStore.ProofState(FINGERPRINT, 200L), 60);
+        LoginCaptchaStore.ConsumeResult<LoginCaptchaStore.ProofState> result =
+            store.consumeProof("proof-hash", FINGERPRINT);
+
+        verify(bucket).set(eq(FINGERPRINT + ":200"), eq(Duration.ofSeconds(60)));
+        assertEquals(LoginCaptchaStore.ConsumeStatus.MATCHED, result.status());
+        assertEquals(new LoginCaptchaStore.ProofState(FINGERPRINT, 200L), result.state());
+        ArgumentCaptor<String> lua = ArgumentCaptor.forClass(String.class);
+        verify(script).eval(eq(RScript.Mode.READ_WRITE), lua.capture(), eq(RScript.ReturnType.VALUE),
+            eq(List.of("cw:admin:login-captcha:proof:proof-hash")), eq(FINGERPRINT));
+        assertTrue(lua.getValue().contains("local prefix = ARGV[1] .. ':'"));
     }
 }

--- a/customer-admin-web/src/types/api.ts
+++ b/customer-admin-web/src/types/api.ts
@@ -60,6 +60,13 @@ export interface SsoLoginRequest {
 export interface LoginCaptchaChallenge {
   challengeId: string
   ttlSeconds: number
+  backgroundImage: string
+  puzzlePieceImage: string
+  canvasWidth: number
+  canvasHeight: number
+  pieceWidth: number
+  pieceHeight: number
+  pieceY: number
 }
 
 /** 拖动轨迹点：横纵坐标归一到千分比，t 为按下后的相对毫秒数。 */
@@ -71,6 +78,8 @@ export interface LoginCaptchaTrackPoint {
 
 export interface LoginCaptchaVerifyRequest {
   challengeId: string
+  /** 拼图块当前位置，按 canvasWidth-pieceWidth 行程归一到 0..1000。 */
+  placementX: number
   trajectory: LoginCaptchaTrackPoint[]
 }
 

--- a/customer-admin-web/src/views/login/Login.vue
+++ b/customer-admin-web/src/views/login/Login.vue
@@ -22,6 +22,8 @@ import {
   type LoginMode,
 } from './loginPageModel'
 
+type LoginSubmitOutcome = 'busy' | 'invalid' | 'verification-required' | 'rejected' | 'navigated'
+
 const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
@@ -41,6 +43,7 @@ const formRef = ref<FormInstance>()
 const loginCaptchaRef = ref<InstanceType<typeof LoginSliderCaptcha>>()
 const submitting = ref(false)
 const captchaProof = ref('')
+const captchaOpen = ref(false)
 const form = reactive({ username: '', password: '', rememberMe: false })
 const rules: FormRules = {
   username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
@@ -154,19 +157,32 @@ async function loadRegisterOptions() {
   }
 }
 
-async function handleSubmit() {
+async function focusFirstInvalidField() {
+  // Element Plus 在 validate() rejected 后还需要一次渲染提交错误样式，再查找可聚焦输入框。
+  await nextTick()
+  await nextTick()
+  // handleSubmit 的 finally 会在当前调用栈结束时解除 submitting；等一个宏任务避免聚焦到 disabled input。
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0))
+  const firstInvalidFieldId = form.username.trim().length === 0
+    ? 'login-username'
+    : form.password.trim().length === 0 ? 'login-password' : undefined
+  if (firstInvalidFieldId) document.getElementById(firstInvalidFieldId)?.focus()
+}
+
+async function handleSubmit(): Promise<LoginSubmitOutcome> {
   if (submitting.value) {
-    return
+    return 'busy'
   }
   submitting.value = true
   try {
     const valid = await formRef.value?.validate().catch(() => false)
     if (!valid) {
-      return
+      void focusFirstInvalidField()
+      return 'invalid'
     }
     if (!captchaProof.value) {
       loginCaptchaRef.value?.requireVerification()
-      return
+      return 'verification-required'
     }
     // 请求发出后，界面仍可能因脚本触发变化；后续处理必须绑定本次提交身份。
     const submission = createLoginSubmission(loginMode.value, form, captchaProof.value)
@@ -180,7 +196,7 @@ async function handleSubmit() {
     } catch {
       // 请求层已展示业务或网络错误，组件只负责恢复可提交状态。
       await loginCaptchaRef.value?.reset()
-      return
+      return 'rejected'
     }
     const rememberKey = REMEMBER_KEY_PREFIX + submission.mode
     if (submission.credentials.rememberMe) {
@@ -197,19 +213,26 @@ async function handleSubmit() {
     if (result.forceChangePassword) {
       ElMessage.warning('首次登录请先修改密码')
       await router.replace({ name: 'ChangePassword' })
-      return
+      return 'navigated'
     }
     const redirect = (route.query.redirect as string) || '/'
     await router.replace(redirect)
+    return 'navigated'
   } finally {
     submitting.value = false
   }
 }
 
 async function handleCaptchaVerified(proof: string) {
-  // 滑块 proof 是一次性登录凭据；验证通过后直接续接统一提交链路，避免用户再次点击。
+  // 拼图 proof 是一次性登录凭据；验证通过后直接续接统一提交链路，避免用户再次点击。
   captchaProof.value = proof
-  await handleSubmit()
+  const outcome = await handleSubmit()
+  // 只有登录业务/网络拒绝才回到验证码入口；表单校验失败由 handleSubmit 聚焦首个无效输入，
+  // 成功导航或强制改密导航则不打断目标页面的焦点。
+  if (outcome === 'rejected' && route.name === 'Login') {
+    await nextTick()
+    loginCaptchaRef.value?.focusEntry()
+  }
 }
 
 loadRememberedUsername(loginMode.value)
@@ -222,9 +245,16 @@ onMounted(() => {
 
 <template>
   <main class="login-page">
-    <LoginBrandStage :images="bgImages" />
+    <LoginBrandStage :images="bgImages" :inert="captchaOpen" :aria-hidden="captchaOpen" />
 
-    <section ref="authSurfaceRef" class="auth-surface" data-login-scroll aria-label="身份验证">
+    <section
+      ref="authSurfaceRef"
+      class="auth-surface"
+      data-login-scroll
+      aria-label="身份验证"
+      :inert="captchaOpen"
+      :aria-hidden="captchaOpen"
+    >
       <div class="auth-toolbar">
         <span class="secure-context"><i aria-hidden="true" /> 安全登录</span>
         <ThemePresetSelector compact />
@@ -275,7 +305,15 @@ onMounted(() => {
             </button>
           </div>
 
-          <el-form ref="formRef" class="login-form" :model="form" :rules="rules" @submit.prevent="handleSubmit">
+          <el-form
+            ref="formRef"
+            class="login-form"
+            :model="form"
+            :rules="rules"
+            :inert="captchaOpen"
+            :aria-hidden="captchaOpen"
+            @submit.prevent="handleSubmit"
+          >
             <label class="field-label" for="login-username">{{ modePresentation.usernameLabel }}</label>
             <el-form-item prop="username">
               <el-input
@@ -310,6 +348,7 @@ onMounted(() => {
               :primary-text-color="primaryTextColor"
               @verified="handleCaptchaVerified"
               @invalidated="captchaProof = ''"
+              @open-change="captchaOpen = $event"
             />
 
             <div class="remember-row">

--- a/customer-admin-web/src/views/login/LoginSliderCaptcha.vue
+++ b/customer-admin-web/src/views/login/LoginSliderCaptcha.vue
@@ -9,29 +9,34 @@ type CaptchaState = 'loading' | 'ready' | 'dragging' | 'verifying' | 'verified' 
 const props = withDefaults(defineProps<{
   disabled?: boolean
   primaryTextColor?: string
-}>(), {
-  disabled: false,
-  primaryTextColor: '#ffffff',
-})
+}>(), { disabled: false, primaryTextColor: '#ffffff' })
 
 const emit = defineEmits<{
   verified: [proof: string]
   invalidated: []
+  'open-change': [open: boolean]
 }>()
 
 const TRACK_MAX = 1000
-const TRACK_COMPLETE = 980
 const CLIENT_MAX_POINTS = 80
 const HANDLE_OUTER_WIDTH = 46
+const FILL_HANDLE_OFFSET_PX = HANDLE_OUTER_WIDTH - 2
 const MIN_KEYBOARD_TRAJECTORY_MS = 320
 
+const modalRef = ref<HTMLElement>()
+const closeRef = ref<HTMLButtonElement>()
+const canvasRef = ref<HTMLElement>()
 const trackRef = ref<HTMLElement>()
 const handleRef = ref<HTMLElement>()
+const isOpen = ref(false)
 const state = ref<CaptchaState>('loading')
 const challenge = ref<LoginCaptchaChallenge>()
 const progress = ref(0)
 const handleOffsetPx = ref(0)
+const canvasWidthPx = ref(0)
+const remainingSeconds = ref(0)
 const errorMessage = ref('')
+const refreshMessage = ref('')
 
 let activePointerId: number | undefined
 let dragStartX = 0
@@ -44,70 +49,108 @@ let disposed = false
 let challengeLoadPromise: Promise<void> | undefined
 let preserveFailureIntent = false
 let expiryTimer: ReturnType<typeof setTimeout> | undefined
+let countdownTimer: ReturnType<typeof setInterval> | undefined
+let proofExpiryTimer: ReturnType<typeof setTimeout> | undefined
 let keyboardSubmitTimer: ReturnType<typeof setTimeout> | undefined
 let resizeObserver: ResizeObserver | undefined
 
 const interactionDisabled = computed(() => (
-  props.disabled
-  || !challenge.value
-  || state.value === 'loading'
-  || state.value === 'verifying'
-  || state.value === 'verified'
+  props.disabled || !challenge.value || state.value === 'loading'
+  || state.value === 'verifying' || state.value === 'verified'
 ))
 
 const statusText = computed(() => {
   switch (state.value) {
-    case 'loading':
-      return '正在准备安全验证…'
-    case 'dragging':
-      return '继续拖动，到达轨道终点'
-    case 'verifying':
-      return '正在校验拖动轨迹…'
-    case 'verified':
-      return '验证通过'
-    case 'failed':
-      return errorMessage.value || '验证未通过，请重新拖动'
-    default:
-      return '按住滑块，拖动完成验证'
+    case 'loading': return '正在准备安全验证…'
+    case 'dragging': return '拖动拼图块，对准图中的缺口'
+    case 'verifying': return '正在校验拖动轨迹…'
+    case 'verified': return '验证通过，正在登录'
+    case 'failed': return errorMessage.value || '验证未通过，请重新拖动'
+    default: return refreshMessage.value || '按住滑块，将拼图块拖到缺口处'
   }
 })
 
+const entryText = computed(() => state.value === 'verified' ? '验证通过' : '完成安全验证')
 const trackStyle = computed(() => ({
   '--captcha-handle-offset': `${handleOffsetPx.value}px`,
-  '--captcha-fill-width': state.value === 'verified' ? '100%' : `${handleOffsetPx.value + 44}px`,
+  '--captcha-fill-width': state.value === 'verified' ? '100%' : `${handleOffsetPx.value + FILL_HANDLE_OFFSET_PX}px`,
   '--captcha-thumb-text': props.primaryTextColor,
 }))
+const canvasStyle = computed(() => ({
+  aspectRatio: challenge.value ? `${challenge.value.canvasWidth} / ${challenge.value.canvasHeight}` : '2 / 1',
+}))
+const pieceStyle = computed(() => {
+  const current = challenge.value
+  const scale = current && current.canvasWidth > 0 && canvasWidthPx.value > 0
+    ? canvasWidthPx.value / current.canvasWidth : 1
+  const pieceWidth = (current?.pieceWidth ?? 0) * scale
+  const pieceHeight = (current?.pieceHeight ?? 0) * scale
+  const travel = Math.max(0, canvasWidthPx.value - pieceWidth)
+  return {
+    width: `${pieceWidth}px`,
+    height: `${pieceHeight}px`,
+    top: `${(current?.pieceY ?? 0) * scale}px`,
+    transform: `translate3d(${travel * progress.value / TRACK_MAX}px, 0, 0)`,
+  }
+})
 
 function clearExpiryTimer() {
-  if (expiryTimer) {
-    clearTimeout(expiryTimer)
-    expiryTimer = undefined
-  }
+  if (expiryTimer) clearTimeout(expiryTimer)
+  expiryTimer = undefined
+  if (countdownTimer) clearInterval(countdownTimer)
+  countdownTimer = undefined
+  remainingSeconds.value = 0
+}
+
+function clearProofExpiryTimer() {
+  if (proofExpiryTimer) clearTimeout(proofExpiryTimer)
+  proofExpiryTimer = undefined
 }
 
 function clearKeyboardSubmitTimer() {
-  if (keyboardSubmitTimer) {
-    clearTimeout(keyboardSubmitTimer)
-    keyboardSubmitTimer = undefined
+  if (keyboardSubmitTimer) clearTimeout(keyboardSubmitTimer)
+  keyboardSubmitTimer = undefined
+}
+
+function updateCountdown(expiresAt: number) {
+  remainingSeconds.value = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000))
+}
+
+function expireChallenge(generation: number) {
+  if (disposed || generation !== requestGeneration) return
+  errorMessage.value = '验证已过期，已刷新，请重新拖动'
+  state.value = 'failed'
+  if (!isOpen.value) {
+    // 浮层关闭时不继续签发 challenge，避免长期停留登录页耗尽来源限额。
+    challenge.value = undefined
+    remainingSeconds.value = 0
+    invalidateProof()
+    return
   }
+  void loadChallenge(true)
 }
 
 function scheduleExpiry(ttlSeconds: number, generation: number) {
   clearExpiryTimer()
-  expiryTimer = setTimeout(() => {
-    if (!disposed && generation === requestGeneration) {
-      void reset()
-    }
-  }, Math.max(1, ttlSeconds) * 1000)
+  const expiresAt = Date.now() + Math.max(1, ttlSeconds) * 1000
+  updateCountdown(expiresAt)
+  countdownTimer = setInterval(() => updateCountdown(expiresAt), 1000)
+  expiryTimer = setTimeout(() => expireChallenge(generation), Math.max(1, ttlSeconds) * 1000)
 }
 
 function measureTrack() {
-  if (!trackRef.value) {
-    maxTravelPx = 0
-    return
-  }
+  if (!trackRef.value) { maxTravelPx = 0; return }
   maxTravelPx = Math.max(0, trackRef.value.clientWidth - HANDLE_OUTER_WIDTH)
   handleOffsetPx.value = maxTravelPx * progress.value / TRACK_MAX
+}
+
+function measureCanvas() { canvasWidthPx.value = canvasRef.value?.clientWidth ?? 0 }
+function measureGeometry() { measureTrack(); measureCanvas() }
+function observeGeometry() {
+  resizeObserver?.disconnect()
+  if (trackRef.value) resizeObserver?.observe(trackRef.value)
+  if (canvasRef.value) resizeObserver?.observe(canvasRef.value)
+  measureGeometry()
 }
 
 function updateProgress(value: number) {
@@ -116,102 +159,149 @@ function updateProgress(value: number) {
 }
 
 function invalidateProof() {
+  clearProofExpiryTimer()
   emit('invalidated')
 }
 
-async function performChallengeLoad() {
+function scheduleProofExpiry(ttlSeconds: number) {
+  clearProofExpiryTimer()
+  proofExpiryTimer = setTimeout(() => {
+    proofExpiryTimer = undefined
+    if (disposed || state.value !== 'verified') return
+    state.value = 'failed'
+    errorMessage.value = '验证结果已过期，请重新验证'
+    challenge.value = undefined
+    trajectory = []
+    updateProgress(0)
+    emit('invalidated')
+  }, Math.max(1, ttlSeconds) * 1000)
+}
+
+async function performChallengeLoad(announceRefresh = false) {
   const generation = ++requestGeneration
   clearExpiryTimer()
-  clearKeyboardSubmitTimer()
   challenge.value = undefined
   trajectory = []
   activePointerId = undefined
   updateProgress(0)
   invalidateProof()
+  refreshMessage.value = ''
   try {
     const nextChallenge = await fetchLoginCaptchaChallenge()
-    if (disposed || generation !== requestGeneration) {
-      return
-    }
+    if (disposed || generation !== requestGeneration) return
     challenge.value = nextChallenge
     state.value = preserveFailureIntent ? 'failed' : 'ready'
+    if (announceRefresh && !preserveFailureIntent) refreshMessage.value = '验证已刷新，请重新拖动'
+    await nextTick()
+    measureGeometry()
     scheduleExpiry(nextChallenge.ttlSeconds, generation)
   } catch (error) {
-    if (disposed || generation !== requestGeneration) {
-      return
-    }
+    if (disposed || generation !== requestGeneration) return
+    remainingSeconds.value = 0
     state.value = 'failed'
-    errorMessage.value = getRequestErrorMessage(error, '验证服务暂不可用，点击滑块重试')
+    errorMessage.value = getRequestErrorMessage(error, '验证服务暂不可用，请刷新后重试')
   }
 }
 
-function loadChallenge(preserveFailure = false): Promise<void> {
+function loadChallenge(preserveFailure = false, announceRefresh = false): Promise<void> {
   // 网络请求保持 single-flight，展示状态以最后一次用户操作为准。
   preserveFailureIntent = preserveFailure
-  if (!preserveFailure) {
-    state.value = 'loading'
-    errorMessage.value = ''
-  }
-  if (challengeLoadPromise) {
-    return challengeLoadPromise
-  }
-  const pending = performChallengeLoad()
+  if (!preserveFailure) { state.value = 'loading'; errorMessage.value = '' }
+  if (challengeLoadPromise) return challengeLoadPromise
+  const pending = performChallengeLoad(announceRefresh)
   challengeLoadPromise = pending
   void pending.finally(() => {
-    if (challengeLoadPromise === pending) {
-      challengeLoadPromise = undefined
-    }
+    if (challengeLoadPromise === pending) challengeLoadPromise = undefined
   })
   return pending
 }
 
-async function reset() {
-  await loadChallenge(false)
+async function reset(announceRefresh = false) { await loadChallenge(false, announceRefresh) }
+
+function openModal(force = false) {
+  if (!force && props.disabled) return
+  isOpen.value = true
+  emit('open-change', true)
+  if (!challenge.value && !challengeLoadPromise) void reset()
+  void nextTick(() => {
+    observeGeometry()
+    closeRef.value?.focus()
+  })
+}
+
+function cancelActiveVerification() {
+  requestGeneration += 1
+  clearExpiryTimer()
+  clearKeyboardSubmitTimer()
+  challenge.value = undefined
+  trajectory = []
+  state.value = 'failed'
+  errorMessage.value = '验证已取消，请重新验证'
+  updateProgress(0)
+  invalidateProof()
+}
+
+function cancelActiveDrag() {
+  const pointerId = activePointerId
+  activePointerId = undefined
+  if (pointerId !== undefined && handleRef.value?.hasPointerCapture(pointerId)) {
+    handleRef.value.releasePointerCapture(pointerId)
+  }
+  clearKeyboardSubmitTimer()
+  trajectory = []
+  updateProgress(0)
+  if (state.value === 'dragging') state.value = challenge.value ? 'ready' : 'loading'
+}
+
+function focusEntry() {
+  document.querySelector<HTMLButtonElement>('[data-login-captcha-entry]:not(:disabled)')?.focus()
+}
+
+function closeModal(restoreFocus = true) {
+  if (state.value === 'verifying') cancelActiveVerification()
+  else if (state.value === 'dragging' || activePointerId !== undefined) cancelActiveDrag()
+  resizeObserver?.disconnect()
+  isOpen.value = false
+  emit('open-change', false)
+  void nextTick(() => {
+    if (!disposed && restoreFocus) focusEntry()
+  })
+}
+
+function handleCloseClick() {
+  closeModal()
 }
 
 function requireVerification() {
-  if (state.value === 'loading' || state.value === 'verifying') {
-    return
+  if (challenge.value && state.value === 'ready') {
+    state.value = 'failed'
+    errorMessage.value = '请先完成拖动验证'
   }
-  state.value = 'failed'
-  errorMessage.value = challenge.value ? '请先完成拖动验证' : '验证服务暂不可用，点击滑块重试'
-  updateProgress(0)
-  void nextTick(() => handleRef.value?.focus())
+  openModal(true)
+  if (!challenge.value && !challengeLoadPromise) void reset()
 }
 
 function normalizedPoint(clientX: number, clientY: number, elapsed: number): LoginCaptchaTrackPoint {
   const x = maxTravelPx <= 0 ? 0 : Math.round((clientX - dragStartX) / maxTravelPx * TRACK_MAX)
   const trackHeight = Math.max(trackRef.value?.clientHeight ?? 1, 1)
   const y = Math.round((clientY - dragStartY) / trackHeight * TRACK_MAX)
-  return {
-    x: Math.min(TRACK_MAX, Math.max(0, x)),
-    y: Math.min(TRACK_MAX, Math.max(-TRACK_MAX, y)),
-    t: Math.max(0, Math.round(elapsed)),
-  }
+  return { x: Math.min(TRACK_MAX, Math.max(0, x)), y: Math.min(TRACK_MAX, Math.max(-TRACK_MAX, y)), t: Math.max(0, Math.round(elapsed)) }
 }
 
 function appendPoint(point: LoginCaptchaTrackPoint, force = false) {
   const previous = trajectory.at(-1)
-  if (previous && point.t <= previous.t) {
-    point = { ...point, t: previous.t + 1 }
-  }
-  if (!force && previous && previous.x === point.x && previous.y === point.y) {
-    return
-  }
-  if (trajectory.length >= CLIENT_MAX_POINTS) {
-    trajectory[CLIENT_MAX_POINTS - 1] = point
-    return
-  }
+  if (previous && point.t <= previous.t) point = { ...point, t: previous.t + 1 }
+  if (!force && previous && previous.x === point.x && previous.y === point.y) return
+  if (trajectory.length >= CLIENT_MAX_POINTS) { trajectory[CLIENT_MAX_POINTS - 1] = point; return }
   trajectory.push(point)
 }
 
 function beginDrag(clientX: number, clientY: number) {
-  measureTrack()
-  if (maxTravelPx <= 0) {
-    return false
-  }
+  measureGeometry()
+  if (maxTravelPx <= 0) return false
   state.value = 'dragging'
   errorMessage.value = ''
+  refreshMessage.value = ''
   dragStartX = clientX
   dragStartY = clientY
   dragStartAt = performance.now()
@@ -221,16 +311,9 @@ function beginDrag(clientX: number, clientY: number) {
 }
 
 function handlePointerDown(event: PointerEvent) {
-  if (props.disabled || event.button !== 0) {
-    return
-  }
-  if (!challenge.value) {
-    void reset()
-    return
-  }
-  if (interactionDisabled.value || !beginDrag(event.clientX, event.clientY)) {
-    return
-  }
+  if (props.disabled || event.button !== 0) return
+  if (!challenge.value) { void reset(); return }
+  if (interactionDisabled.value || !beginDrag(event.clientX, event.clientY)) return
   activePointerId = event.pointerId
   handleRef.value?.setPointerCapture(event.pointerId)
   handleRef.value?.focus()
@@ -238,9 +321,7 @@ function handlePointerDown(event: PointerEvent) {
 }
 
 function handlePointerMove(event: PointerEvent) {
-  if (state.value !== 'dragging' || activePointerId !== event.pointerId) {
-    return
-  }
+  if (state.value !== 'dragging' || activePointerId !== event.pointerId) return
   const point = normalizedPoint(event.clientX, event.clientY, performance.now() - dragStartAt)
   updateProgress(point.x)
   appendPoint(point)
@@ -248,38 +329,30 @@ function handlePointerMove(event: PointerEvent) {
 }
 
 function releasePointer(pointerId: number) {
-  if (handleRef.value?.hasPointerCapture(pointerId)) {
-    handleRef.value.releasePointerCapture(pointerId)
-  }
   activePointerId = undefined
+  if (handleRef.value?.hasPointerCapture(pointerId)) handleRef.value.releasePointerCapture(pointerId)
 }
 
 async function submitTrajectory() {
   const currentChallenge = challenge.value
-  if (!currentChallenge) {
-    await reset()
-    return
-  }
+  if (!currentChallenge) { await reset(); return }
   const generation = ++requestGeneration
   state.value = 'verifying'
-  challenge.value = undefined
   clearExpiryTimer()
   try {
     const result = await verifyLoginCaptcha({
       challengeId: currentChallenge.challengeId,
+      placementX: progress.value,
       trajectory: trajectory.map((point) => ({ ...point })),
     })
-    if (disposed || generation !== requestGeneration) {
-      return
-    }
+    if (disposed || generation !== requestGeneration) return
+    challenge.value = undefined
     state.value = 'verified'
-    updateProgress(TRACK_MAX)
+    scheduleProofExpiry(result.ttlSeconds)
     emit('verified', result.proof)
-    scheduleExpiry(result.ttlSeconds, generation)
+    closeModal(false)
   } catch (error) {
-    if (disposed || generation !== requestGeneration) {
-      return
-    }
+    if (disposed || generation !== requestGeneration) return
     state.value = 'failed'
     errorMessage.value = getRequestErrorMessage(error, '验证未通过，请重新拖动')
     updateProgress(0)
@@ -287,33 +360,34 @@ async function submitTrajectory() {
   }
 }
 
+function scheduleKeyboardSubmit() {
+  const challengeId = challenge.value?.challengeId
+  if (!challengeId) return
+  const generation = requestGeneration
+  const placementX = progress.value
+  const elapsed = performance.now() - dragStartAt
+  state.value = 'verifying'
+  clearKeyboardSubmitTimer()
+  keyboardSubmitTimer = setTimeout(() => {
+    keyboardSubmitTimer = undefined
+    if (disposed || generation !== requestGeneration || challenge.value?.challengeId !== challengeId) return
+    appendPoint({ x: placementX, y: 0, t: Math.max(MIN_KEYBOARD_TRAJECTORY_MS, Math.round(performance.now() - dragStartAt)) }, true)
+    void submitTrajectory()
+  }, Math.max(0, MIN_KEYBOARD_TRAJECTORY_MS - elapsed))
+}
+
 function finishDrag(event: PointerEvent) {
-  if (state.value !== 'dragging' || activePointerId !== event.pointerId) {
-    return
-  }
+  if (state.value !== 'dragging' || activePointerId !== event.pointerId) return
   const point = normalizedPoint(event.clientX, event.clientY, performance.now() - dragStartAt)
   appendPoint(point, true)
   updateProgress(point.x)
   releasePointer(event.pointerId)
-  if (progress.value < TRACK_COMPLETE) {
-    state.value = 'failed'
-    errorMessage.value = '请拖动到轨道终点'
-    trajectory = []
-    updateProgress(0)
-    return
-  }
-  // 到达终点时把最后一点统一为 1000，避免不同轨道像素宽度影响服务端判断。
-  const last = trajectory.at(-1)
-  if (last && last.x !== TRACK_MAX) {
-    trajectory[trajectory.length - 1] = { ...last, x: TRACK_MAX }
-  }
+  // targetX 不会下发客户端；释放位置就是本次 placementX，由服务端判定是否对准缺口。
   void submitTrajectory()
 }
 
 function handlePointerCancel(event: PointerEvent) {
-  if (activePointerId !== event.pointerId) {
-    return
-  }
+  if (activePointerId !== event.pointerId) return
   releasePointer(event.pointerId)
   state.value = 'failed'
   errorMessage.value = '拖动已取消，请重新验证'
@@ -321,72 +395,68 @@ function handlePointerCancel(event: PointerEvent) {
   updateProgress(0)
 }
 
+function handleLostPointerCapture(event: PointerEvent) {
+  if (state.value !== 'dragging' || activePointerId !== event.pointerId) return
+  activePointerId = undefined
+  trajectory = []
+  state.value = 'failed'
+  errorMessage.value = '拖动已中断，请重新验证'
+  updateProgress(0)
+}
+
 function appendKeyboardPoint(nextProgress: number) {
-  const elapsed = performance.now() - dragStartAt
-  appendPoint({ x: nextProgress, y: 0, t: Math.round(elapsed) }, true)
+  appendPoint({ x: nextProgress, y: 0, t: Math.round(performance.now() - dragStartAt) }, true)
   updateProgress(nextProgress)
 }
 
-function scheduleKeyboardSubmit() {
-  const challengeId = challenge.value?.challengeId
-  if (!challengeId) {
-    return
-  }
-  const generation = requestGeneration
-  const elapsed = performance.now() - dragStartAt
-  state.value = 'verifying'
-  clearKeyboardSubmitTimer()
-  keyboardSubmitTimer = setTimeout(() => {
-    keyboardSubmitTimer = undefined
-    if (disposed || generation !== requestGeneration || challenge.value?.challengeId !== challengeId) {
-      return
-    }
-    appendPoint({
-      x: TRACK_MAX,
-      y: 0,
-      t: Math.max(MIN_KEYBOARD_TRAJECTORY_MS, Math.round(performance.now() - dragStartAt)),
-    }, true)
-    void submitTrajectory()
-  }, Math.max(0, MIN_KEYBOARD_TRAJECTORY_MS - elapsed))
-}
-
 function handleKeydown(event: KeyboardEvent) {
-  if (props.disabled || state.value === 'loading' || state.value === 'verifying' || state.value === 'verified') {
-    return
-  }
+  if (props.disabled || state.value === 'loading' || state.value === 'verifying' || state.value === 'verified') return
   if (!challenge.value) {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      void reset()
-    }
+    if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); void reset() }
     return
   }
   if (event.key === 'Home') {
+    event.preventDefault(); state.value = 'ready'; trajectory = []; updateProgress(0); return
+  }
+  if (event.key === 'End') {
     event.preventDefault()
-    state.value = 'ready'
-    trajectory = []
-    updateProgress(0)
+    if (state.value !== 'dragging' && !beginDrag(0, 0)) return
+    appendKeyboardPoint(TRACK_MAX)
     return
   }
-  if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
-    return
-  }
-  event.preventDefault()
-  if (state.value !== 'dragging' && !beginDrag(0, 0)) {
-    return
-  }
-  const direction = event.key === 'ArrowRight' ? 1 : -1
-  appendKeyboardPoint(Math.min(TRACK_MAX, Math.max(0, progress.value + direction * 100)))
-  if (progress.value === TRACK_MAX) {
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    if (state.value !== 'dragging' && !beginDrag(0, 0)) return
+    appendKeyboardPoint(progress.value)
     scheduleKeyboardSubmit()
+    return
   }
+  if (!['ArrowRight', 'ArrowLeft', 'PageUp', 'PageDown'].includes(event.key)) return
+  event.preventDefault()
+  if (state.value !== 'dragging' && !beginDrag(0, 0)) return
+  const direction = event.key === 'ArrowRight' || event.key === 'PageUp' ? 1 : -1
+  const step = event.shiftKey || event.key === 'PageUp' || event.key === 'PageDown' ? 100 : 20
+  appendKeyboardPoint(Math.min(TRACK_MAX, Math.max(0, progress.value + direction * step)))
+}
+
+function focusableElements() {
+  return Array.from(modalRef.value?.querySelectorAll<HTMLElement>('button:not([disabled]), [tabindex]:not([tabindex="-1"])') ?? [])
+}
+
+function handleModalKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') { event.preventDefault(); closeModal(); return }
+  if (event.key !== 'Tab') return
+  const focusables = focusableElements()
+  if (!focusables.length) { event.preventDefault(); modalRef.value?.focus(); return }
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
+  else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
 }
 
 onMounted(() => {
-  resizeObserver = new ResizeObserver(measureTrack)
-  if (trackRef.value) {
-    resizeObserver.observe(trackRef.value)
-  }
+  resizeObserver = new ResizeObserver(measureGeometry)
+  observeGeometry()
   void reset()
 })
 
@@ -394,297 +464,111 @@ onBeforeUnmount(() => {
   disposed = true
   requestGeneration += 1
   clearExpiryTimer()
+  clearProofExpiryTimer()
   clearKeyboardSubmitTimer()
   resizeObserver?.disconnect()
 })
 
-defineExpose({ reset, requireVerification })
+defineExpose({ reset, requireVerification, focusEntry })
 </script>
 
 <template>
   <div class="login-captcha">
-    <div class="captcha-label">
-      <span>安全验证</span>
-      <small>GUARD · 安全拖动确认</small>
-    </div>
-    <div
-      ref="trackRef"
-      class="captcha-track"
-      :class="`is-${state}`"
-      :style="trackStyle"
-      data-login-captcha
-    >
-      <span class="captcha-fill" aria-hidden="true" />
-      <span class="captcha-copy" :class="{ 'is-error': state === 'failed' }" aria-live="polite">
-        {{ statusText }}
-      </span>
-      <span class="captcha-route" aria-hidden="true"><i /><i /><i /><i /><i /></span>
-      <span class="captcha-shield" aria-hidden="true">
-        <svg viewBox="0 0 24 24">
-          <path d="M12 3.4 19 6v5.1c0 4.4-2.8 8-7 9.5-4.2-1.5-7-5.1-7-9.5V6l7-2.6Z" />
-          <path d="m9 12 2 2 4-4" />
-        </svg>
-      </span>
-      <span
-        ref="handleRef"
-        class="captcha-handle"
-        role="slider"
-        tabindex="0"
-        aria-label="拖动验证码"
-        aria-valuemin="0"
-        aria-valuemax="100"
-        :aria-valuenow="Math.round(progress / 10)"
-        :aria-valuetext="statusText"
-        :aria-disabled="interactionDisabled"
-        @pointerdown="handlePointerDown"
-        @pointermove="handlePointerMove"
-        @pointerup="finishDrag"
-        @pointercancel="handlePointerCancel"
-        @keydown="handleKeydown"
-      >
-        <svg v-if="state === 'verified'" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="m5 12.5 4.2 4.2L19 7" />
-        </svg>
-        <svg v-else-if="state === 'failed' && !challenge" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M18.3 8.2A7.6 7.6 0 1 0 19.5 14" />
-          <path d="M18.3 4.5v3.7h-3.7" />
-        </svg>
-        <svg v-else viewBox="0 0 24 24" aria-hidden="true">
-          <path d="m6 7 5 5-5 5" />
-          <path d="m11 7 5 5-5 5" />
-        </svg>
-      </span>
-    </div>
-    <p class="keyboard-hint">可拖动滑块，或聚焦后使用左右方向键完成验证</p>
+    <button type="button" class="captcha-entry" data-login-captcha-entry :disabled="disabled" :aria-expanded="isOpen" aria-controls="login-captcha-dialog" @click="openModal()">
+      <span class="captcha-entry-icon" aria-hidden="true"><i /><i /></span>
+      <span><strong aria-live="polite">{{ entryText }}</strong><small>{{ state === 'failed' ? '验证失败，点击重试' : '完成拼图后自动继续登录' }}</small></span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 6 6 6-6 6" /></svg>
+    </button>
+
+    <Teleport to="body">
+      <div v-if="isOpen" class="captcha-layer" @click.self="handleCloseClick">
+        <section id="login-captcha-dialog" ref="modalRef" class="captcha-dialog" role="dialog" aria-modal="true" aria-labelledby="login-captcha-title" tabindex="-1" @keydown="handleModalKeydown">
+          <header class="captcha-dialog-header">
+            <div><p class="captcha-kicker">SECURITY CHECK</p><h2 id="login-captcha-title">完成安全验证</h2></div>
+            <div class="captcha-header-actions">
+              <button type="button" class="captcha-icon-button" data-login-captcha-refresh aria-label="刷新验证" :disabled="state === 'loading' || state === 'verifying'" @click="reset(true)">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 11a8 8 0 0 0-14.8-4L4 9" /><path d="M4 4v5h5" /><path d="M4 13a8 8 0 0 0 14.8 4L20 15" /><path d="M20 20v-5h-5" /></svg>
+              </button>
+              <button ref="closeRef" type="button" class="captcha-icon-button" aria-label="关闭安全验证" @click="handleCloseClick">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18" /></svg>
+              </button>
+            </div>
+          </header>
+          <div class="captcha-dialog-body">
+            <p class="captcha-instruction">拖动下方滑块，让拼图块与图中的缺口重合</p>
+            <div ref="canvasRef" class="captcha-canvas" :class="`is-${state}`" :style="canvasStyle" role="img" aria-label="登录安全验证拼图">
+              <img v-if="challenge" class="captcha-background" :src="challenge.backgroundImage" alt="拼图背景" draggable="false">
+              <img v-if="challenge" class="captcha-piece" :style="pieceStyle" :src="challenge.puzzlePieceImage" alt="可移动拼图块" draggable="false">
+              <div v-if="state === 'loading'" class="captcha-canvas-loading">正在加载拼图…</div>
+            </div>
+            <div ref="trackRef" class="captcha-track" :class="`is-${state}`" :style="trackStyle" data-login-captcha>
+              <span class="captcha-fill" aria-hidden="true" /><span class="captcha-copy" :class="{ 'is-error': state === 'failed' }" aria-live="polite">{{ statusText }}</span>
+              <span ref="handleRef" class="captcha-handle" role="slider" tabindex="0" aria-label="拖动验证码" aria-valuemin="0" aria-valuemax="1000" :aria-valuenow="progress" :aria-valuetext="`${statusText}，当前位置 ${progress}/1000`" :aria-disabled="interactionDisabled" @pointerdown="handlePointerDown" @pointermove="handlePointerMove" @pointerup="finishDrag" @pointercancel="handlePointerCancel" @lostpointercapture="handleLostPointerCapture" @keydown="handleKeydown">
+                <svg v-if="state === 'verified'" viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12.5 4.2 4.2L19 7" /></svg>
+                <svg v-else-if="state === 'failed' && !challenge" viewBox="0 0 24 24" aria-hidden="true"><path d="M18.3 8.2A7.6 7.6 0 1 0 19.5 14" /><path d="M18.3 4.5v3.7h-3.7" /></svg>
+                <svg v-else viewBox="0 0 24 24" aria-hidden="true"><path d="m6 7 5 5-5 5" /><path d="m11 7 5 5-5 5" /></svg>
+              </span>
+            </div>
+            <div class="captcha-meta"><span aria-live="polite">{{ remainingSeconds > 0 ? `本次验证剩余 ${remainingSeconds} 秒` : '等待验证挑战' }}</span><span>支持鼠标、触摸和键盘</span></div>
+          </div>
+        </section>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <style scoped>
-.login-captcha {
-  margin-bottom: 18px;
-}
-
-.captcha-label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 7px;
-  color: var(--el-text-color-primary);
-  font-size: 13px;
-  font-weight: 650;
-}
-
-.captcha-label small {
-  color: var(--el-color-primary-dark-2);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.11em;
-}
-
-.captcha-track {
-  position: relative;
-  box-sizing: border-box;
-  width: 100%;
-  height: 48px;
-  overflow: hidden;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 8px;
-  background: linear-gradient(180deg, var(--el-fill-color-blank), var(--el-fill-color-extra-light));
-  box-shadow: inset 0 1px 2px rgba(25, 18, 52, 0.03);
-  user-select: none;
-}
-
-.captcha-track.is-failed {
-  border-color: var(--el-color-danger-light-5);
-  background: var(--el-color-danger-light-9);
-}
-
-.captcha-track.is-verified {
-  border-color: var(--el-color-success-light-5);
-  background: var(--el-color-success-light-9);
-}
-
-.captcha-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: var(--captcha-fill-width);
-  background: linear-gradient(90deg, var(--el-color-primary-light-8), transparent);
-  transition: width 100ms ease-out;
-}
-
-.is-verified .captcha-fill {
-  background: var(--el-color-success-light-8);
-}
-
-.is-failed .captcha-fill {
-  background: var(--el-color-danger-light-8);
-}
-
-.captcha-copy {
-  position: absolute;
-  inset: 0 48px 0 50px;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
-  color: var(--el-text-color-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.is-dragging .captcha-copy,
-.is-verifying .captcha-copy {
-  color: var(--el-color-primary-dark-2);
-}
-
-.is-verified .captcha-copy {
-  color: var(--el-color-success-dark-2, #168d78);
-  font-weight: 650;
-}
-
-.captcha-copy.is-error {
-  color: var(--el-color-danger-dark-2, #bd4f5a);
-}
-
-.captcha-route {
-  position: absolute;
-  right: 70px;
-  bottom: 6px;
-  left: 66px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.captcha-route::before {
-  position: absolute;
-  right: 2px;
-  left: 2px;
-  height: 1px;
-  background: linear-gradient(90deg, var(--el-color-primary-light-5), var(--el-color-primary-light-9));
-  content: '';
-}
-
-.captcha-route i {
-  position: relative;
-  z-index: 1;
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
-  background: var(--el-color-primary-light-5);
-}
-
-.is-verified .captcha-route i {
-  background: var(--el-color-success-light-3);
-}
-
-.is-failed .captcha-route i {
-  background: var(--el-color-danger-light-5);
-}
-
-.captcha-shield {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  width: 18px;
-  height: 18px;
-  color: var(--el-text-color-placeholder);
-}
-
-.captcha-shield svg,
-.captcha-handle svg {
-  width: 100%;
-  height: 100%;
-  fill: none;
-  stroke: currentColor;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 1.8;
-}
-
-.captcha-handle {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  display: grid;
-  width: 42px;
-  height: 42px;
-  box-sizing: border-box;
-  place-items: center;
-  border-radius: 6px;
-  background: linear-gradient(135deg, var(--theme-primary-solid, var(--el-color-primary)), var(--theme-primary-solid-active, var(--el-color-primary-dark-2)));
-  box-shadow: 0 5px 14px color-mix(in srgb, var(--theme-primary-solid, var(--el-color-primary)) 28%, transparent);
-  color: var(--captcha-thumb-text);
-  cursor: grab;
-  outline: none;
-  touch-action: none;
-  transform: translate3d(var(--captcha-handle-offset), 0, 0);
-  transition: transform 100ms ease-out, background-color 160ms ease-out, box-shadow 160ms ease-out;
-}
-
-.captcha-handle:focus-visible {
-  box-shadow: 0 0 0 3px var(--el-color-primary-light-7),
-    0 5px 14px color-mix(in srgb, var(--el-color-primary) 28%, transparent);
-}
-
-.is-dragging .captcha-handle {
-  cursor: grabbing;
-  transition: none;
-}
-
-.is-loading .captcha-handle,
-.is-verifying .captcha-handle {
-  cursor: wait;
-  opacity: 0.78;
-}
-
-.is-verified .captcha-handle {
-  color: var(--cw-on-success, #fff);
-  background: linear-gradient(135deg, var(--cw-success-solid, #16856a), var(--cw-success-solid-active, #127159));
-  box-shadow: 0 5px 14px color-mix(in srgb, var(--cw-success-solid, #16856a) 24%, transparent);
-  cursor: default;
-}
-
-.is-failed .captcha-handle {
-  color: var(--cw-on-danger, #fff);
-  background: linear-gradient(135deg, var(--cw-danger-solid, #c2414b), var(--cw-danger-solid-active, #a63840));
-  box-shadow: 0 5px 14px color-mix(in srgb, var(--cw-danger-solid, #c2414b) 20%, transparent);
-  transition: background-color 160ms ease-out, box-shadow 160ms ease-out;
-}
-
-.captcha-handle svg {
-  width: 21px;
-  height: 21px;
-}
-
-.keyboard-hint {
-  margin: 5px 2px 0;
-  color: var(--el-text-color-placeholder);
-  font-size: 10px;
-  line-height: 1.4;
-  text-align: right;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .captcha-fill,
-  .captcha-handle {
-    transition: none;
-  }
-}
-
-@media (max-width: 480px) {
-  .captcha-label small {
-    letter-spacing: 0.06em;
-  }
-
-  .captcha-copy {
-    font-size: 12px;
-  }
-
-  .keyboard-hint {
-    display: none;
-  }
-}
+.login-captcha { margin-bottom: 18px; }
+.captcha-entry { display: flex; width: 100%; min-height: 58px; align-items: center; gap: 12px; box-sizing: border-box; padding: 9px 14px; border: 1px solid var(--el-border-color); border-radius: 12px; background: linear-gradient(120deg, var(--el-fill-color-blank), var(--el-color-primary-light-9)); color: var(--el-text-color-primary); font: inherit; text-align: left; cursor: pointer; transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease; }
+.captcha-entry:hover:not(:disabled) { border-color: var(--el-color-primary-light-3); box-shadow: 0 8px 24px rgba(49, 69, 160, 0.12); transform: translateY(-1px); }
+.captcha-entry:focus-visible, .captcha-icon-button:focus-visible, .captcha-handle:focus-visible { outline: 3px solid var(--el-color-primary-light-5); outline-offset: 2px; }
+.captcha-entry:disabled { cursor: wait; opacity: .72; }
+.captcha-entry-icon { position: relative; display: grid; width: 30px; height: 30px; flex: none; place-items: center; border-radius: 9px; background: var(--el-color-primary); }
+.captcha-entry-icon::before, .captcha-entry-icon::after, .captcha-entry-icon i { position: absolute; display: block; border: 1.5px solid #fff; content: ''; }
+.captcha-entry-icon::before { width: 13px; height: 13px; border-radius: 3px; }
+.captcha-entry-icon::after { width: 6px; height: 6px; border-radius: 2px; background: var(--el-color-primary); }
+.captcha-entry-icon i:first-child, .captcha-entry-icon i:last-child { width: 4px; height: 4px; border: 0; border-radius: 50%; background: #fff; }
+.captcha-entry-icon i:first-child { transform: translate(-8px, -8px); }
+.captcha-entry-icon i:last-child { transform: translate(8px, 8px); }
+.captcha-entry strong, .captcha-entry small { display: block; }
+.captcha-entry strong { font-size: 13px; font-weight: 700; }
+.captcha-entry small { margin-top: 2px; color: var(--el-text-color-secondary); font-size: 12px; }
+.captcha-entry > svg { width: 18px; height: 18px; margin-left: auto; fill: none; stroke: var(--el-color-primary); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2; }
+.captcha-layer { position: fixed; z-index: 3000; inset: 0; display: flex; align-items: center; justify-content: flex-end; padding: 24px clamp(20px, 3vw, 52px); box-sizing: border-box; background: rgba(13, 22, 57, .38); backdrop-filter: blur(3px); }
+.captcha-dialog { width: min(424px, calc(100vw - 40px)); max-height: min(680px, calc(100svh - 48px)); overflow: hidden auto; border: 1px solid color-mix(in srgb, var(--el-color-primary) 20%, var(--el-border-color)); border-radius: 18px; background: var(--el-bg-color); box-shadow: 0 24px 70px rgba(14, 23, 63, .28); color: var(--el-text-color-primary); }
+.captcha-dialog-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 22px 22px 16px; background: linear-gradient(135deg, var(--el-color-primary-light-9), var(--el-bg-color)); }
+.captcha-kicker { margin: 0 0 5px; color: var(--el-color-primary); font-size: 10px; font-weight: 750; letter-spacing: .14em; }
+.captcha-dialog h2 { margin: 0; font-size: 20px; line-height: 1.25; }
+.captcha-header-actions { display: flex; gap: 4px; }
+.captcha-icon-button { display: inline-grid; width: 44px; height: 44px; flex: none; place-items: center; border: 0; border-radius: 10px; background: transparent; color: var(--el-text-color-secondary); cursor: pointer; }
+.captcha-icon-button:hover:not(:disabled) { background: var(--el-color-primary-light-9); color: var(--el-color-primary); }
+.captcha-icon-button:disabled { cursor: wait; opacity: .5; }
+.captcha-icon-button svg { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
+.captcha-dialog-body { padding: 0 22px 23px; }
+.captcha-instruction { margin: 0 0 13px; color: var(--el-text-color-secondary); font-size: 13px; line-height: 1.5; }
+.captcha-canvas { position: relative; width: 100%; min-height: 120px; overflow: hidden; border: 1px solid var(--el-border-color-lighter); border-radius: 10px; background: var(--el-fill-color-extra-light); }
+.captcha-background, .captcha-piece { position: absolute; inset: 0 auto auto 0; display: block; max-width: none; user-select: none; }
+.captcha-background { width: 100%; height: 100%; object-fit: fill; }
+.captcha-piece { z-index: 1; will-change: transform; }
+.captcha-canvas-loading { position: absolute; inset: 0; display: grid; place-items: center; color: var(--el-text-color-secondary); font-size: 13px; }
+.captcha-track { position: relative; width: 100%; height: 48px; box-sizing: border-box; margin-top: 16px; overflow: hidden; border: 1px solid var(--el-border-color-lighter); border-radius: 10px; background: linear-gradient(180deg, var(--el-fill-color-blank), var(--el-fill-color-extra-light)); user-select: none; }
+.captcha-track.is-failed { border-color: var(--el-color-danger-light-5); background: var(--el-color-danger-light-9); }
+.captcha-track.is-verified { border-color: var(--el-color-success-light-5); background: var(--el-color-success-light-9); }
+.captcha-fill { position: absolute; inset: 0 auto 0 0; width: var(--captcha-fill-width); background: linear-gradient(90deg, var(--el-color-primary-light-8), transparent); transition: width 100ms ease-out; }
+.is-verified .captcha-fill { background: var(--el-color-success-light-8); }
+.is-failed .captcha-fill { background: var(--el-color-danger-light-8); }
+.captcha-copy { position: absolute; inset: 0 48px 0 50px; display: grid; place-items: center; overflow: hidden; color: var(--el-text-color-secondary); font-size: 13px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.is-dragging .captcha-copy, .is-verifying .captcha-copy { color: var(--el-color-primary-dark-2); }
+.is-verified .captcha-copy { color: var(--el-color-success-dark-2, #168d78); font-weight: 650; }
+.captcha-copy.is-error { color: var(--el-color-danger-dark-2, #bd4f5a); }
+.captcha-handle { position: absolute; top: 2px; left: 2px; display: grid; width: 42px; height: 42px; box-sizing: border-box; place-items: center; border-radius: 7px; background: linear-gradient(135deg, var(--theme-primary-solid, var(--el-color-primary)), var(--theme-primary-solid-active, var(--el-color-primary-dark-2))); box-shadow: 0 5px 14px color-mix(in srgb, var(--theme-primary-solid, var(--el-color-primary)) 28%, transparent); color: var(--captcha-thumb-text); cursor: grab; outline: none; touch-action: none; transform: translate3d(var(--captcha-handle-offset), 0, 0); transition: transform 100ms ease-out, background-color 160ms ease-out, box-shadow 160ms ease-out; }
+.is-dragging .captcha-handle { cursor: grabbing; transition: none; }
+.is-loading .captcha-handle, .is-verifying .captcha-handle { cursor: wait; opacity: .78; }
+.is-verified .captcha-handle { color: var(--cw-on-success, #fff); background: var(--cw-success-solid, #16856a); cursor: default; }
+.is-failed .captcha-handle { color: var(--cw-on-danger, #fff); background: var(--cw-danger-solid, #c2414b); }
+.captcha-handle svg { width: 21px; height: 21px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
+.captcha-meta { display: flex; justify-content: space-between; gap: 10px; margin-top: 9px; color: var(--el-text-color-placeholder); font-size: 12px; line-height: 1.4; }
+@media (prefers-reduced-motion: reduce) { .captcha-entry, .captcha-fill, .captcha-handle { transition: none; } }
+@media (max-width: 899px) { .captcha-layer { align-items: flex-end; padding: 0; } .captcha-dialog { width: 100%; max-height: min(92svh, 620px); border-radius: 18px 18px 0 0; border-bottom: 0; } }
+@media (max-width: 380px), (max-height: 520px) { .captcha-dialog { max-height: 96svh; } .captcha-dialog-header { padding: 14px 16px 10px; } .captcha-dialog-body { padding: 0 16px 16px; } .captcha-dialog h2 { font-size: 18px; } .captcha-instruction { margin-bottom: 8px; } .captcha-track { margin-top: 10px; } .captcha-meta { font-size: 11px; } }
 </style>

--- a/customer-admin-web/tests/e2e/admin-shell.e2e.ts
+++ b/customer-admin-web/tests/e2e/admin-shell.e2e.ts
@@ -2,6 +2,8 @@ import { expect, test } from './fixtures/adminTestFixture'
 import type { Page, Route } from '@playwright/test'
 import { SQL_REPORT_MENU_TITLE, SQL_REPORT_PATH } from './fixtures/adminRoutes'
 
+const TEST_CAPTCHA_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9WnWQAAAAASUVORK5CYII='
+
 type RgbColor = readonly [number, number, number]
 
 function parseCssColor(rawColor: string): RgbColor {
@@ -461,6 +463,13 @@ test.describe('后台壳层契约', () => {
     await page.route('**/api/auth/login-captcha/challenge', (route) => fulfill(route, {
       challengeId: 'theme-entry-challenge',
       ttlSeconds: 120,
+      backgroundImage: TEST_CAPTCHA_IMAGE,
+      puzzlePieceImage: TEST_CAPTCHA_IMAGE,
+      canvasWidth: 320,
+      canvasHeight: 160,
+      pieceWidth: 56,
+      pieceHeight: 56,
+      pieceY: 52,
     }))
 
     await page.goto('/login', { waitUntil: 'domcontentloaded' })

--- a/customer-admin-web/tests/e2e/login.e2e.ts
+++ b/customer-admin-web/tests/e2e/login.e2e.ts
@@ -23,6 +23,15 @@ const PASSWORD_TOO_WEAK_CODE = 30011
 const EMAIL_CODE_INVALID_CODE = 30012
 const EMAIL_CODE_REISSUE_REQUIRED_CODE = 30013
 const TEST_CAPTCHA_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9WnWQAAAAASUVORK5CYII='
+const LOGIN_PUZZLE_CHALLENGE_DEFAULTS = {
+  backgroundImage: TEST_CAPTCHA_IMAGE,
+  puzzlePieceImage: TEST_CAPTCHA_IMAGE,
+  canvasWidth: 320,
+  canvasHeight: 160,
+  pieceWidth: 56,
+  pieceHeight: 56,
+  pieceY: 52,
+}
 
 const REGISTER_OPTIONS: RegisterOptionsVO = {
   selfServiceEnabled: true,
@@ -41,7 +50,7 @@ interface PendingLoginRequest {
 interface LoginBootstrapOverrides {
   images?: string[]
   challengeResponse?: (attempt: number) => unknown | Promise<unknown>
-  verifyResponse?: (attempt: number, payload: Record<string, unknown>) => unknown
+  verifyResponse?: (attempt: number, payload: Record<string, unknown>) => unknown | Promise<unknown>
 }
 
 interface LoginCaptchaHarness {
@@ -49,8 +58,31 @@ interface LoginCaptchaHarness {
   verificationPayloads: Record<string, unknown>[]
 }
 
+const loginUnknownApiRequests = new WeakMap<Page, string[]>()
+const loginApiFallbackInstalled = new WeakSet<Page>()
+
+test.beforeEach(async ({ page }) => {
+  await installLoginApiFallback(page)
+})
+
+test.afterEach(async ({ page }) => {
+  expect(loginUnknownApiRequests.get(page) ?? [], '登录页存在未显式 mock 的同源 API 请求').toEqual([])
+})
+
 function successResult<T>(data: T) {
   return { code: 0, message: 'success', data }
+}
+
+async function installLoginApiFallback(page: Page) {
+  if (loginApiFallbackInstalled.has(page)) return
+  loginApiFallbackInstalled.add(page)
+  const unknownRequests: string[] = []
+  loginUnknownApiRequests.set(page, unknownRequests)
+  // 先注册兜底，再注册各用例的精确 mock；Playwright 后注册的精确路由优先命中。
+  await page.route(`${LOGIN_E2E_ORIGIN}/api/**`, async (route) => {
+    unknownRequests.push(`${route.request().method()} ${route.request().url()}`)
+    await route.abort('blockedbyclient')
+  })
 }
 
 async function mockLoginCaptcha(
@@ -67,7 +99,15 @@ async function mockLoginCaptcha(
       ?? successResult({
         challengeId: `login-challenge-${harness.challengeRequestCount}`,
         ttlSeconds: 120,
+        ...LOGIN_PUZZLE_CHALLENGE_DEFAULTS,
       })
+    // 兼容各用例只覆盖 challengeId/ttlSeconds 的旧 mock，同时保证拼图响应完整。
+    if (response && typeof response === 'object' && 'data' in response && response.data && typeof response.data === 'object') {
+      ;(response as { data: Record<string, unknown> }).data = {
+        ...LOGIN_PUZZLE_CHALLENGE_DEFAULTS,
+        ...(response.data as Record<string, unknown>),
+      }
+    }
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -78,7 +118,7 @@ async function mockLoginCaptcha(
     const payload = route.request().postDataJSON() as Record<string, unknown>
     harness.verificationPayloads.push(payload)
     const attempt = harness.verificationPayloads.length
-    const response = overrides.verifyResponse?.(attempt, payload) ?? successResult({
+    const response = await overrides.verifyResponse?.(attempt, payload) ?? successResult({
       proof: `login-proof-${attempt}`,
       ttlSeconds: 120,
     })
@@ -222,19 +262,30 @@ async function openLogin(
   await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: '欢迎回来' })).toBeVisible()
   await expect(page.getByRole('button', { name: '创建账号' })).toBeVisible()
-  await expect(page.getByRole('slider', { name: '拖动验证码' }))
-    .toHaveAttribute('aria-valuetext', '按住滑块，拖动完成验证')
+  await expect(page.locator('[data-login-captcha-entry]')).toBeVisible()
   return captchaHarness
 }
 
-async function dragLoginCaptcha(page: Page) {
+async function openLoginCaptcha(page: Page) {
+  const dialog = page.locator('#login-captcha-dialog')
+  if (!(await dialog.isVisible().catch(() => false))) {
+    await page.locator('[data-login-captcha-entry]').click()
+  }
+  await expect(dialog).toBeVisible()
+}
+
+async function dragLoginCaptcha(page: Page, normalizedPlacement = 560) {
+  await openLoginCaptcha(page)
   const track = page.locator('[data-login-captcha]')
   const handle = page.getByRole('slider', { name: '拖动验证码' })
   await expect(handle).toHaveAttribute('aria-disabled', 'false')
-  await expect.poll(async () => {
-    const [trackBox, handleBox] = await Promise.all([track.boundingBox(), handle.boundingBox()])
-    return trackBox && handleBox ? Math.abs(handleBox.x - trackBox.x - 2) : Number.POSITIVE_INFINITY
-  }).toBeLessThanOrEqual(2)
+
+  // 失败恢复时滑块可能仍在返回起点的 CSS 过渡中；先用 Home 归零并等待几何稳定，
+  // 再量取真实起点和终点，避免把过渡中的中间位置当成拖动原点。
+  await handle.focus()
+  await page.keyboard.press('Home')
+  await expect(handle).toHaveAttribute('aria-valuenow', '0')
+  await page.waitForTimeout(150)
   const [trackBox, handleBox] = await Promise.all([track.boundingBox(), handle.boundingBox()])
   expect(trackBox).not.toBeNull()
   expect(handleBox).not.toBeNull()
@@ -244,7 +295,21 @@ async function dragLoginCaptcha(page: Page) {
 
   const startX = handleBox.x + handleBox.width / 2
   const startY = handleBox.y + handleBox.height / 2
-  const endX = trackBox.x + trackBox.width - handleBox.width / 2
+  // 用真实 End/Home 位置测出完整行程，避免复制组件内部的滑块宽度或边框常量。
+  await page.keyboard.press('End')
+  await expect(handle).toHaveAttribute('aria-valuenow', '1000')
+  await page.waitForTimeout(150)
+  const maxHandleBox = await handle.boundingBox()
+  expect(maxHandleBox).not.toBeNull()
+  if (!maxHandleBox) return
+  const measuredMaxCenterX = maxHandleBox.x + maxHandleBox.width / 2
+  const travel = Math.max(0, measuredMaxCenterX - startX)
+  expect(travel).toBeGreaterThan(0)
+
+  await page.keyboard.press('Home')
+  await expect(handle).toHaveAttribute('aria-valuenow', '0')
+  await page.waitForTimeout(150)
+  const endX = startX + travel * normalizedPlacement / 1000
   await page.mouse.move(startX, startY)
   await page.mouse.down()
   for (let step = 1; step <= 10; step += 1) {
@@ -260,8 +325,8 @@ async function dragLoginCaptcha(page: Page) {
 
 async function completeLoginCaptcha(page: Page) {
   await dragLoginCaptcha(page)
-  await expect(page.getByRole('slider', { name: '拖动验证码' }))
-    .toHaveAttribute('aria-valuetext', '验证通过')
+  await expect(page.locator('#login-captcha-dialog')).toHaveCount(0)
+  await expect(page.locator('[data-login-captcha-entry] strong')).toHaveText('验证通过')
 }
 
 async function documentScrollTop(page: Page) {
@@ -419,14 +484,17 @@ test.describe('桌面登录布局', () => {
       localRequest.release()
     }
     await expect(localTab).toBeEnabled()
+    await expect(page.locator('[data-login-captcha-entry]')).toBeFocused()
     await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}${LOGIN_PATH}`)
     await expect(page.locator('#login-username')).toHaveValue('local.richard')
     await expect(page.locator('#login-password')).toHaveValue('Local1234')
     await expect.poll(() => captchaHarness.challengeRequestCount)
       .toBe(challengeCountBeforeRejectedLogin + 1)
+    await openLoginCaptcha(page)
     await expect(page.getByRole('slider', { name: '拖动验证码' }))
-      .toHaveAttribute('aria-valuetext', '按住滑块，拖动完成验证')
+      .toHaveAttribute('aria-valuetext', /按住滑块/)
     expect(localCapture.requestCount()).toBe(1)
+    await page.getByRole('button', { name: '关闭安全验证' }).click()
 
     await ssoTab.click()
     const ssoCapture = await captureRejectedLogin(page, SSO_LOGIN_API)
@@ -446,11 +514,11 @@ test.describe('桌面登录布局', () => {
       })
       expect(ssoRequest.body).not.toHaveProperty('trajectory')
       expect(ssoCapture.requestCount()).toBe(1)
-      await expect(localTab).toBeDisabled()
-      await expect(ssoTab).toBeDisabled()
+      await expect(page.locator('[data-login-captcha-entry]')).toBeVisible()
     } finally {
       ssoRequest.release()
     }
+    await expect(page.locator('[data-login-captcha-entry]')).toBeVisible()
     await expect(ssoTab).toBeEnabled()
     await expect(page).toHaveURL(`${LOGIN_E2E_ORIGIN}${LOGIN_PATH}`)
     await page.waitForTimeout(50)
@@ -477,7 +545,7 @@ test.describe('桌面登录布局', () => {
     await expect(page.locator('.el-message')).toHaveCount(0)
     await expect.poll(() => captchaHarness.challengeRequestCount).toBe(2)
     const slider = page.getByRole('slider', { name: '拖动验证码' })
-    await expect(slider).toHaveAttribute('aria-valuetext', '拖动轨迹无效，请重试')
+    await expect(slider).toHaveAttribute('aria-valuetext', /拖动轨迹无效，请重试/)
     await expect(slider).toHaveAttribute('aria-disabled', 'false')
 
     await page.waitForTimeout(50)
@@ -499,7 +567,7 @@ test.describe('桌面登录布局', () => {
     await page.waitForTimeout(50)
     expect(localCapture.requestCount()).toBe(1)
 
-    expect(captchaHarness.verificationPayloads).toHaveLength(2)
+    await expect.poll(() => captchaHarness.verificationPayloads.length).toBe(2)
     expect(captchaHarness.verificationPayloads[0]).toMatchObject({
       challengeId: 'login-challenge-1',
     })
@@ -510,7 +578,9 @@ test.describe('桌面登录布局', () => {
       const trajectory = payload.trajectory as Array<{ x: number; y: number; t: number }>
       expect(trajectory.length).toBeGreaterThanOrEqual(6)
       expect(trajectory.at(0)).toEqual({ x: 0, y: 0, t: 0 })
-      expect(trajectory.at(-1)?.x).toBe(1000)
+      expect(payload.placementX).toBeGreaterThanOrEqual(550)
+      expect(payload.placementX).toBeLessThanOrEqual(570)
+      expect(trajectory.at(-1)?.x).toBe(payload.placementX)
     }
   })
 
@@ -541,7 +611,7 @@ test.describe('桌面登录布局', () => {
       const slider = page.getByRole('slider', { name: '拖动验证码' })
       await slider.focus()
       await page.keyboard.press('Enter')
-      await expect(slider).toHaveAttribute('aria-valuetext', '正在准备安全验证…')
+      await expect(slider).toHaveAttribute('aria-valuetext', /正在准备安全验证/)
       for (let attempt = 0; attempt < 4; attempt += 1) {
         await slider.click({ force: true })
       }
@@ -549,14 +619,14 @@ test.describe('桌面登录布局', () => {
       await page.waitForTimeout(100)
 
       expect(captchaHarness.challengeRequestCount).toBe(2)
-      await expect(slider).toHaveAttribute('aria-valuetext', '正在准备安全验证…')
+      await expect(slider).toHaveAttribute('aria-valuetext', /正在准备安全验证/)
       await expect(page.getByText('拖动轨迹无效，请重试', { exact: true })).toHaveCount(0)
     } finally {
       releaseSecondChallenge()
     }
 
     const slider = page.getByRole('slider', { name: '拖动验证码' })
-    await expect(slider).toHaveAttribute('aria-valuetext', '按住滑块，拖动完成验证')
+    await expect(slider).toHaveAttribute('aria-valuetext', /按住滑块/)
     await expect(slider).toHaveAttribute('aria-disabled', 'false')
     await expect(page.getByText('拖动轨迹无效，请重试', { exact: true })).toHaveCount(0)
     expect(captchaHarness.challengeRequestCount).toBe(2)
@@ -574,16 +644,19 @@ test.describe('桌面登录布局', () => {
       await route.abort()
     })
     await openLogin(page)
+    await openLoginCaptcha(page)
     const slider = page.getByRole('slider', { name: '拖动验证码' })
     await slider.focus()
 
-    for (let step = 0; step < 10; step += 1) {
+    for (let step = 0; step < 28; step += 1) {
       await page.keyboard.press('ArrowRight')
     }
+    await page.keyboard.press('Enter')
 
-    await expect(slider).toHaveAttribute('aria-valuetext', '验证通过')
+    await expect(page.locator('[data-login-captcha-entry] strong')).toHaveText('验证通过')
     await expect(page.getByText('请输入用户名', { exact: true })).toBeVisible()
     await expect(page.getByText('请输入密码', { exact: true })).toBeVisible()
+    await expect(page.locator('#login-username')).toBeFocused()
     await page.waitForTimeout(50)
     expect(localLoginRequests).toBe(0)
     expect(ssoLoginRequests).toBe(0)
@@ -595,14 +668,16 @@ test.describe('桌面登录布局', () => {
     const localCapture = await captureRejectedLogin(page, LOCAL_LOGIN_API)
     await page.locator('#login-username').fill('keyboard.richard')
     await page.locator('#login-password').fill('Local1234')
+    await openLoginCaptcha(page)
     const slider = page.getByRole('slider', { name: '拖动验证码' })
     await slider.focus()
 
-    for (let step = 0; step < 10; step += 1) {
+    for (let step = 0; step < 28; step += 1) {
       await page.keyboard.press('ArrowRight')
     }
+    await page.keyboard.press('Enter')
 
-    await expect(slider).toHaveAttribute('aria-valuetext', '验证通过')
+    await expect(page.locator('[data-login-captcha-entry] strong')).toHaveText('验证通过')
     const loginRequest = await localCapture.requestCaptured
     try {
       expect(loginRequest.body).toEqual({
@@ -618,9 +693,158 @@ test.describe('桌面登录布局', () => {
     }
     await page.waitForTimeout(50)
     expect(localCapture.requestCount()).toBe(1)
-    expect(captchaHarness.verificationPayloads).toHaveLength(1)
+    await expect.poll(() => captchaHarness.verificationPayloads.length).toBe(1)
     const trajectory = captchaHarness.verificationPayloads[0].trajectory as Array<{ t: number }>
     expect(trajectory.at(-1)?.t).toBeGreaterThanOrEqual(300)
+  })
+})
+
+test.describe('拼图验证浮层可访问性与响应式', () => {
+  test.use({ viewport: { width: 1280, height: 720 } })
+
+  test('浮层打开时隔离背景、陷阱 Tab，Escape 关闭并回到入口，支持中段 placement', async ({ page }) => {
+    await suppressExpectedLoginRejection(page)
+    const captchaHarness = await openLogin(page)
+    await page.locator('[data-login-captcha-entry]').click()
+    const dialog = page.locator('#login-captcha-dialog')
+    await expect(dialog).toBeVisible()
+    await expect(page.locator('[data-login-scroll]')).toHaveAttribute('aria-hidden', 'true')
+    await expect(page.locator('.brand-stage')).toHaveAttribute('aria-hidden', 'true')
+    await expect(page.getByRole('button', { name: '关闭安全验证' })).toBeFocused()
+
+    const refresh = page.getByRole('button', { name: '刷新验证' })
+    const slider = page.getByRole('slider', { name: '拖动验证码' })
+    await slider.focus()
+    await page.keyboard.press('Tab')
+    await expect(refresh).toBeFocused()
+    await refresh.focus()
+    await page.keyboard.press('Shift+Tab')
+    await expect(slider).toBeFocused()
+    await page.keyboard.press('Escape')
+    await expect(dialog).toHaveCount(0)
+    await expect(page.locator('[data-login-captcha-entry]')).toBeFocused()
+    await expect(page.locator('[data-login-scroll]')).toHaveAttribute('aria-hidden', 'false')
+
+    await page.locator('[data-login-captcha-entry]').click()
+    const challengeCountBeforeRefresh = captchaHarness.challengeRequestCount
+    await refresh.click()
+    await expect.poll(() => captchaHarness.challengeRequestCount)
+      .toBe(challengeCountBeforeRefresh + 1)
+    await expect(page.getByText('验证已刷新，请重新拖动', { exact: true })).toBeVisible()
+    await page.getByRole('button', { name: '关闭安全验证' }).click()
+
+    await page.locator('#login-username').fill('middle.placement')
+    await page.locator('#login-password').fill('Local1234')
+    await page.route(LOCAL_LOGIN_API, async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: TEST_BUSINESS_REJECTION_CODE, message: 'E2E rejected', data: null }) })
+    })
+    await dragLoginCaptcha(page, 560)
+    await expect.poll(() => captchaHarness.verificationPayloads.length).toBe(1)
+    const payload = captchaHarness.verificationPayloads[0]
+    expect(payload.placementX).toBeGreaterThanOrEqual(550)
+    expect(payload.placementX).toBeLessThanOrEqual(570)
+    const points = payload.trajectory as Array<{ x: number }>
+    expect(points.at(-1)?.x).toBe(payload.placementX)
+  })
+
+  test('320px 小屏使用 bottom-sheet 内部滚动且无横向溢出', async ({ page }) => {
+    const viewportWidth = 320
+    await page.setViewportSize({ width: viewportWidth, height: 480 })
+    await openLogin(page)
+    await openLoginCaptcha(page)
+    const dialog = page.locator('#login-captcha-dialog')
+    await expect(dialog).toBeVisible()
+    const layout = await dialog.evaluate((element) => ({
+      width: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+      overflowY: getComputedStyle(element).overflowY,
+      maxHeight: getComputedStyle(element).maxHeight,
+    }))
+    expect(layout.width).toBeLessThanOrEqual(viewportWidth)
+    expect(layout.scrollWidth).toBeLessThanOrEqual(layout.width)
+    expect(layout.overflowY).toBe('auto')
+    expect(layout.maxHeight).not.toBe('none')
+    await expect(page.locator('[data-login-captcha-refresh]')).toBeVisible()
+    await expect(page.getByRole('button', { name: '关闭安全验证' })).toHaveCSS('height', '44px')
+  })
+
+  test('TTL 到期会刷新 challenge 并保留明确的过期恢复提示', async ({ page }) => {
+    const captchaHarness = await openLogin(page, {
+      challengeResponse: (attempt) => successResult({
+        challengeId: `short-lived-${attempt}`,
+        ttlSeconds: attempt === 1 ? 1 : 120,
+        ...LOGIN_PUZZLE_CHALLENGE_DEFAULTS,
+      }),
+    })
+    await openLoginCaptcha(page)
+    await expect.poll(() => captchaHarness.challengeRequestCount).toBe(2, { timeout: 3_000 })
+    await expect(page.getByText('验证已过期，已刷新，请重新拖动', { exact: true })).toBeVisible({ timeout: 3_000 })
+  })
+
+  test('浮层关闭后 challenge 过期不会循环签发，重新打开才获取新挑战', async ({ page }) => {
+    const captchaHarness = await openLogin(page, {
+      challengeResponse: (attempt) => successResult({
+        challengeId: `closed-short-lived-${attempt}`,
+        ttlSeconds: attempt === 1 ? 1 : 120,
+        ...LOGIN_PUZZLE_CHALLENGE_DEFAULTS,
+      }),
+    })
+    await openLoginCaptcha(page)
+    await page.getByRole('button', { name: '关闭安全验证' }).click()
+    await page.waitForTimeout(1_300)
+    expect(captchaHarness.challengeRequestCount).toBe(1)
+    await openLoginCaptcha(page)
+    await expect.poll(() => captchaHarness.challengeRequestCount).toBe(2, { timeout: 3_000 })
+  })
+
+  test('验证慢网时保留背景和拼图块，直到响应完成', async ({ page }) => {
+    let releaseVerification!: () => void
+    const verificationReleased = new Promise<void>((resolve) => {
+      releaseVerification = resolve
+    })
+    const captchaHarness = await openLogin(page, {
+      verifyResponse: async () => {
+        await verificationReleased
+        return successResult({ proof: 'slow-login-proof', ttlSeconds: 120 })
+      },
+    })
+
+    await dragLoginCaptcha(page, 560)
+    await expect(page.locator('[data-login-captcha]')).toHaveClass(/is-verifying/)
+    await expect(page.locator('.captcha-background')).toBeVisible()
+    await expect(page.locator('.captcha-piece')).toBeVisible()
+    await expect(page.getByRole('slider', { name: '拖动验证码' })).toHaveAttribute('aria-disabled', 'true')
+    await expect.poll(() => captchaHarness.verificationPayloads.length).toBe(1)
+
+    releaseVerification()
+    await expect(page.locator('#login-captcha-dialog')).toHaveCount(0)
+    await expect(page.locator('[data-login-captcha-entry] strong')).toHaveText('验证通过')
+  })
+
+  test('challenge 刷新失败时倒计时归零并保留明确恢复状态', async ({ page }) => {
+    const captchaHarness = await openLogin(page, {
+      challengeResponse: (attempt) => attempt === 1
+        ? successResult({ challengeId: 'refreshable-challenge', ttlSeconds: 120 })
+        : { code: 30015, message: '刷新失败，请稍后重试', data: null },
+    })
+    await openLoginCaptcha(page)
+    await page.getByRole('button', { name: '刷新验证' }).click()
+    await expect.poll(() => captchaHarness.challengeRequestCount).toBe(2)
+    await expect(page.getByText('刷新失败，请稍后重试', { exact: true })).toBeVisible()
+    await expect(page.getByText('等待验证挑战', { exact: true })).toBeVisible()
+  })
+
+  test('proof 一秒到期后回收入口状态且不重复签发 challenge', async ({ page }) => {
+    const captchaHarness = await openLogin(page, {
+      verifyResponse: () => successResult({ proof: 'short-proof', ttlSeconds: 1 }),
+    })
+    await dragLoginCaptcha(page, 560)
+    await expect(page.locator('[data-login-captcha-entry] strong')).toHaveText('验证通过')
+    await expect(page.locator('[data-login-captcha-entry] small')).toHaveText('完成拼图后自动继续登录')
+    await page.waitForTimeout(1_300)
+    await expect(page.locator('[data-login-captcha-entry] strong')).toHaveText('完成安全验证')
+    await expect(page.locator('[data-login-captcha-entry] small')).toHaveText('验证失败，点击重试')
+    expect(captchaHarness.challengeRequestCount).toBe(1)
   })
 })
 

--- a/docs/功能与配置全量参考.md
+++ b/docs/功能与配置全量参考.md
@@ -997,8 +997,8 @@ cd customer-admin-web && npm ci && npm run dev
 
 | 入口 | 能力 |
 |---|---|
-| `POST /api/auth/login-captcha/challenge` | 匿名签发登录拖动 challenge；按来源 IP 限流，并与 IP、User-Agent 指纹绑定 |
-| `POST /api/auth/login-captcha/verify` | 原子消费 challenge 并校验归一化轨迹，成功后签发短期、一次性的 `captchaProof` |
+| `POST /api/auth/login-captcha/challenge` | 匿名签发带随机缺口的登录拼图 challenge；返回背景/拼图 data URI 与尺寸，目标横坐标仅存服务端；按来源 IP 限流，并与 IP、User-Agent 指纹绑定 |
+| `POST /api/auth/login-captcha/verify` | 原子消费 challenge，校验归一化拼图落点与轨迹终点、时长和采样质量，成功后签发短期、一次性的 `captchaProof` |
 | `POST /api/auth/login` / `POST /api/auth/sso-login` | 本地/OA 登录；都必须携带 `captchaProof`，且 proof 在查用户、BCrypt 或 LDAP Bind 前原子消费。`admin/admin` 首次本地登录返回 `forceChangePassword=true` |
 | `POST /api/auth/register` | 登录页公开自助注册；仅创建 `default` 租户的 `PENDING` 本地账号，不自动授予角色或菜单 |
 | `POST /api/auth/change-password` / `POST /api/auth/logout` | 改密 / 登出 |
@@ -2235,7 +2235,7 @@ Redis 配额旧计数与 MinIO 历史工作区由过渡兼容逻辑承接，完�
 | `admin.subject-quota`（非 `customer-work.*` 前缀，属 admin 自身配置）| enabled(true，`application.yml` 显式开启), default-level(admin-default), lazy-refresh-ms(60000), level-cache-ttl-ms(60000), path-patterns([/api/workspace/*/chat/stream, /api/workspace/*/chat/plan/confirm, /api/workspace/*/vibecoding/**, /api/aiconfig/agent-task/**, /api/eval/run, /api/aiconfig/knowledge-base/*/test-connectivity])（见 §6.32.1；后台登录用户的 AI 用量额度。对外开放实例须把 default-level 换成 `public-trial`，`AdminProductionReadinessValidator` 会强制校验） |
 | `admin.public-deployment`（admin 自身配置）| enabled(false)：对外开放实例总开关。打开后内部运维工具（SQL 客户端/账号本/开发者工具箱）菜单与接口一并下架、自助注册强制验证码与邮箱、审核不允许并入 `default` 租户。详见《部署手册》§8.1 |
 | `admin.registration`（admin 自身配置）| self-service-enabled(true), captcha-enabled(false), email-required(false), trust-forwarded-header(false), trusted-proxy-cidrs([]), rate-limit{max-attempts(5), window-seconds(3600)}, captcha{length(4), ttl-seconds(180), width(120), height(40), max-issue-per-window(30)}, login-lock{enabled(false), max-failures(5), window-seconds(900)}, email-verification{enabled(false), code-length(6), ttl-seconds(600), max-attempts(5), resend-cooldown-seconds(60), max-send-per-email-per-day(10), max-send-per-ip-per-window(10)}。**captcha-enabled / email-required / login-lock.enabled / email-verification.enabled 在对外开放实例上被强制为 true，配 false 不生效**。转发头默认不信任；开启时可信代理 CIDR 不能为空，且仅从命中网段的直接连接方接收 XFF，再从右向左剥离可信代理链。开启邮箱验证后图形码改在「发码」那一步校验，注册那一步只认邮箱验证码 |
-| `admin.login-captcha`（admin 自身配置）| challenge-ttl-seconds(120), proof-ttl-seconds(120), max-issue-per-window(30), max-verify-per-window(120), max-proof-consume-per-window(120), rate-limit-window-seconds(3600), max-in-memory-entries(10000), max-user-agent-length(512)。所有配置必须为正数；独立于注册图形验证码且无关闭开关。签发、轨迹校验与 proof 消费分别按可信来源 IP 限流，三者共用限流窗口时长；轨迹点数、坐标和时长是固定接口协议，不开放运行期调参；challenge/proof 都绑定 IP+UA 并只允许成功消费一次 |
+| `admin.login-captcha`（admin 自身配置）| challenge-ttl-seconds(120), proof-ttl-seconds(120), max-issue-per-window(30), max-verify-per-window(3), max-proof-consume-per-window(120), rate-limit-window-seconds(3600), max-in-memory-entries(10000), max-user-agent-length(512)。所有配置必须为正数，rate-limit-window-seconds 不得小于 challenge-ttl-seconds；独立于注册图形验证码且无关闭开关。签发、拼图落点/轨迹校验与 proof 消费分别按可信来源 IP 限流，三者共用限流窗口时长；验证预算默认每小时 3 次，在读取 challenge 前原子占用，成功、失败、过期或指纹不匹配都不返还，换 User-Agent 不会获得新预算；画布尺寸、轨迹点数、归一化坐标和时长是固定接口协议，不开放运行期调参；随机目标只存服务端，challenge/proof 都绑定 IP+UA 并只允许成功消费一次 |
 | `admin.notification.mail`（admin 自身配置）| enabled(false), host, port(587), username, password, from, from-name(客服智能体平台), start-tls-enabled(true), ssl-enabled(false), timeout-ms(5000), platform-name, login-url：注册审核结果邮件通知。开放注册时为必填项 |
 | `eval`（B6）| store-mode(memory), baseline-enabled(false), baseline-cron(0 0 3 * * ?), judge-timeout-seconds(60)，见 §6.31 |
 | `badcase`（B6）| store-mode(memory), auto-collect(true)，见 §6.31 |

--- a/docs/部署手册.md
+++ b/docs/部署手册.md
@@ -532,9 +532,9 @@ ADMIN_PUBLIC_DEPLOYMENT_ENABLED=true
 | `ADMIN_REGISTRATION_SELF_SERVICE` | `true` | 关闭后只能由管理员预建账号 |
 | `ADMIN_REGISTRATION_TRUST_XFF` | `false` | 是否启用可信代理链解析。单独开启但未配置可信代理 CIDR 会启动失败，不存在“信任所有来源”的退化路径 |
 | `ADMIN_REGISTRATION_TRUSTED_PROXY_CIDRS` | 空 | 直接连接到服务端的可信代理网段，逗号分隔，如 `10.0.0.0/8,fd00::/8`，禁止用 `/0` 退化为信任全网。服务端仅在 `remoteAddr` 命中时读取转发头，并从 XFF 右向左剥离可信代理；异常、超长、跳数过多或全可信链均回退直连地址 |
-| `ADMIN_LOGIN_CAPTCHA_CHALLENGE_TTL_SECONDS` / `ADMIN_LOGIN_CAPTCHA_PROOF_TTL_SECONDS` | `120` / `120` | 登录拖动 challenge 与一次性 proof 的有效期；不建议放大，过期后前端会自动重新签发 |
+| `ADMIN_LOGIN_CAPTCHA_CHALLENGE_TTL_SECONDS` / `ADMIN_LOGIN_CAPTCHA_PROOF_TTL_SECONDS` | `120` / `120` | 登录拼图 challenge 与一次性 proof 的有效期；不建议放大，过期后前端会自动重新签发 |
 | `ADMIN_LOGIN_CAPTCHA_MAX_ISSUE_PER_WINDOW` / `ADMIN_LOGIN_CAPTCHA_RATE_LIMIT_WINDOW_SECONDS` | `30` / `3600` | 单个来源 IP 的 challenge 签发上限与三条限流链路共用窗口；与注册图形码分桶 |
-| `ADMIN_LOGIN_CAPTCHA_MAX_VERIFY_PER_WINDOW` / `ADMIN_LOGIN_CAPTCHA_MAX_PROOF_CONSUME_PER_WINDOW` | `120` / `120` | 同一窗口内单个可信来源 IP 的轨迹校验与 proof 消费上限；在访问 challenge/proof 存储前判定，拦截随机 token 对 Redis 的放大请求 |
+| `ADMIN_LOGIN_CAPTCHA_MAX_VERIFY_PER_WINDOW` / `ADMIN_LOGIN_CAPTCHA_MAX_PROOF_CONSUME_PER_WINDOW` | `3` / `120` | 同一窗口内单个可信来源 IP 的拼图落点/轨迹校验与 proof 消费上限；校验预算在消费 challenge 前原子占用，成功与失败都不返还，因而同源预签发 30 张题也最多提交 3 次真实落点 |
 | `ADMIN_REGISTRATION_EMAIL_VERIFICATION` | `false` | 注册必须先收邮箱验证码。对外部署强制为 true |
 | `ADMIN_MAIL_ENABLED` / `ADMIN_MAIL_HOST` / `ADMIN_MAIL_USERNAME` / `ADMIN_MAIL_PASSWORD` / `ADMIN_MAIL_FROM` | 关闭 | SMTP 连接参数,注册验证码与审核结果通知共用。**开放注册时必填**——验证码发不出去注册就走不下去,而审核结果只发站内信的话,被拒绝的人永远看不到 |
 | `ADMIN_MAIL_LOGIN_URL` | 空 | 写进邮件正文的登录地址 |
@@ -548,20 +548,41 @@ ADMIN_PUBLIC_DEPLOYMENT_ENABLED=true
 
 限流与锁定参数(`admin.registration.rate-limit.*`、`admin.registration.captcha.max-issue-per-window`、`admin.registration.login-lock.*`)默认值在 Java 里:IP 注册 5 次/小时、验证码签发 30 张/小时、登录连续失败 5 次锁 15 分钟。**验证码签发单独计数**——它比注册宽松得多(真人看不清会点着换几张),共用一个桶会让刷新几次图就把注册额度用光;而完全不限的话,这个免登接口本身就是一条廉价的画图消耗路径。它们按"账号+来源 IP"的组合锁定而非只锁账号——只锁账号的话,任何人拿一个已知用户名连打几次就能把真实用户挡在门外。
 
-#### 登录拖动验证码
+#### 登录拼图验证码
 
-本地登录与 OA 登录共用同一条准入链：`challenge → 轨迹核验 → 一次性 proof → 登录原子消费`。
+本地登录与 OA 登录共用同一条准入链：`challenge → 随机拼图 → 落点与轨迹核验 → 一次性 proof → 登录原子消费`。
 登录请求只携带 proof，不携带客户端的“已验证”布尔值或原始轨迹；proof 在用户查询、BCrypt 和 LDAP Bind
 之前消费，密码错误、域控不可用或账号禁用都不会返还。challenge 与 proof 同时绑定来源 IP 和归一化
 User-Agent，因而不能直接搬到另一浏览器或网络环境重放。
+
+challenge 响应包含服务端即时生成的背景图、拼图块 data URI 及画布尺寸，目标横坐标只保存在服务端；客户端
+提交的 `placementX` 和轨迹横坐标都按 `canvasWidth-pieceWidth` 的可移动行程归一化到 `0..1000`。服务端原子
+消费 challenge 后，同时校验落点是否命中随机目标、轨迹终点是否与落点一致，以及时长、采样数和中间点质量；
+失败的 challenge 不可复用，前端会签发新题。验证成功后前端直接续接登录，不要求用户再次点击登录按钮。
+
+落点校验在读取 challenge 前就按可信来源 IP 占用滑动窗口预算，默认每小时 3 次；
+换 User-Agent 不会获得新预算。题目看不清而刷新只占用签发额度，不占用落点猜测额度；一旦提交校验，
+无论 challenge 已过期、指纹不匹配、落点/轨迹失败还是成功签发 proof，都会保留这次计数直到窗口滑出。
+`rate-limit-window-seconds` 在启动时强制不小于 `challenge-ttl-seconds`，避免预签发的题目跨窗口叠加猜测机会。
+
+验证预算刻意按解析后的来源 IP 聚合，因此企业 NAT、统一代理或 CGNAT 下的用户会共享这 3 次额度；同一出口内
+任意调用方都可能让其他用户在窗口内暂时无法验证。正式部署前必须确认来源 IP 的实际分布，并监控
+`LOGIN_CAPTCHA_TOO_FREQUENT` 是否集中命中单个出口。共享出口是常态时，应在网关叠加更高额度的纯 IP 防洪桶，
+并把低额度猜测预算绑定到服务端签发的浏览器会话；不要只把 `max-verify-per-window` 调大，否则会同步放大盲猜概率。
 
 后台没有 Redisson Bean 时使用有容量上限的进程内存储，适合单实例开发；一旦启动时选中 Redis，
 保存或消费响应不确定都 **fail-closed**，运行期不会再切到内存副本。这样会牺牲 Redis 瞬时故障期间的登录
 可用性，但避免“Redis 已成功写入/删除、客户端却收到超时”时同一 challenge 或 proof 在两处复活。
 
-这是一道基础准入而不是风险引擎：静态轨迹没有服务端秘密，脚本仍能构造满足时长与采样约束的数据。
-当前实现用于阻断省略验证、一次性凭据重放、跨来源搬运和低成本批量请求；面向高风险公网对抗时，
-应替换成带随机目标的拼图或接入第三方风控，不能把本滑块宣传成完整的反机器人方案。
+从旧版固定终点滑块升级时，禁止让新旧节点同时处理 `/api/auth/login-captcha/challenge` 与
+`/api/auth/login-captcha/verify`：challenge 状态已升级为 `v2`，但 proof 为承接在途登录仍保持兼容编码，旧节点
+签发的弱验证 proof 可被新节点消费。发布时先将这两个接口只路由到新节点，旧节点可以暂时继续处理普通登录；
+至少等待一个 challenge TTL（默认 120 秒）后再下掉旧节点。网关不能按路径分流时，必须先摘流并排空旧节点，
+再启动新版本，不能直接无隔离滚动混跑。
+
+这仍是一道低成本自动化准入门槛，不是身份认证或完整风险引擎。随机目标能阻断只按固定终点伪造轨迹的脚本，
+一次性凭据与来源绑定用于阻断省略验证、重放和跨来源搬运；面向高风险公网对抗时仍应叠加网关/WAF、登录限流、
+设备与行为风险判定，或接入专业第三方风控，不能把拼图验证码宣传成单独完备的反机器人方案。
 
 #### 成本闸门
 


### PR DESCRIPTION
## 变更摘要

- 将登录页固定终点滑块升级为服务端随机拼图：后端即时生成背景图和透明拼图块，数值目标仅保存在服务端。
- 服务端原子消费 challenge，同时校验拼图落点、轨迹终点、时长和采样质量；成功后签发与 IP + UA 绑定的一次性 proof。
- 登录页改为桌面端右侧拼图面板、移动端 bottom-sheet，支持鼠标、触摸、键盘、焦点陷阱、Escape 恢复焦点及减少动画偏好。
- 验证成功后自动续接本地/OA 登录，不再要求用户二次点击；登录失败、proof 过期、challenge 刷新失败和慢网状态均可恢复。
- 补齐 Redis/进程内存储的一次消费契约、未知 API fail-closed E2E 边界以及发布/配置文档。

## 验证

- Maven 六模块全量门禁：`BUILD SUCCESS`，3599 项测试通过，0 failure / 0 error，6 skipped。
- `customer-admin-web` 单元测试：20 个文件、191 项通过。
- `customer-admin-web` 生产构建：`vue-tsc -b && vite build` 通过。
- `customer-admin-web` Chrome E2E：91/91 通过，包含登录页 26 项、未知同源 API 拦截、响应式与全站路由回归。
- `customer-h5` 单元测试：10 个文件、27 项通过；生产构建通过。
- 真实 Chrome 使用 Java 实际生成的拼图图片完成 1280×720、916×664、390×720、320×480 验收；拖动落点后登录请求携带 proof，最终进入 `/home`，未预期请求为 0。

## 安全与发布边界

- 拼图是低成本自动化准入门槛，不是身份认证或完整风险引擎；高风险公网场景仍需叠加网关/WAF 和行为风险判定。
- 新旧版本发布时，`/api/auth/login-captcha/challenge` 和 `/verify` 必须先只路由到新节点，等待一个 challenge TTL（默认 120 秒）后再下线旧节点；无法按路径分流时需先摘流并排空旧节点。
- 默认落点校验预算为每解析来源 IP 每小时 3 次；共享 NAT/统一代理会共享额度，应监控 `LOGIN_CAPTCHA_TOO_FREQUENT`，不应盲目调大验证次数。
