### PR TITLE
本地/私有化模型纳入治理 + 厂商清单收口（P1-14）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,24 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-09-10 本地模型治理批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1835/9 skip、app-server 137、customer-channel 82、admin 1745/1 skip、gateway 1，
+  **合计 3800**（排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+4**（本地建模）、
+  admin **+4**（厂商覆盖门禁）。本批次无迁移，cw Flyway 仍是下次 **V25**、admin **V102**。三条经验：
+  ① **「支持哪些 X」这类清单只能有一处真相**：本批发现 starter 的 `ChatModelFactory` switch
+  与 admin 的 `ModelProvider` 枚举各写一份，不同步不报错，只表现为「一边能建、另一边登记不进去」——
+  **批次五给 starter 加的四个国产模型在后台一直用不了，隔了一个批次才发现**。
+  已收敛到 `ModelProviders.SUPPORTED` 并加 `ModelProviderCoverageTest`；
+  **光对齐两份清单还不够**，还要断言工厂 switch 真有对应 case，否则清单里写了、
+  工厂没分支的厂商会静默落到 default（用户选 Kimi、请求发去 DashScope，两份清单看起来都对）；
+  ② **`assertNotNull` 常常是无效断言**：本批测「生成参数有没有传进 Ollama 模型」时写了
+  `assertNotNull(options)`，而框架 Builder 自带一份默认 `OllamaOptions`——参数被丢掉时它照样非空、
+  只是里面的值全是 null。**变异测试报的是 NPE 而不是我写的提示语，才暴露出这条断言从未生效**。
+  断言要直接比对目标值，不要断言「容器存在」；
+  ③ **注释声称「另行配置」的东西要去 grep 有没有真的配**：Ollama 分支的注释写着
+  「使用 OllamaOptions（生成参数另行配置）」，而全仓没有任何地方配置它们。
+  这与 `SelfCorrectionMiddleware` 注释声称「在未走退款工具的情况下」而代码里没有那个判定，
+  是同一类问题——**注释描述的是意图，不是事实**。上一版基线见下。）
   （2026-09-09 WS 投递保证批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
   starter 1831/9 skip、app-server 137、customer-channel 82、admin 1741/1 skip、gateway 1，
   **合计 3792**（排除 `RedisSessionPersistenceTest`）；前端 vitest 38 全过（本批 +1）。

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/ModelProvider.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/ModelProvider.java
@@ -12,6 +12,12 @@ import java.util.Arrays;
  *
  * <p>baseUrl 必填由 {@code ModelSaveRequest} 的 {@code @NotBlank} 收口（防御一处），
  * 各厂商默认 Base URL 的预填由前端 {@code ModelManage.vue} 的 providerPresets 负责，后端不重复兜底。</p>
