### PR TITLE
AgentScope 2.0.2 → 2.0.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # customer-work 项目工作手册（AI 会话用）
 
-基于 AgentScope Java 2.0.0 GA 的生产级智能客服系统 + 后台管理系统。本文件只放**每次会话都需要的事实与坑**；
+基于 AgentScope Java 2.0.3 的生产级智能客服系统 + 后台管理系统。本文件只放**每次会话都需要的事实与坑**；
 细节现场读代码和 docs/ 下的文档，不要在这里复制它们。
 
 ## 模块结构
@@ -16,7 +16,7 @@
 
 ## 分支策略
 
-- `main` = AgentScope 2.0.0 GA（2026-07 起）。**有分支保护，禁止直接 push，必须走 PR**。
+- `main` = AgentScope 2.0.3（2026-07 起 2.0.0 GA，批次二升 2.0.2，2026-09-10 升 2.0.3）。**有分支保护，禁止直接 push，必须走 PR**。
 - `legacy-main-1.0.12` 标签 = 升级前 1.0.12 最后状态；`rc2.0` 分支 = RC4 首轮迁移存档；`ga2.0` 分支 = 已并入 main 的历史开发分支（保留不删）。
 
 ## 构建与测试（关键坑，全部实测踩过）
@@ -35,6 +35,24 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
 - **跳过 jacoco 用 `-Djacoco.skip=true`**（不是 `jacoco.check.skip`，那个对本项目的绑定无效）。
 - `customer-admin-server` 测试需要 `export ADMIN_MYSQL_PASSWORD=root`（yml 默认值与本机不符时）。
 - 测试数量随分支持续变化，不把固定总数作为门禁；以本节全模块命令的当前 `BUILD SUCCESS`、0 失败、0 错误为准。
+  （2026-09-10 AgentScope 2.0.3 升级批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
+  starter 1871/9 skip、app-server 137、customer-channel 82、admin 1745/1 skip、gateway 1，
+  **合计 3836**——与升级前完全一致，无行为回归。本批次无新增用例、无迁移，
+  cw Flyway 仍是下次 **V25**、admin **V102**。四条经验：
+  ① **两处编译期破坏都在 admin 侧，starter 零改动**：`AgentRunner.stream` → `streamEvents`
+  且返回类型换成 `Flux<AgentEvent>`（协议转换收归框架）；`TaskRepository` 新增
+  `public shutdown()` 与项目的包级 `@PreDestroy` 方法撞名、`removeTask`/`clear` 不再是接口方法；
+  ② **「记录现状」的探针如期变红，这是它的使命**：`HarnessAgentInterruptForwardingProbeTest`
+  断言"框架还没修 #1683"，升级当天立刻红。2.0.3 补齐了 session-aware interrupt，
+  **反编译确认新 API 的实现就是 `delegate.interrupt(ctx)`、与原绕行等价**，故改用新 API 零风险。
+  写这类探针时一定要在失败消息里写清"红了说明什么、该怎么办"；
+  ③ **升级后要看 deprecation 告警，不只看编译是否通过**：本次发现框架已把整套
+  `rag.Knowledge`（37 处）、`memory.LongTermMemory`（32 处）、`hook.Hook`（20 处）
+  标记为 `forRemoval`——而**逐个反编译对比确认 2.0.2 就带着这些标记，是批次二漏看了**。
+  release notes 没有 Deprecated 段，只有编译告警会说。下次升级前要先查清替代路径；
+  ④ 三条行为变更需留意：agent state 加载失败**不再静默替换**为新会话（原本静默降级的部署会开始报错）、
+  `ThinkingBlock` token 按真实内容计数（**影响配额与账单金额**）、
+  推理模型答案落在 `reasoning_content` 时会重试（可能多一次模型调用）。上一版基线见下。）
   （2026-09-10 槽位填充接入主链路批次实测：全模块 BUILD SUCCESS，0 失败 0 错误，
   starter 1871/9 skip、app-server 137、customer-channel 82、admin 1745/1 skip、gateway 1，
   **合计 3836**（排除 `RedisSessionPersistenceTest`）。本批次自身加 starter **+8**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/a2a/AdminAgentRunner.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/a2a/AdminAgentRunner.java
