### PR TITLE
fix(test): Harness 测试必须释放 Agent，否则后台任务会写崩临时目录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,6 +579,17 @@ mvn -gs scripts/settings-central-direct.xml -s scripts/settings-central-direct.x
   拿不准归属时先问，不要默认放业务模块。starter 改完给下游用要先 `mvn install`（下游解析本地仓库 jar）。
 - 日志只用 info/error（不用 warn），日志文本英文，error 带错误码占位符：
   `log.error("xxx failed, code={}, id={}", "MODULE-ACTION-FAIL", id, e)`
+- **测试里真建出来的 `HarnessAgent` 必须释放**（2.0.3 起）：`HarnessAgent#close()` 的头两件事是
+  `SessionTree.awaitMirrorQuiescence` 与 `MemoryBackgroundTasks.awaitQuiescence`——等会话镜像与
+  记忆刷写的后台线程停下来，**这两个 API 都是 2.0.3 新增的**。不关就会在测试方法返回后继续写
+  workspace，`@TempDir` 上表现为 CI 偶发的 `Failed to delete temp directory`
+  （suppressed 是 `DirectoryNotEmptyException`）。`SubagentEventForwardingTest` 上真实发生过：
+  **三轮 CI 炸了两轮，且两次挂的不是同一个用例**——谁最后跑完谁触发清理谁背锅，
+  看着像随机不稳定，根因其实唯一。
+  `HarnessAgentReleaseContractTest` 扫源码对此下断言（跨四个模块的测试目录），
+  建了不释放当场红。**必须是结构断言而不是运行时断言**：这个竞态本机复现不出来，
+  实测把释放去掉之后，连「关闭后主动删一次 workspace」这种最直接的断言都照样是绿的
+  （机器快，后台在删之前就写完了）。同一形状见 PR #157 的 git 后台维护锁。
 - 持久化扩展走 Store SPI 模式（接口 + InMemory 默认 + MyBatis-Plus 实现 + `@ConditionalOnMissingBean`，
   已套用 8 次：Approval/SlotFilling/DialogStage/Handoff/Feedback/Ticket/UserAccount/ChatLog），别发明新模式。
   持久层规范：贫血 DO(entity/)+BaseMapper(mapper/)+复杂 SQL 进 resources/customerwork/mapper/*.xml，

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SubagentEventForwardingTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/workspace/runtime/SubagentEventForwardingTest.java
@@ -1,5 +1,6 @@
 package com.richard.fyoung.customeradmin.workspace.runtime;
 
+import com.richard.fyoung.customerwork.core.agent.AgentResourceCloser;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
@@ -22,6 +23,7 @@ import io.agentscope.core.permission.PermissionMode;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.HarnessAgent;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -29,15 +31,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -112,6 +118,59 @@ class SubagentEventForwardingTest {
     private final AtomicInteger childModelCalls = new AtomicInteger();
     /** 父 Model 每轮拿到的工具名清单（诊断装配：spawn 工具是否被接线进父 toolkit）。 */
     private final List<String> parentToolNamesOffered = new CopyOnWriteArrayList<>();
