### PR TITLE
视觉 OCR 双引擎降级 + 结构化引用回传（能力差距 空白 6 · P1-6）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,27 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   且无一标 `@Order`，实际顺序由 Bean 定义顺序偶然决定；新增中间件必须在那里定值，
   `MiddlewareOrderContractTest` 会对"不留默认值 / 取值不重复 / 关键相对次序"下断言。
   能力差距全量清单与后续批次三四五见 `docs/智能体能力差距与演进路线图.md`。上一版基线见下。）
+  （2026-09-09 引用回传批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1801/9 skip、app-server 132、customer-channel 82、admin 1741/1 skip、gateway 1，
+  **合计 3757**（排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+13**
+  （来源标记往返 7 + 中间件采集 6）。本批次无迁移，cw Flyway 仍是下次 **V25**、admin **V102**。
+  三个坑：
+  ① **框架在 `RAGMode.AGENTIC` 下用 `Mono.block()` 调 `Knowledge#retrieve`**（2.0.2 字节码实证），
+  `block()` 开新订阅、**Reactor Context 为空**——在任何 `Knowledge` 实现里 `deferContextual`
+  都读不到调用方 Context。**而这条错路用 `StepVerifier` 手工塞 context 去测会全绿**，
+  线上一条都采不到；ThreadLocal 替代路要靠 Reactor 自动传播，那套机制绑在
+  `customer-work.tenant.enabled` 上，单租户部署静默失效；`Knowledge` 又是
+  `KnowledgeProvider.get()` 缓存的全局单例，挂不住请求态。可靠的接入点是
+  `onActing` 的事件流（已回到 Agent 主链，与部署形态无关）；
+  ② **`onReasoning` 的 `messages()` 是整个会话上下文**，拿它采本轮的工具结果会把
+  **前几轮**的一并算进来；`onActing` 的事件流才只含本轮。相应地
+  `ToolResultTextDeltaEvent` 是**增量**，要按 `toolCallId` 累积到 `ToolResultEndEvent`
+  再解析——标记行被切在两个分片之间时，逐片解析会稳定漏掉且不报错；
+  ③ **给 record 加字段要先跑一次全反应堆 `test-compile`**：本批次给
+  `ChatTerminalEnvelope` 与 `ChatResponse` 各加一个字段，只 grep 了前者的构造点，
+  **连续两轮全量都红在 app-server 的测试编译上**（starter 单模块编译通过，照不出来），
+  各浪费 2 分 40 秒。另注意仓库里有**两个同名 `ChatResponse`**
+  （框架 `io.agentscope.core.model` 与项目 DTO），grep 时要分辨。上一版基线见下。）
   （2026-09-02 后台库快照带系统种子批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
   starter 1710/5 skip、app-server 129、customer-channel 80、admin 1734/1 skip、gateway 1，
   **合计 3654**（排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+5**（差异定位单测）、

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminAttachmentConfig.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/config/AdminAttachmentConfig.java
@@ -77,7 +77,8 @@ public class AdminAttachmentConfig {
         VisionOcrUsageRecorder usageRecorder = new MeteredVisionOcrUsageRecorder(
             meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable(),
             quotaGuardProvider == null ? null : quotaGuardProvider.getIfAvailable());
-        return VisionOcrServices.create(properties, modelSupplier, usageRecorder);
+        return VisionOcrServices.create(properties, modelSupplier, usageRecorder,
+            meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable());
     }
 
     /** 附件文件存储：按 {@code storage.type} 选后端（local 本地磁盘 / minio 对象存储），选型收敛在 starter 的 {@link AttachmentFileStorages}（与 8080 侧同一份）。 */

--- a/customer-channel/src/main/java/com/richard/fyoung/customerchannel/CustomerWebAgentConfig.java
+++ b/customer-channel/src/main/java/com/richard/fyoung/customerchannel/CustomerWebAgentConfig.java
@@ -7,6 +7,7 @@ import com.richard.fyoung.customerwork.core.middleware.ContextBudgetMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.DialogStageMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.DynamicOptionsMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.IndirectInjectionGuardMiddleware;
+import com.richard.fyoung.customerwork.core.middleware.KnowledgeCitationMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.LatencyMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.MaskingMiddleware;
 import com.richard.fyoung.customerwork.core.middleware.PromptInjectionGuardMiddleware;
