### PR TITLE
创建评测用例前检查改进状态并冻结复评目标

### DIFF
--- a/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseService.java
+++ b/customer-admin-server/src/main/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseService.java
@@ -158,29 +158,32 @@ public class ImprovementCaseService {
         });
     }
 
+    /**
+     * 先锁定改进项并确认状态，再创建独立可追溯的客服端用例；避免被拒绝的操作留下额外用例。
+     * Admin 行锁覆盖创建与绑定，阻止同一改进项在两步之间进入复评或发布。
+     */
     public ImprovementCaseVO createEvalCase(Long id, ImprovementEvalCaseRequest request,
                                             String operator) {
-        AgentImprovementCase snapshot = require(id);
-        ImprovementSourceType sourceType = ImprovementSourceType.valueOf(snapshot.getSourceType());
-        ImprovementSourceFact source = requireSource(sourceType, snapshot.getSourceKey());
-        if (!StringUtils.hasText(source.getQuestion())) {
-            throw invalid("原始问题缺失，不能构造可复评用例");
-        }
-        ImprovementSignalGateway gateway = signalGatewayProvider.get();
-        if (gateway.evalCaseStore().find(request.evalType(), request.caseId()).isPresent()) {
-            throw invalid("评测用例编号已存在：" + request.caseId());
-        }
-        if (sourceType == ImprovementSourceType.BADCASE) {
-            badcaseGatewayProvider.get().adoptAsEvalCase(snapshot.getSourceKey(), request.caseId(),
-                request.evalType(), request.expected(), request.category(), operator);
-        } else {
-            gateway.evalCaseStore().save(new PersistedEvalCase(request.caseId(), request.evalType(),
-                source.getQuestion(), request.expected(), request.category(), EvalCaseSource.MANUAL,
-                true, "knowledge-gap:" + snapshot.getSourceKey(), System.currentTimeMillis()));
-        }
         return transactionTemplate.execute(status -> {
             AgentImprovementCase row = lock(id);
             assertMutable(row);
+            ImprovementSourceType sourceType = ImprovementSourceType.valueOf(row.getSourceType());
+            ImprovementSourceFact source = requireSource(sourceType, row.getSourceKey());
+            if (!StringUtils.hasText(source.getQuestion())) {
+                throw invalid("原始问题缺失，不能构造可复评用例");
+            }
+            ImprovementSignalGateway gateway = signalGatewayProvider.get();
+            if (gateway.evalCaseStore().find(request.evalType(), request.caseId()).isPresent()) {
+                throw invalid("评测用例编号已存在：" + request.caseId());
+            }
+            if (sourceType == ImprovementSourceType.BADCASE) {
+                badcaseGatewayProvider.get().adoptAsEvalCase(row.getSourceKey(), request.caseId(),
+                    request.evalType(), request.expected(), request.category(), operator);
+            } else {
+                gateway.evalCaseStore().save(new PersistedEvalCase(request.caseId(), request.evalType(),
+                    source.getQuestion(), request.expected(), request.category(), EvalCaseSource.MANUAL,
+                    true, "knowledge-gap:" + row.getSourceKey(), System.currentTimeMillis()));
+            }
             row.setEvalType(request.evalType().name());
             row.setEvalCaseId(request.caseId());
             resetAfterEvalCaseChange(row);
@@ -517,6 +520,7 @@ public class ImprovementCaseService {
     private void assertMutable(AgentImprovementCase row) {
         ImprovementCaseStatus status = statusOf(row);
         if (status == ImprovementCaseStatus.PUBLISHING || status == ImprovementCaseStatus.OBSERVING
+            || status == ImprovementCaseStatus.REEVALUATING
             || status == ImprovementCaseStatus.VERIFIED || status == ImprovementCaseStatus.CANCELLED) {
             throw invalid("当前状态不能更换评测用例：" + status);
         }

--- a/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseServiceTest.java
+++ b/customer-admin-server/src/test/java/com/richard/fyoung/customeradmin/improvement/service/ImprovementCaseServiceTest.java
@@ -16,8 +16,10 @@ import com.richard.fyoung.customeradmin.improvement.domain.ImprovementCaseStatus
 import com.richard.fyoung.customeradmin.improvement.domain.ImprovementEffectStatus;
 import com.richard.fyoung.customeradmin.improvement.domain.ImprovementReevaluationStatus;
 import com.richard.fyoung.customeradmin.improvement.domain.ImprovementSourceType;
+import com.richard.fyoung.customeradmin.improvement.dto.ImprovementEvalCaseRequest;
 import com.richard.fyoung.customeradmin.improvement.entity.AgentImprovementCase;
 import com.richard.fyoung.customeradmin.improvement.jdbc.ImprovementSignalGateway;
+import com.richard.fyoung.customeradmin.improvement.jdbc.ImprovementSourceFact;
 import com.richard.fyoung.customeradmin.improvement.mapper.AgentImprovementCaseMapper;
 import com.richard.fyoung.customeradmin.improvement.mapper.ImprovementSignalMapper;
 import com.richard.fyoung.customerwork.capability.eval.EvalCaseStore;
@@ -27,8 +29,11 @@ import com.richard.fyoung.customerwork.capability.eval.EvalRun;
 import com.richard.fyoung.customerwork.capability.eval.EvalTrigger;
 import com.richard.fyoung.customerwork.capability.eval.EvalType;
 import com.richard.fyoung.customerwork.capability.eval.EvalVersionBinding;
+import com.richard.fyoung.customerwork.safety.tenant.TenantContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 
@@ -40,6 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -56,6 +63,7 @@ class ImprovementCaseServiceTest {
     private ImprovementAutomationProperties properties;
     private ObjectMapper objectMapper;
     private ImprovementCaseService service;
+    private EvalCaseStore evalCaseStore;
 
     @BeforeEach
     void setUp() {
@@ -72,15 +80,76 @@ class ImprovementCaseServiceTest {
         properties.setMaxRecurrenceSignals(0);
         objectMapper = new ObjectMapper();
 
+        evalCaseStore = mock(EvalCaseStore.class);
         ImprovementSignalGatewayProvider gatewayProvider = mock(ImprovementSignalGatewayProvider.class);
         when(gatewayProvider.get()).thenReturn(
-            new ImprovementSignalGateway(signalMapper, mock(EvalCaseStore.class)));
+            new ImprovementSignalGateway(signalMapper, evalCaseStore));
         PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
         when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
         service = new ImprovementCaseService(caseMapper, gatewayProvider,
             mock(BadcaseGatewayProvider.class), mock(AiAgentMapper.class), publisher,
             evalAdminService, publishTaskService, publishTaskMapper, properties, objectMapper,
             transactionManager);
+    }
+
+    /** 原测试只覆盖复评与发布，没有验证创建用例被拒绝时是否已在客服库写入。 */
+    @ParameterizedTest
+    @EnumSource(value = ImprovementCaseStatus.class,
+        names = {"PUBLISHING", "OBSERVING", "VERIFIED", "CANCELLED", "REEVALUATING"})
+    void createEvalCaseMustCheckLockedStateBeforeWriting(ImprovementCaseStatus state) throws Exception {
+        AgentImprovementCase before = row(ImprovementCaseStatus.OWNED, candidate("model-v1"));
+        before.setSourceType(ImprovementSourceType.KNOWLEDGE_GAP.name());
+        before.setSourceKey("knowledge-gap-1");
+        AgentImprovementCase locked = row(state, candidate("model-v1"));
+        locked.setSourceType(ImprovementSourceType.KNOWLEDGE_GAP.name());
+        locked.setSourceKey("knowledge-gap-1");
+        when(caseMapper.selectById(1L)).thenReturn(before);
+        when(caseMapper.lockById(1L)).thenReturn(locked);
+        var fact = new ImprovementSourceFact();
+        fact.setQuestion("退款进度如何");
+        fact.setSignalHash("signal-a");
+        when(signalMapper.findKnowledgeGap("tenant-a", before.getSourceKey())).thenReturn(fact);
+        var request = new ImprovementEvalCaseRequest(
+            "case-new", EvalType.INTENT, "refund", "refund");
+
+        TenantContext.runWith("tenant-a", () ->
+            assertThrows(BizException.class, () -> service.createEvalCase(1L, request, "operator-a")));
+
+        verify(evalCaseStore, never()).save(any());
+        assertEquals("case-target", locked.getEvalCaseId());
+        assertEquals(state.name(), locked.getStatus());
+    }
+
+    @Test
+    void createEvalCaseMustLockBeforeCreationAndBindAfterItSucceeds() throws Exception {
+        AgentImprovementCase row = ownedKnowledgeGapRow();
+        var request = new ImprovementEvalCaseRequest(
+            "case-new", EvalType.INTENT, "refund", "refund");
+        var result = TenantContext.callWith("tenant-a", () ->
+            service.createEvalCase(1L, request, "operator-a"));
+
+        var order = inOrder(caseMapper, evalCaseStore);
+        order.verify(caseMapper).lockById(1L);
+        order.verify(evalCaseStore).save(any());
+        order.verify(caseMapper).updateById(row);
+        assertEquals("case-new", result.evalCaseId());
+        assertEquals(ImprovementCaseStatus.READY_FOR_REEVALUATION, result.status());
+        assertEquals(ImprovementReevaluationStatus.NOT_RUN, result.reevaluationStatus());
+    }
+
+    @Test
+    void failedCaseCreationMustKeepThePriorBinding() throws Exception {
+        AgentImprovementCase row = ownedKnowledgeGapRow();
+        doThrow(new IllegalStateException("case store unavailable"))
+            .when(evalCaseStore).save(any());
+        var request = new ImprovementEvalCaseRequest(
+            "case-new", EvalType.INTENT, "refund", "refund");
+        TenantContext.runWith("tenant-a", () ->
+            assertThrows(IllegalStateException.class, () -> service.createEvalCase(1L, request, "operator-a")));
+
+        verify(caseMapper, never()).updateById(any(AgentImprovementCase.class));
+        assertEquals("case-target", row.getEvalCaseId());
+        assertEquals(ImprovementCaseStatus.OWNED.name(), row.getStatus());
     }
 
     @Test
@@ -271,6 +340,18 @@ class ImprovementCaseServiceTest {
 
         assertEquals(ImprovementCaseStatus.INCONCLUSIVE.name(), lowTraffic.getStatus());
         assertEquals(ImprovementEffectStatus.INCONCLUSIVE.name(), lowTraffic.getEffectStatus());
+    }
+
+    private AgentImprovementCase ownedKnowledgeGapRow() throws Exception {
+        AgentImprovementCase row = row(ImprovementCaseStatus.OWNED, candidate("model-v1"));
+        row.setSourceType(ImprovementSourceType.KNOWLEDGE_GAP.name());
+        row.setSourceKey("knowledge-gap-1");
+        when(caseMapper.lockById(1L)).thenReturn(row);
+        var fact = new ImprovementSourceFact();
+        fact.setQuestion("退款进度如何");
+        fact.setSignalHash("signal-a");
+        when(signalMapper.findKnowledgeGap("tenant-a", row.getSourceKey())).thenReturn(fact);
+        return row;
     }
 
     private AgentImprovementCase row(ImprovementCaseStatus status,

--- a/docs/admin-experience/improvement-eval-guard-validation.md
+++ b/docs/admin-experience/improvement-eval-guard-validation.md
@@ -1,0 +1,24 @@
+# 改进用例创建的状态守卫
+
+基线：0a9f7b55（PR #204），继承已验证的客服辅助版本。
+
+## 问题和原因
+
+已有 ImprovementCaseServiceTest 覆盖复评、发布及效果观察，没有检查 createEvalCase 在拒绝请求前是否已写入客服库。新增五个状态用例实测均失败：PUBLISHING、OBSERVING、VERIFIED、CANCELLED 先调用 EvalCaseStore.save 再拒绝；REEVALUATING 没有拒绝，仍会替换已用于复评的目标用例。
+
+界面 canBind 已禁止以上五种状态。后端需要在持有当前改进项行锁时先检查状态，不能依赖旧页面是否仍显示按钮。
+
+## 调用、职责和修复
+
+调用链为 ImprovementClosurePanel → ImprovementCaseController#createEvalCase → ImprovementCaseService → 客服库 EvalCaseStore / BadcaseService，然后保存 Admin 库中的用例绑定。
+
+状态编排属于 ImprovementCaseService。该方法先在 Admin 事务内 lockById，检查当前状态，再读取原始信号、创建客服端用例及绑定当前改进项。行锁覆盖整个创建和绑定过程，避免同一改进项在两步之间进入复评或发布；REEVALUATING 与界面现有约束保持一致。
+
+没有修改已有用例保存的 upsert 语义，没有新增数据库表或状态机。客服用例与 Admin 状态仍处于两个数据库，这个本地事务不提供分布式回滚。此批解决已复现的拒绝时序与复评中目标替换问题；不同改进项之间的同编号创建竞争、跨库中断恢复需要独立验证，不能据此宣称已经解决。
+
+## 验证
+
+- 修改前，五项失败均来自实际服务方法的行为断言，无编译或夹具错误；四项捕获到禁止发生的 save 调用，一项没有按预期拒绝复评中请求。
+- 修复后同组五项通过；新增成功路径锁定/创建/绑定顺序、创建失败保留原绑定断言。ImprovementCaseServiceTest 全部 15 项通过。
+- 按纯后端守卫改动范围执行相关回归，共 56 项通过，0 失败、0 错误、0 跳过，覆盖改进状态机、自动化租约、信号 Mapper、迁移契约、运行发布任务与 Badcase 服务。两处 Java 源文件及测试在回归期间冻结，散列核对一致。
+- 前端、协议与数据库结构相对基线无变化，沿用基线已完成的两端构建及完整浏览器验证；PR 仍由仓库 CI 执行全部必需检查。敏感模式扫描和 diff 检查通过。本批不把状态守卫单测当作真实分布式故障或跨库原子性验证。


### PR DESCRIPTION
在发布、观察或已结束的改进项中创建评测用例时，原流程会先写客服库，再检查 Admin 状态并报错；复评中还允许更换目标用例。现在先锁定当前改进项并检查状态，再创建及绑定用例，复评中的目标也保持冻结，与界面现有操作限制一致。

五个状态用例在原实现上均失败，修复后全部通过；补充了成功时的锁定/创建/绑定顺序，以及创建失败保留原绑定的断言。相关后端回归 56 项通过（0 失败、0 错误、0 跳过），覆盖改进状态机、租约、信号查询、迁移契约、运行发布任务和 Badcase 服务，敏感扫描及 diff 检查通过。

本批仅修改后端守卫，不改前端、协议或数据库结构。客服用例仍可独立追溯，本地 Admin 事务不提供跨库回滚；本次不宣称解决不同改进项之间的同编号创建竞争或跨库中断恢复。验证边界见 docs/admin-experience/improvement-eval-guard-validation.md。