+
+    /** 本次用例建过的 HarnessAgent，收尾统一释放（见 {@link #releaseAgents()}）。 */
+    private final List<HarnessAgent> builtAgents = new CopyOnWriteArrayList<>();
+
+    /**
+     * 释放建过的每一个 HarnessAgent，并当场验证 workspace 真的可以删干净。
+     *
+     * <h3>不释放会怎样</h3>
+     * <p>{@code HarnessAgent#close()} 做的第一件事就是等后台任务停下来——反编译 2.0.3 的实现，
+     * 依次是 {@code SessionTree.awaitMirrorQuiescence}、{@code MemoryBackgroundTasks.awaitQuiescence}、
+     * {@code shutdownTaskRepository}、{@code WorkspaceIndex.close}。**这两个 awaitQuiescence 都是
+     * 2.0.3 新增的**：从这个版本起，会话镜像与记忆刷写会在 Agent 之外的线程上继续写 workspace。</p>
+     *
+     * <p>本类此前从不释放，于是 JUnit 删 {@code @TempDir} 时后台还在往 {@code probe-user} 里写，
+     * CI 上表现为 {@code IOException: Failed to delete temp directory ... probe-user}，
+     * suppressed 是 {@code DirectoryNotEmptyException}。三轮 CI 里炸了两轮，
+     * 且两次挂的<b>不是同一个用例</b>——谁最后跑完谁触发清理，谁就背锅。</p>
+     *
+     * <h3>为什么还要自己删一遍，以及它守不住什么</h3>
+     * <p>关闭之后主动递归删一次并断言删空，作用是<b>把 JUnit 那句通用的
+     * {@code IOException: Failed to delete temp directory} 换成带具体路径与异常类型的失败信息</b>——
+     * 排查时能直接看出是哪个子目录、被什么挡住。</p>
+     *
+     * <p><b>但它照不出本机的差别</b>：实测把上面那行 {@code builtAgents.add(parent)} 去掉
+     * （即回到不释放的状态），本机这条断言<b>照样是绿的</b>——机器快，后台任务在删之前就写完了。
+     * 所以别把它当成"这个竞态已经被钉死"的证据，它只是在 CI 真的失败时给出更有用的信息。
+     * 真正防复发的是 {@code HarnessAgentReleaseContractTest} 那道结构门禁：
+     * 建了 HarnessAgent 却不释放，源码扫描当场红，不依赖任何运行时时序。</p>
+     */
+    @AfterEach
+    void releaseAgents() throws IOException {
+        builtAgents.forEach(agent -> AgentResourceCloser.closeQuietly(agent, "subagent-probe"));
+        builtAgents.clear();
+
+        if (workspace == null || !Files.exists(workspace)) {
+            return;
+        }
+        List<Path> leftovers;
+        try (Stream<Path> walk = Files.walk(workspace)) {
+            leftovers = walk.sorted(Comparator.reverseOrder()).toList();
+        }
+        List<String> undeletable = new ArrayList<>();
+        for (Path path : leftovers) {
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException e) {
+                undeletable.add(path + " (" + e.getClass().getSimpleName() + ")");
+            }
+        }
+        assertTrue(undeletable.isEmpty(),
+            "Agent 释放后 workspace 仍有删不掉的内容，说明后台任务没有停干净："
+                + String.join(", ", undeletable));
+    }
 
     // ==================== 结局①/②/③ 探针（核心） ====================
 