@@ -175,6 +176,12 @@ public class CustomerWebAgentConfig {
     @Bean
     public ChatTerminalCaptureMiddleware chatTerminalCaptureMiddleware() {
         return new ChatTerminalCaptureMiddleware();
+    }
+
+    /** 采集本轮召回的知识来源；无采集上下文时完全透传。 */
+    @Bean
+    public KnowledgeCitationMiddleware knowledgeCitationMiddleware() {
+        return new KnowledgeCitationMiddleware();
     }
 
     @Bean

--- a/customer-channel/src/test/java/com/richard/fyoung/customerchannel/ChannelGovernanceMiddlewareTest.java
+++ b/customer-channel/src/test/java/com/richard/fyoung/customerchannel/ChannelGovernanceMiddlewareTest.java
@@ -60,7 +60,7 @@ class ChannelGovernanceMiddlewareTest {
      * <p>这三项需要把对应基础设施一并接进本模块，属于独立的一件事；在此之前如实记录，
      * 不用"声明了 12 个"制造覆盖完整的错觉。</p>
      */
-    private static final int MIN_GOVERNANCE_MIDDLEWARES = 12;
+    private static final int MIN_GOVERNANCE_MIDDLEWARES = 13;
 
     @Autowired
     private ObjectProvider<MiddlewareBase> pluggableMiddlewares;

--- a/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchServiceTest.java
+++ b/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/chat/ChatDispatchServiceTest.java
@@ -37,6 +37,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
 /**
  * 对话分发核心单测：关键词转人工不进 LLM、AI 流式桥接、坐席转发、新会话自动建单、标题回填、坐席消息离线只落库。
  * @author owlzhangfq@gmail.com
@@ -87,7 +89,7 @@ class ChatDispatchServiceTest {
         ChatMessage message = ChatMessage.of("MSG-9", SESSION_ID, "TK-1",
             TicketActorType.BOT, null, reply.toString());
         ChatTerminalEnvelope terminal = new ChatTerminalEnvelope("MSG-9", "MODEL_STOP",
-            new ChatUsageSnapshot(8, 2, 0, 10, 0.1), "trace-ws");
+            new ChatUsageSnapshot(8, 2, 0, 10, 0.1), "trace-ws", List.of());
         events.add(new ChatTurnEvent.Completed(new ChatTurnCompletion(message, terminal)));
         return Flux.fromIterable(events);
     }

--- a/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/controller/CustomerServiceControllerTest.java
+++ b/customer-work-app-server/src/test/java/com/richard/fyoung/customerworkapp/controller/CustomerServiceControllerTest.java
@@ -27,6 +27,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
 /**
  * 控制器 Web 层切片测试：用 WebTestClient 驱动 HTTP 行为，
  * Service 被 mock，不触达模型与 Spring 全量上下文（无需 API Key）。
@@ -55,7 +57,7 @@ class CustomerServiceControllerTest {
     void chat_shouldReturnReply() {
         when(chatTurnService.chat(anyString(), eq("你好"))).thenReturn(Mono.just(
             new ChatResponse("u1", "您好，有什么可以帮您？", "MSG-9", "MODEL_STOP",
-                new ChatUsageSnapshot(10, 4, 0, 14, 0.2), "trace-9")));
+                new ChatUsageSnapshot(10, 4, 0, 14, 0.2), "trace-9", List.of())));
 
         webTestClient.post().uri("/api/customer/chat")
             .bodyValue(new ChatRequest("u1", "你好"))
@@ -85,7 +87,7 @@ class CustomerServiceControllerTest {
         when(chatTurnService.chat(anyString(), anyString())).thenAnswer(invocation -> {
             String sessionId = invocation.getArgument(0);
             return Mono.just(new ChatResponse(sessionId, "hi", "MSG-1", "CACHE_HIT",
-                ChatUsageSnapshot.empty(), "trace-1"));
+                ChatUsageSnapshot.empty(), "trace-1", List.of()));
         });
 
         webTestClient.post().uri("/api/customer/chat")
@@ -101,7 +103,7 @@ class CustomerServiceControllerTest {
     @Test
     void chatStream_shouldStreamChunks() {
         ChatTerminalEnvelope terminal = new ChatTerminalEnvelope("MSG-9", "MODEL_STOP",
-            new ChatUsageSnapshot(10, 4, 0, 14, 0.2), "trace-9");
+            new ChatUsageSnapshot(10, 4, 0, 14, 0.2), "trace-9", List.of());
         ChatMessage message = ChatMessage.of("MSG-9", "u1", null,
             TicketActorType.BOT, null, "您好");
         when(chatTurnService.stream(anyString(), anyString(), org.mockito.ArgumentMatchers.isNull()))

--- a/customer-work-app/src/types/api.ts
+++ b/customer-work-app/src/types/api.ts
@@ -204,6 +204,13 @@ export interface ChatMessage {
   senderId: string | null
   content: string
   createdAtMs: number
+  /**
+   * 本条回复引用的知识来源。
+   *
+   * 只有本次会话中实时收到的回复带这个字段——服务端不把引用落进聊天记录，
+   * 因此刷新页面后重新拉取的历史消息没有来源，这是已知缺口而不是数据丢失。
+   */
+  citations?: KnowledgeCitation[]
 }
 
 export interface ReasonPayload {
@@ -260,6 +267,18 @@ export interface WsChatChunk {
   content: string
 }
 
+/**
+ * 一条知识引用：这次回答用到了哪一段知识。
+ *
+ * 兼容旧服务端时整个 citations 字段可能缺失，取值处一律按空数组处理。
+ */
+export interface KnowledgeCitation {
+  knowledgeBase: string
+  documentId: string
+  chunkId: string
+  score: number | null
+}
+
 /** 四种对话协议共用的终止元数据。 */
 export interface ChatTerminalEnvelope {
   messageId: string
@@ -272,6 +291,7 @@ export interface ChatTerminalEnvelope {
     timeSeconds: number
   }
   traceId: string
+  citations?: KnowledgeCitation[]
 }
 
 /** 服务端 -> 用户：流式完成，含已落库全文与会话归属。 */

--- a/customer-work-app/src/views/Chat.vue
+++ b/customer-work-app/src/views/Chat.vue
@@ -392,6 +392,7 @@ function onWsChatDone(data: unknown) {
     senderId: null,
     content: payload.content,
     createdAtMs: payload.ts,
+    citations: payload.citations ?? [],
   })
   streamingContent.value = ''
   streamingSessionId.value = null
@@ -814,6 +815,20 @@ onUnmounted(() => {
                 }}
               </div>
               <div class="bubble">{{ message.content }}</div>
+              <div
+                v-if="message.senderType === 'BOT' && message.citations?.length"
+                class="citations"
+              >
+                <span class="citations-label">参考来源</span>
+                <span
+                  v-for="citation in message.citations"
+                  :key="citation.chunkId"
+                  class="citation-chip"
+                  :title="`文档 ${citation.documentId} · 片段 ${citation.chunkId}`"
+                >
+                  {{ citation.knowledgeBase }}
+                </span>
+              </div>
               <div
                 v-if="message.senderType === 'BOT'"
                 class="feedback-actions"
@@ -1263,6 +1278,29 @@ onUnmounted(() => {
   color: #fff;
   background: linear-gradient(135deg, #268cff, #1268df);
   box-shadow: 0 9px 22px rgba(24, 119, 242, 0.2);
+}
+
+.citations {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.citations-label {
+  color: var(--cw-text-weak, #9aa0a6);
+}
+
+/* 只显示知识库名，文档与片段号放 title：手机屏幕上把整串标识铺开会挤掉正文 */
+.citation-chip {
+  padding: 1px 8px;
+  border-radius: 10px;
+  background: rgba(25, 137, 250, 0.08);
+  color: #1989fa;
+  white-space: nowrap;
 }
 
 .feedback-actions {

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/dto/ChatResponse.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/dto/ChatResponse.java
@@ -26,10 +26,12 @@ public record ChatResponse(
         @Schema(description = "本轮 token 用量")
         ChatUsageSnapshot usage,
         @Schema(description = "调用链标识")
-        String traceId) {
+        String traceId,
+        @Schema(description = "本轮回答用到的知识引用，供用户看出处、运营核查是哪条知识误导了模型")
+        java.util.List<KnowledgeCitation> citations) {
 
     public static ChatResponse from(String sessionId, String reply, ChatTerminalEnvelope terminal) {
         return new ChatResponse(sessionId, reply, terminal.messageId(), terminal.finishReason(),
-            terminal.usage(), terminal.traceId());
+            terminal.usage(), terminal.traceId(), terminal.citations());
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/dto/ChatTerminalEnvelope.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/dto/ChatTerminalEnvelope.java
@@ -12,5 +12,7 @@ public record ChatTerminalEnvelope(
         @Schema(description = "已持久化的助手消息 ID") String messageId,
         @Schema(description = "Agent 终止原因", example = "MODEL_STOP") String finishReason,
         @Schema(description = "本轮模型调用累计用量") ChatUsageSnapshot usage,
-        @Schema(description = "本轮调用 traceId") String traceId) {
+        @Schema(description = "本轮调用 traceId") String traceId,
+        @Schema(description = "本轮回答用到的知识引用；未启用受管知识库或未召回时为空列表")
+        java.util.List<KnowledgeCitation> citations) {
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/dto/KnowledgeCitation.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/dto/KnowledgeCitation.java
@@ -1,0 +1,135 @@
+package com.richard.fyoung.customerwork.core.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 一条知识引用：这次回答用到了哪一段知识。
+ *
+ * <p><b>为什么要回传</b>：此前召回的知识只进模型上下文，用户看不到答案出处，
+ * 运营也无法核查"是哪一条知识把模型带偏了"。知识库改错一句话，
+ * 表现是客服开始给出错误答复，而没有任何线索指向那条知识——
+ * 只能靠人把知识库通读一遍去猜。</p>
+ *
+ * <p>不含正文：引用是溯源线索而不是内容副本，正文在知识库里有权威版本，
+ * 复制一份到响应里既撑大报文，又会在知识更新后变成对不上的旧内容。</p>
+ *
+ * <h3>为什么用文本标记而不是上下文传播</h3>
+ * <p>C 端走 {@code RAGMode.AGENTIC}，检索由模型发起为一次<b>工具调用</b>，框架的
+ * {@code KnowledgeRetrievalTools#retrieveKnowledge} 用 {@code Mono.block()} 调
+ * {@code Knowledge#retrieve}——{@code block()} 开的是新订阅，<b>Reactor Context 是空的</b>。
+ * 因此在检索实现里读 {@code ChatTerminalCapture} 恒为 null，而用 {@code StepVerifier}
+ * 手工塞 context 去测反倒会绿。ThreadLocal 那条路同样不成立：它要靠 Reactor 自动传播
+ * 才能跨过工具执行的线程边界，而那套机制绑在多租户开关上，单租户部署会静默失效。</p>
+ *
+ * <p>于是改为：检索侧把来源写成正文首行的标记（{@link #marker()}），中间件在
+ * {@code onReasoning} 从 {@code ToolResultBlock} 里解析回来（{@link #parseAll(String)}）——
+ * 那已经回到 Agent 主链，与部署形态无关。标记刻意做成自然中文而非隐晦符号：
+ * 它同时是给模型看的出处说明，模型据此能在回答里主动标注来源；即使被原样复述，
+ * 用户看到的也是一句通顺的来源说明，而不是一串乱码。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Schema(description = "知识引用（回答的来源线索）")
+public record KnowledgeCitation(
+        @Schema(description = "知识库名称", example = "售后FAQ") String knowledgeBase,
+        @Schema(description = "来源文档标识", example = "doc-refund-policy") String documentId,
+        @Schema(description = "分片标识，供运营精确定位到段", example = "10237") String chunkId,
+        @Schema(description = "相似度分数，越大越相近", example = "0.87") Double score) {
+
+    /** 标记行的行首前缀，解析时据此认出该行。 */
+    private static final String PREFIX = "【知识来源】";
+
+    /** 字段分隔符。 */
+    private static final String SEPARATOR = " | ";
+
+    /** 分片标识在标记里带的记号，便于人一眼看出那是段号而不是又一个名称。 */
+    private static final String CHUNK_MARK = "#";
+
+    /**
+     * 字段值里的 {@code |} 一律换成全角，避免运营填的知识库名把分隔符撑破。
+     *
+     * <p>用替换而不是转义符：这一行是要给模型和用户看的，反斜杠转义会让它变成技术噪音，
+     * 而全角竖线在中文语境里本就是常见写法，读起来没有区别。</p>
+     */
+    private static final char RAW_PIPE = '|';
+    private static final char SAFE_PIPE = '｜';
+
+    /** 分数保留两位：更细的精度对读者没有意义，还会让标记行变长。 */
+    private static final String SCORE_FORMAT = "%.2f";
+
+    /**
+     * 生成放在知识正文首行的来源标记。
+     *
+     * <p>与 {@link #parseAll(String)} 是同一份格式的两端，改其一必须改另一端——
+     * 因此两者刻意放在同一个类里，并由往返测试钉住。</p>
+     */
+    public String marker() {
+        StringBuilder line = new StringBuilder(PREFIX)
+            .append(escape(knowledgeBase))
+            .append(SEPARATOR).append(escape(documentId))
+            .append(SEPARATOR).append(CHUNK_MARK).append(escape(chunkId));
+        if (score != null) {
+            line.append(SEPARATOR).append(String.format(SCORE_FORMAT, score));
+        }
+        return line.toString();
+    }
+
+    /**
+     * 从任意文本里解析出全部来源标记（逐行扫描，认不出的行原样跳过）。
+     *
+     * <p>解析失败一律跳过而不抛错：这条链路上游是模型生成的文本，
+     * 它可能把标记复述得缺胳膊少腿，为此打断一轮对话是不成比例的。</p>
+     */
+    public static List<KnowledgeCitation> parseAll(String text) {
+        if (text == null || text.isEmpty()) {
+            return List.of();
+        }
+        List<KnowledgeCitation> found = new ArrayList<>();
+        for (String line : text.split("\\R")) {
+            KnowledgeCitation citation = parseLine(line);
+            if (citation != null) {
+                found.add(citation);
+            }
+        }
+        return List.copyOf(found);
+    }
+
+    private static KnowledgeCitation parseLine(String line) {
+        if (line == null) {
+            return null;
+        }
+        int start = line.indexOf(PREFIX);
+        if (start < 0) {
+            return null;
+        }
+        String[] parts = line.substring(start + PREFIX.length()).split("\\s\\|\\s", -1);
+        if (parts.length < 3) {
+            return null;
+        }
+        String chunkId = parts[2].trim();
+        if (chunkId.startsWith(CHUNK_MARK)) {
+            chunkId = chunkId.substring(CHUNK_MARK.length());
+        }
+        if (chunkId.isEmpty()) {
+            return null;
+        }
+        return new KnowledgeCitation(parts[0].trim(), parts[1].trim(), chunkId,
+            parts.length >= 4 ? parseScore(parts[3]) : null);
+    }
+
+    private static Double parseScore(String raw) {
+        try {
+            return Double.valueOf(raw.trim());
+        } catch (NumberFormatException ignored) {
+            // 分数只是展示辅助，解析不出就当没有，不影响引用本身可用
+            return null;
+        }
+    }
+
+    private static String escape(String value) {
+        return value == null ? "" : value.replace(RAW_PIPE, SAFE_PIPE);
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/middleware/KnowledgeCitationMiddleware.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/middleware/KnowledgeCitationMiddleware.java
@@ -1,0 +1,89 @@
+package com.richard.fyoung.customerwork.core.middleware;
+
+import com.richard.fyoung.customerwork.core.dto.KnowledgeCitation;
+import com.richard.fyoung.customerwork.core.service.ChatTerminalCapture;
+import com.richard.fyoung.customerwork.core.service.ChatTerminalCaptureContext;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * 把本轮召回的知识来源采集进终止信封，让用户看得到答案出处、运营查得到是哪条知识。
+ *
+ * <h3>为什么采在这里</h3>
+ * <p>检索侧（{@code ManagedKnowledge}）看似是最自然的采集点，但它接不上本轮请求：
+ * C 端走 {@code RAGMode.AGENTIC}，框架的 {@code KnowledgeRetrievalTools} 用
+ * {@code Mono.block()} 调检索——新订阅、空 Context，读不到 {@link ChatTerminalCapture}；
+ * 而 {@code Knowledge} 实例是全局共享单例（{@code KnowledgeProvider} 缓存了它），
+ * 也挂不住请求态。于是检索侧只负责把来源写成正文首行标记，认领工作放到这里。</p>
+ *
+ * <h3>为什么落 onActing 而不是 onReasoning</h3>
+ * <p>{@code onReasoning} 拿到的 {@code messages()} 是整个会话上下文，里面还躺着<b>前几轮</b>
+ * 的工具结果，照单解析会把上一个问题的引用挂到这一轮的回答上——用户看到一堆与当前答案
+ * 无关的出处，比没有出处更误导。{@code onActing} 的事件流只含本轮真实发生的工具调用。
+ * 本中间件只读事件、不改写，因此不受"改事件流改不了模型上下文"那条限制影响。</p>
+ *
+ * <p>工具结果文本按 {@code toolCallId} 累积到 {@link ToolResultEndEvent} 再解析：
+ * {@link ToolResultTextDeltaEvent} 是<b>增量</b>，标记行可能被切在两个分片之间，
+ * 逐片解析会稳定地漏掉刚好被切开的那几条。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+@Component
+public class KnowledgeCitationMiddleware implements MiddlewareBase {
+
+    @Override
+    public Flux<AgentEvent> onActing(Agent agent, RuntimeContext ctx, ActingInput input,
+                                     Function<ActingInput, Flux<AgentEvent>> next) {
+        return Flux.deferContextual(contextView -> {
+            ChatTerminalCapture capture = ChatTerminalCaptureContext.get(contextView);
+            if (capture == null) {
+                // 工作台、调度任务等没有终止采集上下文的调用方完全透传
+                return next.apply(input);
+            }
+            // 每次订阅一份累积器：同一会话的并发请求各走各的，不会互相串入引用
+            Map<String, StringBuilder> pending = new HashMap<>();
+            return next.apply(input).doOnNext(event -> collect(event, pending, capture));
+        });
+    }
+
+    private void collect(AgentEvent event, Map<String, StringBuilder> pending, ChatTerminalCapture capture) {
+        if (event instanceof ToolResultTextDeltaEvent delta) {
+            if (delta.getDelta() != null && !delta.getDelta().isEmpty()) {
+                pending.computeIfAbsent(keyOf(delta.getToolCallId()), k -> new StringBuilder())
+                    .append(delta.getDelta());
+            }
+            return;
+        }
+        if (event instanceof ToolResultEndEvent end) {
+            StringBuilder text = pending.remove(keyOf(end.getToolCallId()));
+            if (text == null) {
+                return;
+            }
+            List<KnowledgeCitation> found = KnowledgeCitation.parseAll(text.toString());
+            capture.acceptCitations(found);
+        }
+    }
+
+    /** 工具调用 id 缺失时归到同一个桶：宁可把两次调用的文本连在一起，也不要整段丢弃。 */
+    private String keyOf(String toolCallId) {
+        return toolCallId == null || toolCallId.isBlank() ? "" : toolCallId;
+    }
+
+    /** 顺序契约见 {@link MiddlewareOrders}：需在间接注入护栏之前看到工具结果原文。 */
+    @Override
+    public int order() {
+        return MiddlewareOrders.KNOWLEDGE_CITATION;
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/middleware/MiddlewareOrders.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/middleware/MiddlewareOrders.java
@@ -71,6 +71,14 @@ public final class MiddlewareOrders {
     /** 直接提示词注入防护：恶意输入越早挡住越好。 */
     public static final int PROMPT_INJECTION_GUARD = 140;
 
+    /**
+     * 知识引用采集：从工具结果里认领本轮召回的知识来源。
+     *
+     * <p>排在间接注入护栏之外，是为了拿到未被隔离标签包裹的工具结果原文——
+     * 逐行解析虽然不受包裹影响，但让采集依赖"护栏怎么包"是没必要的耦合。</p>
+     */
+    public static final int KNOWLEDGE_CITATION = 137;
+
     /** 间接注入防护：针对工具结果与外部内容。 */
     public static final int INDIRECT_INJECTION_GUARD = 135;
 

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/service/ChatTerminalCapture.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/service/ChatTerminalCapture.java
@@ -2,13 +2,18 @@ package com.richard.fyoung.customerwork.core.service;
 
 import com.richard.fyoung.customerwork.core.dto.ChatTerminalEnvelope;
 import com.richard.fyoung.customerwork.core.dto.ChatUsageSnapshot;
+import com.richard.fyoung.customerwork.core.dto.KnowledgeCitation;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentResultEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
 import io.agentscope.core.message.Msg;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -28,6 +33,14 @@ public final class ChatTerminalCapture {
 
     private final Map<String, ChatUsageSnapshot> usageByReplyId = new ConcurrentHashMap<>();
     private final AtomicReference<String> finishReason = new AtomicReference<>();
+
+    /**
+     * 本轮用到的知识引用。
+     *
+     * <p>用并发容器而不是普通 List：RAGMode.AGENTIC 下检索是模型自己发起的<b>工具调用</b>，
+     * 一轮里可能触发多次，而工具执行是否并行由 Toolkit 配置决定——这里不该依赖它当前是串行的。</p>
+     */
+    private final Queue<KnowledgeCitation> citations = new ConcurrentLinkedQueue<>();
 
     /** 捕获 AgentScope 事件；同一事件重复经过嵌套中间件时不会重复计量。 */
     public void accept(AgentEvent event) {
@@ -51,6 +64,22 @@ public final class ChatTerminalCapture {
         finishReason.set(ERROR);
     }
 
+    /** 记录本轮召回的知识来源；重复调用累加（一轮可能检索多次）。 */
+    public void acceptCitations(List<KnowledgeCitation> found) {
+        if (found != null && !found.isEmpty()) {
+            citations.addAll(found);
+        }
+    }
+
+    /** 本轮全部知识引用，按加入顺序去重（同一分片被多次召回只算一条）。 */
+    public List<KnowledgeCitation> citations() {
+        Map<String, KnowledgeCitation> unique = new LinkedHashMap<>();
+        for (KnowledgeCitation citation : citations) {
+            unique.putIfAbsent(citation.chunkId(), citation);
+        }
+        return List.copyOf(unique.values());
+    }
+
     public ChatUsageSnapshot usage() {
         return usageByReplyId.values().stream()
             .reduce(ChatUsageSnapshot.empty(), ChatUsageSnapshot::plus);
@@ -68,6 +97,6 @@ public final class ChatTerminalCapture {
         } else if (reason == null) {
             reason = usageByReplyId.isEmpty() ? CACHE_HIT : MODEL_STOP;
         }
-        return new ChatTerminalEnvelope(messageId, reason, usage(), traceId);
+        return new ChatTerminalEnvelope(messageId, reason, usage(), traceId, citations());
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentConfig.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentConfig.java
@@ -85,7 +85,8 @@ public class AttachmentConfig {
         VisionOcrUsageRecorder usageRecorder = new MeteredVisionOcrUsageRecorder(
             meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable(),
             quotaGuardProvider == null ? null : quotaGuardProvider.getIfAvailable());
-        return VisionOcrServices.create(properties, modelSupplier, usageRecorder);
+        return VisionOcrServices.create(properties, modelSupplier, usageRecorder,
+            meterRegistryProvider == null ? null : meterRegistryProvider.getIfAvailable());
     }
 
     /** 附件文件存储：文件统一进入 MinIO，构造逻辑收敛在 {@link AttachmentFileStorages}。 */

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentProperties.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/AttachmentProperties.java
@@ -95,6 +95,19 @@ public class AttachmentProperties {
         /** OCR 提示词（engine=model 生效，中文：逐字提取、保留排版、输出 Markdown、不加解释）。 */
         private String prompt = "请逐字提取这张图片中的全部文字内容，保持原有排版结构，以 Markdown 格式输出，不要添加任何解释说明。";
 
+        /**
+         * 主引擎失败时的备用引擎；<b>留空即不降级</b>，与既有单引擎行为完全一致。
+         *
+         * <p>项目本来就有两个 OCR 引擎，此前却是二选一：视觉模型 API 抖动、限流或欠费时，
+         * 附件解析直接落 FAILED，用户看到"解析失败"，而旁边那个能用的引擎闲着。
+         * 客服场景里"有结果"明显优于"没结果"——自建 PaddleOCR 质量不如视觉大模型，
+         * 但它成本为零、可用性独立于外部模型 API。</p>
+         *
+         * <p>默认留空而不是自动配一个：不能假设备用引擎在这个部署里存在
+         * （PaddleOCR 需要自建 serving）。取值同 {@code engine}。</p>
+         */
+        private String fallbackEngine;
+
         /** PaddleOCR 开源 serving 配置（engine=paddleocr 生效）。 */
         private final Paddle paddle = new Paddle();
     }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/FallbackVisionOcrService.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/FallbackVisionOcrService.java
@@ -1,0 +1,87 @@
+package com.richard.fyoung.customerwork.data.attachment;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 主备双引擎的视觉 OCR：主引擎失败时退到备用引擎。
+ *
+ * <p><b>要解决的问题</b>：项目本来就有两个 OCR 引擎——视觉大模型与自建 PaddleOCR serving，
+ * 但此前是二选一：{@code engine=model} 时视觉模型 API 抖动、限流或欠费，附件解析直接落 FAILED，
+ * 用户看到的是"解析失败"，<b>而旁边那个能用的引擎闲着</b>。
+ * 项目在对话模型那侧做了失败转移、熔断、分级路由一整套，附件这条链路一样都没有。</p>
+ *
+ * <p><b>为什么值得降级而不是直接失败</b>：客服场景里"有结果"明显优于"没结果"。
+ * 自建 PaddleOCR 的识别质量不如视觉大模型，但它成本为零、可用性独立于外部模型 API——
+ * 用户传的截图能读出七成文字，也比一句"解析失败"有用。</p>
+ *
+ * <p><b>默认不降级，配了才降</b>：不能假设备用引擎在这个部署里存在（PaddleOCR 需要自建 serving）。
+ * 留空即单引擎，与既有行为完全一致；显式配置 {@code fallback-engine} 才启用。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+public class FallbackVisionOcrService implements VisionOcrService {
+
+    private static final Logger log = LoggerFactory.getLogger(FallbackVisionOcrService.class);
+
+    /** 降级计数指标：回答"主引擎到底有多不稳"，以及降级本身有没有救回来。 */
+    private static final String M_FALLBACK = "customerwork.attachment.ocr.fallback";
+    private static final String TAG_FROM = "from";
+    private static final String TAG_TO = "to";
+    private static final String TAG_RESULT = "result";
+    private static final String RESULT_RECOVERED = "recovered";
+    private static final String RESULT_BOTH_FAILED = "both-failed";
+
+    private final VisionOcrService primary;
+    private final VisionOcrService fallback;
+    private final String primaryEngine;
+    private final String fallbackEngine;
+    private final MeterRegistry meterRegistry;
+
+    public FallbackVisionOcrService(VisionOcrService primary, VisionOcrService fallback,
+                                    String primaryEngine, String fallbackEngine,
+                                    MeterRegistry meterRegistry) {
+        this.primary = primary;
+        this.fallback = fallback;
+        this.primaryEngine = primaryEngine;
+        this.fallbackEngine = fallbackEngine;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public String recognize(byte[] imageBytes, String mimeType) {
+        try {
+            return primary.recognize(imageBytes, mimeType);
+        } catch (Exception primaryError) {
+            // 降级本身必须留痕：它意味着主引擎不可用，而用户侧看起来一切正常
+            log.error("vision ocr primary engine failed, falling back, code={} from={} to={}",
+                "VISION-OCR-FALLBACK", primaryEngine, fallbackEngine, primaryError);
+            return recognizeWithFallback(imageBytes, mimeType, primaryError);
+        }
+    }
+
+    private String recognizeWithFallback(byte[] imageBytes, String mimeType, Exception primaryError) {
+        try {
+            String text = fallback.recognize(imageBytes, mimeType);
+            count(RESULT_RECOVERED);
+            log.info("vision ocr recovered by fallback engine, engine={}", fallbackEngine);
+            return text;
+        } catch (Exception fallbackError) {
+            count(RESULT_BOTH_FAILED);
+            // 抛主引擎的异常并把备用的挂成 suppressed：主引擎才是这个部署期望用的那个，
+            // 它的失败原因更有诊断价值；两个都保留，排查时不必再翻日志对时间
+            primaryError.addSuppressed(fallbackError);
+            throw primaryError instanceof RuntimeException runtime
+                ? runtime : new IllegalStateException("vision ocr failed on both engines", primaryError);
+        }
+    }
+
+    private void count(String result) {
+        if (meterRegistry == null) {
+            return;
+        }
+        meterRegistry.counter(M_FALLBACK, TAG_FROM, primaryEngine, TAG_TO, fallbackEngine,
+            TAG_RESULT, result).increment();
+    }
+}

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/VisionOcrServices.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/attachment/VisionOcrServices.java
@@ -1,5 +1,7 @@
 package com.richard.fyoung.customerwork.data.attachment;
 
+import org.springframework.util.StringUtils;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.agentscope.core.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +42,35 @@ public final class VisionOcrServices {
 
     public static VisionOcrService create(AttachmentProperties properties, Supplier<Model> visionModelSupplier,
                                           VisionOcrUsageRecorder usageRecorder) {
+        return create(properties, visionModelSupplier, usageRecorder, null);
+    }
+
+    /**
+     * 构造 OCR 服务；配了 {@code fallback-engine} 时包成主备双引擎。
+     *
+     * <p>备用引擎与主引擎相同时视为未配置——那不是降级，只是把同一个失败重做一遍。</p>
+     */
+    public static VisionOcrService create(AttachmentProperties properties, Supplier<Model> visionModelSupplier,
+                                          VisionOcrUsageRecorder usageRecorder,
+                                          MeterRegistry meterRegistry) {
         AttachmentProperties.Ocr ocr = properties.getOcr();
-        if (ENGINE_PADDLEOCR.equalsIgnoreCase(ocr.getEngine())) {
+        String primaryEngine = normalize(ocr.getEngine());
+        VisionOcrService primary = build(primaryEngine, properties, visionModelSupplier, usageRecorder);
+
+        String fallbackEngine = normalize(ocr.getFallbackEngine());
+        if (!StringUtils.hasText(fallbackEngine) || fallbackEngine.equals(primaryEngine)) {
+            return primary;
+        }
+        VisionOcrService fallback = build(fallbackEngine, properties, visionModelSupplier, usageRecorder);
+        log.info("vision ocr fallback enabled, primary={} fallback={}", primaryEngine, fallbackEngine);
+        return new FallbackVisionOcrService(primary, fallback, primaryEngine, fallbackEngine, meterRegistry);
+    }
+
+    private static VisionOcrService build(String engine, AttachmentProperties properties,
+                                          Supplier<Model> visionModelSupplier,
+                                          VisionOcrUsageRecorder usageRecorder) {
+        AttachmentProperties.Ocr ocr = properties.getOcr();
+        if (ENGINE_PADDLEOCR.equals(engine)) {
             AttachmentProperties.Paddle paddle = ocr.getPaddle();
             log.info("vision ocr engine: paddleocr (self-hosted serving, base-url={})", paddle.getBaseUrl());
             return new PaddleOcrVisionOcrService(paddle.getBaseUrl(), paddle.getOcrPath(), paddle.getTimeoutSeconds());
@@ -49,5 +78,9 @@ public final class VisionOcrServices {
         log.info("vision ocr engine: model (vision LLM, provider={}, model={})", ocr.getProvider(), ocr.getModelName());
         return new ModelVisionOcrService(visionModelSupplier, ocr.getPrompt(), ocr.getTimeoutSeconds(),
             usageRecorder);
+    }
+
+    private static String normalize(String engine) {
+        return engine == null ? "" : engine.trim().toLowerCase();
     }
 }

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/rag/ManagedKnowledge.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/data/rag/ManagedKnowledge.java
@@ -1,6 +1,7 @@
 package com.richard.fyoung.customerwork.data.rag;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.richard.fyoung.customerwork.core.dto.KnowledgeCitation;
 import com.richard.fyoung.customerwork.data.knowledge.embedding.EmbeddingClient;
 import com.richard.fyoung.customerwork.data.knowledge.entity.KnowledgeChunkDO;
 import com.richard.fyoung.customerwork.data.knowledge.entity.KnowledgeVersionDO;
@@ -164,11 +165,14 @@ public class ManagedKnowledge implements Knowledge {
             }
             String docId = chunk.getExternalId() != null && !chunk.getExternalId().isBlank()
                 ? chunk.getExternalId() : String.valueOf(chunk.getDocRevisionId());
+            KnowledgeCitation citation = new KnowledgeCitation(
+                scored.version().getKbName(), docId, String.valueOf(chunk.getId()), scored.score());
             DocumentMetadata metadata = new DocumentMetadata(
-                TextBlock.builder().text(chunk.getContent()).build(),
+                // 来源写进正文首行而不是只放 metadata：AGENTIC 模式下框架把命中结果格式化成
+                // 工具返回文本时只取 contentText，metadata 整个丢掉，回传与模型都看不到出处
+                TextBlock.builder().text(citation.marker() + "\n" + chunk.getContent()).build(),
                 docId,
                 String.valueOf(chunk.getId()),
-                // 来源信息随文档带出，供回答里的引用标注使用
                 Map.of("knowledgeBase", scored.version().getKbName(),
                     "kbCode", scored.version().getKbCode(),
                     "chunkIndex", chunk.getChunkIndex()));

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/dto/KnowledgeCitationMarkerTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/dto/KnowledgeCitationMarkerTest.java
@@ -1,0 +1,108 @@
+package com.richard.fyoung.customerwork.core.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 来源标记的生成与解析是同一份格式的两端，必须真的做一次往返。
+ *
+ * <p>只断言"生成的字符串长这样"照不出漂移：改了生成端而忘了解析端，那种断言照样绿，
+ * 而线上表现是引用恒为空——检索在工作、标记也写进去了，就是没人认领。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeCitationMarkerTest {
+
+    @Test
+    @DisplayName("生成的标记能被原样解析回来")
+    void markerRoundTrips() {
+        KnowledgeCitation original = new KnowledgeCitation("售后FAQ", "doc-refund-policy", "10237", 0.87);
+
+        List<KnowledgeCitation> parsed = KnowledgeCitation.parseAll(original.marker());
+
+        assertEquals(1, parsed.size());
+        assertEquals(original.knowledgeBase(), parsed.get(0).knowledgeBase());
+        assertEquals(original.documentId(), parsed.get(0).documentId());
+        assertEquals(original.chunkId(), parsed.get(0).chunkId());
+        assertEquals(0.87, parsed.get(0).score(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("知识库名里的竖线不会撑破分隔符")
+    void pipeInFieldDoesNotBreakParsing() {
+        KnowledgeCitation original = new KnowledgeCitation("售后 | 退换货", "doc-a", "77", 0.5);
+
+        List<KnowledgeCitation> parsed = KnowledgeCitation.parseAll(original.marker());
+
+        assertEquals(1, parsed.size(), "字段里的竖线把标记切成了更多段");
+        assertEquals("doc-a", parsed.get(0).documentId(), "文档标识错位了");
+        assertEquals("77", parsed.get(0).chunkId());
+    }
+
+    @Test
+    @DisplayName("从混着正文的多段文本里解析出全部引用")
+    void parsesFromMixedText() {
+        String toolResult = "检索到 2 个结果：\n"
+            + new KnowledgeCitation("售后FAQ", "doc-a", "1", 0.9).marker() + "\n"
+            + "七天无理由退货适用于未拆封商品。\n"
+            + new KnowledgeCitation("物流政策", "doc-b", "2", 0.6).marker() + "\n"
+            + "偏远地区配送时效为 5-7 天。\n";
+
+        List<KnowledgeCitation> parsed = KnowledgeCitation.parseAll(toolResult);
+
+        assertEquals(List.of("1", "2"), parsed.stream().map(KnowledgeCitation::chunkId).toList());
+        assertEquals("物流政策", parsed.get(1).knowledgeBase());
+    }
+
+    @Test
+    @DisplayName("标记被包在其它内容里（如注入护栏的隔离标签）仍能认出")
+    void parsesWhenWrappedByOtherContent() {
+        String wrapped = "<untrusted-abc>\n"
+            + new KnowledgeCitation("售后FAQ", "doc-a", "5", 0.3).marker() + "\n"
+            + "正文\n</untrusted-abc>";
+
+        assertEquals(1, KnowledgeCitation.parseAll(wrapped).size());
+    }
+
+    @Test
+    @DisplayName("残缺或无关的行一律跳过，不抛异常")
+    void malformedLinesAreSkipped() {
+        assertTrue(KnowledgeCitation.parseAll("普通的一段回答，没有任何标记").isEmpty());
+        assertTrue(KnowledgeCitation.parseAll("【知识来源】只有一个字段").isEmpty());
+        assertTrue(KnowledgeCitation.parseAll("【知识来源】库 | 文档 | #").isEmpty(), "分片标识为空的不该被收下");
+        assertTrue(KnowledgeCitation.parseAll(null).isEmpty());
+        assertTrue(KnowledgeCitation.parseAll("").isEmpty());
+    }
+
+    @Test
+    @DisplayName("分数缺失或不是数字时引用本身仍然可用")
+    void scoreIsOptional() {
+        List<KnowledgeCitation> noScore = KnowledgeCitation.parseAll("【知识来源】库 | 文档 | #9");
+        assertEquals(1, noScore.size());
+        assertNull(noScore.get(0).score());
+
+        List<KnowledgeCitation> badScore = KnowledgeCitation.parseAll("【知识来源】库 | 文档 | #9 | 高");
+        assertEquals(1, badScore.size(), "分数解析失败不该让整条引用丢掉");
+        assertNull(badScore.get(0).score());
+        assertEquals("9", badScore.get(0).chunkId());
+    }
+
+    @Test
+    @DisplayName("分数为 null 时标记不写分数段，且能解析回 null")
+    void nullScoreOmitsSegment() {
+        KnowledgeCitation original = new KnowledgeCitation("库", "文档", "3", null);
+
+        String marker = original.marker();
+        List<KnowledgeCitation> parsed = KnowledgeCitation.parseAll(marker);
+
+        assertEquals(1, parsed.size());
+        assertNull(parsed.get(0).score());
+        assertEquals("3", parsed.get(0).chunkId());
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/middleware/KnowledgeCitationMiddlewareTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/middleware/KnowledgeCitationMiddlewareTest.java
@@ -1,0 +1,144 @@
+package com.richard.fyoung.customerwork.core.middleware;
+
+import com.richard.fyoung.customerwork.core.dto.KnowledgeCitation;
+import com.richard.fyoung.customerwork.core.service.ChatTerminalCapture;
+import com.richard.fyoung.customerwork.core.service.ChatTerminalCaptureContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.middleware.ActingInput;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.util.context.Context;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 引用采集中间件：从工具结果事件流里认领本轮召回的知识来源。
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class KnowledgeCitationMiddlewareTest {
+
+    private final KnowledgeCitationMiddleware middleware = new KnowledgeCitationMiddleware();
+
+    private static final ActingInput EMPTY_INPUT = new ActingInput(List.of());
+
+    @Test
+    @DisplayName("从工具结果里采集到引用，并写进终止信封")
+    void collectsCitationsFromToolResult() {
+        ChatTerminalCapture capture = new ChatTerminalCapture();
+        String output = "检索到 1 个结果：\n"
+            + new KnowledgeCitation("售后FAQ", "doc-refund", "10237", 0.87).marker() + "\n"
+            + "七天无理由退货适用于未拆封商品。";
+
+        run(capture, Flux.just(
+            new ToolResultTextDeltaEvent("r", "call-1", "retrieve_knowledge", output),
+            new ToolResultEndEvent("r", "call-1", "retrieve_knowledge", ToolResultState.SUCCESS)));
+
+        List<KnowledgeCitation> citations = capture.citations();
+        assertEquals(1, citations.size());
+        assertEquals("售后FAQ", citations.get(0).knowledgeBase());
+        assertEquals("10237", citations.get(0).chunkId());
+        assertEquals(citations, capture.envelope("MSG-1", "回复", "trace-1").citations(),
+            "采到的引用必须真的出现在终止信封里，否则前端永远拿不到");
+    }
+
+    /**
+     * 分片是这条链路最容易静默失效的地方：标记行被切在两个 delta 之间时，
+     * 逐片解析会稳定地漏掉刚好被切开的那几条，而且不报任何错。
+     */
+    @Test
+    @DisplayName("标记行被切成多个分片时仍能完整解析")
+    void accumulatesDeltasBeforeParsing() {
+        ChatTerminalCapture capture = new ChatTerminalCapture();
+        String marker = new KnowledgeCitation("物流政策", "doc-ship", "88", 0.6).marker();
+        int cut = marker.length() / 2;
+
+        run(capture, Flux.just(
+            new ToolResultTextDeltaEvent("r", "call-1", "retrieve_knowledge", marker.substring(0, cut)),
+            new ToolResultTextDeltaEvent("r", "call-1", "retrieve_knowledge", marker.substring(cut)),
+            new ToolResultEndEvent("r", "call-1", "retrieve_knowledge", ToolResultState.SUCCESS)));
+
+        assertEquals(List.of("88"), capture.citations().stream()
+            .map(KnowledgeCitation::chunkId).toList());
+    }
+
+    @Test
+    @DisplayName("同一分片被多次召回只回传一条")
+    void deduplicatesByChunkId() {
+        ChatTerminalCapture capture = new ChatTerminalCapture();
+        String marker = new KnowledgeCitation("售后FAQ", "doc-a", "5", 0.9).marker();
+
+        run(capture, Flux.just(
+            new ToolResultTextDeltaEvent("r", "call-1", "retrieve_knowledge", marker),
+            new ToolResultEndEvent("r", "call-1", "retrieve_knowledge", ToolResultState.SUCCESS)));
+        run(capture, Flux.just(
+            new ToolResultTextDeltaEvent("r", "call-2", "retrieve_knowledge", marker),
+            new ToolResultEndEvent("r", "call-2", "retrieve_knowledge", ToolResultState.SUCCESS)));
+
+        assertEquals(1, capture.citations().size());
+    }
+
+    @Test
+    @DisplayName("并发的两次工具调用各自解析，不会把文本串在一起")
+    void separatesByToolCallId() {
+        ChatTerminalCapture capture = new ChatTerminalCapture();
+        String first = new KnowledgeCitation("售后FAQ", "doc-a", "1", 0.9).marker();
+        String second = new KnowledgeCitation("物流政策", "doc-b", "2", 0.5).marker();
+        int cut = first.length() / 2;
+
+        // 两次调用的分片交错到达：按 toolCallId 分桶才不会把两段标记接成一段乱码
+        run(capture, Flux.just(
+            new ToolResultTextDeltaEvent("r", "call-1", "retrieve_knowledge", first.substring(0, cut)),
+            new ToolResultTextDeltaEvent("r", "call-2", "retrieve_knowledge", second),
+            new ToolResultTextDeltaEvent("r", "call-1", "retrieve_knowledge", first.substring(cut)),
+            new ToolResultEndEvent("r", "call-2", "retrieve_knowledge", ToolResultState.SUCCESS),
+            new ToolResultEndEvent("r", "call-1", "retrieve_knowledge", ToolResultState.SUCCESS)));
+
+        assertEquals(List.of("2", "1"), capture.citations().stream()
+            .map(KnowledgeCitation::chunkId).toList());
+    }
+
+    @Test
+    @DisplayName("普通业务工具的结果不产生引用")
+    void ignoresUnrelatedToolOutput() {
+        ChatTerminalCapture capture = new ChatTerminalCapture();
+
+        run(capture, Flux.just(
+            new ToolResultTextDeltaEvent("r", "call-1", "query_order", "订单 SO-1 已发货"),
+            new ToolResultEndEvent("r", "call-1", "query_order", ToolResultState.SUCCESS)));
+
+        assertTrue(capture.citations().isEmpty());
+    }
+
+    /**
+     * 工作台、调度任务等调用方没有终止采集上下文，必须原样透传——
+     * 这类"顺带把别人打挂"的回归正是本项目反复出现的形状。
+     */
+    @Test
+    @DisplayName("没有采集上下文时完全透传")
+    void passesThroughWithoutCapture() {
+        AtomicBoolean nextCalled = new AtomicBoolean(false);
+
+        List<AgentEvent> events = middleware.onActing(null, null, EMPTY_INPUT, input -> {
+            nextCalled.set(true);
+            return Flux.just(new ToolResultEndEvent("r", "call-1", "any", ToolResultState.SUCCESS));
+        }).collectList().block();
+
+        assertTrue(nextCalled.get(), "下游中间件必须照常被调用");
+        assertEquals(1, events.size(), "事件流不得被改写或吞掉");
+    }
+
+    private void run(ChatTerminalCapture capture, Flux<AgentEvent> downstream) {
+        middleware.onActing(null, null, EMPTY_INPUT, input -> downstream)
+            .contextWrite(context -> ChatTerminalCaptureContext.withCapture(context, capture))
+            .blockLast();
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/attachment/FallbackVisionOcrServiceTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/attachment/FallbackVisionOcrServiceTest.java
@@ -1,0 +1,158 @@
+package com.richard.fyoung.customerwork.data.attachment;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 视觉 OCR 主备双引擎测试。
+ *
+ * <p><b>守的是什么</b>：项目本来就有两个 OCR 引擎（视觉大模型 / 自建 PaddleOCR），
+ * 但此前是二选一——视觉模型 API 抖动、限流或欠费时，附件解析直接落 FAILED，
+ * 用户看到"解析失败"，而旁边那个能用的引擎闲着。项目在对话模型那侧做了失败转移、熔断、
+ * 分级路由一整套，附件这条链路一样都没有。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class FallbackVisionOcrServiceTest {
+
+    private static final byte[] IMAGE = {1, 2, 3};
+    private static final String MIME = "image/png";
+
+    private VisionOcrService ok(String text, AtomicInteger calls) {
+        return (bytes, mime) -> {
+            calls.incrementAndGet();
+            return text;
+        };
+    }
+
+    private VisionOcrService failing(RuntimeException error, AtomicInteger calls) {
+        return (bytes, mime) -> {
+            calls.incrementAndGet();
+            throw error;
+        };
+    }
+
+    private FallbackVisionOcrService service(VisionOcrService primary, VisionOcrService fallback,
+                                             MeterRegistry registry) {
+        return new FallbackVisionOcrService(primary, fallback, "model", "paddleocr", registry);
+    }
+
+    @Test
+    @DisplayName("主引擎成功时不碰备用引擎")
+    void primarySuccessSkipsFallback() {
+        AtomicInteger primaryCalls = new AtomicInteger();
+        AtomicInteger fallbackCalls = new AtomicInteger();
+
+        String text = service(ok("主引擎结果", primaryCalls), ok("备用结果", fallbackCalls), null)
+            .recognize(IMAGE, MIME);
+
+        assertEquals("主引擎结果", text);
+        assertEquals(1, primaryCalls.get());
+        assertEquals(0, fallbackCalls.get(), "主引擎成功就不该再调备用——那是白花一次成本");
+    }
+
+    /**
+     * 主引擎失败时备用接管。
+     *
+     * <p>客服场景里"有结果"明显优于"没结果"：用户传的截图能读出七成文字，
+     * 也比一句"解析失败"有用。</p>
+     */
+    @Test
+    @DisplayName("主引擎失败时由备用引擎接管")
+    void fallbackTakesOverOnPrimaryFailure() {
+        AtomicInteger fallbackCalls = new AtomicInteger();
+
+        String text = service(
+            failing(new IllegalStateException("vision api 429"), new AtomicInteger()),
+            ok("备用识别结果", fallbackCalls), null).recognize(IMAGE, MIME);
+
+        assertEquals("备用识别结果", text);
+        assertEquals(1, fallbackCalls.get());
+    }
+
+    /**
+     * 两个都失败时抛<b>主引擎</b>的异常，备用的挂成 suppressed。
+     *
+     * <p>主引擎才是这个部署期望用的那个，它的失败原因更有诊断价值；
+     * 两个都保留，排查时不必再翻日志对时间。</p>
+     */
+    @Test
+    @DisplayName("两个引擎都失败时抛主引擎异常并附带备用异常")
+    void bothFailedThrowsPrimaryWithSuppressed() {
+        RuntimeException primaryError = new IllegalStateException("vision api 429");
+        RuntimeException fallbackError = new IllegalStateException("paddleocr connection refused");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> service(
+            failing(primaryError, new AtomicInteger()),
+            failing(fallbackError, new AtomicInteger()), null).recognize(IMAGE, MIME));
+
+        assertSame(primaryError, thrown, "主引擎的失败原因更有诊断价值，应作为主因抛出");
+        assertEquals(1, thrown.getSuppressed().length, "备用引擎的异常必须保留");
+        assertSame(fallbackError, thrown.getSuppressed()[0]);
+    }
+
+    @Test
+    @DisplayName("降级结果进指标：救回来与两个都挂分开计数")
+    void fallbackOutcomeGoesToMetrics() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        service(failing(new IllegalStateException("boom"), new AtomicInteger()),
+            ok("ok", new AtomicInteger()), registry).recognize(IMAGE, MIME);
+
+        double recovered = registry.counter("customerwork.attachment.ocr.fallback",
+            "from", "model", "to", "paddleocr", "result", "recovered").count();
+        assertEquals(1d, recovered, 0.001,
+            "降级救回来了要能被观测到——否则主引擎长期不可用也没人知道");
+    }
+
+    @Test
+    @DisplayName("两个都失败同样计数，与救回来分开")
+    void bothFailedIsCountedSeparately() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        assertThrows(RuntimeException.class, () -> service(
+            failing(new IllegalStateException("a"), new AtomicInteger()),
+            failing(new IllegalStateException("b"), new AtomicInteger()), registry).recognize(IMAGE, MIME));
+
+        assertEquals(1d, registry.counter("customerwork.attachment.ocr.fallback",
+            "from", "model", "to", "paddleocr", "result", "both-failed").count(), 0.001);
+    }
+
+    /** 未配备用引擎时行为与既有单引擎完全一致——不能因为引入降级就改变默认行为。 */
+    @Test
+    @DisplayName("未配备用引擎时工厂返回单引擎实现")
+    void noFallbackConfiguredKeepsSingleEngine() {
+        AttachmentProperties properties = new AttachmentProperties();
+        properties.getOcr().setEngine("paddleocr");
+
+        VisionOcrService built = VisionOcrServices.create(properties, () -> null,
+            VisionOcrUsageRecorder.noop(), null);
+
+        assertTrue(built instanceof PaddleOcrVisionOcrService,
+            "留空即单引擎，与既有行为完全一致");
+    }
+
+    /** 备用与主引擎相同不算降级——那只是把同一个失败重做一遍。 */
+    @Test
+    @DisplayName("备用引擎与主引擎相同时视为未配置")
+    void sameFallbackEngineIsTreatedAsUnset() {
+        AttachmentProperties properties = new AttachmentProperties();
+        properties.getOcr().setEngine("paddleocr");
+        properties.getOcr().setFallbackEngine("PaddleOCR");
+
+        VisionOcrService built = VisionOcrServices.create(properties, () -> null,
+            VisionOcrUsageRecorder.noop(), null);
+
+        assertTrue(built instanceof PaddleOcrVisionOcrService,
+            "同一个引擎重试一次不是降级，取值大小写也应归一");
+    }
+}

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/rag/ManagedKnowledgeTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/data/rag/ManagedKnowledgeTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customerwork.data.rag;
 
+import com.richard.fyoung.customerwork.core.dto.KnowledgeCitation;
 import com.richard.fyoung.customerwork.data.knowledge.embedding.EmbeddingClient;
 import com.richard.fyoung.customerwork.data.knowledge.entity.KnowledgeChunkDO;
 import com.richard.fyoung.customerwork.data.knowledge.entity.KnowledgeVersionDO;
@@ -84,10 +85,21 @@ class ManagedKnowledgeTest {
 
         assertNotNull(docs);
         assertEquals(1, docs.size());
-        assertEquals("七天无理由从签收次日算起", docs.get(0).getMetadata().getContentText());
         assertEquals(0.92d, docs.get(0).getScore(), 1e-6);
         assertEquals("售后FAQ", docs.get(0).getMetadata().getPayloadValue("knowledgeBase"),
             "来源信息要随文档带出，供回答里的引用标注使用");
+
+        // 正文 = 来源标记行 + 原文。标记必须在 getContentText() 里，因为框架把命中结果
+        // 格式化成工具返回文本时只取这一个字段，metadata 整个丢掉
+        String content = docs.get(0).getMetadata().getContentText();
+        assertTrue(content.endsWith("七天无理由从签收次日算起"), "原文必须原样保留在标记之后");
+
+        List<KnowledgeCitation> parsed = KnowledgeCitation.parseAll(content);
+        assertEquals(1, parsed.size(), "检索侧写的标记必须能被采集侧解析回来");
+        assertEquals("售后FAQ", parsed.get(0).knowledgeBase());
+        assertEquals("doc-a", parsed.get(0).documentId());
+        assertEquals("100", parsed.get(0).chunkId(), "分片标识要指向 cw_knowledge_chunk 的主键");
+        assertEquals(0.92d, parsed.get(0).score(), 1e-6);
     }
 
     /**

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/ws/WsFrameTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/ws/WsFrameTest.java
@@ -52,7 +52,7 @@ class WsFrameTest {
     @Test
     void chatDone_shouldCarryUnifiedTerminalEnvelopeAndPersistedMessageScope() throws Exception {
         ChatTerminalEnvelope terminal = new ChatTerminalEnvelope("MSG-9", "MODEL_STOP",
-            new ChatUsageSnapshot(8, 2, 1, 10, 0.3), "trace-9");
+            new ChatUsageSnapshot(8, 2, 1, 10, 0.3), "trace-9", java.util.List.of());
 
         WsFrame frame = WsFrame.chatDone(terminal, "u1:conv-1", "TK-1", "您好", 123L);
         JsonNode data = mapper.readTree(mapper.writeValueAsString(frame)).get("data");

--- a/docs/智能体能力差距与演进路线图.md
+++ b/docs/智能体能力差距与演进路线图.md
@@ -581,9 +581,36 @@ kept.addAll(budgeted.subList(budgeted.size() - tailCount, budgeted.size()));
 |---|---|---|
 | 一 · 止血 | ✅ 5/5 | 生产 RAG 门禁、对话阶段状态机写侧、MCP 超时、H5 记忆授权入口、裁剪配对保护 |
 | 二 · 装配与升级 | ✅ 4/4 | 渠道治理中间件、运行时装配门禁、框架升 2.0.2、20 个中间件顺序契约 |
-| 三 · 知识链路 | ✅ 完整闭环 | 向量 SPI + cw V24 → C 端 `ManagedKnowledge` → 后台投影写入 → 触发接口 |
+| 三 · 知识链路 | ✅ 完整闭环 | 向量 SPI + cw V24 → C 端 `ManagedKnowledge` → 后台投影写入 → 触发接口 → **结构化引用回传（P1-6）** |
 | 四 · 工具与运行时 | 4/5 | 工具执行超时、WS 跨副本广播、状态机型调度器互斥；优雅停机经实测证伪、MCP 连接池不建议做 |
 | 五 · 模型与多模态 | 2/5 | 国产模型专用 Formatter、视觉 OCR 用量记账 |
+
+### 实施期的一处路径改道：引用回传为什么不走上下文传播（P1-6）
+
+最自然的做法是在检索实现里读本轮的 `ChatTerminalCapture` 直接写入。**这条路实测不通**：
+C 端走 `RAGMode.AGENTIC`，检索是模型发起的一次工具调用，框架的
+`KnowledgeRetrievalTools#retrieveKnowledge` 用 `Mono.block()` 调 `Knowledge#retrieve`
+（2.0.2 字节码实证）——`block()` 开的是**新订阅，Reactor Context 为空**，
+在检索侧 `deferContextual` 拿到的恒为 `null`。
+
+危险的是它**测得出绿**：用 `StepVerifier` 手工塞一个带 capture 的 context 去测，
+断言全过，线上却一条引用都采不到。这正是本仓库反复出现的「能力接在用户不走的那条路上」。
+ThreadLocal 那条替代路同样不成立：跨过工具执行的线程边界要靠 Reactor 自动传播，
+而那套机制绑在多租户开关上（`TenantConfig`），单租户部署会静默失效；
+`Knowledge` 又是 `KnowledgeProvider` 缓存的**全局单例**，也挂不住请求态。
+
+改用的方案：检索侧把来源写成正文首行的自然语言标记，
+`KnowledgeCitationMiddleware` 在 `onActing` 的事件流里解析回来——那已回到 Agent 主链，
+与部署形态无关。三个附带决定：
+① 落 `onActing` 而非 `onReasoning`，因为后者拿到的是整个会话上下文，
+会把**前几轮**的工具结果算进这一轮，用户看到一堆与当前答案无关的出处；
+② 按 `toolCallId` 累积分片后再解析——`ToolResultTextDeltaEvent` 是增量，
+标记行被切在两片之间时逐片解析会稳定漏掉，且不报错；
+③ 标记做成给人看的中文而非隐晦符号：它同时是模型的出处说明，
+即使被原样复述，用户看到的也是一句通顺的来源，而不是乱码。
+
+**已知缺口（明示，非静默）**：引用不落聊天记录，刷新页面后重新拉取的历史消息没有来源。
+补齐要给 `cw_chat_log` 加列并走一次迁移，是独立的一件事。
 
 ### 明确不建议做的（含理由）
 


### PR DESCRIPTION
## 背景

承接已合并的 [PR #179](https://github.com/liulangjietou/customer_work/pull/179)，继续
[`docs/智能体能力差距与演进路线图.md`](docs/智能体能力差距与演进路线图.md) 的剩余项。
本 PR 含**两件独立的事**，各自一个 commit：

1. **视觉 OCR 主备双引擎降级**（P0 档空白 6 的 failover 部分）
2. **结构化引用回传**（P1-6，批次三知识链路的收尾）

---

## 一 · 视觉 OCR 主备双引擎降级

项目本来就有两个 OCR 引擎——视觉大模型与自建 PaddleOCR serving——但此前是**二选一**：
`engine=model` 时视觉模型 API 抖动、限流或欠费，附件解析直接落 `FAILED`、用户看到"解析失败"，
**而旁边那个能用的引擎闲着**。项目在对话模型那侧做了失败转移、熔断、分级路由一整套，
附件这条链路一样都没有。

**为什么值得降级而不是直接失败**：客服场景里"有结果"明显优于"没结果"。自建 PaddleOCR 的
识别质量不如视觉大模型，但它成本为零、可用性独立于外部模型 API——用户传的截图能读出七成文字，
也比一句"解析失败"有用。

四条设计约定：

1. **默认留空即不降级**，与既有单引擎行为完全一致。不能假设备用引擎在这个部署里存在
   （PaddleOCR 需要自建 serving），显式配 `fallback-engine` 才启用。
2. **备用与主引擎相同视为未配置**——那不是降级，只是把同一个失败重做一遍。取值大小写归一。
3. **两个都失败时抛主引擎的异常，备用的挂成 `suppressed`**：主引擎才是这个部署期望用的那个，
   它的失败原因更有诊断价值；两个都保留，排查时不必再翻日志对时间。
4. **降级必须留痕**：它意味着主引擎不可用，而用户侧看起来一切正常。`error` 日志带错误码，
   指标把"救回来了"与"两个都挂"分开计数——否则主引擎长期不可用也没人知道。

**未包含**：完整"纳入 ModelOps"（凭据轮换 / 上线认证 / 健康探测）这轮没做，它卡在跨库上：
凭据在 admin 的 `ai_model_config.secret_ref_id`，而 H5 用户上传附件走的是客服端 8080、
**读不到 admin 库**；投影过去又要解决密钥材料共享，是安全敏感设计。应当单独规划一个批次。

顺带核实到：`ai_model_asset` 的 `modality` 与 `supports_multimodal` **都没有运行时消费**，
同为装饰字段。

---

## 二 · 结构化引用回传（P1-6）

召回的知识此前只进模型上下文，回复里没有任何溯源线索。知识库改错一句话，表现是客服开始给出
错误答复，而没有线索指向那条知识——只能靠人把知识库通读一遍去猜。

### 实施期的路径改道（这一段是本 PR 最值得看的部分）

最自然的接法是在检索实现里读本轮的 `ChatTerminalCapture` 直接写入。**实测不通**：
C 端走 `RAGMode.AGENTIC`，检索是模型发起的一次工具调用，框架的
`KnowledgeRetrievalTools#retrieveKnowledge` 用 `Mono.block()` 调 `Knowledge#retrieve`
（2.0.2 字节码实证），而 `block()` 开的是**新订阅、Reactor Context 为空**，读到的恒为 `null`。

危险的是**它测得出绿**：用 `StepVerifier` 手工塞一个带 capture 的 context 去测，断言全过，
线上一条引用都采不到。这正是本仓库反复出现的「能力接在用户不走的那条路上」。

ThreadLocal 那条替代路同样不成立：跨过工具执行的线程边界要靠 Reactor 自动传播，而那套机制
绑在多租户开关上（`TenantConfig`），单租户部署会静默失效；`Knowledge` 又是
`KnowledgeProvider` 缓存的**全局单例**，也挂不住请求态。

**改用的方案**：`ManagedKnowledge` 把来源写成正文首行标记，`KnowledgeCitationMiddleware`
在 `onActing` 的事件流里解析回来——那已回到 Agent 主链，与部署形态无关。

### 三个附带决定

- **落 `onActing` 而非 `onReasoning`**：后者拿到的 `messages()` 是整个会话上下文，会把
  **前几轮**的工具结果算进这一轮，用户看到一堆与当前答案无关的出处，比没有出处更误导。
- **按 `toolCallId` 累积分片后再解析**：`ToolResultTextDeltaEvent` 是增量，标记行被切在
  两个分片之间时，逐片解析会稳定地漏掉那几条，而且不报任何错。
- **标记做成给人看的中文**（`【知识来源】售后FAQ | doc-refund | #10237 | 0.87`）：
  它同时是给模型的出处说明，模型据此能主动标注来源；即使被原样复述，用户看到的也是一句
  通顺的来源说明而不是乱码。生成与解析都放在 `KnowledgeCitation` 上，由往返测试钉住。

### 已知缺口（明示，不是静默）

引用**不落聊天记录**，刷新页面后重新拉取的历史消息没有来源。补齐要给 `cw_chat_log` 加列
并走一次迁移，是独立的一件事，已写进报告附录 D。

---

## 验证

全模块 `BUILD SUCCESS`，0 失败 0 错误，合计 **3757**（排除 `RedisSessionPersistenceTest`）：

| 模块 | 用例 |
|---|---|
| customer-work-starter | 1801 / 9 skip |
| customer-work-app-server | 132 |
| customer-channel | 82 |
| customer-admin-server | 1741 / 1 skip |
| customer-work-gateway | 1 |

引用回传自身加 **13** 条（标记往返 7 + 中间件采集 6），并把 `ManagedKnowledgeTest` 里
原本只断言正文的那条升级成真正的端到端往返（检索侧生成 → 解析侧认领）。
H5 侧 `vue-tsc --noEmit` 与 `npm run build` 均通过。

**踩到的一个坑**：给 `ChatTerminalEnvelope` / `ChatResponse` 两个 record 加字段时，
只 grep 了其中一个的构造点，连续两轮全量都红在下游模块的测试编译上（starter 单模块照不出来）。
改 record 应先跑一次全反应堆 `test-compile` 确认编译面干净，再跑全量。