+ *
+ * <p><b>成员必须与 {@link ModelProviders#SUPPORTED} 完全一致</b>，由
+ * {@code ModelProviderCoverageTest} 下断言。此前这里只有四家原生厂商，
+ * 而 starter 的建模工厂已支持九家——批次五新增的 GLM/DeepSeek/Kimi/MiniMax
+ * 在后台根本登记不进去，Ollama 本地部署更是整个进不了 ModelOps。
+ * 「支持哪些厂商」有两处真相，就一定会出现这种一边能用一边不能用的状态。</p>
  * @author owlzhangfq@gmail.com
  */
 public enum ModelProvider {
@@ -23,7 +29,17 @@ public enum ModelProvider {
     /** Anthropic Claude 原生协议。 */
     ANTHROPIC(ModelProviders.ANTHROPIC),
     /** Google Gemini（Gemini Developer API，非 Vertex）。 */
-    GEMINI(ModelProviders.GEMINI);
+    GEMINI(ModelProviders.GEMINI),
+    /** Ollama 本地私有化部署：跑在自己机房里，<b>不需要 API Key</b>。 */
+    OLLAMA(ModelProviders.OLLAMA),
+    /** 智谱 GLM（OpenAI 兼容协议 + 专用 Formatter）。 */
+    GLM(ModelProviders.GLM),
+    /** DeepSeek（OpenAI 兼容协议 + 专用 Formatter）。 */
+    DEEPSEEK(ModelProviders.DEEPSEEK),
+    /** 月之暗面 Kimi（OpenAI 兼容协议 + 专用 Formatter）。 */
+    KIMI(ModelProviders.KIMI),
+    /** MiniMax（OpenAI 兼容协议 + 专用 Formatter）。 */
+    MINIMAX(ModelProviders.MINIMAX);
 
     private final String code;
 

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelConfigService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/aiconfig/model/service/ModelConfigService.java
@@ -180,7 +180,9 @@ public class ModelConfigService {
 
     @Transactional(rollbackFor = Exception.class)
     public void create(ModelSaveRequest request) {
-        if (!StringUtils.hasText(request.apiKey())) {
+        // 本地私有化部署（ollama）跑在自己机房里，没有 API Key。
+        // 此前这里无条件要求 apiKey，于是「把本地模型纳入 ModelOps」这件事卡在这一行上
+        if (ModelProviders.requiresApiKey(request.provider()) && !StringUtils.hasText(request.apiKey())) {
             throw new BizException(ResultCode.PARAM_MISSING, "新建模型配置必须提供 apiKey");
         }
         String normalizedBaseUrl = validateEndpoint(request.baseUrl());

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/ModelProviderCoverageTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/aiconfig/model/runtime/ModelProviderCoverageTest.java
@@ -1,0 +1,121 @@
+package com.richard.fyoung.customeradmin.aiconfig.model.runtime;
+
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>模型厂商覆盖门禁</b>：三处对「支持哪些厂商」的表述必须一致。
+ *
+ * <h3>守的是什么</h3>
+ * <p>这件事此前有两处真相：starter 的 {@code ChatModelFactory} switch 与 admin 的
+ * {@link ModelProvider} 枚举。两边不同步不会报任何错，只表现为
+ * <b>一边能建、另一边登记不进去</b>——批次五给 starter 加了 GLM/DeepSeek/Kimi/MiniMax
+ * 四家专用 Formatter，而 admin 枚举至今只有四家原生厂商，那四个模型在后台完全用不了；
+ * Ollama 同理，本地私有化部署整个进不了 ModelOps。这个状态持续了一整个批次没人发现。</p>
+ *
+ * <p>现在 {@link ModelProviders#SUPPORTED} 是唯一真相，本测试断言另外两处与它一致。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class ModelProviderCoverageTest {
+
+    /** 从 ChatModelFactory 源码里抽 {@code case ModelProviders.XXX} 的厂商常量名。 */
+    private static final Pattern CASE_PATTERN =
+        Pattern.compile("case\\s+ModelProviders\\.([A-Z_]+)\\s*:");
+
+    @Test
+    @DisplayName("admin 枚举与支持清单完全一致")
+    void adminEnumMatchesSupportedSet() {
+        Set<String> enumCodes = Arrays.stream(ModelProvider.values())
+            .map(ModelProvider::getCode)
+            .collect(Collectors.toCollection(TreeSet::new));
+        Set<String> supported = new TreeSet<>(ModelProviders.SUPPORTED);
+
+        assertEquals(supported, enumCodes,
+            "admin 的 ModelProvider 枚举与 ModelProviders.SUPPORTED 不一致。\n"
+                + "缺的那些厂商：starter 能建模，但后台登记不进去，前端也选不到——不报错，只是用不了。\n"
+                + "多出来的：后台能登记，运行时建模会落到 default 分支，行为与登记时的预期不符。");
+    }
+
+    /**
+     * 建模工厂真的能处理清单里的每一家。
+     *
+     * <p>光对齐两份清单还不够：清单里写了、工厂 switch 里没有对应 case 的厂商，
+     * 会静默落到 {@code default}（DashScope）分支——用户在后台选了 Kimi，
+     * 实际请求发去了 DashScope，而两边的清单看起来都是"支持的"。</p>
+     */
+    @Test
+    @DisplayName("建模工厂为清单里每一家都有专门分支")
+    void factoryHandlesEverySupportedProvider() throws IOException {
+        String source = Files.readString(factorySource(), StandardCharsets.UTF_8);
+
+        Set<String> handled = new TreeSet<>();
+        Matcher matcher = CASE_PATTERN.matcher(source);
+        while (matcher.find()) {
+            handled.add(matcher.group(1));
+        }
+        assertTrue(handled.size() >= 5, "没从工厂源码里解析到足够的 case，正则可能失效了：" + handled);
+
+        Set<String> missing = new TreeSet<>();
+        for (String code : ModelProviders.SUPPORTED) {
+            // DashScope 是 default 分支，没有显式 case，这是刻意的
+            if (ModelProviders.DASHSCOPE.equals(code)) {
+                continue;
+            }
+            if (!handled.contains(code.toUpperCase())) {
+                missing.add(code);
+            }
+        }
+        if (!missing.isEmpty()) {
+            fail("以下厂商在 SUPPORTED 里，但 ChatModelFactory 没有对应分支：" + missing
+                + "\n它们会静默落到 default（DashScope）——用户选了 A，请求发去了 B，两边都不报错。");
+        }
+    }
+
+    @Test
+    @DisplayName("本地部署不要求 API Key，其余厂商要求")
+    void localDeploymentNeedsNoApiKey() {
+        assertTrue(ModelProviders.LOCAL_DEPLOYMENT.contains(ModelProviders.OLLAMA));
+
+        assertTrue(!ModelProviders.requiresApiKey(ModelProviders.OLLAMA),
+            "Ollama 跑在自己机房里，没有 API Key；要求它提供凭据等于把本地部署挡在模型治理之外");
+        assertTrue(ModelProviders.requiresApiKey(ModelProviders.DASHSCOPE));
+        assertTrue(ModelProviders.requiresApiKey(ModelProviders.GLM));
+        assertTrue(ModelProviders.requiresApiKey(null), "厂商未知时按需要凭据处理，方向上更安全");
+    }
+
+    @Test
+    @DisplayName("未知厂商仍然 fast fail，不静默降级")
+    void unknownProviderStillFailsFast() {
+        org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+            () -> ModelProvider.of("not-a-vendor"));
+        org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+            () -> ModelProvider.of(""));
+    }
+
+    /** 定位 starter 的工厂源码（本测试在 admin 模块，需跨模块读文件）。 */
+    private Path factorySource() {
+        Path relative = Paths.get("../customer-work-starter/src/main/java/com/richard/fyoung/"
+            + "customerwork/infra/config/ChatModelFactory.java");
+        assertTrue(Files.exists(relative),
+            "找不到 ChatModelFactory 源码（工作目录应为 customer-admin-server 模块根）：" + relative);
+        return relative;
+    }
+}

--- a/customer-admin-web/src/views/aiconfig/ModelManage.vue
+++ b/customer-admin-web/src/views/aiconfig/ModelManage.vue
@@ -129,7 +129,20 @@ const providerPresets: ProviderPreset[] = [
   { value: 'dashscope', label: '百炼 DashScope', defaultBaseUrl: 'https://dashscope.aliyuncs.com', modelPlaceholder: '如 qwen-max' },
   { value: 'anthropic', label: 'Anthropic Claude', defaultBaseUrl: 'https://api.anthropic.com', modelPlaceholder: '如 claude-sonnet-4-5' },
   { value: 'gemini', label: 'Google Gemini', defaultBaseUrl: 'https://generativelanguage.googleapis.com', modelPlaceholder: '如 gemini-2.5-flash' },
+  { value: 'glm', label: '智谱 GLM', defaultBaseUrl: 'https://open.bigmodel.cn/api/paas/v4', modelPlaceholder: '如 glm-4-plus' },
+  { value: 'deepseek', label: 'DeepSeek', defaultBaseUrl: 'https://api.deepseek.com', modelPlaceholder: '如 deepseek-chat' },
+  { value: 'kimi', label: '月之暗面 Kimi', defaultBaseUrl: 'https://api.moonshot.cn/v1', modelPlaceholder: '如 moonshot-v1-8k' },
+  { value: 'minimax', label: 'MiniMax', defaultBaseUrl: 'https://api.minimaxi.com/v1', modelPlaceholder: '如 abab6.5s-chat' },
+  // 本地私有化部署：跑在自己机房里，没有 API Key，服务端据此免除凭据校验
+  { value: 'ollama', label: 'Ollama（本地部署）', defaultBaseUrl: 'http://localhost:11434', modelPlaceholder: '如 qwen2.5' },
 ]
+
+/** 本地部署没有 API Key，表单不该把它标成必填、也不该拦住提交。 */
+const LOCAL_DEPLOYMENT_PROVIDERS = ['ollama']
+
+function requiresApiKey(provider: string | null | undefined): boolean {
+  return !LOCAL_DEPLOYMENT_PROVIDERS.includes(provider ?? '')
+}
 
 function presetOf(provider: string | null | undefined): ProviderPreset {
   return providerPresets.find((preset) => preset.value === provider) ?? providerPresets[0]
@@ -433,7 +446,13 @@ onMounted(async () => {
             <div><strong>凭据与状态</strong><small>编辑留空不会读取旧值；独立轮换请进入治理详情。</small></div>
           </div>
           <div class="form-grid">
-            <el-form-item :label="dialogMode === 'edit' ? '新凭据（留空不变）' : '凭据'"><el-input v-model="form.apiKey!" type="password" show-password autocomplete="new-password" /></el-form-item>
+            <el-form-item :label="dialogMode === 'edit' ? '新凭据（留空不变）' : '凭据'">
+              <el-input v-model="form.apiKey!" type="password" show-password autocomplete="new-password"
+                :placeholder="requiresApiKey(form.provider) ? '' : '本地部署无需凭据，可留空'" />
+              <div v-if="!requiresApiKey(form.provider)" class="form-tip">
+                本地私有化部署跑在自己的机房里，没有 API Key；凭据留空即可。
+              </div>
+            </el-form-item>
             <el-form-item label="凭据到期时间">
               <el-date-picker v-model="form.secretExpiresAt" type="datetime" value-format="YYYY-MM-DDTHH:mm:ss" placeholder="可选" style="width: 100%" />
             </el-form-item>
@@ -492,5 +511,12 @@ onMounted(async () => {
   .form-grid { grid-template-columns: 1fr; }
   .full-row { grid-column: auto; }
   .toolbar { align-items: stretch; flex-direction: column; }
+}
+
+.form-tip {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--el-text-color-secondary);
 }
 </style>

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/ModelProviders.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/core/constant/ModelProviders.java
@@ -48,6 +48,40 @@ public final class ModelProviders {
     public static final String MINIMAX = "minimax";
 
     /**
+     * {@link com.richard.fyoung.customerwork.infra.config.ChatModelFactory} 实际支持的全部厂商。
+     *
+     * <p><b>为什么要有这份清单</b>：「支持哪些厂商」此前有两处真相——starter 的建模工厂
+     * switch 与 admin 的 {@code ModelProvider} 枚举。两边不同步的后果是
+     * <b>starter 能建、后台却登记不进去</b>：批次五给 starter 加了 GLM/DeepSeek/Kimi/MiniMax
+     * 四家专用 Formatter，而 admin 枚举至今只有四家原生厂商，那四个模型在后台完全用不了；
+     * Ollama 同理，本地私有化部署整个进不了 ModelOps。</p>
+     *
+     * <p>现在以这份清单为唯一真相，两侧都引用它，并由门禁测试断言三者一致
+     * （常量清单 / 工厂 switch / admin 枚举）。新增厂商只需改这里再补工厂分支。</p>
+     */
+    public static final java.util.Set<String> SUPPORTED = java.util.Set.of(
+        DASHSCOPE, OPENAI, ANTHROPIC, GEMINI, OLLAMA, GLM, DEEPSEEK, KIMI, MINIMAX);
+
+    /**
+     * 本地/私有化部署的厂商：跑在自己机房里，<b>没有 API Key</b>。
+     *
+     * <p>后台新建模型此前无条件要求 apiKey，于是即便把 ollama 加进支持清单也仍然登记不了——
+     * 「本地部署纳入模型治理」这件事卡在这一行校验上。</p>
+     */
+    public static final java.util.Set<String> LOCAL_DEPLOYMENT = java.util.Set.of(OLLAMA);
+
+    /** 该厂商是否需要 API Key（本地私有化部署不需要）。 */
+    public static boolean requiresApiKey(String provider) {
+        return !LOCAL_DEPLOYMENT.contains(normalize(provider));
+    }
+
+    /** 归一化 provider 编码：null 与空白按默认厂商处理，其余转小写去空格。 */
+    public static String normalize(String provider) {
+        String normalized = provider == null ? "" : provider.trim().toLowerCase();
+        return normalized.isEmpty() ? DASHSCOPE : normalized;
+    }
+
+    /**
      * 各厂商的默认端点。
      *
      * <p>取自框架各 {@code ModelProvider} 内置的默认值——写在这里是为了让"没配 base-url 时

--- a/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ChatModelFactory.java
+++ b/customer-work-starter/src/main/java/com/richard/fyoung/customerwork/infra/config/ChatModelFactory.java
@@ -15,6 +15,7 @@ import io.agentscope.extensions.model.anthropic.AnthropicChatModel;
 import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
 import io.agentscope.extensions.model.gemini.GeminiChatModel;
 import io.agentscope.extensions.model.ollama.OllamaChatModel;
+import io.agentscope.extensions.model.ollama.options.OllamaOptions;
 import io.agentscope.extensions.model.openai.OpenAIChatModel;
 import org.springframework.util.StringUtils;
 import com.richard.fyoung.customerwork.infra.config.properties.ModelProperties;
@@ -124,8 +125,19 @@ public final class ChatModelFactory {
                 return b.build();
             }
             case ModelProviders.OLLAMA: {
-                // Ollama 本地私有化：使用 OllamaOptions（生成参数另行配置），默认 localhost:11434
-                OllamaChatModel.Builder b = OllamaChatModel.builder().modelName(modelName);
+                // Ollama 本地私有化，默认 localhost:11434。
+                //
+                // 生成参数必须显式映射过去：Ollama 用的是自己的 OllamaOptions 而不是通用
+                // GenerateOptions，此前这一分支两者都没传——温度、maxTokens、topP 配了等于没配，
+                // DynamicOptionsMiddleware 的"精确模式"（温度压到 0.1）在私有化部署上也完全无效。
+                // 而它不报任何错，只表现为"模型好像没按设置来"。框架其实早就提供了
+                // fromGenerateOptions 这个映射，项目只是一直没调。
+                OllamaChatModel.Builder b = OllamaChatModel.builder()
+                    .modelName(modelName)
+                    .stream(stream);
+                if (options != null) {
+                    b.defaultOptions(OllamaOptions.fromGenerateOptions(options));
+                }
                 if (declaredWindow) {
                     b.contextWindowSize(contextWindowSize);
                 }

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/LocalDeploymentModelTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/infra/config/LocalDeploymentModelTest.java
@@ -1,0 +1,98 @@
+package com.richard.fyoung.customerwork.infra.config;
+
+import com.richard.fyoung.customerwork.core.constant.ModelProviders;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.extensions.model.ollama.OllamaChatModel;
+import io.agentscope.extensions.model.ollama.options.OllamaOptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 本地私有化部署（Ollama）的建模。
+ *
+ * <h3>守的是什么</h3>
+ * <p>这一分支此前<b>把生成参数整个丢掉了</b>：Ollama 用的是自己的 {@code OllamaOptions}
+ * 而不是通用 {@code GenerateOptions}，而工厂既没做映射也没传 {@code stream}。
+ * 后果是温度、maxTokens、topP 配了等于没配——{@code DynamicOptionsMiddleware} 的
+ * 「精确模式」（投诉/退款类问题把温度压到 0.1）在私有化部署上完全无效。
+ * 它不报任何错，只表现为"模型好像没按设置来"，而那种偏差很难联想到建模代码。</p>
+ *
+ * <p>框架其实早就提供了 {@link OllamaOptions#fromGenerateOptions} 这个映射，项目只是一直没调——
+ * 与「工具超时重试」是同一形状：能力在框架里，项目从没配过。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class LocalDeploymentModelTest {
+
+    private Model build(GenerateOptions options, boolean stream) {
+        return ChatModelFactory.build(ModelProviders.OLLAMA, "qwen2.5", null,
+            "http://localhost:11434", stream, options, null, null, null);
+    }
+
+    @Test
+    @DisplayName("走 Ollama 原生实现，不落兜底分支")
+    void usesOllamaModel() {
+        assertInstanceOf(OllamaChatModel.class, build(GenerateOptions.builder().build(), false),
+            "ollama 应走本地私有化实现，落到 dashscope 兜底意味着请求发去了公网");
+    }
+
+    /**
+     * 生成参数必须真的传进去。
+     *
+     * <p>反射读私有字段是刻意的：{@code OllamaChatModel} 没有暴露读取 options 的方法，
+     * 而「参数有没有传到」正是这次改动的全部内容——只断言"构建成功"照不出它，
+     * 那恰恰是修复前的状态（构建一直是成功的）。</p>
+     */
+    @Test
+    @DisplayName("温度与 maxTokens 真的传进了 Ollama 模型")
+    void generationOptionsArePassedThrough() throws Exception {
+        GenerateOptions options = GenerateOptions.builder()
+            .temperature(0.1)
+            .maxTokens(512)
+            .build();
+
+        Model model = build(options, false);
+        OllamaOptions applied = readDefaultOptions(model);
+        assertNotNull(applied, "连 defaultOptions 字段都没找到——反射逻辑失效了，这条测试此刻什么也没在守");
+
+        // 不能只断言 applied 非空：框架 Builder 自带一份默认 OllamaOptions，
+        // 参数被丢掉时它照样非空，只是里面的值全是 null（变异测试实证）
+        GenerateOptions roundTrip = applied.toGenerateOptions();
+        assertEquals(Double.valueOf(0.1), roundTrip.getTemperature(),
+            "温度没传进 Ollama 模型——配置里配了多少都不起作用，而且不报任何错");
+        assertEquals(Integer.valueOf(512), roundTrip.getMaxTokens(),
+            "maxTokens 没传进 Ollama 模型");
+    }
+
+    @Test
+    @DisplayName("没有生成参数时不设 options，建模也不应失败")
+    void nullOptionsIsTolerated() {
+        assertInstanceOf(OllamaChatModel.class, build(null, false));
+    }
+
+    @Test
+    @DisplayName("本地部署不需要凭据")
+    void needsNoApiKey() {
+        assertTrue(!ModelProviders.requiresApiKey(ModelProviders.OLLAMA));
+        assertInstanceOf(OllamaChatModel.class, build(GenerateOptions.builder().build(), true),
+            "apiKey 传 null 也应当能建出模型");
+    }
+
+    private OllamaOptions readDefaultOptions(Model model) throws Exception {
+        for (Field field : model.getClass().getDeclaredFields()) {
+            if (OllamaOptions.class.isAssignableFrom(field.getType())) {
+                field.setAccessible(true);
+                return (OllamaOptions) field.get(model);
+            }
+        }
+        return null;
+    }
+}

--- a/docs/智能体能力差距与演进路线图.md
+++ b/docs/智能体能力差距与演进路线图.md
@@ -322,7 +322,7 @@ kept.addAll(budgeted.subList(budgeted.size() - tailCount, budgeted.size()));
 | **P1-11** | WS 会话既无入站幂等也无下行补偿【已修，见附录 D】 | 入站无幂等属实，重发＝双份 LLM 调用（还可能双份工具执行）；「永久丢失」需修正：帧本身都已<b>落库</b>，真正的病根在<b>前端重连后不补拉</b>（`Chat.vue` 只订阅了 `reconnecting`，`open` 上没有补历史） |
 | **P1-12** | 终止条件只有一个全局 `maxIters`【已修，见附录 D】 | `ExceedMaxItersEvent` 全仓零消费方（实测）；框架会走 `firePreSummary` 生成收尾，但**不告诉用户接下来怎么办、也不把人接进来** |
 | **P1-13** | 语义缓存召回按「最近命中时间截断」而非向量检索 | 新写入条目存在冷启动饿死 |
-| **P1-14** | 后台模型治理不覆盖本地/私有化部署 | 且 Ollama 分支静默丢弃全部生成参数 |
+| **P1-14** | 后台模型治理不覆盖本地/私有化部署【已修，见附录 D】 | 实测有<b>三层</b>：建模丢生成参数与 stream；admin 枚举只有 4 家（连批次五新增的四个国产模型也没进去）；新建模型<b>无条件要求 apiKey</b>，而本地部署没有凭据 |
 | **P1-15** | 多智能体协作止于「分工 + 汇总」【实测】 | 无黑板、无投票、无冲突消解逻辑（全靠一句拼进 prompt 的「去重并消解冲突」）、无编排 DSL/图；A2A 只有服务端单向导出，且一个实例只能导出一个 Agent、AgentCard 不声明 skills |
 | **P1-16** | 长期记忆缺语义召回与冲突消解 | 召回靠 `FactRelevanceScorer` 的字符重合度（`EmbeddingClient` 全仓 128 处引用，`core/memory` 包内 0 处）；矛盾事实并存写入、召回时一起塞进提示词；无衰减、无重要度、无写入前 PII 脱敏 |
 
@@ -709,6 +709,34 @@ fail-closed 会让计数器一挂全部消息发不出去，那是把旁路增�
 `WsClient` 的 `open` 事件现在带上 `reconnected` 标志（连上后再清零 `reconnectAttempts` 才拿得到
 这个事实），前端只在重连时补拉——首连前 `onMounted` 已经拉过。补拉前先清掉半截的流式内容，
 否则残留片段会和拉回来的正文重复显示。
+
+### 批次九 · 本地/私有化模型治理（2026-09-10，PR 待建）
+
+报告写了两层，实测是**三层**，而且第二层是**我们自己上一批留下的缺口**：
+
+| # | 缺陷 | 后果 |
+|---|---|---|
+| 1 | `ChatModelFactory` 的 Ollama 分支丢弃生成参数与 `stream` | 温度/maxTokens/topP 配了等于没配，`DynamicOptionsMiddleware` 的「精确模式」在私有化部署上完全无效 |
+| 2 | admin `ModelProvider` 枚举只有 4 家 | Ollama 进不了 ModelOps；**批次五给 starter 加的 GLM/DeepSeek/Kimi/MiniMax 在后台也登记不进去** |
+| 3 | 新建模型**无条件要求 apiKey** | 本地部署没有凭据，即便补了枚举也仍然登记不了 |
+
+第 1 层的注释自己就写着「使用 OllamaOptions（生成参数另行配置）」——而全仓没有任何地方配置它们。
+框架其实早就提供了 `OllamaOptions.fromGenerateOptions` 这个映射，项目只是一直没调，
+与「工具超时重试」是同一形状：**能力在框架里，项目从没配过**。
+
+第 2 层暴露的是更根本的问题：**「支持哪些厂商」有两处真相**——starter 的建模工厂 switch
+与 admin 的枚举。两边不同步不报任何错，只表现为「一边能建、另一边登记不进去」，
+而这个状态从批次五持续到现在没人发现。现已收敛到 `ModelProviders.SUPPORTED` 一处，
+并加 `ModelProviderCoverageTest` 断言三者一致（常量清单 / 工厂 switch / admin 枚举）——
+往清单里塞一个工厂没有分支的假厂商，两条断言同时红（已变异验证）。
+
+第二条断言值得单说：光对齐两份清单还不够。清单里写了、工厂 switch 里没有对应 case 的厂商，
+会**静默落到 default（DashScope）**——用户在后台选了 Kimi，实际请求发去了 DashScope，
+而两边的清单看起来都是「支持的」。
+
+**一个自查发现**：`LocalDeploymentModelTest` 里原本写的 `assertNotNull(applied, ...)` 是**无效断言**——
+框架 Builder 自带一份默认 `OllamaOptions`，参数被丢掉时它照样非空、只是里面的值全是 null。
+变异测试报的是 NPE 而不是我写的那句提示，才暴露出来；已改为直接比对温度与 maxTokens。
 
 ### 明确不建议做的（含理由）
 


### PR DESCRIPTION
## 背景

报告 **P1-14**（后台模型治理不覆盖本地/私有化部署），承接已合并的
[PR #183](https://github.com/liulangjietou/customer_work/pull/183)。

## 报告写了两层，实测是三层

而且**第二层是我们自己上一批留下的缺口**：

| # | 缺陷 | 后果 |
|---|---|---|
| 1 | `ChatModelFactory` 的 Ollama 分支丢弃生成参数与 `stream` | 温度/maxTokens/topP 配了等于没配 |
| 2 | admin `ModelProvider` 枚举只有 4 家 | Ollama 进不了 ModelOps；**批次五给 starter 加的 GLM/DeepSeek/Kimi/MiniMax 在后台也登记不进去** |
| 3 | 新建模型**无条件要求 apiKey** | 本地部署没有凭据，即便补了枚举也登记不了 |

---

## 一 · 生成参数被丢掉

这一分支的注释自己就写着「使用 OllamaOptions（**生成参数另行配置**）」——而全仓没有任何地方
配置它们。Ollama 用的是自己的 `OllamaOptions` 而不是通用 `GenerateOptions`，工厂既没做映射
也没传 `stream`。

后果：`DynamicOptionsMiddleware` 的「精确模式」（投诉/退款类问题把温度压到 0.1）在私有化部署上
**完全无效**，而它不报任何错，只表现为「模型好像没按设置来」——那种偏差很难联想到建模代码。

框架其实早就提供了 `OllamaOptions.fromGenerateOptions`，项目只是一直没调——与「工具超时重试」
是同一形状：**能力在框架里，项目从没配过**。

## 二 · 「支持哪些厂商」有两处真相

这是本 PR 最值得看的部分。starter 的建模工厂 switch 与 admin 的枚举各写一份，
不同步**不报任何错**，只表现为「一边能建、另一边登记不进去」——而这个状态从批次五持续至今。

现收敛到 `ModelProviders.SUPPORTED` 一处，加 `ModelProviderCoverageTest` 断言三者一致
（常量清单 / 工厂 switch / admin 枚举）。

**第二条断言值得单说**：光对齐两份清单还不够。清单里写了、工厂 switch 里没有对应 case 的厂商，
会**静默落到 `default`（DashScope）**——用户在后台选了 Kimi，实际请求发去了 DashScope，
而两边的清单看起来都是「支持的」。已变异验证：往清单里塞一个假厂商，两条断言同时红。

## 三 · 本地部署没有凭据

新建模型此前无条件要求 apiKey。改为按 provider 判定（`ModelProviders.requiresApiKey`），
未知厂商仍按「需要凭据」处理（方向上更安全），`ModelProvider.of` 的 fast fail 保持不变。

前端补齐五个 provider 预设（四个国产 + Ollama），选中本地部署时提示凭据可留空。

---

## 一个自查发现：无效的 assertNotNull

`LocalDeploymentModelTest` 里原本写的是 `assertNotNull(applied, "生成参数被丢掉了")`。
变异测试（把 `defaultOptions` 那行摘掉）报的是 **NPE 而不是我写的那句提示**——
才暴露出框架 Builder 自带一份默认 `OllamaOptions`，参数被丢掉时它照样非空、只是值全为 null。
**那条断言从写下起就没生效过。** 已改为直接比对温度与 maxTokens。

这条记进了 CLAUDE.md：断言要直接比对目标值，不要断言「容器存在」。

## 验证

全模块 `BUILD SUCCESS`，0 失败 0 错误，合计 **3800**（本批 +8）：

| 模块 | 用例 |
|---|---|
| customer-work-starter | 1835 / 9 skip |
| customer-work-app-server | 137 |
| customer-channel | 82 |
| customer-admin-server | 1745 / 1 skip |
| customer-work-gateway | 1 |

前端 `vue-tsc --noEmit` 与 `npm run build` 通过。
