### PR TITLE
feat(schema): 后台库结构快照带上系统种子，执行完即可用 admin 登录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,22 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-09-02 后台库快照带系统种子批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1710/5 skip、app-server 129、customer-channel 80、admin 1734/1 skip、gateway 1，
+  **合计 3654**（排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+5**（差异定位单测）、
+  admin **+1**（种子可复现 + admin 登录链路门禁）。本批次无迁移，cw Flyway 仍是下次 **V24**、admin **V102**。
+  **`mysql/schema-snapshot/customer_admin.sql` 从本批次起含系统种子数据**，执行完即可 admin/admin 登录，
+  详见下方「结构快照」那条。三个坑：
+  ① **种子导出必须跳过 `DEFAULT_GENERATED` 的 CURRENT_TIMESTAMP 列**——12 张种子表的
+  create_time/update_time 全是「迁移执行那一秒」，写死进 INSERT 会让漂移门禁**每跑必红**，
+  而红的原因与任何人的改动都无关，几次之后这道门禁就没人信了；
+  ② **验「导出可复现」必须建两个独立的库**：同一个库连导两次，时间列取的是同一次迁移的时刻，
+  结果当然一样——那是恒真断言。本批次先写成了那样，靠变异测试（故意不跳过时间列）才发现它照不出问题，
+  改成两次独立建库后同一个变异立刻红；
+  ③ **差异定位只认 `CREATE TABLE` 会把种子段的差异全归到最后一张表上**（实测报成 `workbench_token`，
+  实际差在 `ai_model_price`）——指着一张不相干的表报错比不报表名更误导，`tableHint` 已一并认 `INSERT INTO`。
+  另：**用快照建的库没有 `flyway_schema_history`**，应用要以 Flyway 关闭的方式启动（生产 profile 本就关闭），
+  dev profile 直接起会从 V1 重跑撞上已存在的表。上一版基线见下。）
   （2026-09-02 知识库连通性租户上下文修复批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
   starter 1705/5 skip、app-server 129、customer-channel 80、admin 1733/2 skip、gateway 1，
   **合计 3648**（排除 `RedisSessionPersistenceTest`）。本批次自身加 admin **+1**
@@ -357,7 +373,19 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   实测：全新库跑完镜像后有数据的表共 11 张（cw 侧）+ 12 张（admin 侧），清理后只剩系统种子。
 - **改完任何一条迁移都要跑 `./scripts/export-schema-snapshot.sh` 刷新结构快照**
   （`mysql/schema-snapshot/{agent_scope_customer_work,customer_admin}.sql`）。这两份是「这两个库现在长什么样」