@@ -13,9 +13,9 @@ import io.agentscope.core.a2a.server.executor.runner.AgentRequestOptions;
 import io.agentscope.core.a2a.server.executor.runner.AgentRunner;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
-import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.harness.agent.HarnessAgent;
 import org.slf4j.Logger;
@@ -70,7 +70,7 @@ public class AdminAgentRunner implements AgentRunner {
     }
 
     @Override
-    public Flux<Event> stream(List<Msg> requestMessages, AgentRequestOptions options) {
+    public Flux<AgentEvent> streamEvents(List<Msg> requestMessages, AgentRequestOptions options) {
         // defer：装配失败（模型配置缺失、MCP 握手超时等）是同步抛异常而非发错误信号，
         // 不包一层的话异常会直接穿透 A2A 的请求处理链，客户端拿到的是连接中断而不是协议错误响应
         return Flux.defer(() -> {
@@ -78,13 +78,13 @@ public class AdminAgentRunner implements AgentRunner {
             AgentInvocationIdentity identity = new AgentInvocationIdentity(
                 tenantId, QuotaSubjectType.API_KEY, subjectId, true)
                 .forInvocation(AgentInvocationIdentity.CHANNEL_A2A, sessionId, agentCode);
-            Flux<Event> body = TenantContext.callWith(tenantId,
+            Flux<AgentEvent> body = TenantContext.callWith(tenantId,
                 () -> AgentInvocationIdentityContext.callWith(identity, () -> {
                     Agent agent = agentInstanceCache.getOrBuild(agentCode);
                     RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
                     log.info("[a2a] agent invoke: agentCode={} sessionId={} taskId={}",
                         agentCode, ctx.getSessionId(), options == null ? null : options.getTaskId());
-                    return streamEvents(agent, requestMessages, ctx);
+                    return agentEvents(agent, requestMessages, ctx);
                 }));
             return body.contextWrite(context -> context
                 .put(TenantContextThreadLocalAccessor.KEY, tenantId)
@@ -112,29 +112,27 @@ public class AdminAgentRunner implements AgentRunner {
     }
 
     /**
-     * {@code stream(List, StreamOptions, RuntimeContext)} 只声明在 {@link ReActAgent}/{@link HarnessAgent}
-     * 上而不在 {@code Agent} 接口上，因此这里按运行时类型分派。
+     * 按运行时类型分派到细粒度事件流。
      *
-     * <p><b>为什么这里还在用已标记 {@code forRemoval} 的 {@code stream(...)}</b>（对话链路的
-     * {@code ChatService} 已迁到 {@code streamEvents(...)}，本处刻意没跟）：{@link AgentRunner#stream}
-     * 的返回类型被框架写死为 {@code Flux<}{@link Event}{@code >}，就是那个废弃类型本身；框架自带的参考
-     * 实现 {@code BaseReActAgentRunner} 也仍在调 {@code agent.stream(msgs)}——A2A 这一层框架自己都没迁。
-     * 若本方法改用 {@code streamEvents(...)}，拿到 {@code AgentEvent} 后还得手工 {@code new Event(...)}
-     * 喂回接口，废弃 API 的暴露面一点没减少，反而要自行复刻 {@code AgentScopeAgentExecutor} 依赖的
-     * {@code isLast}/{@code messageId} 去重语义（它靠这两个字段判重与拼装回包），平白引入一层易错的
-     * 翻译。等框架把 A2A 层迁到细粒度事件后再跟进。</p>
+     * <p>{@code streamEvents(List, RuntimeContext)} 只声明在 {@link ReActAgent}/{@link HarnessAgent}
+     * 上而不在 {@code Agent} 接口上，因此这里按运行时类型分派。</p>
+     *
+     * <p><b>2.0.3 起改用 {@code streamEvents}</b>。此前刻意停在废弃的 {@code stream(...)} 上，
+     * 原因写在当时的注释里：{@code AgentRunner#stream} 的返回类型被框架写死为
+     * {@code Flux<Event>}（就是那个废弃类型本身），框架自带的 {@code BaseReActAgentRunner}
+     * 也仍在调 {@code agent.stream(msgs)}——A2A 这一层框架自己都没迁，硬迁只会平白多一层
+     * {@code AgentEvent → Event} 的手工翻译。2.0.3 把 {@code AgentRunner} 的返回类型换成了
+     * {@code Flux<AgentEvent>}，协议转换收归框架，那条注释预告的时机到了。</p>
+     *
+     * <p>随之去掉的还有 {@code StreamOptions} 的事件类型过滤：新接口下由框架决定哪些事件
+     * 进 A2A 协议包，调用方不再自行裁剪——自行裁剪会与框架的去重/拼包语义打架。</p>
      */
-    private Flux<Event> streamEvents(Agent agent, List<Msg> msgs, RuntimeContext ctx) {
-        StreamOptions options = StreamOptions.builder()
-            // A2A 客户端要的是可交付的回答与工具产出，思考过程增量不属于协议内容，故不订阅 REASONING 细节
-            .eventTypes(EventType.REASONING, EventType.TOOL_RESULT, EventType.AGENT_RESULT)
-            .incremental(true)
-            .build();
+    private Flux<AgentEvent> agentEvents(Agent agent, List<Msg> msgs, RuntimeContext ctx) {
         if (agent instanceof ReActAgent reActAgent) {
-            return reActAgent.stream(msgs, options, ctx);
+            return reActAgent.streamEvents(msgs, ctx);
         }
         if (agent instanceof HarnessAgent harnessAgent) {
-            return harnessAgent.stream(msgs, options, ctx);
+            return harnessAgent.streamEvents(msgs, ctx);
         }
         return Flux.error(new IllegalStateException("unsupported agent runtime type: " + agent.getClass()));
     }

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/chat/service/ChatService.java
@@ -172,27 +172,37 @@ public class ChatService {
      */
     public boolean interrupt(String agentCode, String sessionId) {
         Agent agent = agentInstanceCache.getOrBuild(agentCode);
-        ReActAgent interruptible = resolveInterruptible(agent);
-        if (interruptible == null) {
+        RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
+        if (!interruptBySession(agent, ctx)) {
             log.info("[workspace] interrupt skipped: unsupported agent runtime, agentCode={}", agentCode);
             return false;
         }
-        RuntimeContext ctx = agentInstanceFactory.contextFor(agentCode, sessionId);
-        interruptible.interrupt(ctx);
         log.info("[workspace] interrupt issued, agentCode={}, sessionId={}", agentCode, sessionId);
         return true;
     }
 
-    /** {@link HarnessAgent} 本身只暴露不带 session 参数的 interrupt()（走错误的 defaultSessionId=agentCode），
-     * 真正按 (agentCode, sessionId) 精确路由需要拿到它内部委托的 {@link ReActAgent}。 */
-    private ReActAgent resolveInterruptible(Agent agent) {
+    /**
+     * 按 {@code (agentCode, sessionId)} 精确中断。
+     *
+     * <p><b>2.0.3 起不再下钻 {@code getDelegate()}</b>：上游 issue #1683 在该版本修复，
+     * {@code HarnessAgent} 补齐了 session-aware 的 {@code interrupt(RuntimeContext)}。
+     * 反编译确认它的实现就是 {@code delegate.interrupt(ctx)}——与原绕行<b>行为完全等价</b>，
+     * 但不再依赖内部结构，框架哪天重构 delegate 也不会断。
+     * （{@code AgentStateAccessor} 那处的 {@code getDelegate()} 仍然必需：
+     * {@code HarnessAgent.getAgentState()} 只有无参版本，取不到按会话的状态。）</p>
+     *
+     * @return 该运行时类型是否支持按会话中断
+     */
+    private boolean interruptBySession(Agent agent, RuntimeContext ctx) {
         if (agent instanceof ReActAgent reActAgent) {
-            return reActAgent;
+            reActAgent.interrupt(ctx);
+            return true;
         }
         if (agent instanceof HarnessAgent harnessAgent) {
-            return harnessAgent.getDelegate();
+            harnessAgent.interrupt(ctx);
+            return true;
         }
-        return null;
+        return false;
     }
 
     /**

--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepository.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/workspace/task/runtime/MybatisTaskRepository.java
@@ -118,8 +118,16 @@ public class MybatisTaskRepository implements TaskRepository {
             ownerId, properties.getLeaseSeconds(), properties.getHeartbeatSeconds());
     }
 
+    /**
+     * 关闭本仓库持有的调度与执行资源。
+     *
+     * <p>2.0.3 起 {@code TaskRepository} 接口本身声明了 {@code shutdown()}，
+     * 这个原本只服务 {@code @PreDestroy} 的包级方法正好是它的实现——
+     * 提升为 public 并显式标注，让"容器销毁时清理"与"框架主动关闭"走同一段代码。</p>
+     */
+    @Override
     @PreDestroy
-    void shutdown() {
+    public void shutdown() {
         if (maintenanceScheduler != null) {
             maintenanceScheduler.shutdownNow();
         }
@@ -268,13 +276,18 @@ public class MybatisTaskRepository implements TaskRepository {
         return true;
     }
 
-    @Override
+    /**
+     * 摘除内存中的任务引用。
+     *
+     * <p>2.0.3 起框架的 {@code TaskRepository} 不再声明这个方法，故去掉 {@code @Override}；
+     * 方法本身保留——本项目的管理台按会话清理时仍在用它。</p>
+     */
     public void removeTask(RuntimeContext rc, String sessionId, String taskId) {
         // 只摘内存引用，不删库：库里那条是管理台要看的历史，删了就查不到"这个任务当时跑成什么样"
         activeTasks.remove(key(rc, sessionId, taskId));
     }
 
-    @Override
+    /** 清空内存引用。同 {@link #removeTask}：2.0.3 起不再是接口方法，但本项目仍在用。 */
     public void clear() {
         activeTasks.clear();
     }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/a2a/AdminA2aSecurityTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/a2a/AdminA2aSecurityTest.java
@@ -8,7 +8,6 @@ import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.agent.RuntimeContext;
-import io.agentscope.core.agent.StreamOptions;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -64,11 +63,12 @@ class AdminA2aSecurityTest {
             captured.set(AgentInvocationIdentity.capture());
             return RuntimeContext.builder().userId("agent-a").sessionId("agent-a").build();
         });
-        when(agent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+        // 2.0.3：A2A runner 改吐细粒度 AgentEvent，协议转换收归框架
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
             .thenReturn(Flux.empty());
 
         new AdminAgentRunner(cache, factory, "agent-a", "test", "tenant-a", "fingerprint")
-            .stream(List.of(), null).blockLast();
+            .streamEvents(List.of(), null).blockLast();
 
         AgentInvocationIdentity identity = captured.get();
         assertEquals("tenant-a", identity.tenantId());

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentInterruptForwardingProbeTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentInterruptForwardingProbeTest.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -51,18 +50,18 @@ class HarnessAgentInterruptForwardingProbeTest {
     }
 
     /**
-     * #1683 现状锁定：{@code HarnessAgent} <b>不</b>暴露 session-aware interrupt 重载。
-     * 若某次框架升级后这两个断言开始失败（方法出现了），说明 #1683 已被修复——行为漂移报警。
+     * #1683 已修复：{@code HarnessAgent} 暴露 session-aware interrupt 重载。
+     *
+     * <p>这两个方法一旦消失，{@code ChatService#interrupt} 会退回到按
+     * {@code defaultSessionId} 中断——那意味着<b>中断信号发给了错误的会话</b>，
+     * 用户点了停止而对话继续跑，且不报任何错。</p>
      */
     @Test
-    void harnessAgent_shouldNotExposeSessionAwareInterrupt_lockingIssue1683() {
-        // 只有无 session 的 interrupt() / interrupt(Msg)，没有 interrupt(RuntimeContext) / interrupt(String,String)
-        assertThrows(NoSuchMethodException.class,
-            () -> HarnessAgent.class.getMethod("interrupt", RuntimeContext.class),
-            "#1683 现状：HarnessAgent 不应有 interrupt(RuntimeContext)——出现即说明框架已修复，需复核绕行方案");
-        assertThrows(NoSuchMethodException.class,
-            () -> HarnessAgent.class.getMethod("interrupt", String.class, String.class),
-            "#1683 现状：HarnessAgent 不应有 interrupt(userId, sessionId)——出现即说明框架已修复");
+    void harnessAgent_exposesSessionAwareInterrupt_issue1683Fixed() throws NoSuchMethodException {
+        assertNotNull(HarnessAgent.class.getMethod("interrupt", RuntimeContext.class),
+            "HarnessAgent 失去了 interrupt(RuntimeContext)——中断会发给错误的会话且不报错");
+        assertNotNull(HarnessAgent.class.getMethod("interrupt", String.class, String.class),
+            "HarnessAgent 失去了 interrupt(userId, sessionId)");
     }
 
     /**
@@ -72,7 +71,8 @@ class HarnessAgentInterruptForwardingProbeTest {
     void delegateReActAgent_shouldExposeSessionAwareInterrupt() throws NoSuchMethodException {
         HarnessAgent agent = buildHarnessAgent();
         ReActAgent delegate = agent.getDelegate();
-        assertNotNull(delegate, "HarnessAgent.getDelegate() 应返回内层 ReActAgent（绕行 #1683 的抓手）");
+        assertNotNull(delegate, "getDelegate() 仍被 AgentStateAccessor 依赖："
+            + "HarnessAgent.getAgentState() 只有无参版本，按会话取状态只能下钻");
         assertInstanceOf(ReActAgent.class, delegate);
         // 委托类具备 session-aware interrupt（框架在 ReActAgent 层原生支持）
         assertNotNull(ReActAgent.class.getMethod("interrupt", RuntimeContext.class));
@@ -80,19 +80,21 @@ class HarnessAgentInterruptForwardingProbeTest {
     }
 
     /**
-     * "中断 → 会话状态不损坏"最小验收：经绕行路径按 (userId, sessionId) 发出中断信号不抛异常，
-     * 且 StateStore 仍可用（中断只是协作式置信号，不破坏已持久化的会话状态）。完整"中断→再次对话"
-     * 需真实模型驱动，属上线联调阶段，此处以离线可判定的状态完好性作门控。
+     * "中断 → 会话状态不损坏"最小验收：直接调 {@code HarnessAgent.interrupt(ctx)}
+     * （2.0.3 起的正路，不再经 delegate）不抛异常，且 StateStore 仍可用——
+     * 中断只是协作式置信号，不破坏已持久化的会话状态。
+     *
+     * <p>完整的"中断 → 再次对话"需真实模型驱动，属上线联调阶段；
+     * 这里以离线可判定的状态完好性作门控。</p>
      */
     @Test
-    void interruptViaDelegate_shouldNotCorruptSession() {
+    void interruptBySession_shouldNotCorruptSession() {
         HarnessAgent agent = buildHarnessAgent();
         RuntimeContext ctx = RuntimeContext.builder().userId("coder").sessionId("s1").build();
 
-        assertDoesNotThrow(() -> agent.getDelegate().interrupt(ctx),
-            "经委托按会话中断不应抛异常");
+        assertDoesNotThrow(() -> agent.interrupt(ctx), "按会话中断不应抛异常");
         assertNotNull(agent.getStateStore(), "中断后 StateStore 仍应可用，会话状态不因中断而损坏");
         // 幂等：再次中断同一会话仍安全
-        assertDoesNotThrow(() -> agent.getDelegate().interrupt(ctx));
+        assertDoesNotThrow(() -> agent.interrupt(ctx));
     }
 }

--- a/docs/MIGRATION-2.0.md
+++ b/docs/MIGRATION-2.0.md
@@ -282,3 +282,68 @@ AgentScope Java 官方 Release Notes 对"2.0 系列"的描述偏总览性质，�
 - **未做"RC4 之后新提交且已关闭"的全量搜索**——只核对了文档历史引用过的 29 个 legacy issue 的关闭情况，
   可能遗漏其他已随 GA 修复、但未被本文档历史引用过的 bug。
 - 详细的逐条结论更新见 [生产就绪评估.md](生产就绪评估.md) 第四～七节。
+
+---
+
+## 10. 2.0.2 → 2.0.3 升级（2026-09-10）
+
+### 10.1 两处编译期破坏，都在 admin 侧
+
+starter 零改动。
+
+**`AgentRunner`**：`stream(List, AgentRequestOptions)` → `streamEvents(...)`，返回类型从
+`Flux<Event>`（A2A 协议事件）换成 `Flux<AgentEvent>`（框架细粒度事件），**协议转换收归框架**。
+
+这正是 `AdminAgentRunner` 那段注释预告的时机——它当时写着「`AgentRunner#stream` 的返回类型被框架
+写死为 `Flux<Event>`，就是那个废弃类型本身；框架自带的 `BaseReActAgentRunner` 也仍在调
+`agent.stream(msgs)`——A2A 这一层框架自己都没迁……等框架把 A2A 层迁到细粒度事件后再跟进」。
+2.0.3 迁了，于是跟进：内部改调 `agent.streamEvents(msgs, ctx)`，并去掉 `StreamOptions`
+的事件类型过滤（新接口下由框架决定哪些事件进协议包，调用方自行裁剪会与框架的去重/拼包语义打架）。
+
+**`TaskRepository`**：接口新增 `public shutdown()`，与项目那个包级私有的 `@PreDestroy` 方法撞名
+（报「正在尝试分配更低的访问权限」）；`removeTask` / `clear` 不再是接口方法。
+前者提升为 public 并标 `@Override`，后者去掉 `@Override` 但保留方法本身（管理台仍在用）。
+
+### 10.2 上游 #1683 修复：探针如期变红
+
+`HarnessAgentInterruptForwardingProbeTest` 断言的是「框架**还没**修 #1683」，
+失败消息写着「出现即说明框架已修复，需复核绕行方案」。升级当天它立刻变红——
+**这正是这类「记录现状」的探针被设计出来要做的事**。
+
+2.0.3 给 `HarnessAgent` 补齐了全部四个 session-aware `interrupt` 重载。反编译确认
+`interrupt(RuntimeContext)` 的实现就是 `delegate.interrupt(ctx)`——与项目原绕行**行为完全等价**，
+所以 `ChatService#interrupt` 改用新 API 是零风险的，收益是不再依赖内部结构。
+
+`AgentStateAccessor` 那处的 `getDelegate()` **刻意保留**：`HarnessAgent.getAgentState()`
+只有无参版本，取不到按会话的状态。
+
+### 10.3 需要留意的行为变更（本次未处理）
+
+| 变更 | 影响 |
+|---|---|
+| agent state 加载失败**不再静默替换**为新会话（#2760） | 原本靠静默降级跑着的部署会开始报错——这是好事，但升级后可能出现新的失败告警 |
+| `ThinkingBlock` token 按真实内容计数（#3009） | token 统计数字会变，**影响配额判定与账单金额** |
+| `Retry empty final responses`（#2755） | 推理模型把答案写进 `reasoning_content` 时会重试，可能多一次模型调用 |
+| `OkHttpTransport` SSE 背压修复（#2963） | 流式首字延迟的**收益**，无需改动 |
+| `ToolResultBlock.metadata` 通过细粒度事件传播（#2315） | 引用回传（PR #180）当初正是因为拿不到 metadata 才改走文本标记，现在有了更干净的替代路径 |
+
+### 10.4 一个从 2.0.2 起就存在、此前被漏看的事实
+
+编译告警显示框架已把**整套 RAG 与长期记忆 API 标记为 `forRemoval`**：
+
+| API | 项目引用处 |
+|---|---|
+| `rag.Knowledge` | 37 |
+| `memory.LongTermMemory` | 32 |
+| `hook.Hook` | 20 |
+| `hook.recorder.JsonlTraceExporter` | 11 |
+| `rag.model.RetrieveConfig` | 10 |
+| `tracing.TracerRegistry` | 7 |
+
+**这不是 2.0.3 引入的**——逐个反编译对比确认 2.0.2 的 class 文件里就带着 `Deprecated` 标记，
+是批次二升级到 2.0.2 时漏看了编译告警。2.0.3 的 release notes 也没有 Deprecated 段、
+未给出替代方案。
+
+**待办**：这几套 API 一旦在某个版本真被移除，项目会直接编译不过。下次升级前应当先查清
+框架给出的替代路径（`Knowledge` 那 37 处可能随知识库改用外部 kb-rag 而自然消解，
+但长期记忆的 32 处、Hook 的 20 处仍需迁移方案）。

--- a/docs/智能体能力差距与演进路线图.md
+++ b/docs/智能体能力差距与演进路线图.md
@@ -341,13 +341,14 @@ kept.addAll(budgeted.subList(budgeted.size() - tailCount, budgeted.size()));
 
 ### 3.1 版本现状：落后两个维护版本
 
-项目根 `pom.xml` 锁定 `<agentscope.version>2.0.0</agentscope.version>`（2026-07-10 GA）。截至 2026-09-04，上游已发布：
+项目根 `pom.xml` 现锁定 `<agentscope.version>2.0.3</agentscope.version>`（审计时是 2.0.0，批次二升 2.0.2、批次十六升 2.0.3）。上游已发布：
 
 | 版本 | 发布日期 | 性质 |
 |---|---|---|
 | v2.0.0 | 2026-07-10 | GA，项目当前锁定 |
 | **v2.0.1** | 2026-08-06 | 首个维护版：新增 4 家一等公民模型 provider、修复内存泄漏、加固 HITL/权限、**改变 Toolkit 默认执行模式** |
 | **v2.0.2** | 2026-09-03 | Channel 可传入 RuntimeContext、agent_spawn 强制同步 RuntimeContext、远程子智能体事件流 |
+| **v2.0.3** | 2026-09-07 | **项目当前版本**：A2A 层迁细粒度事件、`HarnessAgent` 补齐 session-aware interrupt（#1683）、SSE 背压修复、状态版本化 |
 
 依赖深度决定了升级不是小事——项目对框架的引用面：
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <agentscope.version>2.0.2</agentscope.version>
+        <agentscope.version>2.0.3</agentscope.version>
         <springdoc.version>2.3.0</springdoc.version>
         <nacos.version>3.0.2</nacos.version>
         <mybatis-plus.version>3.5.7</mybatis-plus.version>


### PR DESCRIPTION
## 两处编译期破坏，都在 admin 侧（starter 零改动）

**`AgentRunner`**：`stream(List, AgentRequestOptions)` → `streamEvents(...)`，返回类型从
`Flux<Event>`（A2A 协议事件）换成 `Flux<AgentEvent>`（框架细粒度事件）——**协议转换收归框架**。

这正是 `AdminAgentRunner` 那段注释预告的时机。它当时写着：

> `AgentRunner#stream` 的返回类型被框架写死为 `Flux<Event>`，就是那个废弃类型本身；
> 框架自带的 `BaseReActAgentRunner` 也仍在调 `agent.stream(msgs)`——**A2A 这一层框架自己都没迁**……
> 等框架把 A2A 层迁到细粒度事件后再跟进。

2.0.3 迁了，于是跟进：内部改调 `agent.streamEvents(msgs, ctx)`，并去掉 `StreamOptions` 的事件类型
过滤——新接口下由框架决定哪些事件进协议包，调用方自行裁剪会与框架的去重/拼包语义打架。

**`TaskRepository`**：接口新增 `public shutdown()`，与项目那个包级私有的 `@PreDestroy` 方法撞名
（报「正在尝试分配更低的访问权限」）；`removeTask` / `clear` 不再是接口方法。

## 上游 #1683 修复：探针如期变红

`HarnessAgentInterruptForwardingProbeTest` 断言的是「框架**还没**修 #1683」，失败消息写着
「出现即说明框架已修复，需复核绕行方案」。**升级当天它立刻变红——这正是这类探针被设计出来要做的事。**

2.0.3 给 `HarnessAgent` 补齐了全部四个 session-aware `interrupt` 重载。
**反编译确认 `interrupt(RuntimeContext)` 的实现就是 `delegate.interrupt(ctx)`**——与项目原绕行
行为完全等价，所以 `ChatService#interrupt` 改用新 API 是零风险的，收益是不再依赖内部结构。

`AgentStateAccessor` 那处的 `getDelegate()` **刻意保留**：`HarnessAgent.getAgentState()`
只有无参版本，取不到按会话的状态。

探针随之调转方向：从「锁定框架还没修」改为「守住修好之后的行为」——这两个方法一旦消失，
中断会发给错误的会话，用户点了停止而对话继续跑，且不报任何错。

---

## ⚠️ 需要留意的行为变更（本 PR 未处理）

| 变更 | 影响 |
|---|---|
| agent state 加载失败**不再静默替换**为新会话（#2760） | 原本靠静默降级跑着的部署**会开始报错**——这是好事，但升级后可能出现新的失败告警 |
| `ThinkingBlock` token 按真实内容计数（#3009） | token 统计数字会变，**影响配额判定与账单金额** |
| `Retry empty final responses`（#2755） | 推理模型答案落在 `reasoning_content` 时会重试，可能多一次模型调用 |
| `OkHttpTransport` SSE 背压修复（#2963） | 流式首字延迟的**收益**，无需改动 |
| `ToolResultBlock.metadata` 通过细粒度事件传播（#2315） | 引用回传（PR #180）当初正是因为拿不到 metadata 才改走文本标记，现在有了更干净的替代路径 |

## ⚠️ 一个从 2.0.2 起就存在、此前被漏看的事实

编译告警显示框架已把**整套 RAG 与长期记忆 API 标记为 `forRemoval`**：

| API | 项目引用处 |
|---|---|
| `rag.Knowledge` | **37** |
| `memory.LongTermMemory` | **32** |
| `hook.Hook` | 20 |
| `JsonlTraceExporter` | 11 |
| `rag.model.RetrieveConfig` | 10 |
| `tracing.TracerRegistry` | 7 |

**这不是 2.0.3 引入的**——逐个反编译对比确认 **2.0.2 的 class 文件里就带着 `Deprecated` 标记**，
是批次二升级到 2.0.2 时漏看了编译告警。release notes 也没有 Deprecated 段、未给出替代方案。

**待办**：这几套 API 一旦真被移除，项目会直接编译不过。下次升级前应先查清替代路径
（`Knowledge` 那 37 处可能随知识库改用外部 kb-rag 而自然消解，但长期记忆 32 处、Hook 20 处仍需方案）。

## 验证

全模块 `BUILD SUCCESS`，0 失败 0 错误，合计 **3836**——**与升级前完全一致，无行为回归**。