### PR TITLE
fix(admin): 知识库连通性测试回写时恢复租户上下文

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,14 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-09-02 知识库连通性租户上下文修复批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1705/5 skip、app-server 129、customer-channel 80、admin 1733/2 skip、gateway 1，
+  **合计 3648**（排除 `RedisSessionPersistenceTest`）。本批次自身加 admin **+1**
+  （知识库连通性测试的租户上下文回归）。**"异步回调要显式恢复租户上下文"这条已复发一次**：
+  MCP 与模型健康探测都做了，知识库测完回写时漏了，表现是前端显示测试通过、库里 test_status 不变，
+  同时抛一个 500。补测试时注意**既有的两条用例只断言"updateById 被调用过"，照不出这个缺陷**——
+  单测没挂 MP 拦截器，缺上下文也不会抛，必须断言"落库那一刻 `TenantContext.get()` 是发起时的租户"。
+  本批次无迁移，cw Flyway 仍是下次 **V24**、admin **V102**。上一版基线见下。）
   （2026-09-01 找回密码批次实测（已 rebase 到含 PR #173 的 main 之后）：全模块 BUILD SUCCESS，
   0 失败 0 错误，starter 1705/5 skip、app-server 129、customer-channel 80、admin 1732/1 skip、gateway 1，
   **合计 3647**（排除 `RedisSessionPersistenceTest`）。本批次自身加 admin **+35**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseService.java
@@ -22,6 +22,7 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminRagProperties;
 import com.richard.fyoung.customerwork.core.constant.StatusFlags;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeBaseEndpoint;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
@@ -212,6 +213,7 @@ public class KnowledgeBaseService {
     public CompletableFuture<KnowledgeBaseTestResult> testConnectivity(Long id) {
         AiKnowledgeBase entity = requireKnowledgeBase(id);
         KnowledgeBaseEndpoint endpoint = toEndpoint(entity, cryptoUtil.decrypt(entity.getApiKey()));
+        String tenantId = currentTenant();
 
         return CompletableFuture
             .supplyAsync(() -> probe(endpoint), TEST_EXECUTOR)
@@ -227,7 +229,8 @@ public class KnowledgeBaseService {
                 return KnowledgeBaseTestResult.failed("连通性测试超时或执行异常");
             })
             .thenApply(result -> {
-                persistTestResult(id, result);
+                // CompletableFuture 回调不继承 Servlet 线程的租户上下文，按发起测试时已校验的租户恢复后回写。
+                TenantContext.runWith(tenantId, () -> persistTestResult(id, result));
                 return result;
             });
     }
@@ -346,6 +349,11 @@ public class KnowledgeBaseService {
         vo.setCreateTime(entity.getCreateTime());
         vo.setUpdateTime(entity.getUpdateTime());
         return vo;
+    }
+
+    /** 当前请求线程的租户；无上下文（理论上不会发生，Controller 都在拦截器覆盖范围内）时回落默认租户。 */
+    private String currentTenant() {
+        return TenantContext.isPresent() ? TenantContext.require() : TenantContext.DEFAULT;
     }
 
     /** 知识库存在性校验（本模块唯一防御点）。 */

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/knowledgebase/service/KnowledgeBaseServiceTest.java
@@ -17,6 +17,7 @@ import com.richard.fyoung.customeradmin.common.result.ResultCode;
 import com.richard.fyoung.customeradmin.config.AdminRagProperties;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeBaseEndpoint;
 import com.richard.fyoung.customerwork.data.rag.search.KnowledgeNode;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,6 +28,7 @@ import org.springframework.dao.DuplicateKeyException;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -288,6 +290,33 @@ class KnowledgeBaseServiceTest {
 
         assertEquals(ConnectivityTestStatus.FAILED, result.testStatus());
         verify(knowledgeBaseMapper).updateById(any(AiKnowledgeBase.class));
+    }
+
+    /**
+     * 回写发生在 {@code CompletableFuture} 的工作线程上，它不继承 Servlet 线程的 ThreadLocal。
+     * 缺租户上下文时持久层拦截器会 fail-closed 抛 {@code TenantContextMissingException}，
+     * 表现为测试结果显示成功、库里的 test_status 却纹丝不动（异常还被 500 抛回前端）。
+     * 断言"落库那一刻"看得到租户，而不是"没抛异常"——单测没挂拦截器，后者恒真。
+     */
+    @Test
+    void testConnectivity_shouldPersistResultWithinCapturedTenant() throws Exception {
+        when(knowledgeBaseMapper.selectById(1L)).thenReturn(existing(1L, "sk-1"));
+        AtomicReference<String> persistedTenant = new AtomicReference<>();
+        when(knowledgeBaseMapper.updateById(any(AiKnowledgeBase.class))).thenAnswer(invocation -> {
+            persistedTenant.set(TenantContext.get());
+            return 1;
+        });
+
+        KnowledgeBaseTestResult result;
+        TenantContext.set("tenant-a");
+        try {
+            result = service.testConnectivity(1L).get();
+        } finally {
+            TenantContext.clear();
+        }
+
+        assertEquals(ConnectivityTestStatus.SUCCESS, result.testStatus());
+        assertEquals("tenant-a", persistedTenant.get());
     }
 
     @Test