-  的直接答案，只读、不参与建库，改它们不会对任何库生效。**生成源必须是临时空库跑完迁移的产物，不是开发机的
+  的直接答案，**由迁移产物生成，手工改它们不会对任何库生效**（真源永远是迁移）。
+  **admin 那份自 2026-09-02 起在结构之后带系统种子数据段**（菜单权限树 166 行、角色、默认租户、
+  admin 账号等 12 张表），执行完就是一个能直接 `admin/admin` 登录的库——此前它自称能「全新建库」，
+  建出来却是谁也进不去的空壳。三条约定：
+  ① **导哪些行不由人工清单决定，照实导出迁移产物里的全部数据行**。挑子集会让快照与迁移产物不再等价，
+  两条建库路径给出不同结果，正是本仓库反复踩过的形状；随迁移带出的示例配置交给
+  `scripts/clear-demo-data.sh --public` 清，不在导出器里另立一套判定；
+  ② **cw 侧刻意不开这个开关**（`CustomerAdminSchemaSnapshotTest.INCLUDE_SEED_DATA`）：
+  客服端的演示业务数据归 `mysql/01` 完整镜像管，引进快照只会多一份要清理的脏数据；
+  ③ **快照重放在 `SHOW CREATE TABLE` 层面不幂等**：只写 `COLLATE` 不写 `CHARACTER SET` 的列，
+  建库后 MySQL 会回吐 `CHARACTER SET utf8mb4`。这只是显示形态，实测结构等价
+  （1308 列、536 索引、12 张种子表逐项一致），**比对两条建库路径要用 information_schema，
+  不要 diff `SHOW CREATE` 文本**。**生成源必须是临时空库跑完迁移的产物，不是开发机的
   长期业务库**——本机库被并行分支的迁移反复试跑过，沉积的结构与迁移产物无法区分，直接 dump 等于把污染固化。
   漏刷新由 `CustomerWorkSchemaSnapshotTest` / `CustomerAdminSchemaSnapshotTest` 拦下：它们每次跑测试都重新
   迁移一个临时库比对快照，不一致会指出是哪张表的第几行。**门禁与生成共用 `SchemaSnapshotExporter` 一段逻辑**，

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/schema/CustomerAdminSchemaSnapshotTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/schema/CustomerAdminSchemaSnapshotTest.java
@@ -16,6 +16,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -44,6 +45,19 @@ class CustomerAdminSchemaSnapshotTest {
     private static final String MIGRATION_LOCATION = "classpath:db/migration";
     private static final int SOCKET_TIMEOUT_MS = 500;
 
+    /**
+     * 本库的快照带系统种子数据段。
+     *
+     * <p>后台库的迁移自带菜单权限树、角色、默认租户与 admin 账号，缺了它们建出来的库<b>登录页
+     * 就过不去</b>——快照虽自称能「全新建库」，建出来却没人进得去。客服端库那侧不开这个开关：
+     * 它的演示业务数据归 {@code mysql/01} 的完整镜像管，引进快照只会多一份要清理的脏数据。</p>
+     */
+    private static final boolean INCLUDE_SEED_DATA = true;
+
+    /** 登录一次至少要读到的四张表，缺任何一张按快照建出来的库都进不去。 */
+    private static final java.util.List<String> LOGIN_CHAIN_TABLES =
+        java.util.List.of("sys_tenant", "sys_user", "sys_role", "sys_user_role");
+
     @Test
     void snapshotShouldStayInSyncWithMigrations() throws Exception {
         assumeTrue(reachable(), "MySQL 不可达，跳过后台库结构快照门禁");
@@ -54,7 +68,7 @@ class CustomerAdminSchemaSnapshotTest {
             migrate(dataSource);
             String exported;
             try (Connection connection = dataSource.getConnection()) {
-                exported = SchemaSnapshotExporter.export(connection, header(connection));
+                exported = SchemaSnapshotExporter.export(connection, header(connection), INCLUDE_SEED_DATA);
             }
 
             Path snapshot = repositoryRoot().resolve(SNAPSHOT_PATH);
@@ -77,6 +91,79 @@ class CustomerAdminSchemaSnapshotTest {
     }
 
     /**
+     * 种子段的两条硬性质：导出可复现，且 admin 的登录链路真的在里面。
+     *
+     * <p><b>可复现</b>：同一个库连导两次必须逐字一致。种子行里只要混进一个随导出时刻变化的值
+     * （{@code DEFAULT CURRENT_TIMESTAMP} 是最常见的一个，将来还可能是 {@code DEFAULT (UUID())}），
+     * 上面那条漂移门禁就会变成「每跑必红」，而红的原因与任何人的改动都无关——那种门禁没人会信，
+     * 几次之后就被当噪音跳过了。这条断言把那种故障提前变成一句指名道姓的失败。</p>
+     *
+     * <p><b>登录链路</b>：本快照存在的意义是「执行完能登进去」。漂移门禁只保证快照等于迁移产物，
+     * 哪天迁移把 admin 种子挪走或改了绑定，快照会忠实地跟着变、门禁照样绿，而建出来的库谁也进不去。
+     * 所以这里单独钉住那条链路：admin 账号启用、绑着超管角色、所属租户存在且激活，且这些行确实
+     * 进了快照文本。</p>
+     */
+    @Test
+    void seedDataShouldBeReproducibleAndCarryAdminLoginChain() throws Exception {
+        assumeTrue(reachable(), "MySQL 不可达，跳过后台库种子数据门禁");
+        String first = migrateAndExport();
+        assumeTrue(first != null, "MySQL 测试账号无建库权限，跳过后台库种子数据门禁");
+        String second = migrateAndExport();
+        assumeTrue(second != null, "MySQL 测试账号无建库权限，跳过后台库种子数据门禁");
+
+        assertNull(SchemaSnapshotExporter.describeDifference(first, second),
+            "两个独立建起来的库导出结果不一致：种子行里混进了随建库时刻变化的值，"
+                + "会让上面那条漂移门禁变成「每跑必红」。给该列在 SchemaSnapshotExporter 里补跳过规则。");
+
+        for (String table : LOGIN_CHAIN_TABLES) {
+            assertTrue(first.contains("INSERT INTO `" + table + "`"),
+                "快照缺少 " + table + " 的种子数据段，按它建出来的库无法登录");
+        }
+    }
+
+    /**
+     * 新建一个库跑完迁移并导出，顺带断言这一份产物里的 admin 登录链路完整。
+     *
+     * <p>两次调用必须建<b>两个不同的库</b>：种子行的 create_time 取的是迁移执行那一刻，同一个库
+     * 连导两次当然一样，那种写法是恒真断言，照不出任何问题。只有两次独立建库才能让「时刻」真的
+     * 不同，从而验出有没有随时刻变化的值漏进 INSERT。</p>
+     *
+     * @return 导出的快照文本；测试账号无建库权限时返回 {@code null}
+     */
+    private String migrateAndExport() throws Exception {
+        String database = "admin_seed_" + randomSuffix();
+        if (!createDatabase(database)) {
+            return null;
+        }
+        try (HikariDataSource dataSource = dataSource(database)) {
+            migrate(dataSource);
+            try (Connection connection = dataSource.getConnection()) {
+                assertEquals(1, adminLoginChainCount(connection),
+                    "迁移没有留下可登录的超级管理员：需要 sys_user(admin, 启用) → sys_user_role → "
+                        + "sys_role(super_admin) → sys_tenant(该用户所属租户, ACTIVE) 这条链路完整，"
+                        + "否则按本快照建出来的库登录页过不去。");
+                return SchemaSnapshotExporter.export(connection, header(connection), INCLUDE_SEED_DATA);
+            }
+        } finally {
+            dropDatabase(database);
+        }
+    }
+
+    /** 登录链路是否完整：admin 启用、绑超管角色、所属租户存在且激活，三者缺一不可。 */
+    private int adminLoginChainCount(Connection connection) throws Exception {
+        String sql = "SELECT COUNT(*) FROM `sys_user` u "
+            + "JOIN `sys_user_role` ur ON ur.`user_id` = u.`id` "
+            + "JOIN `sys_role` r ON r.`id` = ur.`role_id` "
+            + "JOIN `sys_tenant` t ON t.`tenant_code` = u.`tenant_id` "
+            + "WHERE u.`username` = 'admin' AND u.`status` = 1 AND u.`deleted` = 0 "
+            + "AND r.`role_code` = 'super_admin' AND t.`status` = 'ACTIVE'";
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            return resultSet.next() ? resultSet.getInt(1) : 0;
+        }
+    }
+
+    /**
      * 构造快照文件头。
      *
      * <p>只放由迁移本身决定的信息：写入生成时间或机器名会让每次导出的文本都不同，门禁就永远是红的。</p>
@@ -91,17 +178,24 @@ class CustomerAdminSchemaSnapshotTest {
             + "-- 对应版本：Flyway V" + lastAppliedVersion(connection) + "\n"
             + "-- 真源：customer-admin-server/src/main/resources/db/migration/\n"
             + "--       改结构一律新增迁移，改本文件不会生效。\n"
-            + "-- 用途：结构查阅与全新建库。**不要对已有库执行**，这里没有 IF NOT EXISTS 保护。\n"
+            + "-- 内容：全部表结构 + 迁移写入的系统种子数据（菜单权限树、角色、默认租户、admin 账号等）。\n"
+            + "--       种子行里的 create_time/update_time 不进 INSERT，由建库时的默认值现场填充——\n"
+            + "--       那两列的值是迁移执行那一秒，写死会让快照每次重新生成都不一样。\n"
+            + "-- 用途：结构查阅与全新建库。执行完即可用 admin / admin 登录（超级管理员，\n"
+            + "--       AuthService 检测到仍是初始密码会强制改密）。**不要对已有库执行**，\n"
+            + "--       这里既没有 IF NOT EXISTS 保护，种子数据也会撞主键。\n"
             + "--       生产手工初始化仍按 mysql/02-customer-admin/ 的迁移副本顺序执行，\n"
-            + "--       那条路径会留下 flyway_schema_history，之后能继续增量升级。\n"
+            + "--       那条路径会留下 flyway_schema_history，之后能继续增量升级；本文件没有它，\n"
+            + "--       建出来的库无法再走 Flyway 增量升级。\n"
+            + "--       随迁移带出的示例配置（SQL 查询功能等）用 scripts/clear-demo-data.sh --public 清理。\n"
             + "-- 建库：CREATE DATABASE `" + DATABASE_NAME + "`\n"
             + "--         DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\n"
-            + "-- COLLATE 说明：快照里同时出现 utf8mb4_0900_ai_ci 与 utf8mb4_unicode_ci 是既有状况，\n"
-            + "--               不是导出错误。MySQL 8 的规则：建表语句写了 DEFAULT CHARSET=utf8mb4\n"
-            + "--               却没写 COLLATE 时，用的是该字符集的默认 collation(utf8mb4_0900_ai_ci)\n"
-            + "--               而非库的；显式写了 COLLATE 的按其声明；只有既不写 CHARSET 也不写\n"
-            + "--               COLLATE 的少数表才继承上面的建库参数——所以导出必须固定按上面的参数\n"
-            + "--               建库，换一套参数会让那几张表的输出跟着变。\n"
+            + "-- COLLATE 说明：V100 全量对齐之后，本快照应只出现 utf8mb4_unicode_ci 一种排序规则；\n"
+            + "--               再冒出 utf8mb4_0900_ai_ci 就是有人建表漏写了 COLLATE。MySQL 8 的规则：\n"
+            + "--               建表语句写了 DEFAULT CHARSET=utf8mb4 却没写 COLLATE 时，用的是该字符集\n"
+            + "--               的默认 collation(utf8mb4_0900_ai_ci) 而非库的；显式写了 COLLATE 的按其\n"
+            + "--               声明；只有既不写 CHARSET 也不写 COLLATE 的表才继承上面的建库参数——\n"
+            + "--               所以导出必须固定按上面的参数建库，换一套参数会让那几张表的输出跟着变。\n"
             + "-- ----------------------------------------------------------------------------\n"
             + "\n"
             + "SET NAMES utf8mb4;\n";

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/migration/SchemaSnapshotExporter.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/migration/SchemaSnapshotExporter.java
@@ -7,6 +7,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -19,6 +21,9 @@ import java.util.regex.Pattern;
  *
  * <p>导出源必须是<b>按仓库标准流程新建并跑完迁移的临时库</b>，不能是开发机上的长期业务库：后者
  * 沉积了并行分支试跑过的结构，快照会把这些沉积物一并固化，且没有任何机制能发现。</p>
+ *
+ * <p>可选的<b>系统种子数据段</b>见 {@link #export(Connection, String, boolean)}：只有迁移本身
+ * 写入的行才会出现在那里，同样由迁移产物决定，不需要另一份人工维护的清单。</p>
  *
  * @author owlzhangfq@gmail.com
  */
@@ -36,12 +41,48 @@ public final class SchemaSnapshotExporter {
     /** 建表语句前缀：用于把差异行回溯到所属表。 */
     private static final String CREATE_TABLE_PREFIX = "CREATE TABLE `";
 
+    /** 种子段的语句前缀：数据段整体排在全部建表语句之后，只认建表前缀会把这里的差异
+     *  一律归到最后一张表上——指着一张毫不相干的表报错，比不报表名更难查。 */
+    private static final String INSERT_INTO_PREFIX = "INSERT INTO `";
+
     private static final String SECTION_RULE =
         "-- ----------------------------------------------------------------------------";
+
+    /** 数据段的小节标题后缀，与结构段的同名小节区分开。 */
+    private static final String SEED_SECTION_SUFFIX = " · 系统种子数据";
 
     private static final String LIST_TABLES_SQL =
         "SELECT table_name FROM information_schema.tables "
             + "WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' ORDER BY table_name";
+
+    private static final String LIST_COLUMNS_SQL =
+        "SELECT column_name, column_default, extra, data_type FROM information_schema.columns "
+            + "WHERE table_schema = DATABASE() AND table_name = ? ORDER BY ordinal_position";
+
+    private static final String LIST_PRIMARY_KEY_SQL =
+        "SELECT column_name FROM information_schema.statistics "
+            + "WHERE table_schema = DATABASE() AND table_name = ? AND index_name = 'PRIMARY' "
+            + "ORDER BY seq_in_index";
+
+    /**
+     * 值由导出时刻决定的自动列标记。
+     *
+     * <p>种子行的 {@code create_time}/{@code update_time} 取的是迁移执行那一秒，每次重新生成快照
+     * 都不一样。照原样写进 INSERT，门禁会变成「每跑必红」——而红的原因与任何人的改动都无关，
+     * 几次之后就没人再信它了。这类列一律不进 INSERT 列清单，由建库时的
+     * {@code DEFAULT CURRENT_TIMESTAMP} 现场填充，语义上也正是「这一行是建库那一刻写入的」。</p>
+     */
+    private static final String GENERATED_DEFAULT_EXTRA = "DEFAULT_GENERATED";
+
+    /** 与上面配套：只跳「默认值就是当前时间」的列，别的表达式默认值仍照常导出。 */
+    private static final String CURRENT_TIMESTAMP_DEFAULT = "CURRENT_TIMESTAMP";
+
+    /** 数值类型不加引号，保持与迁移脚本里的字面形态一致。 */
+    private static final Set<String> NUMERIC_TYPES =
+        Set.of("bigint", "int", "mediumint", "smallint", "tinyint", "decimal", "float", "double", "bit");
+
+    /** 合法的库内标识符：库名、表名、列名都走这一处校验。 */
+    private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[a-z0-9_]+");
 
     /**
      * 写入模式开关：置 true 时由生成侧覆写仓库内的快照文件，否则只做漂移比对。
@@ -60,21 +101,46 @@ public final class SchemaSnapshotExporter {
     }
 
     /**
-     * 导出当前连接所指库的全量表结构。
+     * 导出当前连接所指库的全量表结构（不含任何数据行）。
      *
      * @param connection 指向已完成迁移的库的连接
      * @param header     文件头文本，由调用方给出（不同库的说明与执行方式不同），需自带结尾换行
      * @return 归一化后的完整快照文本
      */
     public static String export(Connection connection, String header) throws SQLException {
+        return export(connection, header, false);
+    }
+
+    /**
+     * 导出当前连接所指库的全量表结构，并可附带迁移写入的系统种子数据。
+     *
+     * <p>带上数据段之后，快照单文件执行完就是一个<b>可直接登录使用</b>的库：菜单权限树、角色、
+     * 默认租户与 admin 账号都在里面。此前的纯结构快照虽然自称能「全新建库」，建出来却是一个谁也
+     * 进不去的空壳——库建好了，登录页过不去。</p>
+     *
+     * <p>导哪些行不由人工清单决定，而是<b>照实导出迁移产物里的全部数据行</b>。挑子集会让快照与
+     * 迁移产物不再等价，两条建库路径给出不同结果——那正是本仓库反复踩过的形状（表排序规则那次）。
+     * 演示/示例数据的清理有 {@code scripts/clear-demo-data.sh} 专职负责，不在这里另立一套判定。</p>
+     *
+     * @param connection      指向已完成迁移的库的连接
+     * @param header          文件头文本，需自带结尾换行
+     * @param includeSeedData 是否在结构之后追加种子数据段
+     * @return 归一化后的完整快照文本
+     */
+    public static String export(Connection connection, String header, boolean includeSeedData)
+        throws SQLException {
+        List<String> tables = listBaseTables(connection);
         StringBuilder snapshot = new StringBuilder(header);
-        for (String table : listBaseTables(connection)) {
+        for (String table : tables) {
             snapshot.append(LINE_SEPARATOR)
                 .append(SECTION_RULE).append(LINE_SEPARATOR)
                 .append("-- ").append(table).append(LINE_SEPARATOR)
                 .append(SECTION_RULE).append(LINE_SEPARATOR)
                 .append(normalize(showCreateTable(connection, table)))
                 .append(';').append(LINE_SEPARATOR);
+        }
+        if (includeSeedData) {
+            appendSeedData(snapshot, connection, tables);
         }
         return snapshot.toString();
     }
@@ -111,13 +177,20 @@ public final class SchemaSnapshotExporter {
             + "  首行内容：" + extraLines[commonLines];
     }
 
-    /** 从差异位置往上找最近的建表语句，把差异落到具体某张表上。 */
+    /** 从差异位置往上找最近的建表或种子插入语句，把差异落到具体某张表上。 */
     private static String tableHint(String[] lines, int index) {
         for (int cursor = Math.min(index, lines.length - 1); cursor >= 0; cursor--) {
-            if (lines[cursor].startsWith(CREATE_TABLE_PREFIX)) {
-                String remainder = lines[cursor].substring(CREATE_TABLE_PREFIX.length());
+            String line = lines[cursor];
+            String prefix = line.startsWith(CREATE_TABLE_PREFIX) ? CREATE_TABLE_PREFIX
+                : line.startsWith(INSERT_INTO_PREFIX) ? INSERT_INTO_PREFIX : null;
+            if (prefix != null) {
+                String remainder = line.substring(prefix.length());
                 int end = remainder.indexOf('`');
-                return end > 0 ? "（表 " + remainder.substring(0, end) + "）" : "";
+                if (end > 0) {
+                    return "（表 " + remainder.substring(0, end)
+                        + (INSERT_INTO_PREFIX.equals(prefix) ? " 的种子数据" : "") + "）";
+                }
+                return "";
             }
         }
         return "（文件头）";
@@ -138,6 +211,149 @@ public final class SchemaSnapshotExporter {
         return tables;
     }
 
+    /**
+     * 追加种子数据段：逐表导出迁移写入的行，空表跳过。
+     *
+     * <p>表序沿用结构段的表名序。本库没有外键约束（导出时已实测为 0 条），INSERT 之间不存在
+     * 先后依赖；哪天真加了外键，这里要改成按依赖拓扑排序，否则建库会在约束上失败。</p>
+     */
+    private static void appendSeedData(StringBuilder snapshot, Connection connection, List<String> tables)
+        throws SQLException {
+        for (String table : tables) {
+            List<SeedColumn> columns = seedColumns(connection, table);
+            if (columns.isEmpty()) {
+                continue;
+            }
+            String rows = selectSeedRows(connection, table, columns);
+            if (rows.isEmpty()) {
+                continue;
+            }
+            snapshot.append(LINE_SEPARATOR)
+                .append(SECTION_RULE).append(LINE_SEPARATOR)
+                .append("-- ").append(table).append(SEED_SECTION_SUFFIX).append(LINE_SEPARATOR)
+                .append(SECTION_RULE).append(LINE_SEPARATOR)
+                .append("INSERT INTO ").append(quoted(table)).append(" (")
+                .append(columnList(columns)).append(") VALUES").append(LINE_SEPARATOR)
+                .append(rows).append(';').append(LINE_SEPARATOR);
+        }
+    }
+
+    /** 取该表要写进 INSERT 的列，剔除值由导出时刻决定的自动时间列。 */
+    private static List<SeedColumn> seedColumns(Connection connection, String table) throws SQLException {
+        List<SeedColumn> columns = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(LIST_COLUMNS_SQL)) {
+            statement.setString(1, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String name = resultSet.getString(1);
+                    String columnDefault = resultSet.getString(2);
+                    String extra = resultSet.getString(3);
+                    String dataType = resultSet.getString(4);
+                    if (generatedFromExportMoment(columnDefault, extra)) {
+                        continue;
+                    }
+                    columns.add(new SeedColumn(name, NUMERIC_TYPES.contains(lowerCase(dataType))));
+                }
+            }
+        }
+        return columns;
+    }
+
+    /** 判定「这一列的值取自导出那一刻」：默认值是当前时间，且由 MySQL 自动生成。 */
+    private static boolean generatedFromExportMoment(String columnDefault, String extra) {
+        if (columnDefault == null || !lowerCase(columnDefault).startsWith(lowerCase(CURRENT_TIMESTAMP_DEFAULT))) {
+            return false;
+        }
+        return extra != null && lowerCase(extra).contains(lowerCase(GENERATED_DEFAULT_EXTRA));
+    }
+
+    /** 按确定顺序读出该表全部行，拼成 VALUES 列表；空表返回空串。 */
+    private static String selectSeedRows(Connection connection, String table, List<SeedColumn> columns)
+        throws SQLException {
+        String sql = "SELECT " + columnList(columns) + " FROM " + quoted(table)
+            + " ORDER BY " + orderBy(connection, table, columns);
+        StringBuilder rows = new StringBuilder();
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                if (rows.length() > 0) {
+                    rows.append(',').append(LINE_SEPARATOR);
+                }
+                rows.append("  (");
+                for (int index = 0; index < columns.size(); index++) {
+                    if (index > 0) {
+                        rows.append(", ");
+                    }
+                    rows.append(literal(resultSet.getString(index + 1), columns.get(index)));
+                }
+                rows.append(')');
+            }
+        }
+        return rows.toString();
+    }
+
+    /**
+     * 行序必须确定，否则同一套迁移两次导出的 VALUES 顺序可能不同，门禁会红在一个假差异上。
+     *
+     * <p>优先按主键排；没有主键的表退化为按全部导出列排——只要值一样，顺序就一样。</p>
+     */
+    private static String orderBy(Connection connection, String table, List<SeedColumn> columns)
+        throws SQLException {
+        List<String> primaryKey = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(LIST_PRIMARY_KEY_SQL)) {
+            statement.setString(1, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    primaryKey.add(quoted(resultSet.getString(1)));
+                }
+            }
+        }
+        return primaryKey.isEmpty() ? columnList(columns) : String.join(", ", primaryKey);
+    }
+
+    /** 单个值的 SQL 字面量：NULL 直出，数值不加引号，其余转义后加引号。 */
+    private static String literal(String value, SeedColumn column) {
+        if (value == null) {
+            return "NULL";
+        }
+        return column.numeric() ? value : "'" + escape(value) + "'";
+    }
+
+    /**
+     * 按 MySQL 字面量规则转义。
+     *
+     * <p>换行与制表符转成转义序列而不是原样保留：一行 VALUES 对应一行文本，
+     * {@link #describeDifference} 才能把差异定位到具体某一行，人也才看得动 diff。</p>
+     */
+    private static String escape(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '\\' -> escaped.append("\\\\");
+                case '\'' -> escaped.append("\\'");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                case '\0' -> escaped.append("\\0");
+                case 0x1A -> escaped.append("\\Z");
+                default -> escaped.append(character);
+            }
+        }
+        return escaped.toString();
+    }
+
+    private static String columnList(List<SeedColumn> columns) {
+        StringBuilder list = new StringBuilder();
+        for (SeedColumn column : columns) {
+            if (list.length() > 0) {
+                list.append(", ");
+            }
+            list.append(quoted(column.name()));
+        }
+        return list.toString();
+    }
+
     private static String showCreateTable(Connection connection, String table) throws SQLException {
         try (Statement statement = connection.createStatement();
              ResultSet resultSet = statement.executeQuery("SHOW CREATE TABLE " + quoted(table))) {
@@ -154,9 +370,22 @@ public final class SchemaSnapshotExporter {
     }
 
     private static String quoted(String identifier) {
-        if (!identifier.matches("[a-z0-9_]+")) {
+        if (!SAFE_IDENTIFIER.matcher(identifier).matches()) {
             throw new IllegalArgumentException("illegal database identifier: " + identifier);
         }
         return "`" + identifier + "`";
+    }
+
+    private static String lowerCase(String text) {
+        return text.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * 参与种子导出的一列。
+     *
+     * @param name    列名
+     * @param numeric 是否数值类型（决定字面量加不加引号）
+     */
+    private record SeedColumn(String name, boolean numeric) {
     }
 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/migration/SchemaSnapshotDifferenceTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/migration/SchemaSnapshotDifferenceTest.java
@@ -1,0 +1,68 @@
+package com.richard.fyoung.customerwork.infra.migration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 快照差异描述的定位准确性。
+ *
+ * <p>差异描述是漂移门禁唯一的排查线索：快照有十几万字符，报错里那句「哪张表」决定了人要看一眼
+ * 还是自己 diff 一遍。种子数据段整体排在全部建表语句之后，若只按建表前缀回溯，数据段里的任何
+ * 差异都会被归到<b>最后一张表</b>上——指着一张毫不相干的表报错，比不报表名更误导。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class SchemaSnapshotDifferenceTest {
+
+    @Test
+    void identicalSnapshotsShouldReportNoDifference() {
+        String snapshot = "CREATE TABLE `sys_user` (\n  `id` bigint\n);\n";
+        assertNull(SchemaSnapshotExporter.describeDifference(snapshot, snapshot));
+    }
+
+    @Test
+    void structureDifferenceShouldNameOwningTable() {
+        String expected = "CREATE TABLE `sys_user` (\n  `id` bigint NOT NULL\n);\n";
+        String actual = "CREATE TABLE `sys_user` (\n  `id` bigint DEFAULT NULL\n);\n";
+        String difference = SchemaSnapshotExporter.describeDifference(expected, actual);
+        assertTrue(difference != null && difference.contains("表 sys_user"),
+            "结构差异应指出所属表，实际：" + difference);
+    }
+
+    /** 数据段差异必须报自己那张表，不能回溯到它前面最后一条建表语句上。 */
+    @Test
+    void seedDifferenceShouldNameSeedTableNotLastCreatedTable() {
+        String head = "CREATE TABLE `sys_user` (\n  `id` bigint\n);\n"
+            + "CREATE TABLE `workbench_token` (\n  `id` bigint\n);\n"
+            + "INSERT INTO `ai_model_price` (`id`) VALUES\n";
+        String difference = SchemaSnapshotExporter.describeDifference(head + "  (1);\n", head + "  (2);\n");
+        assertTrue(difference != null && difference.contains("表 ai_model_price 的种子数据"),
+            "种子数据差异应指出自己那张表，实际：" + difference);
+        assertTrue(difference != null && !difference.contains("workbench_token"),
+            "种子数据差异不应归到前面最后一张建表上，实际：" + difference);
+    }
+
+    @Test
+    void headerDifferenceShouldBeReportedAsHeader() {
+        String difference = SchemaSnapshotExporter.describeDifference(
+            "-- 对应版本：Flyway V100\n", "-- 对应版本：Flyway V101\n");
+        assertTrue(difference != null && difference.contains("文件头"),
+            "文件头差异应标记为文件头，实际：" + difference);
+    }
+
+    /** 一侧整段缺失（例如旧快照还没有种子段）时，要说明是哪一侧多出、从哪张表开始。 */
+    @Test
+    void extraTrailingLinesShouldBeReported() {
+        // 结尾刻意不留换行：留了的话 split 会在两侧各产生一个空尾元素，
+        // 先撞上的是「空行 vs 有内容」的逐行差异，走不到「多出行」这个分支。
+        String expected = "CREATE TABLE `sys_user` (\n  `id` bigint\n);";
+        String difference = SchemaSnapshotExporter.describeDifference(
+            expected, expected + "\nINSERT INTO `sys_user` (`id`) VALUES\n  (1);");
+        assertTrue(difference != null && difference.contains("迁移产物")
+            && difference.contains("多出"), "多出的行应说明是哪一侧多出，实际：" + difference);
+        assertTrue(difference != null && difference.contains("sys_user"),
+            "应指出从哪张表开始多出，实际：" + difference);
+    }
+}

--- a/mysql/schema-snapshot/customer_admin.sql
+++ b/mysql/schema-snapshot/customer_admin.sql
@@ -7,17 +7,24 @@
 -- 对应版本：Flyway V101
 -- 真源：customer-admin-server/src/main/resources/db/migration/
 --       改结构一律新增迁移，改本文件不会生效。
--- 用途：结构查阅与全新建库。**不要对已有库执行**，这里没有 IF NOT EXISTS 保护。
+-- 内容：全部表结构 + 迁移写入的系统种子数据（菜单权限树、角色、默认租户、admin 账号等）。
+--       种子行里的 create_time/update_time 不进 INSERT，由建库时的默认值现场填充——
+--       那两列的值是迁移执行那一秒，写死会让快照每次重新生成都不一样。
+-- 用途：结构查阅与全新建库。执行完即可用 admin / admin 登录（超级管理员，
+--       AuthService 检测到仍是初始密码会强制改密）。**不要对已有库执行**，
+--       这里既没有 IF NOT EXISTS 保护，种子数据也会撞主键。
 --       生产手工初始化仍按 mysql/02-customer-admin/ 的迁移副本顺序执行，
---       那条路径会留下 flyway_schema_history，之后能继续增量升级。
+--       那条路径会留下 flyway_schema_history，之后能继续增量升级；本文件没有它，
+--       建出来的库无法再走 Flyway 增量升级。
+--       随迁移带出的示例配置（SQL 查询功能等）用 scripts/clear-demo-data.sh --public 清理。
 -- 建库：CREATE DATABASE `customer_admin`
 --         DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
--- COLLATE 说明：快照里同时出现 utf8mb4_0900_ai_ci 与 utf8mb4_unicode_ci 是既有状况，
---               不是导出错误。MySQL 8 的规则：建表语句写了 DEFAULT CHARSET=utf8mb4
---               却没写 COLLATE 时，用的是该字符集的默认 collation(utf8mb4_0900_ai_ci)
---               而非库的；显式写了 COLLATE 的按其声明；只有既不写 CHARSET 也不写
---               COLLATE 的少数表才继承上面的建库参数——所以导出必须固定按上面的参数
---               建库，换一套参数会让那几张表的输出跟着变。
+-- COLLATE 说明：V100 全量对齐之后，本快照应只出现 utf8mb4_unicode_ci 一种排序规则；
+--               再冒出 utf8mb4_0900_ai_ci 就是有人建表漏写了 COLLATE。MySQL 8 的规则：
+--               建表语句写了 DEFAULT CHARSET=utf8mb4 却没写 COLLATE 时，用的是该字符集
+--               的默认 collation(utf8mb4_0900_ai_ci) 而非库的；显式写了 COLLATE 的按其
+--               声明；只有既不写 CHARSET 也不写 COLLATE 的表才继承上面的建库参数——
+--               所以导出必须固定按上面的参数建库，换一套参数会让那几张表的输出跟着变。
 -- ----------------------------------------------------------------------------
 
 SET NAMES utf8mb4;
@@ -2200,3 +2207,314 @@ CREATE TABLE `workbench_token` (
   KEY `idx_workbench_token_user` (`user_id`),
   KEY `idx_workbench_token_tenant` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='内网工作台个人访问令牌';
+
+-- ----------------------------------------------------------------------------
+-- ai_model_price · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `ai_model_price` (`id`, `provider`, `model_name`, `input_price`, `output_price`, `cached_price`, `currency`, `effective_from`, `remark`, `create_by`, `update_by`, `deleted`) VALUES
+  (1, 'dashscope', 'qwen-max', 2.400000, 9.600000, 0.480000, 'CNY', '2026-01-01 00:00:00', '示意价格，上线前按厂商实际报价维护', NULL, NULL, 0);
+
+-- ----------------------------------------------------------------------------
+-- ai_system_tool · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `ai_system_tool` (`id`, `tool_code`, `tool_name`, `description`, `enabled`, `remark`, `create_by`, `update_by`, `deleted`) VALUES
+  (1, 'httpclient', 'HTTP请求工具', 'http请求工具', 1, 'http请求工具', NULL, NULL, 0),
+  (2, 'devtoolbox', '开发者工具箱', '开发者常用本地工具集：JSON格式化/压缩/校验/转义/去转义/Unicode解码、时间戳转换、Base64/URL/Hex编解码、哈希(HMAC)、UUID生成、AES加解密(CBC/ECB/CTR/GCM)、正则测试、X.509证书/CSR解析、私钥与证书配对校验、cron表达式解析、JWT解析、文本比对、JSON/YAML/XML互转', 1, '纯本地计算，无外部依赖；注意 cert_match 需传入私钥明文、jwt_decode 可能传入令牌与签名密钥，均会进入模型上下文与对话历史', NULL, NULL, 0);
+
+-- ----------------------------------------------------------------------------
+-- sql_datasource · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sql_datasource` (`id`, `name`, `jdbc_url`, `username`, `password`, `enabled`, `remark`, `create_by`, `update_by`, `deleted`, `tenant_id`) VALUES
+  (1, '审计日志测试查看', 'jdbc:mysql://localhost:3306/agent_scope_customer_work', 'root', 'J9DLVag0gGSLSKGUpocWq72j0qZ4cuke/NYhL9fW3XU=', 1, '', 1, 1, 0, 'default');
+
+-- ----------------------------------------------------------------------------
+-- sql_define · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sql_define` (`id`, `define_key`, `datasource_id`, `sql_describe`, `query_sql`, `count_sql`, `auto_load`, `enabled`, `remark`, `create_by`, `update_by`, `deleted`, `tenant_id`) VALUES
+  (1, 'defineKey', 1, '审计日志', 'SELECT id, session_id AS \'会话ID\',duration_ms as \'操作耗时\', create_time AS \'创建时间\'\nFROM customer_admin.ai_coding_audit_log WHERE create_time >= :startTime\nORDER BY id DESC LIMIT :pageNum, :pageSize', 'SELECT count(*)\nFROM customer_admin.ai_coding_audit_log WHERE create_time >= :startTime', 1, 1, '', 1, 1, 0, 'default');
+
+-- ----------------------------------------------------------------------------
+-- sql_define_param · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sql_define_param` (`id`, `define_id`, `param_name`, `param_desc`, `param_type`, `date_format`, `required`, `default_value`, `drop_down`, `is_page_num`, `is_page_size`, `sort`, `create_by`, `update_by`, `deleted`, `tenant_id`) VALUES
+  (1, 1, 'startTime', '', 'STRING', NULL, 0, '${now-14d}', '', 0, 0, 0, 1, 1, 0, 'default'),
+  (2, 1, 'pageNum', '分页页码', 'INTEGER', NULL, 0, '0', '', 1, 0, 0, 1, 1, 0, 'default'),
+  (3, 1, 'pageSize', '', 'INTEGER', NULL, 0, '30', '', 0, 1, 0, 1, 1, 0, 'default');
+
+-- ----------------------------------------------------------------------------
+-- sql_field_transform · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sql_field_transform` (`id`, `define_id`, `field_name`, `transform_type`, `transform_config`, `create_by`, `update_by`, `deleted`, `tenant_id`) VALUES
+  (1, 1, 'create_time', 'DATE_FORMAT', 'yyyy-MM-dd HH:mm:ss', 1, 1, 0, 'default');
+
+-- ----------------------------------------------------------------------------
+-- sys_permission · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sys_permission` (`id`, `parent_id`, `perm_name`, `perm_code`, `type`, `path`, `icon`, `icon_type`, `sort`, `create_by`, `update_by`, `deleted`) VALUES
+  (1, 0, '系统管理', 'system', 1, '/system', 'Setting', 'library', 1, NULL, NULL, 0),
+  (2, 0, 'AI 配置', 'aiconfig', 1, '/aiconfig', 'Opportunity', 'library', 2, NULL, NULL, 0),
+  (3, 0, '智能体工作区', 'workspace', 1, '/workspace', 'Service', 'library', 3, NULL, NULL, 0),
+  (4, 0, 'Projects', 'project', 1, '/project', 'Files', 'library', 4, NULL, NULL, 0),
+  (10, 1, '用户管理', 'user', 1, '/system/user', 'User', 'library', 1, NULL, NULL, 0),
+  (11, 1, '角色权限', 'role', 1, '/system/role', 'Avatar', 'library', 2, NULL, NULL, 0),
+  (12, 1, '操作日志', 'log', 1, '/system/log', 'Tickets', 'library', 3, NULL, NULL, 0),
+  (13, 1, '菜单管理', 'menu', 1, '/system/menu', 'Menu', 'library', 4, NULL, NULL, 0),
+  (20, 2, '模型配置', 'model', 1, '/aiconfig/model', 'Cpu', 'library', 1, NULL, NULL, 0),
+  (21, 2, 'MCP 管理', 'mcp', 1, '/aiconfig/mcp', 'Connection', 'library', 2, NULL, NULL, 0),
+  (22, 2, 'Skill 管理', 'skill', 1, '/aiconfig/skill', 'Tools', 'library', 3, NULL, NULL, 0),
+  (23, 2, '智能体管理', 'agent', 1, '/aiconfig/agent', 'MagicStick', 'library', 4, NULL, NULL, 0),
+  (24, 10, '查看用户', 'user:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (25, 10, '新增用户', 'user:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (26, 10, '编辑用户', 'user:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (27, 10, '删除用户', 'user:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (28, 11, '查看角色', 'role:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (29, 11, '新增角色', 'role:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (30, 11, '编辑角色', 'role:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (31, 11, '删除角色', 'role:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (32, 12, '查看日志', 'log:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (33, 20, '查看模型', 'model:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (34, 20, '新增模型', 'model:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (35, 20, '编辑模型', 'model:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (36, 20, '删除模型', 'model:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (37, 21, '查看MCP', 'mcp:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (38, 21, '新增MCP', 'mcp:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (39, 21, '编辑MCP', 'mcp:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (40, 21, '删除MCP', 'mcp:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (41, 22, '查看Skill', 'skill:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (42, 22, '新增Skill', 'skill:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (43, 22, '编辑Skill', 'skill:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (44, 22, '删除Skill', 'skill:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (45, 23, '查看智能体', 'agent:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (46, 23, '新增智能体', 'agent:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (47, 23, '编辑智能体', 'agent:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (48, 23, '删除智能体', 'agent:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (49, 13, '查看菜单', 'menu:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (50, 13, '新增菜单', 'menu:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (51, 13, '编辑菜单', 'menu:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (52, 13, '删除菜单', 'menu:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (60, 2, '定时任务', 'scheduler', 1, '/aiconfig/scheduled-task', 'Timer', 'library', 5, NULL, NULL, 0),
+  (61, 60, '查看定时任务', 'scheduler:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (62, 60, '新增定时任务', 'scheduler:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (63, 60, '编辑定时任务', 'scheduler:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (64, 60, '删除定时任务', 'scheduler:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (65, 60, '手动触发定时任务', 'scheduler:trigger', 2, NULL, NULL, 'library', 5, NULL, NULL, 0),
+  (100, 1, 'AI编码审计', 'ai-audit', 1, '/system/ai-audit', 'DataAnalysis', 'library', 5, NULL, NULL, 0),
+  (101, 100, '查看AI编码审计', 'ai-audit:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (110, 0, 'SQL配置管理', 'sql-config', 1, '', 'DataLine', 'library', 6, NULL, NULL, 0),
+  (111, 110, '数据源管理', 'sql-datasource', 1, '/sql/datasource', 'Coin', 'library', 1, NULL, NULL, 0),
+  (112, 110, 'SQL定义', 'sql-define', 1, '/sql/define', 'Document', 'library', 2, NULL, NULL, 0),
+  (113, 111, '查看数据源', 'sql-datasource:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (114, 111, '新增数据源', 'sql-datasource:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (115, 111, '编辑数据源', 'sql-datasource:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (116, 111, '删除数据源', 'sql-datasource:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (117, 112, '查看SQL定义', 'sql-define:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (118, 112, '新增SQL定义', 'sql-define:add', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (119, 112, '编辑SQL定义', 'sql-define:edit', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (120, 112, '删除SQL定义', 'sql-define:delete', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (121, 110, '执行SQL查询', 'sql-query:view', 2, NULL, NULL, 'library', 5, NULL, NULL, 0),
+  (122, 110, '导出SQL查询', 'sql-query:export', 2, NULL, NULL, 'library', 6, NULL, NULL, 0),
+  (124, 2, '系统工具', 'system-tool', 1, '/aiconfig/system-tool', 'SetUp', 'library', 6, NULL, NULL, 0),
+  (125, 124, '查看系统工具', 'system-tool:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (126, 124, '编辑系统工具', 'system-tool:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (130, 0, '客服工单', 'ticket', 1, '/ticket', 'Headset', 'library', 6, NULL, NULL, 0),
+  (131, 130, '用户工单', 'user-ticket', 1, '/ticket/user-ticket', 'Tickets', 'library', 1, NULL, NULL, 0),
+  (132, 131, '查看用户工单', 'user-ticket:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (133, 131, '抢单受理工单', 'user-ticket:claim', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (134, 131, '回复工单', 'user-ticket:reply', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (135, 131, '转派工单', 'user-ticket:transfer', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (136, 131, '解决工单', 'user-ticket:resolve', 2, NULL, NULL, 'library', 5, NULL, NULL, 0),
+  (137, 131, '关闭工单', 'user-ticket:close', 2, NULL, NULL, 'library', 6, NULL, NULL, 0),
+  (138, 131, '编辑工单', 'user-ticket:edit', 2, NULL, NULL, 'library', 7, NULL, NULL, 0),
+  (139, 130, '用户订单', 'user-order', 1, '/ticket/user-order', 'List', 'library', 2, NULL, NULL, 0),
+  (140, 139, '查看用户订单', 'user-order:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (141, 139, '编辑用户订单', 'user-order:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (150, 1, '开发者工具箱', 'devtools', 1, '/system/devtools', 'Tools', 'library', 6, NULL, NULL, 0),
+  (151, 150, '查看开发者工具箱', 'devtools:view', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (160, 0, '我的工作台', 'workbench', 1, '', 'Grid', 'library', 7, NULL, NULL, 0),
+  (161, 160, '内网工作台', 'workbench-site:view', 1, '/workbench/site', 'Monitor', 'library', 1, NULL, NULL, 0),
+  (162, 161, '新增内网工作台站点', 'workbench-site:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (163, 161, '编辑内网工作台站点', 'workbench-site:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (164, 161, '删除内网工作台站点', 'workbench-site:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (165, 160, 'SQL 客户端', 'sql-console:query', 1, '/workbench/sql-console', 'DataAnalysis', 'library', 2, NULL, NULL, 0),
+  (166, 165, '导出SQL查询结果', 'sql-console:export', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (180, 1, '登录页图片', 'login-image:view', 1, '/system/login-image', 'Picture', 'library', 7, NULL, NULL, 0),
+  (181, 180, '上传登录页图片', 'login-image:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (182, 180, '编辑登录页图片', 'login-image:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (183, 180, '删除登录页图片', 'login-image:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (190, 2, '渠道接入', 'channel-robot:view', 1, '/aiconfig/channel-robot', 'Connection', 'library', 7, NULL, NULL, 0),
+  (191, 190, '新增渠道机器人', 'channel-robot:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (192, 190, '编辑渠道机器人', 'channel-robot:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (193, 190, '删除渠道机器人', 'channel-robot:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (194, 1, '智能体耗时统计', 'agent-call-stats:view', 1, '/system/agent-call-stats', 'Timer', 'library', 6, NULL, NULL, 0),
+  (195, 194, '删除调用日志', 'agent-call-stats:delete', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (200, 2, '知识库管理', 'knowledge-base:view', 1, '/aiconfig/knowledge-base', 'Collection', 'library', 8, NULL, NULL, 0),
+  (201, 200, '新增知识库', 'knowledge-base:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (202, 200, '编辑知识库', 'knowledge-base:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (203, 200, '删除知识库', 'knowledge-base:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (204, 0, '内容风控', 'contentguard', 1, '/contentguard', 'Lock', 'library', 8, NULL, NULL, 0),
+  (205, 204, '敏感词词库', 'sensitive-word:view', 1, '/contentguard/sensitive-word', 'ChatLineSquare', 'library', 1, NULL, NULL, 0),
+  (206, 205, '新增敏感词', 'sensitive-word:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (207, 205, '编辑敏感词', 'sensitive-word:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (208, 205, '删除敏感词', 'sensitive-word:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (209, 204, '限流规则', 'rate-limit-rule:view', 1, '/contentguard/rate-limit', 'Odometer', 'library', 2, NULL, NULL, 0),
+  (210, 209, '新增限流规则', 'rate-limit-rule:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (211, 209, '编辑限流规则', 'rate-limit-rule:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (212, 209, '删除限流规则', 'rate-limit-rule:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (213, 204, '命中看板', 'sensitive-hit-log:view', 1, '/contentguard/hit-log', 'DataAnalysis', 'library', 3, NULL, NULL, 0),
+  (214, 2, '后台任务', 'agent-task:view', 1, '/aiconfig/agent-task', 'Timer', 'library', 9, NULL, NULL, 0),
+  (215, 214, '取消任务', 'agent-task:cancel', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (216, 1, '字典管理', 'dict:view', 1, '/system/dict', 'Collection', 'library', 8, NULL, NULL, 0),
+  (217, 216, '新增字典', 'dict:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (218, 216, '编辑字典', 'dict:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (219, 216, '删除字典', 'dict:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (220, 1, '租户管理', 'tenant:view', 1, '/system/tenant', 'OfficeBuilding', 'library', 9, NULL, NULL, 0),
+  (221, 220, '新增租户', 'tenant:add', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (222, 220, '编辑租户', 'tenant:edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (223, 220, '删除租户', 'tenant:delete', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (224, 1, '配额与计费', 'billing:view', 1, '/system/billing', 'Wallet', 'library', 10, NULL, NULL, 0),
+  (225, 224, '编辑配额', 'billing:quota-edit', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (226, 224, '编辑单价', 'billing:price-edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (227, 224, '导出账单', 'billing:export', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (228, 1, '配置版本', 'config-version:view', 1, '/system/config-version', 'DocumentCopy', 'library', 11, NULL, NULL, 0),
+  (229, 228, '回滚配置', 'config-version:rollback', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (230, 228, '灰度发布', 'config-version:gray', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (231, 0, '运营闭环', 'ops', 1, '/ops', 'TrendCharts', 'library', 4, NULL, NULL, 0),
+  (232, 231, '评测中心', 'eval:view', 1, '/ops/eval', 'DataAnalysis', 'library', 1, NULL, NULL, 0),
+  (233, 232, '触发评测', 'eval:run', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (234, 231, 'badcase回流', 'badcase:view', 1, '/ops/badcase', 'Warning', 'library', 2, NULL, NULL, 0),
+  (235, 234, '筛选与回流', 'badcase:adopt', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (236, 231, '语义缓存', 'semantic-cache:view', 1, '/ops/semantic-cache', 'Lightning', 'library', 3, NULL, NULL, 0),
+  (237, 231, '提示词版本', 'prompt-version:view', 1, '/ops/prompt-version', 'Document', 'library', 4, NULL, NULL, 0),
+  (238, 231, '满意度看板', 'csat:view', 1, '/ops/csat', 'Star', 'library', 5, NULL, NULL, 0),
+  (239, 231, '知识盲区', 'knowledge-gap:view', 1, '/ops/knowledge-gap', 'QuestionFilled', 'library', 6, NULL, NULL, 0),
+  (240, 231, '死信队列', 'dead-letter:view', 1, '/ops/dead-letter', 'RefreshRight', 'library', 7, NULL, NULL, 0),
+  (241, 236, '清除缓存', 'semantic-cache:evict', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (242, 239, '补充知识', 'knowledge-gap:fill', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (243, 240, '重开死信', 'dead-letter:reopen', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (244, 204, '用户额度', 'subject-quota:view', 1, '/contentguard/subject-quota', 'Stopwatch', 'library', 4, NULL, NULL, 0),
+  (245, 244, '维护等级', 'subject-quota:level-edit', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (246, 244, '分配用户等级', 'subject-quota:user-edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (247, 22, '下载技能包', 'skill:export', 2, NULL, NULL, 'library', 5, NULL, NULL, 0),
+  (248, 224, '手工归集', 'billing:aggregate', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (249, 20, '模型健康探测', 'model:health-test', 2, NULL, NULL, 'library', 5, NULL, NULL, 0),
+  (250, 232, '编辑发布门禁策略', 'eval:gate-policy-edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (251, 232, '紧急豁免发布门禁', 'eval:gate-override', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (252, 20, '模型上线认证', 'model:certify', 2, NULL, NULL, 'library', 6, NULL, NULL, 0),
+  (253, 20, '查看模型实验', 'model-experiment:view', 2, NULL, NULL, 'library', 7, NULL, NULL, 0),
+  (254, 20, '创建模型实验', 'model-experiment:create', 2, NULL, NULL, 'library', 8, NULL, NULL, 0),
+  (255, 20, '启动模型实验', 'model-experiment:start', 2, NULL, NULL, 'library', 9, NULL, NULL, 0),
+  (256, 20, '停止模型实验', 'model-experiment:stop', 2, NULL, NULL, 'library', 10, NULL, NULL, 0),
+  (257, 1, 'SLO 错误预算', 'slo:view', 1, '/system/slo', 'DataAnalysis', 'library', 9, NULL, NULL, 0),
+  (258, 257, '编辑 SLO 策略', 'slo:edit', 2, NULL, NULL, 'library', 1, NULL, NULL, 0),
+  (259, 257, '评估错误预算', 'slo:evaluate', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (260, 231, '业务结果与成本', 'business-outcome:view', 1, '/ops/business-outcome', 'PieChart', 'library', 8, NULL, NULL, 0),
+  (261, 228, '查看高风险审批', 'governance:view', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (262, 228, '复核高风险变更', 'governance:approve', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (263, 20, '模型健康路由覆盖', 'model:health-override', 2, NULL, NULL, 'library', 7, NULL, NULL, 0),
+  (264, 200, '同步知识文档源', 'knowledge-base:source-sync', 2, NULL, NULL, 'library', 4, NULL, NULL, 0),
+  (265, 232, '编辑评测数据集', 'eval:dataset-edit', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (266, 232, '审核评测数据集版本', 'eval:dataset-review', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (267, 194, '隔离重放调用', 'agent-call-stats:replay', 2, NULL, NULL, 'library', 2, NULL, NULL, 0),
+  (268, 257, '确认 SLO 告警', 'slo:ack', 2, NULL, NULL, 'library', 3, NULL, NULL, 0),
+  (269, 231, '管理改进闭环', 'improvement:manage', 2, NULL, NULL, 'library', 20, NULL, NULL, 0);
+
+-- ----------------------------------------------------------------------------
+-- sys_role · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sys_role` (`id`, `role_name`, `role_code`, `remark`, `status`, `create_by`, `update_by`, `deleted`, `tenant_id`, `data_scope`, `control_plane`) VALUES
+  (1, '超级管理员', 'super_admin', '拥有全部权限，系统初始化内置', 1, NULL, NULL, 0, 'default', 'ALL', 1),
+  (2, '运营管理员', 'operator', '默认无权限，需超管手动分配', 1, NULL, NULL, 0, 'default', 'ALL', 1),
+  (3, '租户管理员', 'tenant_admin', '租户开通时自动创建，拥有本租户内全部管理权限', 1, NULL, NULL, 0, 'default', 'TENANT', 0);
+
+-- ----------------------------------------------------------------------------
+-- sys_role_permission · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sys_role_permission` (`id`, `role_id`, `permission_id`, `tenant_id`) VALUES
+  (1, 3, 23, 'default'),
+  (2, 3, 195, 'default'),
+  (3, 3, 267, 'default'),
+  (4, 3, 194, 'default'),
+  (5, 3, 215, 'default'),
+  (6, 3, 214, 'default'),
+  (7, 3, 46, 'default'),
+  (8, 3, 48, 'default'),
+  (9, 3, 47, 'default'),
+  (10, 3, 45, 'default'),
+  (13, 3, 2, 'default'),
+  (14, 3, 235, 'default'),
+  (15, 3, 234, 'default'),
+  (17, 3, 260, 'default'),
+  (18, 3, 191, 'default'),
+  (19, 3, 193, 'default'),
+  (20, 3, 192, 'default'),
+  (21, 3, 190, 'default'),
+  (22, 3, 204, 'default'),
+  (23, 3, 238, 'default'),
+  (32, 3, 265, 'default'),
+  (33, 3, 266, 'default'),
+  (34, 3, 251, 'default'),
+  (35, 3, 250, 'default'),
+  (36, 3, 233, 'default'),
+  (37, 3, 232, 'default'),
+  (41, 3, 201, 'default'),
+  (42, 3, 203, 'default'),
+  (43, 3, 202, 'default'),
+  (44, 3, 264, 'default'),
+  (45, 3, 200, 'default'),
+  (46, 3, 242, 'default'),
+  (47, 3, 239, 'default'),
+  (48, 3, 12, 'default'),
+  (49, 3, 32, 'default'),
+  (67, 3, 231, 'default'),
+  (68, 3, 4, 'default'),
+  (69, 3, 237, 'default'),
+  (74, 3, 11, 'default'),
+  (75, 3, 29, 'default'),
+  (76, 3, 31, 'default'),
+  (77, 3, 30, 'default'),
+  (78, 3, 28, 'default'),
+  (79, 3, 60, 'default'),
+  (80, 3, 62, 'default'),
+  (81, 3, 64, 'default'),
+  (82, 3, 63, 'default'),
+  (83, 3, 65, 'default'),
+  (84, 3, 61, 'default'),
+  (115, 3, 246, 'default'),
+  (116, 3, 244, 'default'),
+  (117, 3, 1, 'default'),
+  (118, 3, 130, 'default'),
+  (119, 3, 10, 'default'),
+  (120, 3, 139, 'default'),
+  (121, 3, 141, 'default'),
+  (122, 3, 140, 'default'),
+  (123, 3, 131, 'default'),
+  (124, 3, 133, 'default'),
+  (125, 3, 137, 'default'),
+  (126, 3, 138, 'default'),
+  (127, 3, 134, 'default'),
+  (128, 3, 136, 'default'),
+  (129, 3, 135, 'default'),
+  (130, 3, 132, 'default'),
+  (131, 3, 25, 'default'),
+  (132, 3, 27, 'default'),
+  (133, 3, 26, 'default'),
+  (134, 3, 24, 'default'),
+  (140, 3, 3, 'default');
+
+-- ----------------------------------------------------------------------------
+-- sys_tenant · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sys_tenant` (`id`, `tenant_code`, `tenant_name`, `status`, `contact_name`, `contact_phone`, `contact_email`, `remark`, `expire_time`, `create_by`, `update_by`, `deleted`, `access_epoch`) VALUES
+  (1, 'default', '默认租户', 'ACTIVE', NULL, NULL, NULL, '升级前的存量数据归属，等价于原单租户系统', NULL, NULL, NULL, 0, 0);
+
+-- ----------------------------------------------------------------------------
+-- sys_user · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sys_user` (`id`, `username`, `password`, `nickname`, `email`, `email_verified`, `login_type`, `status`, `approval_status`, `approval_by`, `approval_time`, `approval_remark`, `last_login_time`, `last_login_ip`, `create_by`, `update_by`, `deleted`, `tenant_id`, `level_code`, `auth_epoch`) VALUES
+  (1, 'admin', '$2a$10$M7Z.8TA1.6l01JSeZRGAb.olJkoDmvk4JSX81kNlZ5rzE1LCsDCFC', '超级管理员', NULL, 0, 'LOCAL', 1, 'APPROVED', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 'default', NULL, 0);
+
+-- ----------------------------------------------------------------------------
+-- sys_user_role · 系统种子数据
+-- ----------------------------------------------------------------------------
+INSERT INTO `sys_user_role` (`id`, `user_id`, `role_id`, `tenant_id`) VALUES
+  (1, 1, 1, 'default');


### PR DESCRIPTION
## 问题

`mysql/schema-snapshot/customer_admin.sql` 只有 88 张表的 DDL，文件头却写着用途是「结构查阅与**全新建库**」。照它建出来的库没有菜单权限树、没有角色、没有默认租户、也没有 admin 账号——**登录页直接过不去**，等于一个谁也进不去的空壳。

## 改动

让快照在结构之后带上迁移写入的系统种子数据段（实测 12 张表：`sys_permission` 166 行、`sys_role`、`sys_role_permission` 70 行、`sys_user`、`sys_user_role`、`sys_tenant`、`ai_model_price`、`ai_system_tool` 与 4 张 sql 示例配置表）。

**导哪些行不由人工清单决定，照实导出迁移产物里的全部数据行。** 挑子集会让快照与迁移产物不再等价、两条建库路径给出不同结果，那是本仓库反复踩过的形状（表排序规则那次）；随迁移带出的示例配置交给已有的 `scripts/clear-demo-data.sh --public` 清，不在导出器里另立一套判定。

几个要点：

- **种子行的 `create_time`/`update_time` 不进 INSERT**：它们是 `DEFAULT_GENERATED`，值为「迁移执行那一秒」，写死会让漂移门禁**每跑必红**，而红的原因与任何人的改动都无关——那种门禁几次之后就被当噪音跳过了。改由建库时的默认值现场填充，语义上也正是「这一行是建库那一刻写入的」。
- **行序按主键排**，保证同一套迁移在任意时刻导出逐字一致。
- **差异定位一并识别 `INSERT INTO`**：只认 `CREATE TABLE` 时，种子段的差异会全被归到最后一张表上（实测报成 `workbench_token`，实际差在 `ai_model_price`）——指着一张不相干的表报错比不报表名更误导。
- **客服端库那侧不开这个开关**：它的演示业务数据归 `mysql/01` 完整镜像管，引进快照只会多一份要清理的脏数据。cw 快照本次一个字未变。
- **文件头 COLLATE 说明同步修正**：V100 全量对齐后快照里只应有 `utf8mb4_unicode_ci` 一种，原文案还写着「两种并存是既有状况」，已不成立（现存的 2 处 `0900_ai_ci` 全在那段注释自己里）。

## 门禁

- `seedDataShouldBeReproducibleAndCarryAdminLoginChain`：种子导出可复现 + admin 登录链路完整（`sys_user` 启用 → `sys_user_role` → `super_admin` → 租户 `ACTIVE`）+ 四张表的种子确实进了快照。
  可复现性刻意**建两个独立的库**比对：同一个库连导两次，时间列取自同一次迁移，结果当然一样——那是恒真断言。本 PR 先写成了那样，靠变异测试才发现它照不出问题；改成两次独立建库后，同一个变异（故意不跳过时间列）立刻红。
- 新增 `SchemaSnapshotDifferenceTest`（5 条）钉住差异定位准确性，含「种子段差异不得归到前面最后一张建表上」。

## 实测验收

用本快照建一个全新库，然后：

1. 执行成功，88 张表；
2. 与跑完 Flyway 迁移的库**完全等价**——`information_schema` 层面 **1308 列**（类型/可空/默认/字符集/排序规则/注释字节）、**536 项索引**、**12 张种子表数据**逐项一致；
3. 启动 `customer-admin-server` 连该库（独立端口，Flyway 关闭）→ **`admin` / `admin` 登录成功**，`nickname=超级管理员`、`forceChangePassword=true`（V2 设计的首登强制改密）、菜单树返回 9 个顶级菜单（系统管理 13 子、AI 配置 9 子、运营闭环 9 子…）。

补充两条实测事实（已写进 CLAUDE.md）：

- 用快照建的库**没有 `flyway_schema_history`**，应用要以 Flyway 关闭的方式启动（生产 profile 本就关闭），dev profile 直接起会从 V1 重跑撞上已存在的表。
- 快照重放在 `SHOW CREATE TABLE` 层面**不幂等**：只写 `COLLATE` 不写 `CHARACTER SET` 的列，建库后 MySQL 会回吐 `CHARACTER SET utf8mb4`。这只是显示形态，结构等价——**比对两条建库路径要用 `information_schema`，不要 diff `SHOW CREATE` 文本**。

## 关于默认账号的取舍

用的是迁移里的种子哈希 `admin` / `admin`（`AuthService` 检测到仍是初始密码会强制改密），**没有导本机开发库里那行真实的 admin**——那行的密码哈希和昵称是使用者本人在用的，提交进仓库等于把个人凭据入库，BCrypt 离线爆破是现实威胁。

## 测试

全模块 `BUILD SUCCESS`，0 失败 0 错误：starter 1710/5 skip、app-server 129、customer-channel 80、admin 1734/1 skip、gateway 1，**合计 3654**（排除 `RedisSessionPersistenceTest`，本机 Redis 无密码）。本批次自身 **+6**（starter +5、admin +1）。

本批次无迁移，cw Flyway 仍是下次 V24、admin V102。