@@ -246,6 +305,7 @@ class SubagentEventForwardingTest {
             .subagentFactory(SUBAGENT_ID, id -> buildChildAgent(stateStore, permission))
             .disableDynamicSubagents()  // 只测静态注册的子 Agent 路径，关掉运行时动态造 Agent 的噪音
             .build();
+        builtAgents.add(parent);
 
         RuntimeContext ctx = RuntimeContext.builder()
             .userId("probe-user").sessionId("probe-session").build();

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentInterruptForwardingProbeTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentInterruptForwardingProbeTest.java
@@ -69,11 +69,16 @@ class HarnessAgentInterruptForwardingProbeTest {
      */
     @Test
     void delegateReActAgent_shouldExposeSessionAwareInterrupt() throws NoSuchMethodException {
-        HarnessAgent agent = buildHarnessAgent();
-        ReActAgent delegate = agent.getDelegate();
-        assertNotNull(delegate, "getDelegate() 仍被 AgentStateAccessor 依赖："
-            + "HarnessAgent.getAgentState() 只有无参版本，按会话取状态只能下钻");
-        assertInstanceOf(ReActAgent.class, delegate);
+        // try-with-resources 不可省：2.0.3 起 HarnessAgent#close() 的头两件事是
+        // SessionTree.awaitMirrorQuiescence 与 MemoryBackgroundTasks.awaitQuiescence，
+        // 也就是等会话镜像与记忆刷写的后台线程停下来。不关就一直往 workspace 写，
+        // 在 @TempDir 上表现为 CI 偶发的 "Failed to delete temp directory"。
+        try (HarnessAgent agent = buildHarnessAgent()) {
+            ReActAgent delegate = agent.getDelegate();
+            assertNotNull(delegate, "getDelegate() 仍被 AgentStateAccessor 依赖："
+                + "HarnessAgent.getAgentState() 只有无参版本，按会话取状态只能下钻");
+            assertInstanceOf(ReActAgent.class, delegate);
+        }
         // 委托类具备 session-aware interrupt（框架在 ReActAgent 层原生支持）
         assertNotNull(ReActAgent.class.getMethod("interrupt", RuntimeContext.class));
         assertNotNull(ReActAgent.class.getMethod("interrupt", String.class, String.class));

--- a/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentReleaseContractTest.java
+++ b/customer-work-starter/src/test/java/com/richard/fyoung/customerwork/core/agent/HarnessAgentReleaseContractTest.java
@@ -1,0 +1,108 @@
+package com.richard.fyoung.customerwork.core.agent;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * <b>释放契约门禁</b>：测试里真建出来的 {@code HarnessAgent} 必须被释放。
+ *
+ * <h3>守的是什么</h3>
+ * <p>AgentScope 2.0.3 起，{@code HarnessAgent#close()} 的头两件事是
+ * {@code SessionTree.awaitMirrorQuiescence} 与 {@code MemoryBackgroundTasks.awaitQuiescence}
+ * ——等会话镜像与记忆刷写的后台线程停下来（这两个 API 都是 2.0.3 新增的）。
+ * 不调 close，那些线程就会在测试方法返回之后继续往 workspace 里写。</p>
+ *
+ * <p>后果在 {@code @TempDir} 上最直接：JUnit 收尾删临时目录时撞上正在写的文件，报
+ * {@code IOException: Failed to delete temp directory}，suppressed 是
+ * {@code DirectoryNotEmptyException}。这在 {@code SubagentEventForwardingTest} 上真实发生过——
+ * 三轮 CI 炸了两轮，而且<b>两次挂的不是同一个用例</b>：谁最后跑完谁触发清理，谁就背锅，
+ * 看起来像随机的测试不稳定，其实根因唯一。</p>
+ *
+ * <h3>为什么必须是结构断言</h3>
+ * <p>这个竞态<b>本机复现不出来</b>：实测把释放去掉之后，本机连"关闭后主动删一次 workspace"
+ * 这种直接断言都照样是绿的——机器快，后台在删之前就写完了。也就是说任何运行时断言在这里都可能
+ * 恒真，只有 CI 的慢机器才照得出来。同一形状本仓库记过一次（PR #157 的 git 后台维护锁，
+ * 本机与容器 1400 轮都没复现）。</p>
+ *
+ * <p>因此改用源码扫描对结构本身下断言：建了就必须释放，不依赖任何运行时时序，
+ * 新写一个不释放的测试当场红。</p>
+ *
+ * @author owlzhangfq@gmail.com
+ */
+class HarnessAgentReleaseContractTest {
+
+    /** 真建一个 HarnessAgent 的标志性调用（mock 不算——mock 不会起后台线程）。 */
+    private static final String BUILD_MARKER = "HarnessAgent.Builder.fromAgent";
+
+    /** 认可的释放证据。 */
+    private static final List<String> RELEASE_MARKERS = List.of(
+        "try (HarnessAgent",          // try-with-resources
+        "AgentResourceCloser.closeQuietly",
+        ".close()");
+
+    private static final List<String> TEST_SOURCE_ROOTS = List.of(
+        "customer-work-starter/src/test/java",
+        "customer-admin-server/src/test/java",
+        "customer-work-app-server/src/test/java",
+        "customer-channel/src/test/java");
+
+    @Test
+    @DisplayName("真建 HarnessAgent 的测试必须释放它")
+    void everyBuiltHarnessAgentIsReleased() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        int checked = 0;
+
+        for (Path root : existingRoots()) {
+            try (Stream<Path> stream = Files.walk(root)) {
+                for (Path file : stream.filter(p -> p.toString().endsWith(".java")).toList()) {
+                    String source = Files.readString(file, StandardCharsets.UTF_8);
+                    if (!source.contains(BUILD_MARKER)) {
+                        continue;
+                    }
+                    checked++;
+                    boolean released = RELEASE_MARKERS.stream().anyMatch(source::contains);
+                    if (!released) {
+                        offenders.add(file.getFileName().toString());
+                    }
+                }
+            }
+        }
+
+        assertTrue(checked >= 2,
+            "应至少扫描到 2 个真建 HarnessAgent 的测试，实际 " + checked + " —— 扫描路径可能失效了");
+
+        if (!offenders.isEmpty()) {
+            fail("以下测试建了 HarnessAgent 却没有释放，后台任务会在测试结束后继续写 workspace：\n"
+                + String.join("\n", offenders)
+                + "\n修法：try-with-resources 包住，或收集起来在 @AfterEach 里走 "
+                + "AgentResourceCloser.closeQuietly。\n"
+                + "本机跑不出问题不代表没问题——这个竞态只在 CI 的慢机器上暴露。");
+        }
+    }
+
+    private List<Path> existingRoots() {
+        List<Path> roots = new ArrayList<>();
+        for (String candidate : TEST_SOURCE_ROOTS) {
+            Path fromRepoRoot = Paths.get(candidate);
+            Path fromModule = Paths.get("..").resolve(candidate).normalize();
+            if (Files.exists(fromRepoRoot)) {
+                roots.add(fromRepoRoot);
+            } else if (Files.exists(fromModule)) {
+                roots.add(fromModule);
+            }
+        }
+        return roots;
+    }
+}


### PR DESCRIPTION
## 现象

CI 上 `SubagentEventForwardingTest` 报：

```
java.io.IOException: Failed to delete temp directory /tmp/junit.... 
The following paths could not be deleted: <root>, probe-user
Suppressed: java.nio.file.DirectoryNotEmptyException
```

**三轮 CI 炸了两轮，且两次挂的不是同一个用例**（`parentOwnEvents_shouldCarryNullSource` 与 `spawnTool_shouldBeOfferedToParentModel_assemblyGuard`）。谁最后跑完谁触发 `@TempDir` 清理，谁就背锅——看起来像随机的测试不稳定，根因其实唯一。

## 根因

反编译 2.0.3 的 `HarnessAgent#close()`，它做的第一件事就是等后台停下来：

```
SessionTree.awaitMirrorQuiescence(N, SECONDS)      ← 等会话镜像后台写静默
MemoryBackgroundTasks.awaitQuiescence(N, SECONDS)  ← 等后台记忆任务静默
shutdownTaskRepository()
WorkspaceIndex.close()
delegate.close()
```

`MemoryBackgroundTasks` 与 `awaitMirrorQuiescence` **都是 2.0.3 新增的**。从这个版本起，会话镜像与记忆刷写会在 Agent 之外的线程上继续写 workspace，而这两个测试从不关闭 Agent，于是 JUnit 删临时目录时后台还在往 `probe-user` 里写。

**生产链路没有这个问题**：`AgentResourceCloser` 一直在调 `close()`。

## 范围：扫了一遍，不是四处而是两处

| 测试 | 真建 | 已释放 | workspace |
|---|---|---|---|
| `SubagentEventForwardingTest` | 是 | **否** | `@TempDir`，已在 CI 上炸过 |
| `HarnessAgentInterruptForwardingProbeTest` | 是 | **否** | `target/` 固定目录 |
| `HarnessMemoryPolicyTest` | 是 | 是（try-with-resources） | `@TempDir` |
| `HarnessOptInPolicyTest` | 否（纯 mock） | — | — |

正确写法项目里本来就有，只是没贯彻到全部。

## 主要交付是那道门禁，不是这两处修复

`HarnessAgentReleaseContractTest` 扫四个模块的测试目录，建了 `HarnessAgent` 却不释放就当场红。变异验证过：抹掉 admin 那个测试的释放痕迹，门禁点名 `SubagentEventForwardingTest.java`（它跨模块也扫得到）。

**为什么必须是结构断言**：这个竞态本机复现不出来。第一版我写的是「关闭之后主动递归删一次 workspace 并断言删空，把偶发变成确定」，做变异（去掉释放）后**本机照样绿**——机器快，后台在删之前就写完了。那条断言因此改成如实说明它只是让 CI 的失败信息更好读（带具体路径与异常类型，而不是 JUnit 那句通用的 IOException），不再声称把偶发变成了确定。

同一形状本仓库记过一次：PR #157 的 git 后台维护锁，本机 500 轮、Linux 容器 900 轮都没复现，最后只能用「根因还在不在」当证据。

## 验收

全模块 BUILD SUCCESS，0 失败 0 错误，合计 **3837**（基线 3836 + 门禁 1 条）。