### PR DESCRIPTION
## 问题

后台「知识库管理 → 测试连通性」抛 500：

```
TenantContextMissingException: tenant context is required but absent in current execution chain
  at CustomerWorkTenantLineHandler.getTenantId
  at KnowledgeBaseService.persistTestResult(KnowledgeBaseService.java:268)
  at KnowledgeBaseService.lambda$testConnectivity$4(KnowledgeBaseService.java:230)
  at CompletableFuture$UniApply.tryFire
```

探测本身跑在独立线程池（不占 Tomcat 线程，这是对的），但 `thenApply` 回调里的
`persistTestResult` 也跟着跑在工作线程上。`TenantContext` 是 ThreadLocal，
不跨线程传播，MyBatis-Plus 租户拦截器改写 `updateById` 时取不到租户，fail-closed 抛错。

对用户的表现：探测结果算出来了，`test_status` / `test_time` 却始终不落库，同时收到一个 500。

## 修复

按 `McpService#testConnectivity` 的既有手法：在发起测试的请求线程上捕获租户，
回写时 `TenantContext.runWith(tenantId, ...)` 恢复。可见性此前已由
`requireKnowledgeBase`（走租户过滤的 `selectById`）锁定，恢复的就是那次查询用的租户。

## 横向核对其余同类链路

| 链路 | 异步回调里落库 | 结论 |
|---|---|---|
| `KnowledgeBaseService#testConnectivity` | 是 | ❌ 本次修复 |
| `McpService#testConnectivity` | 是 | ✅ 已有 `TenantContext.runWith` |
| `ModelHealthService#probe`（模型连通性，`ModelConfigService#testConnectivity` 委托给它） | 是 | ✅ 已有 `TenantContext.callWith` + `CrossTenantOperations` |
| `SqlDatasourceService#testConnection` | 否（只返回结果，不落库） | ✅ 无此问题 |
| `McpService#listDebugTools` / `callDebugTool` | 否 | ✅ 无此问题 |

顺带扫了 admin 全部异步派发点（`supplyAsync` / `submit` / `@Async` / `new Thread`），
`AiCodingAuditRecorder`、`KnowledgeService`、`MybatisTaskRepository`、`TenantAccessPublishWorker`
均已显式恢复上下文，无遗漏。

## 测试

补一条 `testConnectivity_shouldPersistResultWithinCapturedTenant`，断言**落库那一刻**
`TenantContext.get()` 等于发起测试时的租户。

既有的两条用例只断言 `updateById` 被调用过 —— 单测里没挂 MP 拦截器，缺上下文也不会抛，
那种断言照不出这个缺陷。新用例在未修复的代码上验证过会精确红（回退生产代码跑了一次：
24 run / 1 failure，正是这条）。

全模块回归：BUILD SUCCESS，0 失败 0 错误，
starter 1705/5 skip、app-server 129、channel 80、admin 1733/2 skip、gateway 1，
合计 **3648**（排除 `RedisSessionPersistenceTest`），比基线 3647 恰好多本次新增的 1 条。

无迁移，无接口契约变更。